### PR TITLE
Fix for issue #14 (writing large messages on Windows)

### DIFF
--- a/pika/asyncore_adapter.py
+++ b/pika/asyncore_adapter.py
@@ -59,6 +59,7 @@ class RabbitDispatcher(asyncore.dispatcher):
     def __init__(self, connection):
         asyncore.dispatcher.__init__(self)
         self.connection = connection
+        self.max_write = connection.suggested_buffer_size()
 
     def handle_connect(self):
         self.connection.on_connected()
@@ -89,7 +90,7 @@ class RabbitDispatcher(asyncore.dispatcher):
         return bool(self.connection.outbound_buffer)
 
     def handle_write(self):
-        fragment = self.connection.outbound_buffer.read()
+        fragment = self.connection.outbound_buffer.read(self.max_write)
         r = self.send(fragment)
         self.connection.outbound_buffer.consume(r)
 

--- a/pika/blocking_adapter.py
+++ b/pika/blocking_adapter.py
@@ -74,7 +74,7 @@ class BlockingConnection(pika.connection.Connection):
 
     def flush_outbound(self):
         while self.outbound_buffer:
-            fragment = self.outbound_buffer.read()
+            fragment = self.outbound_buffer.read(self.suggested_buffer_size())
             r = self.socket.send(fragment)
             self.outbound_buffer.consume(r)
 


### PR DESCRIPTION
As Windows craps out on send() for very large messages, I changed the logic to send blocks of the negotiated fragment size. This stops Windows from returning error 10055 (WSAENOBUFS) to pika on the send() call.

If you prefer, I can make this change Windows specific. I haven't seen any issues with the changed logic in my testing on Linux thus far though.
