### PR TITLE
pika debug logging improvements

### DIFF
--- a/docs/log.rst
+++ b/docs/log.rst
@@ -10,15 +10,14 @@ To turn Pika debug logging on::
      import logging
      import pika.log
 
-     pika.log.DEBUG = True
-
      logging.basicConfig(level=logging.DEBUG)
+     logging.getLogger('pika').setLevel(logging.DEBUG)
 
 Once this is done you will receive all low level information about what Pika is doing including the frames it is sending and receiving from RabbitMQ.
 
 .. function:: debug(msg[, *args[, **kwargs]])
 
-   Logs a message with level :const:`DEBUG` on the root logger. The *msg* is the
+   Logs a message with level :const:`DEBUG` on the "pika" logger. The *msg* is the
    message format string, and the *args* are the arguments which are merged into
    *msg* using the string formatting operator. (Note that this means that you can
    use keywords in the format string, together with a single dictionary argument.)

--- a/pika/log.py
+++ b/pika/log.py
@@ -46,23 +46,13 @@
 #
 # ***** END LICENSE BLOCK *****
 
-DEBUG = False
-
 import logging
 
-DEBUG = logging.DEBUG
-ERROR = logging.ERROR
-INFO = logging.INFO
-WARNING = logging.WARNING
-
-
-def debug(*args, **kwargs):
-    pass
+logger = logging.getLogger('pika')
+logger.setLevel(logging.WARN)
 
 # Define these attributes as references to their logging counterparts
-info = logging.info
-error = logging.error
-warning = logging.warning
-
-if DEBUG:
-    debug = logging.debug
+info = logger.info
+error = logger.error
+warning = logger.warning
+debug = logger.debug


### PR DESCRIPTION
I was trying to use pika in an application I'm writing that used the DEBUG log level. I was disappointed to discover the library was spamming a lot of log messages to the root logger.

pika/log.py had some attempts to disable the debug logging by default, but they failed due to the DEBUG variable being overwritten with the contents of logging.DEBUG, resulting in the messages always being logged to the root logger.

The preferred practice for libraries is to create their own named loggers, or logger hierarchy, instead of writing to the root logger and relying on other tricks to disable the logging. 

My patch creates a logger called 'pika' and sets the default log level to WARNING, which disables all the debug messages by default, even if the root logger is configured to log at the DEBUG level.

I've also updated the docs to show how to enable pika's debug logging
