### PR TITLE
Changed timeout for poll to be in milliseconds

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -407,7 +407,7 @@ class PollPoller(SelectPoller):
     def poll(self):
 
         # Poll until TIMEOUT waiting for an event
-        events = self._poll.poll(SelectPoller.TIMEOUT)
+        events = self._poll.poll(int(SelectPoller.TIMEOUT*1000))
 
         # If we didn't timeout pass the event to the handler
         if events:


### PR DESCRIPTION
I changed the timeout to be in milliseconds as required for the 'poll' poller.

http://docs.python.org/library/select.html#poll-objects

Thanks
