### PR TITLE
More logical validation of long RpcParameters

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -143,5 +143,6 @@ def validate_type(field_name, value, data_type):
     if data_type == 'short' and not isinstance(value, int):
         raise InvalidRPCParameterType("%s must be a int" % field_name)
 
-    if data_type == 'long' and not isinstance(value, long):
-        raise InvalidRPCParameterType("%s must be a int" % field_name)
+    if data_type == 'long' and not ( isinstance(value, long) or 
+                                    isinstance(value, int)):
+        raise InvalidRPCParameterType("%s must be a long" % field_name)


### PR DESCRIPTION
I came upon a strange bug when setting 
`channel.basic_qos(prefetch_size=0, prefetch_count=1)`
What I got was InvalidRpcParameterType("prefetch_size must be a int"). This was clearly the case but what it actually was validates as was a long. This is now corrected both in error message and validation.
If error is raised it says that it should be "long" but a int validates just as good.
