### PR TITLE
BlockingConnection channel close blocks forever

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -255,6 +255,9 @@ class BlockingChannel(Channel):
         connection.callbacks.add(channel_number,
                                  spec.Channel.OpenOk,
                                  transport._on_rpc_complete)
+        connection.callbacks.add(channel_number,
+                                 spec.Channel.CloseOk,
+                                 transport._on_rpc_complete)
         Channel.__init__(self, connection, channel_number, None, transport)
         self.basic_get_ = Channel.basic_get
         self._consumers = {}


### PR DESCRIPTION
When using the BlockingConnection adapter, closing a channel seems to block forever:

https://gist.github.com/962980

It appears that `BlockingChannelTransport.send_method` will loop forever unless `_received_response` becomes `True`. By adding the `transport._on_rpc_complete` callback (which sets `_received_response` to `True` among other things), the loop terminates correctly, ending with a successful channel closure.
