### PR TITLE
Allow GPL 2 or later.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,7 +1,8 @@
 This package, Pika, an AMQP client library for use with RabbitMQ and
 other AMQP servers, is licensed under the MPL, and may also be used
-under the terms of the GPL. For the MPL, please see
-LICENSE-MPL-Pika. For the GPL, please see LICENSE-GPL-2.0.
+under the terms of the GNU General Public License Version 2 or later
+(the "GPL"). For the MPL, please see LICENSE-MPL-Pika. For the GPL 2
+please see LICENSE-GPL-2.0.
 
 If you have any questions regarding licensing, please contact us at
 info@rabbitmq.com.


### PR DESCRIPTION
The words "or later" were lost in translation, during commit 4085f5c58aa521c88a085057eedd241a860e01cc.
