### PR TITLE
fix the Unicode test

### DIFF
--- a/tests/functional/unicode_tests.py
+++ b/tests/functional/unicode_tests.py
@@ -20,20 +20,20 @@ class TestUnicode(support.tools.AsyncPattern):
 
     def __init__(self):
         # UTf-8 Values to test with
-        self.exchange = u"أرنب"
-        self.queue = u"ճագար"
-        self.routing_key = u"兔"
-        self.app_id = u"კურდღლების"
-        self.values = [u'κουνέλι',
-                       u'ארנב',
-                       u'ख़रगोश',
-                       u'ウサギ',
-                       u'토끼',
-                       u'зајакот',
-                       u'кролик',
-                       u'กระต่าย',
-                       u'tavşan',
-                       u'зец']
+        self.exchange = "أرنب"
+        self.queue = "ճագար"
+        self.routing_key = "兔"
+        self.app_id = "კურდღლების"
+        self.values = ['κουνέλι',
+                       'ארנב',
+                       'ख़रगोश',
+                       'ウサギ',
+                       '토끼',
+                       'зајакот',
+                       'кролик',
+                       'กระต่าย',
+                       'tavşan',
+                       'зец']
         self.received = []
         self.properties = BasicProperties(app_id=self.app_id,
                                           content_type="text/plain",


### PR DESCRIPTION
it's failing for me on Python 2.6. The failures are caused by passing Python unicode objects into Pika instead of using UTF-8 encoded blobs. The fix is to use the 'blob' syntax instead of u'blob', which gets parsed by Python into str objects, as opposed to unicode.
