### PR TITLE
Send Close-Ok after receiving a channel Close from the server.

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -631,6 +631,12 @@ specified a %s. Reconnections will fail.",
                 self._channels[channel_number].close(frame.method.reply_code,
                                                      frame.method.reply_text,
                                                      True)  # Forced close
+                # Send a Channel.CloseOk frame
+                self._rpc(channel_number, spec.Channel.CloseOk())
+                # Remove the CloseOk callback
+                self.callbacks.remove(channel_number,
+                                      spec.Channel.CloseOk)
+
             # Remove the channel from our dict
             del(self._channels[channel_number])
 


### PR DESCRIPTION
The spec says that the response to receiving Close must be to send
Close-Ok. When a channel was being closed due to an exception, Pika
was not sending Close-Ok back, which made it impossible to reopen that
channel (see issue #84).

Additionally, if the channel is already going away, the Close-Ok
callback that the connection adds should be removed. Not doing that
results in a warning about a duplicate callback being added.
