### PR TITLE
Capabilities should be sent to the server under the key "capabilities", not "client-properites"

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -370,7 +370,7 @@ specified a %s. Reconnections will fail.",
         # Specify our client properties
         properties = {'product': PRODUCT,
                       'platform': 'Python %s' % python_version(),
-                      'client-properties': {'basic.nack': True,
+                      'capabilities': {'basic.nack': True,
                                             'consumer_cancel_notify': True,
                                             'publisher_confirms': True},
                       'information': 'See http://pika.github.com',


### PR DESCRIPTION
Capabilities should be sent to the server under the key "capabilities", not "client-properties".

See http://www.rabbitmq.com/extensions.html#capabilities for more details.
