### PR TITLE
deleting a queue that has a consumer declared causes a NotImplementedError

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -213,6 +213,12 @@ class Channel(spec.DriverMixin):
                            self._on_basic_get_empty,
                            False)
 
+        # Add a callback for Basic.Cancel
+        self.callbacks.add(self.channel_number,
+                           spec.Basic.Cancel,
+                           self._on_basic_cancel,
+                           False)
+
         # Add a callback for when the server closes our channel
         self.callbacks.add(self.channel_number,
                            spec.Channel.Close,
@@ -478,6 +484,17 @@ class Channel(spec.DriverMixin):
         When we receive an empty reply do nothing but log it
         """
         pass
+
+    def _on_basic_cancel(self, frame):
+        """
+        When the broker cancels a consumer, delete it from our internal
+        dictionary.
+        """
+        # Delete the consumer from our _consumers dictionary
+        if frame.method.consumer_tag in self._consumers:
+            del self._consumers[frame.method.consumer_tag]
+
+        # The server does not expect a confirmation, so we're done
 
     def flow(self, callback, active):
         """

--- a/tests/functional/queue_consume_and_delete_test.py
+++ b/tests/functional/queue_consume_and_delete_test.py
@@ -1,0 +1,48 @@
+# ***** BEGIN LICENSE BLOCK *****
+#
+# For copyright and licensing please refer to COPYING.
+#
+# ***** END LICENSE BLOCK *****
+"""
+Declare a queue, consume from it and delete it without cancelling.
+"""
+import nose
+import support
+import support.tools
+from pika.adapters import SelectConnection
+
+
+class TestQueueConsumeAndDelete(support.tools.AsyncPattern):
+
+    @nose.tools.timed(2)
+    def test_consume_and_delete(self):
+        self.confirmed = False
+        self.connection = self._connect(SelectConnection, support.PARAMETERS)
+        self.connection.ioloop.start()
+        if not self.confirmed:
+            assert False, 'Did not receive the remote queue delete callback.'
+        pass
+
+    def _on_channel(self, channel):
+        self.channel = channel
+        self.channel.exchange_declare(exchange='queue_delete_exchange',
+                                      type="direct", auto_delete=True,
+                                      callback=self._on_exchange_declare)
+
+    def _on_exchange_declare(self, frame):
+        self._queue_declare()
+
+    def _on_queue_declared(self, frame):
+        self.channel.queue_bind(queue=self._queue,
+                                exchange='queue_delete_exchange',
+                                callback=self._on_queue_bound)
+
+    def _on_queue_bound(self, frame):
+        self.channel.basic_consume(consumer_callback=lambda *args: None,
+                                   queue=self._queue)
+        self.channel.queue_delete(callback=self._on_queue_deleted,
+                                  queue=self._queue)
+
+    def _on_queue_deleted(self, frame):
+        self.confirmed = True
+        self.connection.close()


### PR DESCRIPTION
The following test case demonstrates the problem: https://gist.github.com/1254796. It declares a queue, calls basic_consume on it and then deletes it without cancelling anything.

Wireshark shows that after deleting a queue that has a consumer, the server sends a Cancel message that makes Pika error out with the following traceback: https://gist.github.com/1254803

That's using the master branch of Pika and RabbitMQ 2.6.1. Since we've started seeing this only recently, I poked around the commit history and found out that reverting 8aa865e7e792ac699de0d89442e611bcbfbfe097 makes the problem go away, although the commit almost certainly only unmasked a issue that was already present.

Changing the has_content method in spec.py to return True for Basic.Cancel also makes the error go away, but since that file is autogenerated, it's probably not the right solution.

I'm not sure what's the root cause of the problem, seems that getting a Basic.Cancel from the server is legit and deleting a queue without cancelling basic_consume shouldn't result in an error (or at least it should be more friendly).
