### PR TITLE
on_connect_attempt_failure is not called on ReconnectionStrategies

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -33,20 +33,17 @@ class BlockingConnection(BaseConnection):
         BaseConnection.__init__(self, parameters, None, reconnection_strategy)
 
     def _adapter_connect(self):
-        try:
-            BaseConnection._adapter_connect(self)
-            self.socket.setblocking(1)
-            # Set the timeout for reading/writing on the socket
-            self.socket.settimeout(SOCKET_TIMEOUT)
-            self._socket_timeouts = 0
-            self._on_connected()
-            self._timeouts = dict()
-            while not self.is_open:
-                self._flush_outbound()
-                self._handle_read()
-            return self
-        except Exception, err:
-            self.reconnection.on_connect_attempt_failure(self, err)
+        BaseConnection._adapter_connect(self)
+        self.socket.setblocking(1)
+        # Set the timeout for reading/writing on the socket
+        self.socket.settimeout(SOCKET_TIMEOUT)
+        self._socket_timeouts = 0
+        self._on_connected()
+        self._timeouts = dict()
+        while not self.is_open:
+            self._flush_outbound()
+            self._handle_read()
+        return self
 
     def close(self, code=200, text='Normal shutdown'):
         BaseConnection.close(self, code, text)

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -271,7 +271,10 @@ specified a %s. Reconnections will fail.",
         self.connection_state = CONNECTION_INIT
 
         # Try and connect
-        self._adapter_connect()
+        try:
+            self._adapter_connect()
+        except Exception, err:
+            self.reconnection.on_connect_attempt_failure(self, err)
 
     def force_reconnect(self):
         # We're not closing and we're not open, so reconnect


### PR DESCRIPTION
The entry point for reconnection strategies is not called by the connection currently.  Patch catches errors on _connect() and passes the connection _and_ the error to the reconnection strategy (on the assumption that reconnection strategies will often want to log the error and/or report it out-of-band).  Extends the on_connect_attempt_failure API accordingly.
