### PR TITLE
Fix NameError in credentials.py

### DIFF
--- a/pika/credentials.py
+++ b/pika/credentials.py
@@ -4,6 +4,7 @@
 #
 # ***** END LICENSE BLOCK *****
 
+import pika.log as log
 
 class PlainCredentials(object):
     """


### PR DESCRIPTION
When PlainCredentials's erase_on_connect flag is enabled, log NameError occurs.
Easy way to confirm this error is to change examples/demo_tornado.py as follows :

```
credentials = pika.PlainCredentials('guest', 'guest', True)
```
