### PR TITLE
Make TwistedConnection usable

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -315,6 +315,7 @@ class TwistedConnection(BaseConnection):
 
     def doWrite(self):
         self._handle_write()
+        self._manage_event_state()
 
 
 class TwistedProtocolConnection(BaseConnection):


### PR DESCRIPTION
TwistedConnection had missing connection initialisation arguments. It also has an infinite write loop because the write state wasn't being reset, resulting in absurd CPU usage.
