### PR TITLE
Poller will stop writing events

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -749,7 +749,7 @@ class Connection(object):
 
         #pika.frame.log_frame(frame.name, marshalled_frame)
         self.outbound_buffer.write(marshalled_frame)
-        #self._flush_outbound()
+        self._flush_outbound()
         self._detect_backpressure()
 
     def _detect_backpressure(self):


### PR DESCRIPTION
Hi,

When base_connection does a _handle_events() with a WRITE, it will call _manage_event_state(), which will possibly unset WRITE if the buffer is empty.  Subsequent writes to the outbound buffer will never get processed, because the WRITE event is never set.  I'm "uncommenting" the call to connection._flush_outbound() in connection._send_frame(), which will in turn call base_connection._manage_event_state() and set the WRITE event.

Please let me know if you have any questions.
Thanks,
Logan
