### PR TITLE
Add support for TCP keepalives.

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -87,6 +87,17 @@ class BaseConnection(Connection):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM, 0)
         self.socket.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
 
+        # Enable TCP keepalive and set any provided keepalive parameters
+        params = self.parameters
+        if params.tcp_keepalive:
+            self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+            for opt, var in ((socket.TCP_KEEPIDLE,  params.tcp_keepidle),
+                             (socket.TCP_KEEPINTVL, params.tcp_keepintvl),
+                             (socket.TCP_KEEPCNT,   params.tcp_keepcnt)):
+                if var is not None:
+                    self.socket.setsockopt(socket.SOL_TCP, opt, var)
+
         # Wrap the SSL socket if we SSL turned on
         ssl_text = ""
         if self.parameters.ssl:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -52,6 +52,8 @@ class ConnectionParameters(object):
     - channel_max: Maximum number of channels to allow, defaults to 0 for None
     - frame_max: The maximum byte size for an AMQP frame. Defaults to 131072
     - heartbeat: Heartbeat Interval. 0 for heartbeat off.
+    - tcp_keepalive: Enable TCP keepalive, defaults to False.
+    - tcp_keepidle, tcp_keepintvl, tcp_keepcnt: TCP keepalive behavior tuning.
     """
     def __init__(self,
                  host='localhost',
@@ -64,7 +66,11 @@ class ConnectionParameters(object):
                  ssl=False,
                  ssl_options=None,
                  connection_attempts=1,
-                 retry_delay=2):
+                 retry_delay=2,
+                 tcp_keepalive=False,
+                 tcp_keepidle=None,
+                 tcp_keepintvl=None,
+                 tcp_keepcnt=None):
 
         # Validate the host type
         if not isinstance(host, str):
@@ -142,6 +148,13 @@ class ConnectionParameters(object):
         if not isinstance(retry_delay, int):
             raise TypeError("retry_delay must be an int")
 
+        # Validate the tcp keepalive parameters:
+        if not isinstance(tcp_keepalive, bool):
+            raise TypeError("tcp_keepalive must be a bool")
+        if any (var is not None and not isinstance(var, int)
+                for var in (tcp_keepidle, tcp_keepintvl, tcp_keepcnt)):
+            raise TypeError("tcp_keepidle/intvl/cnt must be either None or int")
+
         # Assign our values
         self.host = host
         self.port = port
@@ -154,7 +167,10 @@ class ConnectionParameters(object):
         self.ssl_options = ssl_options
         self.connection_attempts = connection_attempts
         self.retry_delay = retry_delay
-
+        self.tcp_keepalive = tcp_keepalive
+        self.tcp_keepidle  = tcp_keepidle
+        self.tcp_keepintvl = tcp_keepintvl
+        self.tcp_keepcnt   = tcp_keepcnt
 
 class Connection(object):
 


### PR DESCRIPTION
Here's a patch to enable TCP keepalives. It can be used in conjunction with AMQP heartbeats or by itself to improve robustness over unreliable networks.
