### PR TITLE
Fix for high availability clusters

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -109,7 +109,7 @@ class BaseConnection(Connection):
         log.info("Connecting fd %d to %s:%i%s", self.socket.fileno(),
                  self.parameters.host,
                  self.parameters.port, ssl_text)
-        self.socket.settimeout(CONNECTION_TIMEOUT)
+        self.socket.settimeout(self.parameters.socket_timeout or CONNECTION_TIMEOUT)
         self.socket.connect((self.parameters.host,
                              self.parameters.port))
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -37,7 +37,7 @@ class BlockingConnection(BaseConnection):
         BaseConnection._adapter_connect(self)
         self.socket.setblocking(1)
         # Set the timeout for reading/writing on the socket
-        self.socket.settimeout(SOCKET_TIMEOUT)
+        self.socket.settimeout(paramaters.socket_timeout or SOCKET_TIMEOUT)
         self._socket_timeouts = 0
         self._on_connected()
         self._timeouts = dict()

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -52,6 +52,7 @@ class ConnectionParameters(object):
     - channel_max: Maximum number of channels to allow, defaults to 0 for None
     - frame_max: The maximum byte size for an AMQP frame. Defaults to 131072
     - heartbeat: Heartbeat Interval. 0 for heartbeat off.
+    - socket_timeout: Socket timeout value will default CONNECTION_TIMEOUT (2secs). Use for high latency networks
     """
     def __init__(self,
                  host='localhost',
@@ -64,7 +65,8 @@ class ConnectionParameters(object):
                  ssl=False,
                  ssl_options=None,
                  connection_attempts=1,
-                 retry_delay=2):
+                 retry_delay=2,
+                 socket_timeout=None):
 
         # Validate the host type
         if not isinstance(host, str):
@@ -142,6 +144,10 @@ class ConnectionParameters(object):
         if not isinstance(retry_delay, int):
             raise TypeError("retry_delay must be an int")
 
+        # Validate the socket timeout delay
+        if not isinstance(socket_timeout, int):
+            raise TypeError("socket_timeout must be an int")
+
         # Assign our values
         self.host = host
         self.port = port
@@ -154,6 +160,9 @@ class ConnectionParameters(object):
         self.ssl_options = ssl_options
         self.connection_attempts = connection_attempts
         self.retry_delay = retry_delay
+        # When working with high latency networks it might be necessary to have a timeout value for
+        # both Connecting and Read/Write to sockets that is higher than the 2 second interval set by Pika.
+        self.socket_timeout = socket_timeout
 
 
 class Connection(object):


### PR DESCRIPTION
When using a high availability proxy (such as HAProxy) pika is always able to open a socket to the proxy even when there is no RabbitMQ backend. 
This caused an infinite loop while waiting for the RabbitMQ connection to be open.
