### PR TITLE
Use socket_timeout from parameters as connection timeout

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -33,7 +33,6 @@ class BaseConnection(connection.Connection):
     WRITE = 0x0004
     ERROR = 0x0008
 
-    SOCKET_TIMEOUT = 2
     ERRORS_TO_IGNORE = [errno.EWOULDBLOCK, errno.EAGAIN, errno.EINTR]
     HANDSHAKE = 'do_handshake_on_connect'
     def __init__(self, parameters=None,
@@ -360,7 +359,7 @@ class BaseConnection(connection.Connection):
         LOGGER.info("Connecting fd %d to %s:%i%s",
                     self.socket.fileno(), self.params.host,
                     self.params.port, ssl_text)
-        self.socket.settimeout(self.SOCKET_TIMEOUT)
+        self.socket.settimeout(self.params.socket_timeout)
         self.socket.connect((self.params.host, self.params.port))
         self.socket.setblocking(0)
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -25,7 +25,6 @@ class BlockingConnection(base_connection.BaseConnection):
     messages from Basic.Deliver, Basic.GetOk, and Basic.Return.
 
     """
-    SOCKET_TIMEOUT = 0.25
     SOCKET_TIMEOUT_THRESHOLD = 10
     SOCKET_TIMEOUT_MESSAGE = "Timeout exceeded, disconnected"
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -45,7 +45,7 @@ class ConnectionParameters(object):
                  ssl=False,
                  ssl_options=None,
                  connection_attempts=1,
-                 retry_delay=2,
+                 retry_delay=2.0,
                  socket_timeout=DEFAULT_SOCKET_TIMEOUT,
                  locale=DEFAULT_LOCALE):
         """Create a new ConnectionParameters instance.
@@ -71,8 +71,8 @@ class ConnectionParameters(object):
             described at http://docs.python.org/dev/library/ssl.html
         :param int connection_attempts: Maximum number of retry attempts.
             None for infinite. Defaults to 1
-        :param int retry_delay: Time to wait in seconds, before the next attempt
-            Defaults to 2
+        :param int|float retry_delay: Time to wait in seconds, before the next
+            attempt. Defaults to 2
         :param int|float socket_timeout: Use for high latency networks
             Defaults to 0.25
         :param str locale: Set the locale value
@@ -109,8 +109,9 @@ class ConnectionParameters(object):
         if (connection_attempts is not None and
             not isinstance(connection_attempts, int)):
             raise TypeError("connection_attempts must be either None or int")
-        if not isinstance(retry_delay, int):
-            raise TypeError("retry_delay must be an int")
+        if (not isinstance(retry_delay, int) and
+            not isinstance(retry_delay, float)):
+            raise TypeError("retry_delay must be a float or int")
         if (not isinstance(socket_timeout, int) and
             not isinstance(socket_timeout, float)):
             raise TypeError("socket_timeout must be a float or int")

--- a/tests/timeout_tests.py
+++ b/tests/timeout_tests.py
@@ -1,0 +1,38 @@
+# -*- coding: utf8 -*-
+"""
+Tests for connection parameters.
+"""
+import socket
+from mock import patch
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from pika import ConnectionParameters, BaseConnection
+from pika.exceptions import AMQPConnectionError
+
+
+def mock_timeout(*args, **kwargs):
+    raise socket.timeout
+
+
+class ConnectionTests(unittest.TestCase):
+
+    def test_parameters(self):
+        params = ConnectionParameters(socket_timeout=0.5,
+                                      retry_delay=0.1,
+                                      connection_attempts=3,
+                                      )
+        self.assertEqual(params.socket_timeout, 0.5)
+        self.assertEqual(params.retry_delay, 0.1)
+        self.assertEqual(params.connection_attempts, 3)
+
+
+    @patch.object(socket.socket, 'settimeout')
+    @patch.object(socket.socket, 'connect')
+    def test_connection_timeout(self, connect, settimeout):
+        connect.side_effect = mock_timeout
+        with self.assertRaises(AMQPConnectionError):
+            BaseConnection(ConnectionParameters(socket_timeout=2.0))
+        settimeout.assert_called_with(2.0)


### PR DESCRIPTION
Setting socket timeouts in Pika is a little bit confusing. Especially overriding the default connection timeout (250ms for blocking connections) involves subclassing the BlockingConnection to set the class attribute.

This patch removes the `SOCKET_TIMEOUT` class attribute which was only used for setting the initial connection timeout and instead reuses the already available `socket_timeout` from the connection parameters.

It also allows float values for `retry_delay`.
