### PR TITLE
Do not send Basic.CancelOk to server; add 'one_shot' to add_callback params; Add add_on_basic_cancel_callback; extend on_basic_cancel; correct consumer_tag creation and duplicate check.

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -262,10 +262,10 @@ class Channel(spec.DriverMixin):
         # If a consumer tag was not passed, create one
         if not consumer_tag:
             consumer_tag = 'ctag%i.%i' % (self.channel_number,
-                                          len(self._consumers))
+                                          len(self._consumers)+len(self._cancelled))
 
         # Make sure we've not already registered this consumer tag
-        if consumer_tag in self._consumers:
+        if consumer_tag in self._consumers or consumer_tag in self._cancelled:
             raise exceptions.DuplicateConsumerTag(consumer_tag)
 
         # The consumer tag has not been used before, add it to our consumers


### PR DESCRIPTION
When the server sends a Basic.Cancel, do not send back a Basic.CancelOk as it results in a 503 response (NOT IMPLEMENTED) from the server.

Add the 'one_shot=True' param to Channel.add_callback so that it can be set to False when needed, e.g. to handle Basic.Cancel for failover of the master node(s) of mirrored queues when the current connection is to a node other than the failed master of each queue.

Add Channel.add_on_basic_cancel_callback so that an application callback can be triggered by a Basic.Cancel from the server. Extend Channel.on_basic_cancel to process the callback.

Correct Channel.basic_consume to add the lengths of both _consumers and _cancelled when creating a consumer_tag and to consider both as well when checking for duplicates. This avoids inaccurate duplicate checks (though possibly this is overzealous) but more importantly it eliminates the possibility of BasicReject being called in error due to a duplicate assigned consumer_tag in a scenario such as the failover of a mirrored queue where the proper application response is to only redo BasicConsume and unacked messages will be redelivered by the server.
