### PR TITLE
Exception raised when the socket is closed

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1052,8 +1052,9 @@ class Connection(object):
         if not from_adapter:
             self._adapter_disconnect()
         self._set_connection_state(self.CONNECTION_CLOSED)
-        for channel in self._channels:
-            self._channels[channel].on_remote_close(method_frame)
+        if method_frame:
+            for channel in self._channels:
+                self._channels[channel].on_remote_close(method_frame)
         self._process_connection_closed_callbacks()
         self._remove_connection_callbacks()
 


### PR DESCRIPTION
I got this error when the socket was closed:

  File "/opt/lib/python2.6/site-packages/openx_python_rabbit_client/client.py", line 140, in start_consumer
    self.connection.ioloop.start()
  File "/opt/lib/python2.6/site-packages/pika/adapters/select_connection.py", line 102, in start
    self.poller.start()
  File "/opt/lib/python2.6/site-packages/pika/adapters/select_connection.py", line 385, in start
    self.poll()
  File "/opt/lib/python2.6/site-packages/pika/adapters/select_connection.py", line 440, in poll
    self._handler(fileno, event, write_only=write_only)
  File "/opt/lib/python2.6/site-packages/pika/adapters/base_connection.py", line 275, in _handle_events
    self._handle_read()
  File "/opt/lib/python2.6/site-packages/pika/adapters/base_connection.py", line 295, in _handle_read
    return self._handle_error(error)
  File "/opt/lib/python2.6/site-packages/pika/adapters/base_connection.py", line 259, in _handle_error
    self._handle_disconnect()
  File "/opt/lib/python2.6/site-packages/pika/adapters/base_connection.py", line 208, in _handle_disconnect
    self._on_connection_closed(None, True)
  File "/opt/lib/python2.6/site-packages/pika/connection.py", line 753, in _on_connection_closed
    self._channels[channel].on_remote_close(method_frame)
  File "/opt/lib/python2.6/site-packages/pika/channel.py", line 505, in on_remote_close
    self.closing = (frame_value.method.reply_code,
AttributeError: 'NoneType' object has no attribute 'method'

My solution was to skip closing channels if method is set to None.
