### PR TITLE
Fix closing connection while a channel is still open

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -814,7 +814,8 @@ class BlockingChannel(channel.Channel):
 
     def _on_close(self, method_frame):
         LOGGER.warning('Received Channel.Close, closing: %r', method_frame)
-        self._send_method(spec.Channel.CloseOk(), None, False)
+        if not self.connection.is_closed:
+            self._send_method(spec.Channel.CloseOk(), None, False)
         self._set_state(self.CLOSED)
         raise exceptions.ChannelClosed(self._reply_code, self._reply_text)
 


### PR DESCRIPTION
Not sure if this is the way you want to fix this, but I was running into an issue where if you shut down RabbitMQ while pika has an open channel, it would try to send Channel.Close over a closed socket which would trigger another _on_close call that would send another Channel.Close and it'd get stuck in a recursive loop.
