### PR TITLE
removed call to cleanup from Channel._shutdown

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1035,7 +1035,6 @@ class Channel(object):
         self._set_state(self.CLOSING)
         self._send_method(spec.Channel.Close(self._reply_code,
                                              self._reply_text, 0, 0))
-        self._cleanup()
 
     def _unexpected_frame(self, frame_value):
         LOGGER.warning('Unexpected frame: %r', frame_value)


### PR DESCRIPTION
In commit e67f0e807 to address issue #261 `self._cleanup()` was added to `Channel._shutdown`. This wasn't necessary though as `connection.Connection._on_channel_closeok` makes a call to `cleanup`. 

Calling it from `Channel._shutdown` causes any callbacks hooked to a `Channel.CloseOk` to get nuked before they have a chance to fire. I'm pretty sure the problem mentioned in #261 was caused by channel errors when closing channels which had consumers, which was fixed in my 566745507 patch. Ignoring my patch though, calling `self._cleanup` in `Channel._on_close` rightly addresses #261.

I hope this doesn't sound douchy. I can't seem to word it without it sounding so, though. :P
