### PR TITLE
Fix channel._on_close() without a method frame.

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -867,8 +867,11 @@ class BlockingChannel(channel.Channel):
             self._send_method(spec.Channel.CloseOk(), None, False)
         self._set_state(self.CLOSED)
         self._cleanup()
-        raise exceptions.ChannelClosed(method_frame.method.reply_code,
-                                       method_frame.method.reply_text)
+        if method_frame is None:
+            raise exceptions.ChannelClosed(0, 'Not specified')
+        else:
+            raise exceptions.ChannelClosed(method_frame.method.reply_code,
+                                           method_frame.method.reply_text)
 
     def _on_openok(self, method_frame):
         """Open the channel by sending the RPC command and remove the reply


### PR DESCRIPTION
If a channel close is triggered by connection close which doesn't have a
method_frame (eg, because of a socket disconnection due to missed
heartbeats), channel._on_close() will be called with a method_frame of
None.  This patch handles this, to avoid looking up attributes on None.
