### PR TITLE
pass a Method frame to Channel._on_close in Connection._on_disconnect

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1159,8 +1159,9 @@ class Connection(object):
                        self.params.host, self.params.port,
                        reply_code, reply_text)
         self._set_connection_state(self.CONNECTION_CLOSED)
-        method_frame = spec.Channel.Close(reply_code, reply_text)
         for channel in self._channels:
+            method_frame = frame.Method(
+                channel, spec.Channel.Close(reply_code, reply_text))
             self._channels[channel]._on_close(method_frame)
         self._process_connection_closed_callbacks(reply_code, reply_text)
         self._remove_connection_callbacks()

--- a/tests/connection_tests.py
+++ b/tests/connection_tests.py
@@ -61,3 +61,11 @@ class ConnectionTests(unittest.TestCase):
         '''if connection isn't closing _on_close_ready should not be called'''
         self.connection._on_channel_closeok(mock.Mock())
         self.assertFalse(on_close_ready.called, '_on_close_ready should not have been called')
+
+    def test_on_disconnect(self):
+        '''if connection isn't closing _on_close_ready should not be called'''
+        self.connection._on_disconnect(0, 'Undefined')
+        self.assertTrue(self.channel._on_close.called, 'channel._on_close should have been called')
+        method_frame = self.channel._on_close.call_args[0][0]
+        self.assertEqual(method_frame.method.reply_code, 0)
+        self.assertEqual(method_frame.method.reply_text, 'Undefined')


### PR DESCRIPTION
The channel's _on_close method expects a Method frame and was getting a spec.Channel.Close object instead.
