### PR TITLE
Fix channel_close in Twisted adapter and don't stop IOLoop

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -257,6 +257,12 @@ class TwistedConnection(base_connection.BaseConnection):
     IReadWriteDescriptor interface.
 
     """
+    def __init__(self, parameters=None,
+                 on_open_callback=None,
+                 stop_ioloop_on_close=False):
+        super(TwistedConnection, self).__init__(parameters, on_open_callback,
+                                                stop_ioloop_on_close)
+
     def _adapter_connect(self):
         """Connect to the RabbitMQ broker"""
         # Connect (blockignly!) to the server


### PR DESCRIPTION
This addresses some of the issues raised in #288.

The Twisted adapter's channel_closed callback was accepting wrong parameters and the stop_ioloop_on_close parameter should probably be False by default in TwistedConnection.
