### PR TITLE
Fixed channel close event calling convention

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -837,9 +837,7 @@ class Channel(object):
         self._set_state(self.CLOSED)
         self.callbacks.process(self.channel_number,
                                '_on_channel_close',
-                               self, self,
-                               method_frame.method.reply_code,
-                               method_frame.method.reply_text)
+                               self, method_frame)
         self._cleanup()
 
     def _on_closeok(self, method_frame):
@@ -852,8 +850,7 @@ class Channel(object):
         self._set_state(self.CLOSED)
         self.callbacks.process(self.channel_number,
                                '_on_channel_close',
-                               self, self,
-                               0, '')
+                               self, method_frame)
         self._cleanup()
 
     def _on_deliver(self, method_frame, header_frame, body):


### PR DESCRIPTION
Changes made in c221b5aee2 breaks server-side channel close events. As it is now, an exception is thrown. Per https://github.com/pika/pika/blob/master/pika/channel.py#L93 the callback expects a method frame.

exceptions.TypeError: channel_closed() takes exactly 2 arguments (4 given)
