### PR TITLE
Use getaddrinfo to get ipv6 working

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -162,8 +162,9 @@ class BaseConnection(connection.Connection):
     def _create_and_connect_to_socket(self):
         """Create socket and connect to it, using SSL if enabled."""
         LOGGER.debug('Creating the socket')
-        connInfo = socket.getaddrinfo(self.params.host, self.params.port, 0, 0, socket.getprotobyname("tcp"))[0]
-        self.socket = socket.socket(connInfo[0], socket.SOCK_STREAM, 0)
+        conn_info = socket.getaddrinfo(self.params.host, self.params.port, 
+                                       0, 0, socket.getprotobyname("tcp"))[0]
+        self.socket = socket.socket(conn_info[0], socket.SOCK_STREAM, 0)
         #self.socket.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
         if self.params.ssl:
             self.socket = self._wrap_socket(self.socket)


### PR DESCRIPTION
I've improved https://github.com/pika/pika/issues/309 solution by using getaddrinfo.
In this way I get the first result got by getaddrinfo and use the resulting data to select if to use ipv6 or ipv4 as network protocol based on the input address.
I've removed socket.has_ipv6 since it could return true also without ipv6 connection nor ipv6 dns resolving.
