### PR TITLE
Add NullHandler to prevent logging warnings

### DIFF
--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -5,6 +5,15 @@
 # ***** END LICENSE BLOCK *****
 __version__ = '0.9.13'
 
+import logging
+try:
+    # not available in python 2.6
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
 from pika.connection import ConnectionParameters
 from pika.connection import URLParameters
 from pika.credentials import PlainCredentials
@@ -14,3 +23,7 @@ from pika.adapters.base_connection import BaseConnection
 from pika.adapters.asyncore_connection import AsyncoreConnection
 from pika.adapters.blocking_connection import BlockingConnection
 from pika.adapters.select_connection import SelectConnection
+
+
+# Add NullHandler to prevent logging warnings
+logging.getLogger(__name__).addHandler(NullHandler())


### PR DESCRIPTION
When logging messages are emitted without configuring logging, a warning message is printed to console. Example:

```
No handlers could be found for logger "pika.adapters.base_connection"
```

This pull request fixes this issue. More information can be found here: http://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
