### PR TITLE
Alternative solution to fix #345. 

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -143,7 +143,7 @@ class BaseConnection(connection.Connection):
             raise exceptions.ProbableAccessDeniedError
         elif self.is_open:
             LOGGER.warning("Socket closed when connection was open")
-        elif not self.is_closing:
+        elif not self.is_closed:
             LOGGER.warning('Unknown state on disconnect: %i',
                            self.connection_state)
 


### PR DESCRIPTION
Not necessarily a better solution, but stays consistent with the previous code. I also added a fix for an logging error caused by this line.

```
elif not self.is_closing:
    LOGGER.warning('Unknown state on disconnect: %i',
                   self.connection_state)
```

I have gone through the code, and my only assumption is that this should `self.is_closed`, and not `self.is_closing`.
