### PR TITLE
Fix for Issue #357.

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -197,7 +197,8 @@ class BlockingConnection(base_connection.BaseConnection):
             self._close_channels(reply_code, reply_text)
         while self._has_open_channels:
             self.process_data_events()
-        self._send_connection_close(reply_code, reply_text)
+        if self.socket:
+            self._send_connection_close(reply_code, reply_text)
         while self.is_closing:
             self.process_data_events()
         if self.heartbeat:


### PR DESCRIPTION
There is probably a better approach to fixing this, as it could be a logic issue, but I think this is an acceptable solution.

Removing `self.socket = None` from `_adapter_disconnect` yields the same result as checking for it to be `None` in `close()`, but as I don't know if that affects other parts of the library, I decided against changing it.

New output when the server becomes unreachable (e.g. server is shutdown) with the suggested fix.

```
DEBUG:Incremented callback reference counter: {'callback': <bound method BlockingChannel._on_rpc_complete of <pika.adapters.blocking_connection.BlockingChannel object at 0xb74e6b8c>>, 'only': None, 'one_shot': True, 'arguments': None, 'calls': 3}
ERROR:Socket Error on fd 3: 104
WARNING:Socket closed when connection was open
DEBUG:Added: {'callback': <bound method BlockingConnection._on_connection_start of <pika.adapters.blocking_connection.BlockingConnection object at 0x8b920ac>>, 'only': None, 'one_shot': True, 'arguments': None, 'calls': 1}
CRITICAL:Attempted to send frame when closed
CRITICAL:Attempted to send frame when closed
Traceback (most recent call last):
  File "/home/eandersson/repo/x/t2.py", line 19, in <module>
    print channel.basic_publish(exchange='', routing_key='hello', body='Hello World!')
  File "/usr/local/lib/python2.7/dist-packages/pika-0.9.13-py2.7.egg/pika/adapters/blocking_connection.py", line 522, in basic_publish
    (properties, body))
  File "/usr/local/lib/python2.7/dist-packages/pika-0.9.13-py2.7.egg/pika/adapters/blocking_connection.py", line 1107, in _rpc
    self.connection.process_data_events()
  File "/usr/local/lib/python2.7/dist-packages/pika-0.9.13-py2.7.egg/pika/adapters/blocking_connection.py", line 219, in process_data_events
    raise exceptions.ConnectionClosed()
pika.exceptions.ConnectionClosed
```
