### PR TITLE
Fixed a typo in the name of the Asyncore Connection adapter

### DIFF
--- a/docs/modules/adapters/asyncore.rst
+++ b/docs/modules/adapters/asyncore.rst
@@ -1,4 +1,4 @@
-Aynscore Connection Adapter
+Asyncore Connection Adapter
 ===========================
 .. automodule:: pika.adapters.asyncore_connection
 .. autoclass:: pika.adapters.asyncore_connection.AsyncoreConnection


### PR DESCRIPTION
Changed the spelling to Asyncore from Aynscore
