### PR TITLE
Fix memory leak with Channel._cancelled-list

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -5,6 +5,7 @@ implementing the methods and behaviors for an AMQP Channel.
 import collections
 import logging
 import warnings
+import uuid
 
 import pika.frame as frame
 import pika.exceptions as exceptions
@@ -202,9 +203,8 @@ class Channel(object):
         self._validate_channel_and_callback(consumer_callback)
 
         # If a consumer tag was not passed, create one
-        consumer_tag = consumer_tag or 'ctag%i.%i' % (self.channel_number,
-                                                      len(self._consumers) +
-                                                      len(self._cancelled))
+        consumer_tag = consumer_tag or 'ctag%i.%s' % (self.channel_number,
+                                                      uuid.uuid4().get_hex())
 
         if consumer_tag in self._consumers or consumer_tag in self._cancelled:
             raise exceptions.DuplicateConsumerTag(consumer_tag)


### PR DESCRIPTION
Channel object stores used consumer tags to _channel-list when basic_cancel is called and checks that new consumer_tag is not in that list when basic_consume is called. Items from _cancelled-list are never removed, thus the list is ever increasing. In our use case we call basic_consume/basic_cancel repeatedly to poll multiple queues (in order to emulate task priorities) and thus the list grows rapidly.

The pull-request changes the Channel._cancelled to be deque of size 10 and changes the automatic consumer_tag creation to use uuid to guarantee uniqueness.

I was not able to figure out why the used consumer tags were stored permanently in the first place, and thus the deque with arbitrary small size. Would it be enough to pop ctag from the list at _on_cancelok()?
