### PR TITLE
Fix for #374 (Channel.basic_get with Twisted raises error)

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -147,7 +147,19 @@ class TwistedChannel(object):
             d = defer.Deferred()
             self.__calls.add(d)
             d.addCallback(self.__clear_call, d)
-            kwargs['callback'] = d.callback
+
+            def single_argument(*args):
+                """
+                Make sure that the deferred is called with a single argument.
+                In case the original callback fires with more than one, convert
+                to a tuple.
+                """
+                if len(args) > 1:
+                    d.callback(tuple(args))
+                else:
+                    d.callback(*args)
+
+            kwargs['callback'] = single_argument
 
             try:
                 method(*args, **kwargs)


### PR DESCRIPTION
Twisted deferreds expect a single argument, and the docstring
of TwistedChannel says it will call them with a tuple
in case the original callback receives more than one.

This commit makes the comment true.

Fixes #374.
