### PR TITLE
Successive Basic.Get requests on the same asynchronous channel creates a race condition

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -935,11 +935,12 @@ class Channel(object):
 
         """
         if self._on_getok_callback is not None:
-            self._on_getok_callback(self,
-                                    method_frame.method,
-                                    header_frame.properties,
-                                    body)
+            callback = self._on_getok_callback
             self._on_getok_callback = None
+            callback(self,
+                     method_frame.method,
+                     header_frame.properties,
+                     body)
         else:
             LOGGER.error('Basic.GetOk received with no active callback')
 


### PR DESCRIPTION
When calling Channel.basic_get on an async channel, there is a race condition in Channel._on_getok which sets self._on_getok_callback = None.  If the callback for the first basic_get issues a follow up basic_get, the Channel._on_getok ends up deleting the _on_getok_callback for the 2nd basic_get.

Example using Tornado generators:

``` python
args, kwargs = yield tornado.gen.Task(ch.basic_get, queue=my_queue)
_, method, props, body = args
logger.warn('Recv: %s', body)

args, kwargs = yield tornado.gen.Task(ch.basic_get, queue=my_queue)
_, method, props, body = args
logger.warn('Recv: %s', body)
```

```
2013-07-15 11:27:44,546 DEBUG    __main__         [+]  Bound queue (test_queue) to exchange (test_exchange)
2013-07-15 11:27:44,546 DEBUG    pika.callback    [+]  Added: {'callback': <function decorated at 0x107759398>, 'only': None, 'one_shot': True, 'arguments': None, 'calls': 1}
2013-07-15 11:27:44,548 WARNING  __main__         [#]  Recv: 1
2013-07-15 11:27:44,548 DEBUG    pika.callback    [+]  Added: {'callback': <function decorated at 0x107759500>, 'only': None, 'one_shot': True, 'arguments': None, 'calls': 1}
2013-07-15 11:27:44,548 ERROR    pika.channel     [-]  Removing Basic.GetOk callback (this line is added by me)
2013-07-15 11:27:44,549 ERROR    pika.channel     [-]  Basic.GetOk received with no active callback
```
