### PR TITLE
Propagate low-level connection errors to the AMQPConnectionError.

### DIFF
--- a/pika/adapters/asyncore_connection.py
+++ b/pika/adapters/asyncore_connection.py
@@ -141,7 +141,9 @@ class AsyncoreConnection(base_connection.BaseConnection):
         into our various state methods.
 
         """
-        if super(AsyncoreConnection, self)._adapter_connect():
+        error = super(AsyncoreConnection, self)._adapter_connect()
+        if not error:
             self.socket = PikaDispatcher(self.socket, None, self._handle_events)
             self.ioloop = self.socket
             self._on_connected()
+        return error

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -212,8 +212,9 @@ class BlockingConnection(base_connection.BaseConnection):
 
         """
         self._set_connection_state(self.CONNECTION_INIT)
-        if not self._adapter_connect():
-            raise exceptions.AMQPConnectionError('Could not connect')
+        error = self._adapter_connect()
+        if error:
+            raise exceptions.AMQPConnectionError(error)
 
     def process_data_events(self):
         """Will make sure that data events are processed. Your app can
@@ -280,8 +281,9 @@ class BlockingConnection(base_connection.BaseConnection):
         """
         # Remove the default behavior for connection errors
         self.callbacks.remove(0, self.ON_CONNECTION_ERROR)
-        if not super(BlockingConnection, self)._adapter_connect():
-            raise exceptions.AMQPConnectionError(1)
+        error = super(BlockingConnection, self)._adapter_connect()
+        if error:
+            raise exceptions.AMQPConnectionError(error)
         self.socket.settimeout(self.SOCKET_CONNECT_TIMEOUT)
         self._frames_written_without_read = 0
         self._socket_timeouts = 0
@@ -292,7 +294,6 @@ class BlockingConnection(base_connection.BaseConnection):
             self.process_data_events()
         self.socket.settimeout(self.params.socket_timeout)
         self._set_connection_state(self.CONNECTION_OPEN)
-        return True
 
     def _adapter_disconnect(self):
         """Called if the connection is being requested to disconnect."""

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -57,12 +57,12 @@ class SelectConnection(BaseConnection):
         :rtype: bool
 
         """
-        if super(SelectConnection, self)._adapter_connect():
+        error = super(SelectConnection, self)._adapter_connect()
+        if not error:
             self.ioloop.start_poller(self._handle_events,
                                      self.event_state,
                                      self.socket.fileno())
-            return True
-        return False
+        return error
 
     def _flush_outbound(self):
         """Call the state manager who will figure out that we need to write then

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -61,12 +61,12 @@ class TornadoConnection(base_connection.BaseConnection):
         :rtype: bool
 
         """
-        if super(TornadoConnection, self)._adapter_connect():
+        error = super(TornadoConnection, self)._adapter_connect()
+        if not error:
             self.ioloop.add_handler(self.socket.fileno(),
                                     self._handle_events,
                                     self.event_state)
-            return True
-        return False
+        return error
 
     def _adapter_disconnect(self):
         """Disconnect from the RabbitMQ broker"""

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -273,12 +273,12 @@ class TwistedConnection(base_connection.BaseConnection):
     def _adapter_connect(self):
         """Connect to the RabbitMQ broker"""
         # Connect (blockignly!) to the server
-        if super(TwistedConnection, self)._adapter_connect():
+        error = super(TwistedConnection, self)._adapter_connect()
+        if not error:
             # Set the I/O events we're waiting for (see IOLoopReactorAdapter
             # docstrings for why it's OK to pass None as the file descriptor)
             self.ioloop.update_handler(None, self.event_state)
-            return True
-        return False
+        return error
 
     def _adapter_disconnect(self):
         """Called when the adapter should disconnect"""
@@ -434,7 +434,7 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
         if d:
             d.callback(res)
 
-    def connectionFailed(self, connection_unused):
+    def connectionFailed(self, connection_unused, error_message=None):
         d, self.ready = self.ready, None
         if d:
             attempts = self.params.connection_attempts

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -9,12 +9,15 @@ class AMQPError(Exception):
 class AMQPConnectionError(AMQPError):
     def __repr__(self):
         if len(self.args) == 1:
-            if (self.args[0] == 1):
+            if self.args[0] == 1:
                 return ('No connection could be opened after 1 '
                         'connection attempt')
-            else:
+            elif isinstance(self.args[0], int):
                 return ('No connection could be opened after %s '
                         'connection attempts' %
+                        self.args[0])
+            else:
+                return ('No connection could be opened: %s' %
                         self.args[0])
         elif len(self.args) == 2:
             return '%s: %s' % (self.args[0], self.args[1])


### PR DESCRIPTION
When debugging connection failures, it's more helpful to know the exact cause than the number of connection attempts. While the information is available in the log, this is not immediately obvious. 

This is an attempt to propagate this information to the raised error. There is a backwards-incompatibility in that if someone has added a custom on_open_error_callback, the function is expected to accept an extra argument.
