### PR TITLE
smart_next_channel_number

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1120,11 +1120,32 @@ class Connection(object):
 
         """
         limit = self.params.channel_max or channel.MAX_CHANNELS
+        base = 1
+
         if len(self._channels) == limit:
             raise exceptions.NoFreeChannels()
         if not self._channels:
-            return 1
-        return max(self._channels.keys()) + 1
+            return base
+
+        # first channel number
+        used_numbers = sorted(self._channels.keys())
+
+        left = 0
+        right = len(used_numbers) - 1
+        # look for free channel numbers
+        while True:
+            if used_numbers[right] == right + base:
+                return right + 1 + base
+
+            if used_numbers[left] > left + base:
+                return left + base
+
+            middle = left + (right - left) // 2
+            if used_numbers[middle] > base + middle:
+                right = middle
+            else:
+                left = middle + 1
+
 
     def _on_channel_closeok(self, method_frame):
         """Remove the channel from the dict of channels when Channel.CloseOk is

--- a/tests/connection_tests.py
+++ b/tests/connection_tests.py
@@ -81,3 +81,14 @@ class ConnectionTests(unittest.TestCase):
         method_frame = self.channel._on_close.call_args[0][0]
         self.assertEqual(method_frame.method.reply_code, 0)
         self.assertEqual(method_frame.method.reply_text, 'Undefined')
+
+    def test_next_channel_number(self):
+        """_next_channel_number must return lowest available channel number"""
+        self.connection._channels = {}
+        self.assertEqual(1, self.connection._next_channel_number(), 'first channel must be number 1')
+        for i in xrange(1, 50):
+            self.connection._channels = {channel_num: 'channel' for channel_num in xrange(1, 50)}
+            self.connection._channels.pop(i)
+            next_number = self.connection._next_channel_number()
+            self.assertEqual(i, next_number,
+                             'Channel number %i was released, but %i returned' % (i, next_number))


### PR DESCRIPTION
this patch fixes issue, when _next_channel_number() cannot return channel number of previously closed channel, if there are opened channels with greater numbers. 
this can lead to exhaustion of channel numbers pool for connection that actively opens and closes channels.
