### PR TITLE
Fix the spelling of UnsupportedAMQPFieldException

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -85,7 +85,7 @@ def encode_value(pieces, value):
         pieces.append(struct.pack('>c', 'V'))
         return 1
     else:
-        raise exceptions.UnspportedAMQPFieldException(pieces, value)
+        raise exceptions.UnsupportedAMQPFieldException(pieces, value)
 
 
 def decode_table(encoded, offset):

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -117,9 +117,13 @@ class InvalidFieldTypeException(ProtocolSyntaxError):
         return 'Unsupported field kind %s' % self.args[0]
 
 
-class UnspportedAMQPFieldException(ProtocolSyntaxError):
+class UnsupportedAMQPFieldException(ProtocolSyntaxError):
     def __repr__(self):
         return 'Unsupported field kind %s' % type(self.args[1])
+
+
+class UnspportedAMQPFieldException(UnsupportedAMQPFieldException):
+    """Deprecated version of UnsupportedAMQPFieldException"""
 
 
 class MethodNotImplemented(AMQPError):

--- a/tests/data_tests.py
+++ b/tests/data_tests.py
@@ -57,7 +57,7 @@ class DataTests(unittest.TestCase):
         self.assertEqual(byte_count, 191)
 
     def test_encode_raises(self):
-        self.assertRaises(exceptions.UnspportedAMQPFieldException,
+        self.assertRaises(exceptions.UnsupportedAMQPFieldException,
                           data.encode_table,
                           [], {'foo': set([1, 2, 3])})
 


### PR DESCRIPTION
Keep UnspportedAMQPFieldException for backwards compatibility purposes

Signed-off-by: Garrett Cooper yanegomi@gmail.com
Sponsored-by: Zonar Systems, Inc
