### PR TITLE
Added the force_binary parameter to Connection.channel()

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -646,7 +646,7 @@ class Connection(object):
         """
         raise NotImplementedError
 
-    def channel(self, on_open_callback, channel_number=None):
+    def channel(self, on_open_callback, channel_number=None, force_binary=False):
         """Create a new channel with the next available channel number or pass
         in a channel number to use. Must be non-zero if you would like to
         specify but it is recommended that you let Pika manage the channel
@@ -655,13 +655,15 @@ class Connection(object):
         :param method on_open_callback: The callback when the channel is opened
         :param int channel_number: The channel number to use, defaults to the
                                    next available.
+        :param bool force_binary: Prevents channel from autodetecting unicode
         :rtype: pika.channel.Channel
 
         """
         if not channel_number:
             channel_number = self._next_channel_number()
         self._channels[channel_number] = self._create_channel(channel_number,
-                                                              on_open_callback)
+                                                              on_open_callback,
+                                                              force_binary)
         self._add_channel_callbacks(channel_number)
         self._channels[channel_number].open()
         return self._channels[channel_number]
@@ -928,15 +930,16 @@ class Connection(object):
         warnings.warn('This method is deprecated, use Connection.connect',
                       DeprecationWarning)
 
-    def _create_channel(self, channel_number, on_open_callback):
+    def _create_channel(self, channel_number, on_open_callback, force_binary):
         """Create a new channel using the specified channel number and calling
         back the method specified by on_open_callback
 
         :param int channel_number: The channel number to use
         :param method on_open_callback: The callback when the channel is opened
+        :param bool force_binary: Prevents channel from autodetecting unicode
 
         """
-        return channel.Channel(self, channel_number, on_open_callback)
+        return channel.Channel(self, channel_number, on_open_callback, force_binary)
 
     def _create_heartbeat_checker(self):
         """Create a heartbeat checker instance if there is a heartbeat interval


### PR DESCRIPTION
There seems to be no way to properly create a binary-only channel (which should have been the default to begin with!!!). My application was running into unicode errors with its binary protocol and I had to hack the channel (manually replace its frame dispatcher) to make it work correctly. This little patch adds the proper parameter to Connection.channel() and should not cause any backwards incompatibilities.
