### PR TITLE
URLParameters and ConnectionParameters accept unicode strings

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -211,7 +211,7 @@ class Parameters(object):
         :raises: TypeError
 
         """
-        if not isinstance(locale, str):
+        if not isinstance(locale, basestring):
             raise TypeError('locale must be a str')
         return True
 
@@ -287,7 +287,7 @@ class Parameters(object):
         :raises: TypeError
 
         """
-        if not isinstance(virtual_host, str):
+        if not isinstance(virtual_host, basestring):
             raise TypeError('virtual_host must be a str')
         return True
 
@@ -357,7 +357,7 @@ class ConnectionParameters(Parameters):
             self.host = host
         if port is not None and self._validate_port(port):
             self.port = port
-        if virtual_host and self._validate_host(virtual_host):
+        if virtual_host and self._validate_virtual_host(virtual_host):
             self.virtual_host = virtual_host
         if credentials and self._validate_credentials(credentials):
             self.credentials = credentials

--- a/tests/parameter_tests.py
+++ b/tests/parameter_tests.py
@@ -1,0 +1,37 @@
+import unittest
+import pika
+
+
+class ConnectionTests(unittest.TestCase):
+
+    def test_parameters_accepts_plain_string_virtualhost(self):
+        parameters = pika.ConnectionParameters(virtual_host="prtfqpeo")
+        self.assertEqual(parameters.virtual_host, "prtfqpeo")
+
+    def test_parameters_accepts_plain_string_virtualhost(self):
+        parameters = pika.ConnectionParameters(virtual_host=u"prtfqpeo")
+        self.assertEqual(parameters.virtual_host, "prtfqpeo")
+
+    def test_parameters_accept_plain_string_locale(self):
+        parameters = pika.ConnectionParameters(locale="en_US")
+        self.assertEqual(parameters.locale, "en_US")
+
+    def test_parameters_accept_unicode_locale(self):
+        parameters = pika.ConnectionParameters(locale=u"en_US")
+        self.assertEqual(parameters.locale, "en_US")
+
+    def test_urlparameters_accepts_plain_string(self):
+        parameters = pika.URLParameters("amqp://prtfqpeo:oihdglkhcp0@myserver.mycompany.com:5672/prtfqpeo?locale=en_US")
+        self.assertEqual(parameters.port, 5672)
+        self.assertEqual(parameters.virtual_host, "prtfqpeo")
+        self.assertEqual(parameters.credentials.password, "oihdglkhcp0")
+        self.assertEqual(parameters.credentials.username, "prtfqpeo")
+        self.assertEqual(parameters.locale, "en_US")
+
+    def test_urlparameters_accepts_unicode_string(self):
+        parameters = pika.URLParameters(u"amqp://prtfqpeo:oihdglkhcp0@myserver.mycompany.com:5672/prtfqpeo?locale=en_US")
+        self.assertEqual(parameters.port, 5672)
+        self.assertEqual(parameters.virtual_host, "prtfqpeo")
+        self.assertEqual(parameters.credentials.password, "oihdglkhcp0")
+        self.assertEqual(parameters.credentials.username, "prtfqpeo")
+        self.assertEqual(parameters.locale, "en_US")


### PR DESCRIPTION
When passing a unicode string to `URLParameters` or as the `virtual_host` or `locale` arguments to `ConnectionParameters`, a `TypeError` is raised.

The only field that is correctly validated is `host`, because it checks against `basestring`, not `str`.

Also, in `ConnectionParameters`, the field `virtual_host` is validated by `_validate_host`, not by `_validate_virtual_host` as in `URLParameters`.
