### PR TITLE
Save timeouts in ordered dict instead of dict

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -5,7 +5,6 @@ platform pika is running on.
 import logging
 import select
 import time
-from collections import OrderedDict
 
 from pika.adapters.base_connection import BaseConnection
 


### PR DESCRIPTION
When more than one timeout callback is scheduled to run in SelectPoller, the order in which they will be executed is random because they're kept in a dict.

This simple change will make the callbacks be called in the same order they were scheduled.
