### PR TITLE
Successfully reconnect in Tornado Consumer example

### DIFF
--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -104,16 +104,10 @@ consumer.py::
             closed. See the on_connection_closed method.
 
             """
-            # This is the old connection IOLoop instance, stop its ioloop
-            self._connection.ioloop.stop()
-
             if not self._closing:
 
                 # Create a new connection
                 self._connection = self.connect()
-
-                # There is now a new connection, needs a new ioloop to run
-                self._connection.ioloop.start()
 
         def add_on_channel_close_callback(self):
             """This method tells pika to call the on_channel_closed method if


### PR DESCRIPTION
Stopping and starting Tornado's IO Loop causes the process to terminate as mentioned in #381. Removing these lines allows the consumer to successfully reconnect:

```
INFO       2014-04-02 17:28:29,286 __main__                       connect                              50  : Connecting to amqp://guest:guest@localhost:5672/%2F
INFO       2014-04-02 17:28:29,287 pika.adapters.base_connection  _create_and_connect_to_socket        164 : Connecting to 127.0.0.1:5672
INFO       2014-04-02 17:28:29,287 __main__                       run                                  316 : Staarted ioloop
INFO       2014-04-02 17:28:29,289 __main__                       on_connection_open                   95  : Connection opened
INFO       2014-04-02 17:28:29,289 __main__                       add_on_connection_close_callback     66  : Adding connection close callback
INFO       2014-04-02 17:28:29,289 __main__                       open_channel                         307 : Creating a new channel
INFO       2014-04-02 17:28:29,290 __main__                       on_channel_open                      143 : Channel opened
INFO       2014-04-02 17:28:29,290 __main__                       add_on_channel_close_callback        115 : Adding channel close callback
INFO       2014-04-02 17:28:29,291 __main__                       setup_exchange                       156 : Declaring exchange message
INFO       2014-04-02 17:28:29,291 __main__                       on_exchange_declareok                168 : Exchange declared
INFO       2014-04-02 17:28:29,291 __main__                       setup_queue                          179 : Declaring queue text
INFO       2014-04-02 17:28:29,292 __main__                       on_queue_declareok                   193 : Binding message to text with example.text
INFO       2014-04-02 17:28:29,292 __main__                       on_bindok                            290 : Queue bound
INFO       2014-04-02 17:28:29,293 __main__                       start_consuming                      277 : Issuing consumer related RPC commands
INFO       2014-04-02 17:28:29,293 __main__                       add_on_cancel_callback               203 : Adding consumer cancellation callback
WARNING    2014-04-02 17:28:32,034 pika.adapters.base_connection  _check_state_on_disconnect           145 : Socket closed when connection was open
WARNING    2014-04-02 17:28:32,034 pika.adapters.base_connection  _handle_ioloop_stop                  242 : Connection is closed but not stopping IOLoop
WARNING    2014-04-02 17:28:32,034 pika.connection                _on_disconnect                       1284: Disconnected from RabbitMQ at localhost:5672 (0): Not specified
WARNING    2014-04-02 17:28:32,034 __main__                       on_connection_closed                 84  : Connection closed, reopening in 5 seconds: (0) Not specified
INFO       2014-04-02 17:28:37,039 __main__                       connect                              50  : Connecting to amqp://guest:guest@localhost:5672/%2F
INFO       2014-04-02 17:28:37,039 pika.adapters.base_connection  _create_and_connect_to_socket        164 : Connecting to 127.0.0.1:5672
INFO       2014-04-02 17:28:37,042 __main__                       on_connection_open                   95  : Connection opened
INFO       2014-04-02 17:28:37,042 __main__                       add_on_connection_close_callback     66  : Adding connection close callback
INFO       2014-04-02 17:28:37,042 __main__                       open_channel                         307 : Creating a new channel
INFO       2014-04-02 17:28:37,043 __main__                       on_channel_open                      143 : Channel opened
INFO       2014-04-02 17:28:37,043 __main__                       add_on_channel_close_callback        115 : Adding channel close callback
INFO       2014-04-02 17:28:37,043 __main__                       setup_exchange                       156 : Declaring exchange message
INFO       2014-04-02 17:28:37,044 __main__                       on_exchange_declareok                168 : Exchange declared
INFO       2014-04-02 17:28:37,044 __main__                       setup_queue                          179 : Declaring queue text
INFO       2014-04-02 17:28:37,045 __main__                       on_queue_declareok                   193 : Binding message to text with example.text
INFO       2014-04-02 17:28:37,046 __main__                       on_bindok                            290 : Queue bound
INFO       2014-04-02 17:28:37,046 __main__                       start_consuming                      277 : Issuing consumer related RPC commands
INFO       2014-04-02 17:28:37,046 __main__                       add_on_cancel_callback               203 : Adding consumer cancellation callback
```
