### PR TITLE
removed relative imports and importing urlparse from urllib.parse for py3+

### DIFF
--- a/pika/adapters/__init__.py
+++ b/pika/adapters/__init__.py
@@ -20,27 +20,27 @@
   with the libev event loop and employing nonblocking IO
 
 """
-from base_connection import BaseConnection
-from asyncore_connection import AsyncoreConnection
-from blocking_connection import BlockingConnection
-from select_connection import SelectConnection
-from select_connection import IOLoop
+from pika.adapters.base_connection import BaseConnection
+from pika.adapters.asyncore_connection import AsyncoreConnection
+from pika.adapters.blocking_connection import BlockingConnection
+from pika.adapters.select_connection import SelectConnection
+from pika.adapters.select_connection import IOLoop
 
 # Dynamically handle 3rd party library dependencies for optional imports
 try:
-    from tornado_connection import TornadoConnection
+    from pika.adapters.tornado_connection import TornadoConnection
 except ImportError:
     TornadoConnection = None
 
 try:
-    from twisted_connection import TwistedConnection
-    from twisted_connection import TwistedProtocolConnection
+    from pika.adapters.twisted_connection import TwistedConnection
+    from pika.adapters.twisted_connection import TwistedProtocolConnection
 except ImportError:
     TwistedConnection = None
     TwistedProtocolConnection = None
 
 try:
-    from libev_connection import LibevConnection
+    from pika.adapters.libev_connection import LibevConnection
 except ImportError:
     LibevConnection = None
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1,12 +1,17 @@
 """Core connection objects"""
 import ast
+import sys
 import collections
 import logging
 import math
 import platform
 import urllib
-import urlparse
 import warnings
+
+if sys.version_info > (3,):
+    import urllib.parse as urlparse
+else:
+    import urlparse
 
 from pika import __version__
 from pika import callback


### PR DESCRIPTION
with these changes I was able to install pika in python3.4 on centos6
