### PR TITLE
URGENT - The current pika library build is broken, this pull fixes an exception that always occurs when channels are created

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -651,7 +651,7 @@ class Connection(object):
         """
         raise NotImplementedError
 
-    def channel(self, on_open_callback, channel_number=None, force_binary=False):
+    def channel(self, on_open_callback, channel_number=None):
         """Create a new channel with the next available channel number or pass
         in a channel number to use. Must be non-zero if you would like to
         specify but it is recommended that you let Pika manage the channel
@@ -660,15 +660,13 @@ class Connection(object):
         :param method on_open_callback: The callback when the channel is opened
         :param int channel_number: The channel number to use, defaults to the
                                    next available.
-        :param bool force_binary: Prevents channel from autodetecting unicode
         :rtype: pika.channel.Channel
 
         """
         if not channel_number:
             channel_number = self._next_channel_number()
         self._channels[channel_number] = self._create_channel(channel_number,
-                                                              on_open_callback,
-                                                              force_binary)
+                                                              on_open_callback)
         self._add_channel_callbacks(channel_number)
         self._channels[channel_number].open()
         return self._channels[channel_number]
@@ -937,16 +935,15 @@ class Connection(object):
         warnings.warn('This method is deprecated, use Connection.connect',
                       DeprecationWarning)
 
-    def _create_channel(self, channel_number, on_open_callback, force_binary):
+    def _create_channel(self, channel_number, on_open_callback):
         """Create a new channel using the specified channel number and calling
         back the method specified by on_open_callback
 
         :param int channel_number: The channel number to use
         :param method on_open_callback: The callback when the channel is opened
-        :param bool force_binary: Prevents channel from autodetecting unicode
 
         """
-        return channel.Channel(self, channel_number, on_open_callback, force_binary)
+        return channel.Channel(self, channel_number, on_open_callback)
 
     def _create_heartbeat_checker(self):
         """Create a heartbeat checker instance if there is a heartbeat interval


### PR DESCRIPTION
A previous commit (efea53d109352400830609ecdca86707782fb822) removed the force_binary implementation. This has broken pika since the connection.py _create_channel method still uses the old Channel() constructor that includes a force_binary flag. This commit removes force_binary from connection.py
