### PR TITLE
Use default username and password if not specified in URLParameters

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -461,8 +461,10 @@ class URLParameters(Parameters):
                     self.ssl else self.DEFAULT_PORT
         elif self._validate_port(parts.port):
             self.port = parts.port
-        self.credentials = pika_credentials.PlainCredentials(parts.username,
-                                                             parts.password)
+
+        if parts.username is not None:
+            self.credentials = pika_credentials.PlainCredentials(parts.username,
+                                                                 parts.password)
 
         # Get the Virtual Host
         if len(parts.path) <= 1:

--- a/tests/unit/parameter_tests.py
+++ b/tests/unit/parameter_tests.py
@@ -2,7 +2,7 @@ import unittest
 import pika
 
 
-class ConnectionTests(unittest.TestCase):
+class ParameterTests(unittest.TestCase):
 
     def test_parameters_accepts_plain_string_virtualhost(self):
         parameters = pika.ConnectionParameters(virtual_host="prtfqpeo")
@@ -35,3 +35,25 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(parameters.credentials.password, "oihdglkhcp0")
         self.assertEqual(parameters.credentials.username, "prtfqpeo")
         self.assertEqual(parameters.locale, "en_US")
+
+    def test_urlparameters_uses_default_port_if_not_specified(self):
+        parameters = pika.URLParameters("amqp://myserver.mycompany.com")
+        self.assertEqual(parameters.port, pika.URLParameters.DEFAULT_PORT)
+
+    def test_urlparameters_uses_default_virtual_host_if_not_specified(self):
+        parameters = pika.URLParameters("amqp://myserver.mycompany.com")
+        self.assertEqual(parameters.virtual_host, pika.URLParameters.DEFAULT_VIRTUAL_HOST)
+
+    def test_urlparameters_uses_default_virtual_host_if_only_slash_is_specified(self):
+        parameters = pika.URLParameters("amqp://myserver.mycompany.com/")
+        self.assertEqual(parameters.virtual_host, pika.URLParameters.DEFAULT_VIRTUAL_HOST)
+
+    def test_urlparameters_uses_default_username_and_password_if_not_specified(self):
+        parameters = pika.URLParameters("amqp://myserver.mycompany.com")
+        self.assertEqual(parameters.credentials.username, pika.URLParameters.DEFAULT_USERNAME)
+        self.assertEqual(parameters.credentials.password, pika.URLParameters.DEFAULT_PASSWORD)
+
+    def test_urlparameters_accepts_blank_username_and_password(self):
+        parameters = pika.URLParameters("amqp://:@myserver.mycompany.com")
+        self.assertEqual(parameters.credentials.username, "")
+        self.assertEqual(parameters.credentials.password, "")


### PR DESCRIPTION
Currently, URLParameters will set the username and password to "None" if they are not specified in the URL. I added a couple tests for this case as well as some others for "default" scenarios.
