### PR TITLE
do not use socket.sendall

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -357,8 +357,9 @@ class BaseConnection(connection.Connection):
         if self.outbound_buffer:
             frame = self.outbound_buffer.popleft()
             try:
-                self.socket.sendall(frame)
-                bytes_written = len(frame)
+                bytes_written = self.socket.send(frame)
+                if bytes_written != len(frame):
+                    self.outbound_buffer.appendleft(frame[bytes_written:])
             except socket.timeout:
                 raise
             except socket.error as error:


### PR DESCRIPTION
`socket.sendall` is not compatible with non blocking connections. Use
`socket.send` instead and manually slice the data frame as needed.

I don't have a test case for it, because cannot think of any good way of reproducing the error.

Related to https://github.com/pika/pika/issues/481
