### PR TITLE
Lower default TIMEOUT to 0.01

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -189,7 +189,7 @@ class SelectPoller(object):
     to override the update_handler and start methods for additional types.
 
     """
-    TIMEOUT = 1
+    TIMEOUT = 0.01
 
     def __init__(self, fileno, handler, events, state_manager):
         """Create an instance of the SelectPoller


### PR DESCRIPTION
See: https://github.com/pika/pika/issues/493

I guess setting the TIMEOUT to 0.01 is a good compromise for modern machines, until somebody writes a better fix.