### PR TITLE
Making delivery_tag required for Channel.basic_reject

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -335,7 +335,7 @@ class Channel(object):
                          callback,
                          [spec.Basic.QosOk])
 
-    def basic_reject(self, delivery_tag=None, requeue=True):
+    def basic_reject(self, delivery_tag, requeue=True):
         """Reject an incoming message. This method allows a client to reject a
         message. It can be used to interrupt and cancel large incoming messages,
         or return untreatable messages to their original queue.

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -388,6 +388,10 @@ class ChannelTests(unittest.TestCase):
     def test_basic_reject_raises_channel_closed(self):
         self.assertRaises(exceptions.ChannelClosed, self.obj.basic_reject,
                           1, False)
+    
+    def test_basic_reject_raises_type_error(self):
+        self.assertRaises(TypeError, self.obj.basic_reject,
+                          requeue = False)
 
     @mock.patch('pika.spec.Basic.Reject')
     @mock.patch('pika.channel.Channel._send_method')
@@ -1273,3 +1277,5 @@ class ChannelTests(unittest.TestCase):
         warning.assert_called_with('Received remote Channel.Close (%s): %s',
                                    method_frame.method.reply_code,
                                    method_frame.method.reply_text)
+
+unittest.main()


### PR DESCRIPTION
`delivery_tag` defaults to `None` on `Channel.basic_reject`.

Calling `Channel.basic_reject` without `delivery_tag` raises soemthing like this:

The change make `delivery_tag` a requiered arg so you will get a `TypeError` instead asking for the missing arg.

```
Traceback (most recent call last):
  File "some_file.py", line 86, in <module>
    channel.start_consuming()
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/blocking_connection.py", line 955, in start_consuming
    self.connection.process_data_events()
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/blocking_connection.py", line 240, in process_data_events
    if self._handle_read():
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/blocking_connection.py", line 348, in _handle_read
    super(BlockingConnection, self)._handle_read()
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/base_connection.py", line 351, in _handle_read
    self._on_data_available(data)
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 1285, in _on_data_available
    self._process_frame(frame_value)
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 1365, in _process_frame
    self._deliver_frame_to_channel(frame_value)
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 976, in _deliver_frame_to_channel
    return self._channels[value.channel_number]._handle_content_frame(value)
  File "/usr/local/lib/python2.7/dist-packages/pika/channel.py", line 792, in _handle_content_frame
    self._on_deliver(*response)
  File "/usr/local/lib/python2.7/dist-packages/pika/channel.py", line 886, in _on_deliver
    body)
  File "/home/computing-node-client/automation/rpc_gen_vnc_passwd.py", line 80, in on_request
    ch.basic_reject(requeue = True)
  File "/usr/local/lib/python2.7/dist-packages/pika/channel.py", line 352, in basic_reject
    return self._send_method(spec.Basic.Reject(delivery_tag, requeue))
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/blocking_connection.py", line 1159, in _send_method
    self.connection.send_method(self.channel_number, method_frame, content)
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/blocking_connection.py", line 274, in send_method
    self._send_method(channel_number, method_frame, content)
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 1503, in _send_method
    self._send_frame(frame.Method(channel_number, method_frame))
  File "/usr/local/lib/python2.7/dist-packages/pika/adapters/blocking_connection.py", line 417, in _send_frame
    super(BlockingConnection, self)._send_frame(frame_value)
  File "/usr/local/lib/python2.7/dist-packages/pika/connection.py", line 1486, in _send_frame
    marshaled_frame = frame_value.marshal()
  File "/usr/local/lib/python2.7/dist-packages/pika/frame.py", line 74, in marshal
    pieces = self.method.encode()
  File "/usr/local/lib/python2.7/dist-packages/pika/spec.py", line 2176, in encode
    pieces.append(struct.pack('>Q', self.delivery_tag))
struct.error: cannot convert argument to integer
```