### PR TITLE
Fix SSLError event processing.

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -113,7 +113,6 @@ class BlockingConnection(base_connection.BaseConnection):
 
     """
     WRITE_TO_READ_RATIO = 10
-    DO_HANDSHAKE = True
     SLEEP_DURATION = 0.1
     SOCKET_CONNECT_TIMEOUT = 0.25
     SOCKET_TIMEOUT_THRESHOLD = 12


### PR DESCRIPTION
Do not try to use IOLoop to handle socket events.
Poll for events using select.
Catch socket timeout exception.
Remove unused class variable DO_HANDSHAKE.