### PR TITLE
Fix heartbeat behaviour after connection failure.

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -129,8 +129,7 @@ class BaseConnection(connection.Connection):
 
     def _adapter_disconnect(self):
         """Invoked if the connection is being told to disconnect"""
-        if hasattr(self, 'heartbeat') and self.heartbeat is not None:
-            self.heartbeat.stop()
+        self._remove_heartbeat()
         if self.socket:
             self.socket.close()
         self.socket = None

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -216,8 +216,7 @@ class BlockingConnection(base_connection.BaseConnection):
             self._send_connection_close(reply_code, reply_text)
         while self.is_closing:
             self.process_data_events()
-        if self.heartbeat:
-            self.heartbeat.stop()
+        self._remove_heartbeat()
         self._remove_connection_callbacks()
         self._adapter_disconnect()
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -584,6 +584,8 @@ class Connection(object):
                            on_open_error_callback or self._on_connection_error,
                            False)
 
+        self.heartbeat = None
+
         # On connection callback
         if on_open_callback:
             self.add_on_open_callback(on_open_callback)
@@ -959,6 +961,14 @@ class Connection(object):
                          self.params.heartbeat)
             return heartbeat.HeartbeatChecker(self, self.params.heartbeat)
 
+    def _remove_heartbeat(self):
+        """Stop the heartbeat checker if it exists
+
+        """
+        if self.heartbeat:
+            self.heartbeat.stop()
+            self.heartbeat = None
+
     def _deliver_frame_to_channel(self, value):
         """Deliver the frame to the channel specified in the frame.
 
@@ -1185,9 +1195,7 @@ class Connection(object):
             self.closing = (method_frame.method.reply_code,
                             method_frame.method.reply_text)
 
-        # Stop the heartbeat checker if it exists
-        if self.heartbeat:
-            self.heartbeat.stop()
+        self._remove_heartbeat()
 
         # If this did not come from the connection adapter, close the socket
         if not from_adapter:

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -116,6 +116,7 @@ class HeartbeatChecker(object):
         duration = self._max_idle_count * self._interval
         text = HeartbeatChecker._STALE_CONNECTION % duration
         self._connection.close(HeartbeatChecker._CONNECTION_FORCED, text)
+        self._connection._adapter_disconnect()
         self._connection._on_disconnect(HeartbeatChecker._CONNECTION_FORCED,
                                         text)
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -388,12 +388,13 @@ class ConnectionTests(unittest.TestCase):
         method_frame.method = mock.Mock(spec=spec.Connection.Close)
         method_frame.method.reply_code = 1
         method_frame.method.reply_text = 'hello'
-        self.connection.heartbeat = mock.Mock()
+        heartbeat = mock.Mock()
+        self.connection.heartbeat = heartbeat
         self.connection._adapter_disconnect = mock.Mock()
         self.connection._on_connection_closed(method_frame, from_adapter=False)
         #Check
         self.assertTupleEqual((1, 'hello'), self.connection.closing)
-        self.connection.heartbeat.stop.assert_called_once_with()
+        heartbeat.stop.assert_called_once_with()
         self.connection._adapter_disconnect.assert_called_once_with()
 
     @mock.patch('pika.frame.decode_frame')

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -127,10 +127,11 @@ class HeartbeatTests(unittest.TestCase):
         self.obj._idle_byte_intervals = 3
         self.obj._idle_heartbeat_intervals = 4
         self.obj._close_connection()
-        self.mock_conn.close.assert_called_once_with(self.obj._CONNECTION_FORCED,
-                                                     self.obj._STALE_CONNECTION %
-                                                     (self.obj._max_idle_count *
-                                                      self.obj._interval))
+        reason = self.obj._STALE_CONNECTION % (self.obj._max_idle_count * self.obj._interval)
+        self.mock_conn.close.assert_called_once_with(self.obj._CONNECTION_FORCED, reason)
+        self.mock_conn._on_disconnect.assert_called_once_with(self.obj._CONNECTION_FORCED,
+                                                              reason)
+        self.mock_conn._adapter_disconnect.assert_called_once_with()
 
     def test_has_received_data_false(self):
         self.obj._bytes_received = 100


### PR DESCRIPTION
Make sure socket is closed and heartbeat is not executed when no longer active.

This is one way to fix issue #502 