### PR TITLE
Socket improvements

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -28,6 +28,7 @@ class BaseConnection(connection.Connection):
     ERROR = 0x0008
 
     ERRORS_TO_IGNORE = [errno.EWOULDBLOCK, errno.EAGAIN, errno.EINTR]
+    ERRORS_TO_ABORT = [errno.EBADF, errno.ECONNABORTED, errno.EPIPE]
     DO_HANDSHAKE = True
     WARN_ABOUT_IOLOOP = False
 
@@ -272,14 +273,15 @@ class BaseConnection(connection.Connection):
             LOGGER.critical("Tried to handle an error where no error existed")
             return
 
-        # Ok errors, just continue what we were doing before
         if error_code in self.ERRORS_TO_IGNORE:
+            # Ok errors, just continue what we were doing before
             LOGGER.debug("Ignoring %s", error_code)
             return
 
-        # Socket is closed, so lets just go to our handle_close method
-        elif error_code in (errno.EBADF, errno.ECONNABORTED):
-            LOGGER.error("Socket is closed")
+        elif error_code in self.ERRORS_TO_ABORT:
+            # Socket is closed, so lets just go to our handle_close method
+            LOGGER.error("Fatal Socket Error on fd %d: %r",
+                         self.socket.fileno(), error_value)
 
         elif self.params.ssl and isinstance(error_value, ssl.SSLError):
 
@@ -290,12 +292,9 @@ class BaseConnection(connection.Connection):
             else:
                 LOGGER.error("SSL Socket error on fd %d: %r",
                              self.socket.fileno(), error_value)
-        elif error_code == errno.EPIPE:
-            # Broken pipe, happens when connection reset
-            LOGGER.error("Socket connection was broken")
         else:
             # Haven't run into this one yet, log it.
-            LOGGER.error("Socket Error on fd %d: %s",
+            LOGGER.error("Unknown Socket Error on fd %d: %s",
                          self.socket.fileno(), error_code)
 
         # Disconnect from our IOLoop and let Connection know what's up

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -123,6 +123,9 @@ class BaseConnection(connection.Connection):
             error = self._create_and_connect_to_socket(sock_addr)
             if not error:
                 return None
+            else:
+                self._cleanup_socket()
+
         # Failed to connect
         return error
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -61,7 +61,6 @@ class BaseConnection(connection.Connection):
             raise RuntimeError("SSL specified but it is not available")
         self.base_events = self.READ | self.ERROR
         self.event_state = self.base_events
-        self.fd = None
         self.ioloop = ioloop
         self.socket = None
         self.stop_ioloop_on_close = stop_ioloop_on_close
@@ -372,7 +371,6 @@ class BaseConnection(connection.Connection):
 
         """
         super(BaseConnection, self)._init_connection_state()
-        self.fd = None
         self.base_events = self.READ | self.ERROR
         self.event_state = self.base_events
         self.socket = None

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -309,23 +309,23 @@ class BaseConnection(connection.Connection):
         :param bool write_only: Only handle write events
 
         """
-        if not fd:
+        if not self.socket:
             LOGGER.error('Received events on closed socket: %d', fd)
             return
 
-        if events & self.WRITE:
+        if self.socket and (events & self.WRITE):
             self._handle_write()
             self._manage_event_state()
 
-        if not write_only and (events & self.READ):
+        if self.socket and not write_only and (events & self.READ):
             self._handle_read()
 
-        if write_only and (events & self.READ) and (events & self.ERROR):
+        if self.socket and write_only and (events & self.READ) and (events & self.ERROR):
             LOGGER.error('BAD libc:  Write-Only but Read+Error. '
                          'Assume socket disconnected.')
             self._handle_disconnect()
 
-        if events & self.ERROR:
+        if self.socket and (events & self.ERROR):
             LOGGER.error('Error event %r, %r', events, error)
             self._handle_error(error)
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -312,9 +312,7 @@ class BlockingConnection(base_connection.BaseConnection):
 
     def _adapter_disconnect(self):
         """Called if the connection is being requested to disconnect."""
-        if self.socket:
-            self.socket.close()
-        self.socket = None
+        self._cleanup_socket()
         self._check_state_on_disconnect()
         self._init_connection_state()
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -295,7 +295,7 @@ class TwistedConnection(base_connection.BaseConnection):
     def _adapter_disconnect(self):
         """Called when the adapter should disconnect"""
         self.ioloop.remove_handler(None)
-        self.socket.close()
+        self._cleanup_socket()
 
     def _handle_disconnect(self):
         """Do not stop the reactor, this would cause the entire process to exit,


### PR DESCRIPTION
Most important fix here is to stop processing events if socket is closed during error on handle_read or handle_write. It also seems like previous check for closed socket should not be checking for method parameter fd.

Calling socket.shutdown() was inspired by this:
http://engineering.imvu.com/2014/03/06/charming-python-how-to-actually-close-a-socket-by-calling-shutdown-before-calling-close/