### PR TITLE
Make _send_method() deliver frames contiguously, resolving issue 507

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -406,15 +406,17 @@ class BlockingConnection(base_connection.BaseConnection):
         if self.closing[0] not in [0, 200]:
             raise exceptions.ConnectionClosed(*self.closing)
 
-    def _send_frame(self, frame_value):
+    def _send_frame(self, frame_value, frame_acc=None):
         """This appends the fully generated frame to send to the broker to the
         output buffer which will be then sent via the connection adapter.
 
         :param frame_value: The frame to write
         :type frame_value:  pika.frame.Frame|pika.frame.ProtocolHeader
+        :param frame_acc:   The frame accumulator, optional
+        :type frame_acc:    list of marshaled frames, or None
 
         """
-        super(BlockingConnection, self)._send_frame(frame_value)
+        super(BlockingConnection, self)._send_frame(frame_value, frame_acc)
         self._frames_written_without_read += 1
         if self._frames_written_without_read >= self.WRITE_TO_READ_RATIO:
             if not isinstance(frame_value, frame.Method):

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -387,12 +387,14 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
         # Disconnect from the server
         self.transport.loseConnection()
 
-    def _send_frame(self, frame_value):
+    def _send_frame(self, frame_value, frame_acc=None):
         """Send data the Twisted way, by writing to the transport. No need for
         buffering, Twisted handles that by itself.
 
         :param frame_value: The frame to write
         :type frame_value:  pika.frame.Frame|pika.frame.ProtocolHeader
+        :param frame_acc:   The frame accumulator, ignored.
+        :type frame_acc:    list (empty because it is ignored)
 
         """
         if self.is_closed:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1472,28 +1472,43 @@ class Connection(object):
                                                     self.params.frame_max,
                                                     self.params.heartbeat))
 
-    def _send_frame(self, frame_value):
+
+    def _send_frame(self, frame_value, frame_acc=None):
         """This appends the fully generated frame to send to the broker to the
-        output buffer which will be then sent via the connection adapter.
+        either the output buffer or to the frame accumulator frame_acc (if it
+        is defined).
+
+        When frame_acc is specified, it is the caller's responsiblity to
+        send the buffered frames to the output buffer by passing frame_acc to
+        _flush_buffered_frames().
 
         :param frame_value: The frame to write
         :type frame_value:  pika.frame.Frame|pika.frame.ProtocolHeader
+        :type frame_acc:    Optional list to accumulate this frame onto
 
         """
         if self.is_closed:
             LOGGER.critical('Attempted to send frame when closed')
             return
+
         marshaled_frame = frame_value.marshal()
-        self.bytes_sent += len(marshaled_frame)
-        self.frames_sent += 1
-        self.outbound_buffer.append(marshaled_frame)
+        if frame_acc is None:
+            self.bytes_sent += len(marshaled_frame)
+            self.frames_sent += 1
+            self.outbound_buffer.append(marshaled_frame)
+        else:
+            frame_acc.append(marshaled_frame)
         self._flush_outbound()
         if self.params.backpressure_detection:
             self._detect_backpressure()
 
 
-    def _send_method_unbuffered(self, channel_number, method_frame, content=None):
-        """Constructs a RPC method frame and then sends it to the broker.
+    def _send_method(self, channel_number, method_frame, content=None):
+        """Constructs an RPC method frame and then sends it to the broker.
+        Note that the entire message is buffered and delivered to the broker
+        as a contiguous set of frames.  This can have an impact in latency for
+        large messages since they must be buffered in their entirety prior to
+        being sent to the broker.
 
         :param int channel_number: The channel number for the frame
         :param pika.object.Method method_frame: The method frame to send
@@ -1501,14 +1516,21 @@ class Connection(object):
                               properties and body.
 
         """
-        self._send_frame(frame.Method(channel_number, method_frame))
+        frames_acc = []
+        self._send_frame(frame.Method(channel_number, method_frame),
+                frames_acc)
 
         # If it's not a tuple of Header, str|unicode then return
         if not isinstance(content, tuple):
+            self._flush_buffered_frames(frames_acc)
             return
 
         length = len(content[1])
-        self._send_frame(frame.Header(channel_number, length, content[0]))
+        try:
+            self._send_frame(frame.Header(channel_number, length,
+                content[0]), frames_acc)
+        except Exception, e:
+            raise
         if content[1]:
             chunks = int(math.ceil(float(length) / self._body_max_length))
             for chunk in range(0, chunks):
@@ -1517,78 +1539,18 @@ class Connection(object):
                 if end > length:
                     end = length
                 self._send_frame(frame.Body(channel_number,
-                                            content[1][start:end]))
-
-
-    def _send_frame_buffered(self, frame_value, frame_acc):
-        """This appends the fully generated frame to send to the broker to the
-        frame accumulator (frame_acc) which will then be sent via the
-        connection adapter when _flush_buffered_frames() is called with the
-        frame accumulator.
-
-        :param frame_value: The frame to write
-        :type frame_value:  pika.frame.Frame|pika.frame.ProtocolHeader
-        :param frame_acc:   The frame accumulator
-        :type frame_acc:    list
-
-        """
-        if frame_acc is None:
-            frame_acc = []
-        if self.is_closed:
-            LOGGER.critical('Attempted to send frame when closed')
-            return
-        marshaled_frame = frame_value.marshal()
-        self.bytes_sent += len(marshaled_frame)
-        self.frames_sent += 1
-        frame_acc.append(marshaled_frame)
-        self._flush_outbound()
-        if self.params.backpressure_detection:
-            self._detect_backpressure()
-        return frame_acc
-
-
-    def _send_method_buffered(self, channel_number, method_frame, content=None):
-        """Constructs a RPC method frame and then sends it to the broker.
-
-        :param int channel_number: The channel number for the frame
-        :param pika.object.Method method_frame: The method frame to send
-        :param tuple content: If set, is a content frame, is tuple of
-                              properties and body.
-
-        """
-        LOGGER.debug("\n ===== Entered conn:_send_method_buffered()")
-        # Accumulate the frames for this method here.
-        frames = []
-        self._send_frame_buffered(frame.Method(channel_number, method_frame), frames)
-
-        # If it's not a tuple of Header, str|unicode then return
-        if not isinstance(content, tuple):
-            self._flush_buffered_frames(frames)
-            return
-
-        length = len(content[1])
-        try:
-            self._send_frame_buffered(frame.Header(channel_number, length,
-                content[0]), frames)
-        except Exception, e:
-            raise
-        if content[1]:
-            chunks = int(math.ceil(float(length) / self._body_max_length))
-            LOGGER.debug("Number of body chunks: %d", chunks)
-            for chunk in range(0, chunks):
-                start = chunk * self._body_max_length
-                end = start + self._body_max_length
-                if end > length:
-                    end = length
-                self._send_frame_buffered(frame.Body(channel_number,
-                                            content[1][start:end]), frames)
-        self._flush_buffered_frames(frames)
+                                            content[1][start:end]), frames_acc)
+        self._flush_buffered_frames(frames_acc)
 
 
     def _flush_buffered_frames(self, frame_acc):
         """Put accumulated marshaled frames onto the outbound buffer.
-        This might still be subject to a race condition on access to the
-        outbound_buffer, but I *think* it is significantly lessened.
+        The method sending path is still not thread safe (for multiple writing
+        threads publishing to the same channel), but it is safe otherwise.
+
+        :param frame_acc: The frame accumulator.
+        :type  frame_acc: List of marshaled frames
+
         """
         for marshaled_frame in frame_acc:
             self.bytes_sent += len(marshaled_frame)
@@ -1598,12 +1560,6 @@ class Connection(object):
         self._flush_outbound()
         if self.params.backpressure_detection:
             self._detect_backpressure()
-
-
-    def _send_method(self, *args):
-        """Wrapper around the buffered and unbuffered _send_method* methods."""
-        return self._send_method_buffered(*args)
-        # return self._send_method_unbuffered(*args)
 
     def _set_connection_state(self, connection_state):
         """Set the connection state.


### PR DESCRIPTION
This addresses issue #507.
I think that the twisted_connection may still exhibit the same problem after this fix -- I simply patched twisted_connection._send_frame() to ignore the extra frame accumulator parameter.