### PR TITLE
make skip IncompatibleProtocolError as optional for client to adapt scenarios like ELB connection

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -146,7 +146,8 @@ class BaseConnection(connection.Connection):
         """
         if self.connection_state == self.CONNECTION_PROTOCOL:
             LOGGER.error('Incompatible Protocol Versions')
-            raise exceptions.IncompatibleProtocolError
+            if not self.params.skip_incompatible_protocol_error:
+                raise exceptions.IncompatibleProtocolError
         elif self.connection_state == self.CONNECTION_START:
             LOGGER.error("Socket closed while authenticating indicating a "
                          "probable authentication error")

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -62,6 +62,7 @@ class Parameters(object):
     DEFAULT_PASSWORD = 'guest'
     DEFAULT_PORT = 5672
     DEFAULT_RETRY_DELAY = 2.0
+    DEFAULT_SKIP_INCOMPATIBLE_PROTOCOL_ERROR = False
     DEFAULT_SOCKET_TIMEOUT = 0.25
     DEFAULT_SSL = False
     DEFAULT_SSL_OPTIONS = {}
@@ -82,6 +83,7 @@ class Parameters(object):
         self.locale = self.DEFAULT_LOCALE
         self.port = self.DEFAULT_PORT
         self.retry_delay = self.DEFAULT_RETRY_DELAY
+        self.skip_incompatible_protocol_error = self.DEFAULT_SKIP_INCOMPATIBLE_PROTOCOL_ERROR
         self.ssl = self.DEFAULT_SSL
         self.ssl_options = self.DEFAULT_SSL_OPTIONS
         self.socket_timeout = self.DEFAULT_SOCKET_TIMEOUT
@@ -245,6 +247,18 @@ class Parameters(object):
             raise TypeError('retry_delay must be a float or int')
         return True
 
+    def _validate_skip_incompatible_protocol_error(self, skip_incompatible_protocol_error):
+        """Validate that the skip_incompatible_protocol_error option is a bool.
+
+        :param bool skip_incompatible_protocol_error: The skip_incompatible_protocol_error value
+        :rtype: bool
+        :raises: TypeError
+
+        """
+        if not isinstance(skip_incompatible_protocol_error, bool):
+            raise TypeError('skip_incompatible_protocol_error must be a bool')
+        return True
+
     def _validate_socket_timeout(self, socket_timeout):
         """Validate that the socket_timeout value is an int or float
 
@@ -315,6 +329,7 @@ class ConnectionParameters(Parameters):
     :param int|float socket_timeout: Use for high latency networks
     :param str locale: Set the locale value
     :param bool backpressure_detection: Toggle backpressure detection
+    :param bool skip_incompatible_protocol_error: Not raising IncompatibleProtocolError as it is normal error
 
     """
     def __init__(self,
@@ -331,7 +346,8 @@ class ConnectionParameters(Parameters):
                  retry_delay=None,
                  socket_timeout=None,
                  locale=None,
-                 backpressure_detection=None):
+                 backpressure_detection=None,
+                 skip_incompatible_protocol_error=None):
         """Create a new ConnectionParameters instance.
 
         :param str host: Hostname or IP Address to connect to
@@ -348,6 +364,7 @@ class ConnectionParameters(Parameters):
         :param int|float socket_timeout: Use for high latency networks
         :param str locale: Set the locale value
         :param bool backpressure_detection: Toggle backpressure detection
+        :param bool skip_incompatible_protocol_error: Not raising IncompatibleProtocolError as it is normal error
 
         """
         super(ConnectionParameters, self).__init__()
@@ -390,6 +407,9 @@ class ConnectionParameters(Parameters):
         if (backpressure_detection is not None and
             self._validate_backpressure(backpressure_detection)):
             self.backpressure_detection = backpressure_detection
+        if (skip_incompatible_protocol_error is not None and
+            self._validate_skip_incompatible_protocol_error(skip_incompatible_protocol_error)):
+            self.skip_incompatible_protocol_error = skip_incompatible_protocol_error
 
 
 class URLParameters(Parameters):

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -8,6 +8,8 @@ try:
 except ImportError:
     import unittest
 
+from pika import exceptions
+from pika import connection
 from pika.adapters import base_connection
 
 
@@ -17,3 +19,25 @@ class BaseConnectionTests(unittest.TestCase):
       def foo():
           return True
       self.assertRaises(ValueError, base_connection.BaseConnection, foo)
+
+    class TestBaseConnection(base_connection.BaseConnection):
+        def __init__(self):
+            pass
+
+    def test_check_state_on_disconnect_skip_false_should_raise_incompatible_protocol_error(self):
+        base_conn = self.TestBaseConnection()
+        base_conn.connection_state = base_conn.CONNECTION_PROTOCOL
+        base_conn.params = mock.Mock(spec=connection.ConnectionParameters)
+        base_conn.params.skip_incompatible_protocol_error = False
+        self.assertRaises(exceptions.IncompatibleProtocolError,
+                          base_conn._check_state_on_disconnect)
+
+    def test_check_state_on_disconnect_skip_true_should_return_normally(self):
+        base_conn = self.TestBaseConnection()
+        base_conn.connection_state = base_conn.CONNECTION_PROTOCOL
+        base_conn.params = mock.Mock(spec=connection.ConnectionParameters)
+        base_conn.params.skip_incompatible_protocol_error = True
+        try:
+            base_conn._check_state_on_disconnect()
+        except exceptions.IncompatibleProtocolError:
+            self.fail("IncompatibleProtocolError should not be raised")

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -208,14 +208,15 @@ class ConnectionTests(unittest.TestCase):
             'ssl': True,
             'connection_attempts': 2,
             'locale': 'en',
-            'ssl_options': {'ssl': 'options'}
+            'ssl_options': {'ssl': 'options'},
+            'skip_incompatible_protocol_error': True
         }
         conn = connection.ConnectionParameters(**kwargs)
         #check values
         for t_param in ('host', 'port', 'virtual_host', 'channel_max',
                 'frame_max', 'backpressure_detection', 'ssl',
                 'credentials', 'retry_delay', 'connection_attempts',
-                'locale'):
+                'locale', 'skip_incompatible_protocol_error'):
             self.assertEqual(kwargs[t_param], getattr(conn, t_param), t_param)
         self.assertEqual(kwargs['heartbeat_interval'], conn.heartbeat)
 
@@ -246,7 +247,8 @@ class ConnectionTests(unittest.TestCase):
                 ('backpressure_detection', 'true'),
                 ('ssl', {'ssl': 'dict'}),
                 ('ssl_options', True),
-                ('connection_attempts', 'hello')
+                ('connection_attempts', 'hello'),
+                ('skip_incompatible_protocol_error', 123)
                 ):
             bkwargs = copy.deepcopy(kwargs)
             bkwargs[bad_field] = bad_value


### PR DESCRIPTION
In my scenario with configurations
* tornado server publishes message to MQ through ELB
* ELB in front of rabbitMQ(s)
* rabbitMQ setup as a cluster

when some of rabbitMQ is down and the cluster is not in function, tornado's pika connection will receive error like below, and all the error handling and re-connection mechanism will NOT be invoked since the exception breaks the calls to _on_connection_closed which registered error handling callbacks.

"""
[2014-11-19 01:04:30,841][ERROR  ][tornado.application:681] : Exception in I/O handler for fd 21#012Traceback (most recent call last):#01
2  File "/tornado/ioloop.py", line 671, in start#012    self._handlers[fd](fd,
events)#012  File "/tornado/stack_context.py", line 331, in wrapped#012    raise_exc_info(exc)#012  File "/tornado/stack_context.py", line 302, in wrapped#012
    ret = fn(*args, **kwargs)#012  File "/pika/adapters/base_connection.py”, line 322, in _handle_events#012    self._handle_read()#012 
File "/pika/adapters/base_connection.py", line 348, in _handle_read#012   
return self._handle_disconnect()#012  File "/pika/adapters/base_connection.py", line 248, in _handle_disconnect#012    self._adapter_disconnect()#012  File "/pika/adapters/tornado_connection.py", line 75, in _adapter_disconnect#012   
super(TornadoConnection, self)._adapter_disconnect()#012  File "/pika/adapters/base_connection.py", line 137, in _adapter_disconnect#012
self._check_state_on_disconnect()#012  File "/pika/adapters/base_connection.py", line 149, in _check_state_on_disconnect#012   
raise exceptions.IncompatibleProtocolError#012IncompatibleProtocolError
"""

/adapters/base_connection.py
```
    def _handle_disconnect(self):
        """Called internally when the socket is disconnected already
        """
        self._adapter_disconnect()   # BREAKS HERE !
        self._on_connection_closed(None, True)
```

In this scenario "IncompatibleProtocolError" is not treated as severe error and the connection can be recovered by re-connecting. Therefore I proposed that client can have option to skip this error for the appropriate scenario.

Thanks.