### PR TITLE
pika: callback: Display exception message when callback fails.

### DIFF
--- a/pika/callback.py
+++ b/pika/callback.py
@@ -229,7 +229,12 @@ class CallbackManager(object):
         # Call each callback
         for callback in callbacks:
             LOGGER.debug('Calling %s for "%s:%s"', callback, prefix, key)
-            callback(*args, **keywords)
+            try:
+                callback(*args, **keywords)
+            except:
+                LOGGER.exception('Calling %s for "%s:%s" failed',
+                        callback, prefix, key)
+                raise
         return True
 
     @sanitize_prefix


### PR DESCRIPTION
This makes things a *LOT* easier to trace when callbacks mysteriously
don't work.

Otherwise, if the callback generates an exception, you get nothing in the logs and your error disappears into a big black hole, at best you know it didn't work but you don't know why.