### PR TITLE
write starvation fixes

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -7,7 +7,6 @@ import errno
 import logging
 import socket
 import ssl
-import collections
 
 from pika import connection
 from pika import exceptions
@@ -389,7 +388,6 @@ class BaseConnection(connection.Connection):
                 LOGGER.debug("Would block, requeuing frame")
                 self.outbound_buffer.appendleft(frame)
             else:
-                LOGGER.warning("Socket error: %s", errno.errorcode[error.errno])
                 return self._handle_error(error)
 
         #LOGGER.debug("wrote %s bytes", bytes_written)

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -353,6 +353,11 @@ class BaseConnection(connection.Connection):
         except socket.timeout:
             self._handle_timeout()
             return 0
+
+        except ssl.SSLWantReadError:
+            # ssl wants more data but there is nothing currently
+            # available in the socket, wait for it to become readable.
+            return 0
             
         except socket.error as error:
             if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK):

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -241,8 +241,6 @@ class BlockingConnection(base_connection.BaseConnection):
                 self._socket_timeouts = 0
         except AttributeError:
             raise exceptions.ConnectionClosed()
-        except socket.timeout:
-            self._handle_timeout()
         self._flush_outbound()
         self.process_timeouts()
 
@@ -373,11 +371,8 @@ class BlockingConnection(base_connection.BaseConnection):
     def _flush_outbound(self):
         """Flush the outbound socket buffer."""
         if self.outbound_buffer:
-            try:
-                if self._handle_write():
-                    self._socket_timeouts = 0
-            except socket.timeout:
-                return self._handle_timeout()
+            if self._handle_write():
+                self._socket_timeouts = 0
 
     def _on_connection_closed(self, method_frame, from_adapter=False):
         """Called when the connection is closed remotely. The from_adapter value

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -61,11 +61,14 @@ class TornadoConnection(base_connection.BaseConnection):
         """Connect to the remote socket, adding the socket to the IOLoop if
         connected.
 
+        Set the socket non-blocking after super() call
+
         :rtype: bool
 
         """
         error = super(TornadoConnection, self)._adapter_connect()
         if not error:
+            self.socket.setblocking(0) 
             self.ioloop.add_handler(self.socket.fileno(),
                                     self._handle_events,
                                     self.event_state)
@@ -99,7 +102,7 @@ class TornadoConnection(base_connection.BaseConnection):
             self.outbound_buffer.appendleft(frame)
             
         except socket.error as error:
-			# If the socket is non-blocking, we'll come here instead
+            # If the socket is non-blocking, we'll come here instead
             if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
                 LOGGER.warning("Would block, requeuing frame")
                 self.outbound_buffer.appendleft(frame)

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -59,14 +59,13 @@ class TornadoConnection(base_connection.BaseConnection):
 
     def _adapter_connect(self):
         """Connect to the remote socket, adding the socket to the IOLoop if
-        connected. Set the socket non-blocking after super() call.
+        connected. 
 
         :rtype: bool
 
         """
         error = super(TornadoConnection, self)._adapter_connect()
         if not error:
-            self.socket.setblocking(0)
             self.ioloop.add_handler(self.socket.fileno(),
                                     self._handle_events,
                                     self.event_state)


### PR DESCRIPTION
Hi, this contains some changes to the way writes are sent in pika that addresses some issues we were seeing when using the tornado adapter. There's more detail in the individual commit messages but the basic premise is that we should get the data out on the wire as quickly as possible. Unfortunately the use sendall() and timeouts isn't really suited to that way of working so the socket has been changed to non-blocking (after the connect sequence) and we simply handle the write errors when the socket buffer is full.

The changes seem to be generally applicable to other connection adapters and in fact there seems to be a bug with BlockingConnections on master that is fixed by applying these changes.

I've load tested the various adapters and In general I see much more consistent and reliable behaviour now (no random timeouts, pipeline stalls etc).

Cheers,

Will