### PR TITLE
Alternative fix for #403

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -239,8 +239,6 @@ class BlockingConnection(base_connection.BaseConnection):
         try:
             if self._handle_read():
                 self._socket_timeouts = 0
-        except AttributeError:
-            raise exceptions.ConnectionClosed()
         except socket.timeout:
             self._handle_timeout()
         self._flush_outbound()
@@ -344,6 +342,8 @@ class BlockingConnection(base_connection.BaseConnection):
         keeps track of how many frames have been written since the last read.
 
         """
+        if not hasattr(self, '_read_poller'):
+            raise exceptions.ConnectionClosed()
         if self._read_poller.ready():
             super(BlockingConnection, self)._handle_read()
             self._frames_written_without_read = 0


### PR DESCRIPTION
I think catching the AttributeError in process_data_events was to
try and catch situations where the read_poller hadn't yet been created.
So explicitly check for that situation in _handle_read and stop
improperly trapping AttributeErrors