### PR TITLE
A fix the write starvation problem that we see with tornado and pika

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -166,7 +166,7 @@ class BaseConnection(connection.Connection):
         """Close the socket cleanly"""
         if self.socket:
             try:
-                if hasattr('socket', self.socket):
+                if hasattr(self.socket, 'socket'):
                     self.socket.socket.shutdown(socket.SHUT_RDWR)
                 else:
                     self.socket.shutdown(socket.SHUT_RDWR)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -374,11 +374,8 @@ class BlockingConnection(base_connection.BaseConnection):
     def _flush_outbound(self):
         """Flush the outbound socket buffer."""
         if self.outbound_buffer:
-            try:
-                if self._handle_write():
-                    self._socket_timeouts = 0
-            except socket.timeout:
-                return self._handle_timeout()
+            if self._handle_write():
+                self._socket_timeouts = 0
 
     def _on_connection_closed(self, method_frame, from_adapter=False):
         """Called when the connection is closed remotely. The from_adapter value

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -75,16 +75,6 @@ class SelectConnection(BaseConnection):
             self.ioloop.remove_handler(self.socket.fileno())
         super(SelectConnection, self)._adapter_disconnect()
 
-    def _flush_outbound(self):
-        """Call the state manager who will figure out that we need to write
-            then call the poller's poll function to force it to process events.
-        """
-        self._manage_event_state()
-        # Force our poller to come up for air, but in write only mode
-        # write only mode prevents messages from coming in and kicking off
-        # events through the consumer
-        self.ioloop.poll(write_only=True)
-
 
 class IOLoop(object):
     """Singlton wrapper that decides which type of poller to use, creates an

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -55,7 +55,7 @@ class TornadoConnection(base_connection.BaseConnection):
 
     def _adapter_connect(self):
         """Connect to the remote socket, adding the socket to the IOLoop if
-        connected
+        connected. 
 
         :rtype: bool
 

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -8,7 +8,7 @@ import pika
 
 LOGGER = logging.getLogger(__name__)
 PARAMETERS = pika.URLParameters('amqp://guest:guest@localhost:5672/%2f')
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 5
 
 
 class AsyncTestCase(unittest.TestCase):

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -8,7 +8,7 @@ import pika
 
 LOGGER = logging.getLogger(__name__)
 PARAMETERS = pika.URLParameters('amqp://guest:guest@localhost:5672/%2f')
-DEFAULT_TIMEOUT = 5
+DEFAULT_TIMEOUT = 15
 
 
 class AsyncTestCase(unittest.TestCase):

--- a/tests/acceptance/select_adapter_tests.py
+++ b/tests/acceptance/select_adapter_tests.py
@@ -50,8 +50,8 @@ class TestConsumeCancel(AsyncTestCase):
 
     def on_queue_declared(self, frame):
         for i in range(0, 100):
-            msg_body = '{}:{}:{}'.format(self.__class__.__name__, i,
-                                         time.time())
+            msg_body = '{0}:{1}:{2}'.format(self.__class__.__name__, i,
+                                            time.time())
             self.channel.basic_publish('', self.queue_name, msg_body)
         self.ctag = self.channel.basic_consume(self.on_message,
                                                queue=self.queue_name,


### PR DESCRIPTION
This is #545 rebased to master.

As noted in the original PR this is primarily to fix a problem we see
with the tornado adapter but seems to be applicable to all adapters
so the patch addresses the issue in base_connection.

By default (in base_connection) Pika buffers all writes and only
attempts to send the next time it drops into the ioloop and detects
the socket as writable. This causes some odd behaviour in a number
of cases.
1. A process generating large numbers of messages will not actually
send them until it finishes the processing and drops into the ioloop.
2. A process that is consuming a large queue will only send messages
when it's read buffer is empty. If the messages are small this means
it may end up consuming 000s of messages for every one it manages to
publish. This behaviour stalls pipelines of processes.

SelectConnection had previously overridden _flush_outbound to force
a drop into the ioloop with a write_only flag set. This fixed
the behaviour for this connection type but left all the others broken.

This patch tries to send the data on the socket as soon as it's
generated and handles failed sends due to the socket buffer being full
by requeing the data.