### PR TITLE
Fix incorrect x-expires argument in acceptance tests

### DIFF
--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -91,7 +91,8 @@ class BoundQueueTestCase(AsyncTestCase):
                                    exclusive=True,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT})
+                                   arguments={'x-expires': self.TIMEOUT * 1000}
+                                   )
 
     def on_queue_declared(self, frame):
         self.channel.queue_bind(self.on_ready, self.queue, self.exchange,

--- a/tests/acceptance/asyncore_adapter_tests.py
+++ b/tests/acceptance/asyncore_adapter_tests.py
@@ -114,7 +114,7 @@ class TestQueueDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=False,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -138,7 +138,7 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -164,7 +164,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_channel_closed(self, channel, reply_code, reply_text):
         self.stop()
@@ -176,7 +176,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                                    exclusive=False,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT})
+                                   arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_bad_result(self, frame):
         self.channel.queue_delete(None, str(id(self)), nowait=True)

--- a/tests/acceptance/libev_adapter_tests.py
+++ b/tests/acceptance/libev_adapter_tests.py
@@ -115,7 +115,7 @@ class TestQueueDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=False,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -141,7 +141,7 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -169,7 +169,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_channel_closed(self, channel, reply_code, reply_text):
         self.stop()
@@ -181,7 +181,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                                    exclusive=False,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT})
+                                   arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_bad_result(self, frame):
         self.channel.queue_delete(None, str(id(self)), nowait=True)

--- a/tests/acceptance/select_adapter_tests.py
+++ b/tests/acceptance/select_adapter_tests.py
@@ -144,7 +144,7 @@ class TestQueueDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=False,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -168,7 +168,7 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -194,7 +194,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_channel_closed(self, channel, reply_code, reply_text):
         self.stop()
@@ -206,7 +206,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                                    exclusive=False,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT})
+                                   arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_bad_result(self, frame):
         self.channel.queue_delete(None, str(id(self)), nowait=True)

--- a/tests/acceptance/tornado_adapter_tests.py
+++ b/tests/acceptance/tornado_adapter_tests.py
@@ -102,7 +102,7 @@ class TestQueueDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=False,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -126,7 +126,7 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
@@ -152,7 +152,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                               exclusive=True,
                               auto_delete=True,
                               nowait=False,
-                              arguments={'x-expires': self.TIMEOUT})
+                              arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_channel_closed(self, channel, reply_code, reply_text):
         self.stop()
@@ -164,7 +164,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase):
                                    exclusive=False,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT})
+                                   arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_bad_result(self, frame):
         self.channel.queue_delete(None, str(id(self)), nowait=True)


### PR DESCRIPTION
The x-expires argument to queue.declare is a value in MS.
The tests were using a timeout value in seconds which was
causing intermittent failures.