### PR TITLE
Update blocking_connection.retry_on_eintr workink on Python3

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -44,7 +44,9 @@ def retry_on_eintr(f):
             try:
                 return f(*args, **kwargs)
             except select.error as e:
-                if e[0] != errno.EINTR:
+                # Starting with Python 3.3, select.error is now an alias of OSError
+                ern = e.errno if isinstance(e, OSError) else e[0]
+                if ern != errno.EINTR:
                     raise
 
     return inner


### PR DESCRIPTION
Update `retry_on_eintr` in `adapters.blocking_connection` to be compatible with Python >= 3.3 : 

 - [select.error](https://docs.python.org/2/library/select.html#select.error) in python 2.7
 - [select.error](https://docs.python.org/3/library/select.html#select.error) in python 3