### PR TITLE
Implement BlockingConnection adapter on top of SelectConnection

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1,127 +1,164 @@
-"""The blocking connection adapter module implements blocking semantics on top
-of Pika's core AMQP driver. While most of the asynchronous expectations are
-removed when using the blocking connection adapter, it attempts to remain true
-to the asynchronous RPC nature of the AMQP protocol, supporting server sent
-RPC commands.
-
-The user facing classes in the module consist of the
-:py:class:`~pika.adapters.blocking_connection.BlockingConnection`
-and the :class:`~pika.adapters.blocking_connection.BlockingChannel`
-classes.
-
+"""BlockingConnection adapter implemented as a wrapper around SelectConnection.
+All public API calls complete synchronously without callbacks.
 """
-import os
+
+from collections import namedtuple, deque
 import logging
-import select
-import socket
 import time
-import warnings
-import errno
-from functools import wraps
 
-from pika import frame
-from pika import callback as callback_manager
-from pika import channel
+import pika.channel
 from pika import exceptions
-from pika import spec
-from pika import utils
-from pika.adapters import base_connection
-from pika.compat import dictkeys, unicode_type
-
-if os.name == 'java':
-    from select import cpython_compatible_select as select_function
-else:
-    from select import select as select_function
+import pika.spec
+# NOTE: import SelectConnection after others to avoid circular depenency
+from pika.adapters.select_connection import SelectConnection
 
 LOGGER = logging.getLogger(__name__)
 
 
-def retry_on_eintr(f):
-
-    @wraps(f)
-    def inner(*args, **kwargs):
-        while True:
-            try:
-                return f(*args, **kwargs)
-            except select.error as e:
-                if e[0] != errno.EINTR:
-                    raise
-
-    return inner
-
-
-class ReadPoller(object):
-    """A poller that will check to see if data is ready on the socket using
-    very short timeouts to avoid having to read on the socket, speeding up the
-    BlockingConnection._handle_read() method.
-
+class _CallbackResult(object):
+    """ CallbackResult is a non-thread-safe implementation for receiving
+    callback results; INTERNAL USE ONLY!
     """
-    POLL_TIMEOUT = 10
-
-    @retry_on_eintr
-    def __init__(self, fd, poll_timeout=POLL_TIMEOUT):
-        """Create a new instance of the ReadPoller which wraps poll and select
-        to determine if the socket has data to read on it.
-
-        :param int fd: The file descriptor for the socket
-        :param float poll_timeout: How long to wait for events (milliseconds)
+    def __init__(self, value_class=None):
+        """
+        :param callable value_class: only needed if the CallbackResult
+                                     instance will be used with
+                                     `set_value_once` and `append_element`.
+                                     *args and **kwargs of the value setter
+                                     methods will be passed to this class.
 
         """
-        self.fd = fd
-        self.poll_timeout = poll_timeout
-        if hasattr(select, 'poll') and os.name != 'java':
-            self.poller = select.poll()
-            self.poll_events = select.POLLIN | select.POLLPRI
-            self.poller.register(self.fd, self.poll_events)
-        else:
-            self.poller = None
-            self.poll_timeout = float(poll_timeout) / 1000
+        self._value_class = value_class
+        self.reset()
 
-    @retry_on_eintr
+    def reset(self):
+        self._ready = False
+        self._values = None
+
+    def __bool__(self):
+        """ Called by python runtime to implement truth value testing and the
+        built-in operation bool(); NOTE: python 3.x
+        """
+        return self.is_ready()
+
+    # python 2.x version of __bool__
+    __nonzero__ = __bool__
+
+    def __enter__(self):
+        """ Entry into context manager that automatically resets the object
+        on exit; this usage pattern helps garbage-collection by eliminating
+        potential circular references.
+        """
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.reset()
+
+    def is_ready(self):
+        return self._ready
+
+    @property
     def ready(self):
-        """Check to see if the socket has data to read.
+        return self._ready
 
-        :rtype: bool
+    def signal_once(self, *_args, **_kwargs):
+        """ Set as ready
 
+        :raises AssertionError: if result was already signalled
         """
-        if self.poller:
-            events = self.poller.poll(self.poll_timeout)
-            return bool(events)
+        assert not self._ready, '_CallbackResult was already set'
+        self._ready = True
+
+    def set_value_once(self, *args, **kwargs):
+        """ Set as ready with value; the value may be retrived via the `value`
+        property getter
+
+        :raises AssertionError: if result was already set
+        """
+        self.signal_once()
+        try:
+            self._values = (self._value_class(*args, **kwargs),)
+        except Exception as e:
+            LOGGER.error(
+                "set_value_once failed: value_class=%r; args=%r; kwargs=%r",
+                self._value_class, args, kwargs)
+            raise
+
+    def append_element(self, *args, **kwargs):
+        """
+        """
+        assert not self._ready or isinstance(self._values, list), (
+            '_CallbackResult state is incompatible with append_element: '
+            'ready=%r; values=%r' % (self._ready, self._values))
+
+        try:
+            value = self._value_class(*args, **kwargs)
+        except Exception as e:
+            LOGGER.error(
+                "append_element failed: value_class=%r; args=%r; kwargs=%r",
+                self._value_class, args, kwargs)
+            raise
+
+        if self._values is None:
+            self._values = [value]
         else:
-            ready, unused_wri, unused_err = select_function([self.fd], [], [],
-                                                            self.poll_timeout)
-            return bool(ready)
+            self._values.append(value)
+
+        self._ready = True
 
 
-class BlockingConnection(base_connection.BaseConnection):
-    """The BlockingConnection creates a layer on top of Pika's asynchronous core
-    providing methods that will block until their expected response has returned.
-    Due to the asynchronous nature of the `Basic.Deliver` and `Basic.Return` calls
-    from RabbitMQ to your application, you can still implement
-    continuation-passing style asynchronous methods if you'd like to receive
-    messages from RabbitMQ using
-    :meth:`basic_consume <BlockingChannel.basic_consume>` or if you want  to be
-    notified of a delivery failure when using
-    :meth:`basic_publish <BlockingChannel.basic_publish>` .
+    @property
+    def value(self):
+        """
+        :returns: a reference to the value that was set via `set_value_once`
+        :raises AssertionError: if result was not set or value is incompatible
+                                with `set_value_once`
+        """
+        assert self._ready, '_CallbackResult was not set'
+        assert isinstance(self._values, tuple) and len(self._values) == 1, (
+            '_CallbackResult value is incompatible with set_value_once: %r'
+            % (self._values,))
 
-    `Basic.Get` is a blocking call which will either return the Method Frame,
-    Header Frame and Body of a message, or it will return a `Basic.GetEmpty`
-    frame as the method frame.
+        return self._values[0]
 
-    For more information about communicating with the blocking_connection
-    adapter, be sure to check out the
-    :class:`BlockingChannel <BlockingChannel>` class which implements the
-    :class:`Channel <pika.channel.Channel>` based communication for the
-    blocking_connection adapter.
+
+    @property
+    def elements(self):
+        """
+        :returns: a reference to the list containing one or more elements that
+            were added via `append_element`
+        :raises AssertionError: if result was not set or value is incompatible
+                                with `append_element`
+        """
+        assert self._ready, '_CallbackResult was not set'
+        assert isinstance(self._values, list) and len(self._values) > 0, (
+            '_CallbackResult value is incompatible with append_element: %r'
+            % (self._values,))
+
+        return self._values
+
+
+class BlockingConnection(object):
+    """
+    TODO flesh out docstring
 
     """
-    WRITE_TO_READ_RATIO = 10
-    DO_HANDSHAKE = True
-    SLEEP_DURATION = 0.1
-    SOCKET_CONNECT_TIMEOUT = 0.25
-    SOCKET_TIMEOUT_THRESHOLD = 12
-    SOCKET_TIMEOUT_CLOSE_THRESHOLD = 3
-    SOCKET_TIMEOUT_MESSAGE = "Timeout exceeded, disconnected"
+    # Connection-opened callback args
+    _OnOpenedArgs = namedtuple('BlockingConnection__OnOpenedArgs',
+                               'connection')
+
+    # Connection-establishment error callback args
+    _OnOpenErrorArgs = namedtuple('BlockingConnection__OnOpenErrorArgs',
+                                  'connection error_text')
+
+    # Connection-closing callback args
+    _OnClosedArgs = namedtuple('BlockingConnection__OnClosedArgs',
+                               'connection reason_code reason_text')
+
+    # Channel-opened callback args
+    _OnChannelOpenedArgs = namedtuple(
+        'BlockingConnection__OnChannelOpenedArgs',
+        'channel')
 
     def __init__(self, parameters=None):
         """Create a new instance of the Connection object.
@@ -130,78 +167,99 @@ class BlockingConnection(base_connection.BaseConnection):
         :raises: RuntimeError
 
         """
-        super(BlockingConnection, self).__init__(parameters,
-                                                 on_open_callback=None,
-                                                 stop_ioloop_on_close=False)
-        self._socket_timeouts = 0
+        # Receives on_open_callback args from Connection
+        self._opened_result = _CallbackResult(self._OnOpenedArgs)
 
-    def add_on_close_callback(self, callback_method_unused):
-        """This is not supported in BlockingConnection. When a connection is
-        closed in BlockingConnection, a pika.exceptions.ConnectionClosed
-        exception will raised instead.
+        # Receives on_open_error_callback args from Connection
+        self._open_error_result= _CallbackResult(self._OnOpenErrorArgs)
 
-        :param method callback_method_unused: Unused
-        :raises: NotImplementedError
+        # Receives on_close_callback args from Connection
+        self._closed_result = _CallbackResult(self._OnClosedArgs)
 
-        """
-        raise NotImplementedError('Blocking connection will raise '
-                                  'ConnectionClosed exception')
+        # Set to True when when user calls close() on the connection
+        # NOTE: this is a workaround to detect socket error because
+        # on_close_callback passes reason_code=0 when called due to socket error
+        self._user_initiated_close = False
 
-    def add_on_open_callback(self, callback_method_unused):
-        """This method is not supported in BlockingConnection.
+        # TODO verify suitability of stop_ioloop_on_close value
+        self._impl = SelectConnection(
+            parameters=parameters,
+            on_open_callback=self._opened_result.set_value_once,
+            on_open_error_callback=self._open_error_result.set_value_once,
+            on_close_callback=self._closed_result.set_value_once,
+            stop_ioloop_on_close=False)
 
-        :param method callback_method_unused: Unused
-        :raises: NotImplementedError
+        self._process_io_for_connection_setup()
 
-        """
-        raise NotImplementedError('Connection callbacks not supported in '
-                                  'BlockingConnection')
-
-    def add_on_open_error_callback(self, callback_method_unused,
-                                   remove_default=False):
-        """This method is not supported in BlockingConnection.
-
-        A pika.exceptions.AMQPConnectionError will be raised instead.
-
-        :param method callback_method_unused: Unused
-        :raises: NotImplementedError
+    def _clean_up(self):
+        """ Perform clean-up that is necessary for re-connecting
 
         """
-        raise NotImplementedError('Connection callbacks not supported in '
-                                  'BlockingConnection')
+        self._opened_result.reset()
+        self._closed_result.reset()
+        self._open_error_result.reset()
+        self._user_initiated_close = False
 
-    def add_timeout(self, deadline, callback_method):
-        """Add the callback_method to the IOLoop timer to fire after deadline
-        seconds. Returns a handle to the timeout. Do not confuse with
-        Tornado's timeout where you pass in the time you want to have your
-        callback called. Only pass in the seconds until it's to be called.
+    def _process_io_for_connection_setup(self):
+        """ Perform follow-up processing for connection setup request: flush
+        connection output and process input while waiting for connection-open
+        or connection-error.
 
-        :param int deadline: The number of seconds to wait to call callback
-        :param method callback_method: The callback method
-        :rtype: str
-
+        :raises AMQPConnectionError: on connection open error
         """
+        self._flush_output(self._opened_result.is_ready,
+                           self._open_error_result.is_ready)
 
-        value = {
-            'deadline': time.time() + deadline,
-            'callback': callback_method
-        }
-        timeout_id = hash(frozenset(value.items()))
-        self._timeouts[timeout_id] = value
-        return timeout_id
+        if self._open_error_result.ready:
+            raise exceptions.AMQPConnectionError(
+                self._open_error_result.value.error_text)
 
-    def channel(self, channel_number=None):
-        """Create a new channel with the next available or specified channel #.
+        assert self._opened_result.ready
+        assert self._opened_result.value.connection is self._impl
 
-        :param int channel_number: Specify the channel number
+    def _flush_output(self, *waiters):
+        """ Flush output and process input while waiting for any of the given
+        callbacks to return true. The wait is aborted upon connection-close.
+        Otherwise, processing continues until the output is flushed AND at least
+        one of the callbacks returns true. If there are no callbacks, then
+        processing ends when all output is flushed.
 
+        :param waiters: sequence of zero or more callables taking no args and
+                        returning true when it's time to stop processing.
+                        Their results are OR'ed together.
         """
-        self._channel_open = False
-        if not channel_number:
-            channel_number = self._next_channel_number()
-        LOGGER.debug('Opening channel %i', channel_number)
-        self._channels[channel_number] = BlockingChannel(self, channel_number)
-        return self._channels[channel_number]
+        if self._impl.is_closed:
+            raise exceptions.ConnectionClosed()
+
+        # Conditions for terminating the processing loop:
+        #   connection closed
+        #         OR
+        #   empty outbound buffer and no waiters
+        #         OR
+        #   empty outbound buffer and any waiter is ready
+        is_done = (lambda:
+            self._closed_result.ready or
+            (not self._impl.outbound_buffer and
+             (not waiters or any(ready() for ready in  waiters))))
+
+        # Process I/O until our completion condition is satisified
+        while not is_done():
+            self._impl.ioloop.poll()
+            self._impl.ioloop.process_timeouts()
+
+        if self._closed_result.ready:
+            result = self._closed_result.value
+            if result.reason_code not in [0, 200]:
+                LOGGER.critical('Connection close detected; result=%r', result)
+                raise exceptions.ConnectionClosed(*result)
+            elif not self._user_initiated_close:
+                # NOTE: unfortunately, upon socket error, on_close_callback
+                # presently passes reason_code=0, so we don't detect that as an
+                # error
+                LOGGER.critical('Connection close detected')
+                raise exceptions.ConnectionClosed()
+            else:
+                LOGGER.info('Connection closed; result=%r', result)
 
     def close(self, reply_code=200, reply_text='Normal shutdown'):
         """Disconnect from RabbitMQ. If there are any open channels, it will
@@ -213,68 +271,46 @@ class BlockingConnection(base_connection.BaseConnection):
         :param str reply_text: The text reason for the close
 
         """
-        LOGGER.info("Closing connection (%s): %s", reply_code, reply_text)
-        self._set_connection_state(self.CONNECTION_CLOSING)
-        self._remove_connection_callbacks()
-        if self._has_open_channels:
-            self._close_channels(reply_code, reply_text)
-        while self._has_open_channels:
-            self.process_data_events()
-        if self.socket:
-            self._send_connection_close(reply_code, reply_text)
-        while self.is_closing:
-            self.process_data_events()
-        self._remove_heartbeat()
-        self._remove_connection_callbacks()
-        self._adapter_disconnect()
+        LOGGER.info('Closing connection (%s): %s', reply_code, reply_text)
+        self._user_initiated_close = True
+        self._impl.close(reply_code, reply_text)
+
+        self._flush_output(self._closed_result.is_ready)
+
+        assert self._closed_result.ready
+
+    def channel(self, channel_number=None):
+        """Create a new channel with the next available channel number or pass
+        in a channel number to use. Must be non-zero if you would like to
+        specify but it is recommended that you let Pika manage the channel
+        numbers.
+
+        :rtype: pika.synchronous_connection.BlockingChannel
+        """
+        with _CallbackResult(self._OnChannelOpenedArgs) as openedArgs:
+            channel = self._impl.channel(
+                on_open_callback=openedArgs.set_value_once,
+                channel_number=channel_number)
+
+            channel = BlockingChannel(channel, self)
+            channel._flush_output(openedArgs.is_ready)
+
+        return channel
 
     def connect(self):
         """Invoke if trying to reconnect to a RabbitMQ server. Constructing the
         Connection object should connect on its own.
 
         """
-        self._set_connection_state(self.CONNECTION_INIT)
-        self._adapter_connect()
+        assert not self._impl.is_open, (
+            'Connection was not closed; connection_state=%r'
+            % (self._impl.connection_state,))
 
-    def process_data_events(self):
-        """Will make sure that data events are processed. Your app can
-        block on this method.
+        self._clean_up()
 
-        """
-        try:
-            if self._handle_read():
-                self._socket_timeouts = 0
-        except socket.timeout:
-            self._handle_timeout()
-        self._flush_outbound()
-        self.process_timeouts()
+        self._impl.connect()
 
-    def process_timeouts(self):
-        """Process the self._timeouts event stack"""
-        for timeout_id in dictkeys(self._timeouts):
-            if self._deadline_passed(timeout_id):
-                self._call_timeout_method(self._timeouts.pop(timeout_id))
-
-    def remove_timeout(self, timeout_id):
-        """Remove the timeout from the IOLoop by the ID returned from
-        add_timeout.
-
-        :param str timeout_id: The id of the timeout to remove
-
-        """
-        if timeout_id in self._timeouts:
-            del self._timeouts[timeout_id]
-
-    def send_method(self, channel_number, method_frame, content=None):
-        """Constructs a RPC method frame and then sends it to the broker.
-
-        :param int channel_number: The channel number for the frame
-        :param pika.object.Method method_frame: The method frame to send
-        :param tuple content: If set, is a content frame, is tuple of
-                              properties and body.
-
-        """
-        self._send_method(channel_number, method_frame, content)
+        self._process_io_for_connection_setup()
 
     def sleep(self, duration):
         """A safer way to sleep than calling time.sleep() directly which will
@@ -282,163 +318,176 @@ class BlockingConnection(base_connection.BaseConnection):
         connection will "sleep" or block the number of seconds specified in
         duration in small intervals.
 
-        :param int duration: The time to sleep
+        :param float duration: The time to sleep in seconds
 
         """
+        assert duration >= 0, duration
+
         deadline = time.time() + duration
-        while time.time() < deadline:
-            time.sleep(self.SLEEP_DURATION)
-            self.process_data_events()
+        self._flush_output(lambda: time.time() >= deadline)
 
-    def _adapter_connect(self):
-        """Connect to the RabbitMQ broker
+    #
+    # Connections state properties
+    #
 
-        :raises: pika.Exceptions.AMQPConnectionError
-
+    @property
+    def is_closed(self):
         """
-        # Remove the default behavior for connection errors
-        self.callbacks.remove(0, self.ON_CONNECTION_ERROR)
-        error = super(BlockingConnection, self)._adapter_connect()
-        if error:
-            # Restore disconnected state and raise
-            self._adapter_disconnect(reset_only=True)
-            raise exceptions.AMQPConnectionError(error)
-        self.socket.settimeout(self.SOCKET_CONNECT_TIMEOUT)
-        self._frames_written_without_read = 0
-        self._socket_timeouts = 0
-        self._timeouts = dict()
-        self._read_poller = ReadPoller(self.socket.fileno())
-        self._on_connected()
-        while not self.is_open:
-            self.process_data_events()
-        self.socket.settimeout(self.params.socket_timeout)
-        self._set_connection_state(self.CONNECTION_OPEN)
-
-    def _adapter_disconnect(self, reset_only=False):
-        """Called if the connection is being requested to disconnect.
-
-        :param bool reset_only: if true, just reset the connection and don't
-          bother interpreting connection state
+        Returns a boolean reporting the current connection state.
         """
-        self._remove_heartbeat()
-        self._cleanup_socket()
-        self._read_poller = None
-        try:
-            if not reset_only:
-                # NOTE: this may raise an exception
-                self._check_state_on_disconnect()
-        finally:
-            # Complete transition to diconnected state
-            self._init_connection_state()
+        return self._impl.is_closed
 
-    @staticmethod
-    def _call_timeout_method(timeout_value):
-        """Execute the method that was scheduled to be called.
-
-        :param dict timeout_value: The configuration for the timeout
-
+    @property
+    def is_closing(self):
         """
-        LOGGER.debug('Invoking scheduled call of %s', timeout_value['callback'])
-        timeout_value['callback']()
+        Returns a boolean reporting the current connection state.
+        """
+        return self._impl.is_closing
 
-    def _deadline_passed(self, timeout_id):
-        """Returns True if the deadline has passed for the specified timeout_id.
+    @property
+    def is_open(self):
+        """
+        Returns a boolean reporting the current connection state.
+        """
+        return self._impl.is_open
 
-        :param str timeout_id: The id of the timeout to check
+    #
+    # Properties that reflect server capabilities for the current connection
+    #
+
+    @property
+    def basic_nack_supported(self):
+        """Specifies if the server supports basic.nack on the active connection.
+
         :rtype: bool
 
         """
-        if timeout_id not in self._timeouts:
-            return False
-        return self._timeouts[timeout_id]['deadline'] <= time.time()
+        return self._impl.basic_nack
 
-    def _handle_read(self):
-        """If the ReadPoller says there is data to read, try adn read it in the
-        _handle_read of the parent class. Once read, reset the counter that
-        keeps track of how many frames have been written since the last read.
+    @property
+    def consumer_cancel_notify_supported(self):
+        """Specifies if the server supports consumer cancel notification on the
+        active connection.
 
-        """
-        if self._read_poller.ready():
-            super(BlockingConnection, self)._handle_read()
-            self._frames_written_without_read = 0
-
-    def _handle_timeout(self):
-        """Invoked whenever the socket times out"""
-        self._socket_timeouts += 1
-        threshold = (self.SOCKET_TIMEOUT_THRESHOLD if not self.is_closing else
-                     self.SOCKET_TIMEOUT_CLOSE_THRESHOLD)
-
-        LOGGER.debug('Handling timeout %i with a threshold of %i',
-                     self._socket_timeouts, threshold)
-        if self._socket_timeouts > threshold:
-            if not self.is_closing:
-                LOGGER.critical('Closing connection due to timeout')
-            self._on_connection_closed(None, True)
-
-    def _flush_outbound(self):
-        """Flush the outbound socket buffer."""
-        if self.outbound_buffer:
-            if self._handle_write():
-                self._socket_timeouts = 0
-
-    def _on_connection_closed(self, method_frame, from_adapter=False):
-        """Called when the connection is closed remotely. The from_adapter value
-        will be true if the connection adapter has been disconnected from
-        the broker and the method was invoked directly instead of by receiving
-        a Connection.Close frame.
-
-        :param pika.frame.Method: The Connection.Close frame
-        :param bool from_adapter: Called by the connection adapter
-        :raises: pika.exceptions.ConnectionClosed
+        :rtype: bool
 
         """
-        if self._is_connection_close_frame(method_frame):
-            self.closing = (method_frame.method.reply_code,
-                            method_frame.method.reply_text)
-            LOGGER.warning("Disconnected from RabbitMQ at %s:%i (%s): %s",
-                           self.params.host, self.params.port, self.closing[0],
-                           self.closing[1])
+        return self._impl.consumer_cancel_notify
 
-        # Save the codes because self.closing gets reset by _adapter_disconnect
-        reply_code, reply_text = self.closing
+    @property
+    def exchange_exchange_bindings_supported(self):
+        """Specifies if the active connection supports exchange to exchange
+        bindings.
 
-        self._set_connection_state(self.CONNECTION_CLOSED)
-        self._remove_connection_callbacks()
-        if not from_adapter:
-            self._adapter_disconnect()
-        for chan in self._channels:
-            self._channels[chan]._on_close(method_frame)
-        self._remove_connection_callbacks()
-        if reply_code not in [0, 200]:
-            LOGGER.error("Raising ConnectionClosed due to reply_code=%s",
-                         reply_code)
-            raise exceptions.ConnectionClosed(reply_code, reply_text)
-        elif from_adapter:
-            raise exceptions.ConnectionClosed("Socket connection lost")
-
-    def _send_frame(self, frame_value):
-        """This appends the fully generated frame to send to the broker to the
-        output buffer which will be then sent via the connection adapter.
-
-        :param frame_value: The frame to write
-        :type frame_value:  pika.frame.Frame|pika.frame.ProtocolHeader
+        :rtype: bool
 
         """
-        super(BlockingConnection, self)._send_frame(frame_value)
-        self._frames_written_without_read += 1
-        if self._frames_written_without_read >= self.WRITE_TO_READ_RATIO:
-            if not isinstance(frame_value, frame.Method):
-                self._frames_written_without_read = 0
-                self.process_data_events()
+        return self._impl.exchange_exchange_bindings
+
+    @property
+    def publisher_confirms_supported(self):
+        """Specifies if the active connection can use publisher confirmations.
+
+        :rtype: bool
+
+        """
+        return self._impl.publisher_confirms
 
 
-class BlockingChannel(channel.Channel):
+class ConsumerDeliveryEvt(object):
+    """Consumer delivery event returned via `BlockingChannel.get_event`;
+    contains method, properties, and body of the delivered message.
+    """
+
+    __slots__ = ('method', 'properties', 'body')
+
+    def __init__(self, method, properties, body):
+        """
+        :param spec.Basic.Deliver method: NOTE: consumer_tag and delivery_tag
+          are valid only within the current channel
+        :param spec.BasicProperties properties: message properties
+        :param body: message body; None if no body
+        :type body: str or unicode or None
+        """
+        self.method = method
+        self.properties = properties
+        self.body = body
+
+
+class ConsumerCancellationEvt(object):
+    """Server-initiated consumer cancellation event returned by
+    `BlockingChannel.get_event`. After receiving this event, there will be no
+    further deliveries for the consumer identified by `consumer_tag`
+    """
+
+    __slots__ = ('consumer_tag')
+
+    def __init__(self, consumer_tag):
+        """
+        :param str consumer_tag: Identifier for the cancelled consumer, valid
+          within the current channel.
+        """
+        self.consumer_tag = consumer_tag
+
+    def __repr__(self):
+        return "%s(consumer_tag=%r)" % (self.__class__.__name__,
+                                        self.consumer_tag)
+
+
+class ReturnedMessage(object):
+    """Represents a message returned via Basic.Return"""
+
+    __slots__ = ('method', 'properties', 'body')
+
+    def __init__(self, method, properties, body):
+        """
+        :param spec.Basic.Return method:
+        :param spec.BasicProperties properties: message properties
+        :param body: message body; None if no body
+        :type body: str or unicode or None
+        """
+        self.method = method
+        self.properties = properties
+        self.body = body
+
+
+class UnroutableError(exceptions.AMQPError):
+    """Exception containing one or more unroutable returned messages"""
+
+    def __init__(self, messages):
+        """
+        :param messages: sequence of returned unroutable messages
+        :type messages: sequence of ReturnedMessage objects
+        """
+        super(UnroutableError, self).__init__(
+            "%s unroutable message(s) returned" % (len(messages)))
+
+        self.messages = messages
+
+
+class NackError(exceptions.AMQPError):
+    """This exception is raised when a message published in
+    publisher-acknowledgements mode is Nack'ed by the broker
+    """
+
+    def __init__(self, messages):
+        """
+        :param messages: sequence of returned unroutable messages
+        :type messages: sequence of ReturnedMessage objects
+        """
+        super(NackError, self).__init__(
+            "%s message(s) NACKed" % (len(messages)))
+
+        self.messages = messages
+
+
+class BlockingChannel(object):
     """The BlockingChannel implements blocking semantics for most things that
     one would use callback-passing-style for with the
     :py:class:`~pika.channel.Channel` class. In addition,
-    the `BlockingChannel` class implements a :term:`generator` that allows you
-    to :doc:`consume messages </examples/blocking_consumer_generator>` without
-    using callbacks.
+    the `BlockingChannel` class implements a :term:`generator` that allows
+    you to :doc:`consume messages </examples/blocking_consumer_generator>`
+    without using callbacks.
 
     Example of creating a BlockingChannel::
 
@@ -447,143 +496,660 @@ class BlockingChannel(channel.Channel):
         # Create our connection object
         connection = pika.BlockingConnection()
 
-        # The returned object will be a blocking channel
+        # The returned object will be a synchronous channel
         channel = connection.channel()
 
-    :param BlockingConnection connection: The connection
-    :param int channel_number: The channel number for this instance
+    :param channel_impl: Channel implementation object as returned from
+                         SelectConnection.channel()
+    :param BlockingConnection connection: The connection object
+
+    TODO fill in missing channel methods see BlockingChannel methods in
+    http://pika.readthedocs.org/en/latest/modules/adapters/blocking.html
 
     """
-    NO_RESPONSE_FRAMES = ['Basic.Ack', 'Basic.Reject', 'Basic.RecoverAsync']
 
-    def __init__(self, connection, channel_number):
+    # Used for Basic.Deliver, Basic.Cancel, Basic.Return and Basic.GetOk from
+    # broker
+    #_OnMessageDeliveredArgs = namedtuple(
+    _RxMessageArgs = namedtuple(
+        'BlockingChannel__RxMessageArgs',
+        [
+            # implementation Channel instance
+            'channel',
+            # Basic.Deliver, Basic.Cancel, Basic.Return or Basic.GetOk
+            'method',
+            # pika.spec.BasicProperties; ignore if Basic.Cancel
+            'properties',
+            # returned message body; ignore if Basic.Cancel
+            'body'
+        ])
+
+
+    # For use by any _CallbackResult that expects method_frame as the only
+    # arg
+    _MethodFrameCallbackResultArgs = namedtuple(
+        'BlockingChannel__MethodFrameCallbackResultArgs',
+        'method_frame')
+
+    # Broker's basic-ack/basic-nack when delivery confirmation is enabled;
+    # may concern a single or multiple messages
+    _OnMessageConfirmationReportArgs = namedtuple(
+        'BlockingChannel__OnMessageConfirmationReportArgs',
+        'method_frame')
+
+    # Basic.GetEmpty response args
+    _OnGetEmptyResponseArgs = namedtuple(
+        'BlockingChannel__OnGetEmptyResponseArgs',
+        'method_frame')
+
+    # Parameters for broker-inititated Channel.Close request: reply_code
+    # holds the broker's non-zero error code and reply_text holds the
+    # corresponding error message text.
+    _OnChannelClosedByBrokerArgs = namedtuple(
+        'BlockingChannel__OnChannelClosedByBrokerArgs',
+        'method_frame')
+
+
+    def __init__(self, channel_impl, connection):
         """Create a new instance of the Channel
 
-        :param BlockingConnection connection: The connection
-        :param int channel_number: The channel number for this instance
+        :param channel_impl: Channel implementation object as returned from
+                             SelectConnection.channel()
+        :param BlockingConnection connection: The connection object
 
         """
-        super(BlockingChannel, self).__init__(connection, channel_number)
-        self.connection = connection
-        self._confirmation = False
-        self._force_data_events_override = None
-        self._generator = None
-        self._generator_messages = list()
-        self._frames = dict()
-        self._replies = list()
-        self._wait = False
-        self._received_response = False
-        self._response = None
-        self.open()
+        self._impl = channel_impl
+        self._connection = connection
 
-    def basic_cancel(self, consumer_tag='', nowait=False):
-        """This method cancels a consumer. This does not affect already
-        delivered messages, but it does mean the server will not send any more
-        messages for that consumer. The client may receive an arbitrary number
-        of messages in between sending the cancel method and receiving the
-        cancel-ok reply. It may also be sent from the server to the client in
-        the event of the consumer being unexpectedly cancelled (i.e. cancelled
-        for any reason other than the server receiving the corresponding
-        basic.cancel from the client). This allows clients to be notified of
-        the loss of consumers due to events such as queue deletion.
+        # Whether RabbitMQ delivery confirmation has been enabled
+        self._delivery_confirmation = False
 
-        :param str consumer_tag: Identifier for the consumer
-        :param bool nowait: Do not expect a Basic.CancelOk response
+        # Receives message delivery confirmation report (Basic.ack or
+        # Basic.nack) from broker when delivery confirmations are enabled
+        self._message_confirmation_result = _CallbackResult(
+            self._OnMessageConfirmationReportArgs)
+
+        # deque of pending events: ConsumerDeliveryEvt and
+        # ConsumerCancellationEvt objects that will be returned by
+        # `BlockingChannel.get_event()`
+        self._pending_events = deque()
+
+        # Holds ReturnedMessage objects received via Basic.Return
+        self._returned_messages = []
+
+        # Receives Basic.ConsumeOk reply from server
+        self._basic_consume_ok_result = _CallbackResult()
+
+        # Receives the broker-inititated Channel.Close parameters
+        self._channel_closed_by_broker_result = _CallbackResult(
+            self._OnChannelClosedByBrokerArgs)
+
+        # Receives args from Basic.GetEmpty response
+        #  http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
+        self._basic_getempty_result = _CallbackResult(
+            self._OnGetEmptyResponseArgs)
+
+        self._impl.add_on_return_callback(self._on_message_returned)
+
+        self._impl.add_on_cancel_callback(
+            lambda method_frame:
+                self._pending_events.append(
+                    ConsumerCancellationEvt(method_frame.method.consumer_tag))
+        )
+
+        self._impl.add_callback(
+            self._basic_consume_ok_result.signal_once,
+            replies=[pika.spec.Basic.ConsumeOk],
+            one_shot=False)
+
+        self._impl.add_callback(
+            self._channel_closed_by_broker_result.set_value_once,
+            replies=[pika.spec.Channel.Close],
+            one_shot=True)
+
+        self._impl.add_callback(
+            self._basic_getempty_result.set_value_once,
+            replies=[pika.spec.Basic.GetEmpty],
+            one_shot=False)
+
+        LOGGER.info("Created channel=%s", self._impl.channel_number)
+
+    @property
+    def connection(self):
+        return self._connection
+
+    @property
+    def is_closed(self):
+        """Returns True if the channel is closed.
+
+        :rtype: bool
 
         """
-        if consumer_tag not in self._consumers:
-            return
-        self._cancelled.append(consumer_tag)
-        replies = [(spec.Basic.CancelOk,
-                    {'consumer_tag': consumer_tag})] if nowait is False else []
-        self._rpc(spec.Basic.Cancel(consumer_tag=consumer_tag,
-                                    nowait=nowait), self._on_cancelok, replies)
+        return self._impl.is_closed
+
+    @property
+    def is_closing(self):
+        """Returns True if the channel is closing.
+
+        :rtype: bool
+
+        """
+        return self._impl.is_closing
+
+    @property
+    def is_open(self):
+        """Returns True if the channel is open.
+
+        :rtype: bool
+
+        """
+        return self._impl.is_open
+
+    _ALWAYS_READY_WAITERS = ((lambda: True), )
+
+    def _flush_output(self, *waiters):
+        """ Flush output and process input while waiting for any of the given
+        callbacks to return true. The wait is aborted upon channel-close or
+        connection-close.
+        Otherwise, processing continues until the output is flushed AND at least
+        one of the callbacks returns true. If there are no callbacks, then
+        processing ends when all output is flushed.
+
+        :param waiters: sequence of zero or more callables taking no args and
+                        returning true when it's time to stop processing.
+                        Their results are OR'ed together.
+        """
+        if self._impl.is_closed:
+            raise exceptions.ChannelClosed()
+
+        if not waiters:
+            waiters = self._ALWAYS_READY_WAITERS
+
+        self._connection._flush_output(
+            self._channel_closed_by_broker_result.is_ready,
+            *waiters)
+
+        if self._channel_closed_by_broker_result:
+            # Channel was force-closed by broker
+            raise exceptions.ChannelClosed(
+                self._channel_closed_by_broker_result.value)
+
+    def _on_message_returned(self, channel, method, properties, body):
+        """ Called as the result of Basic.Return from broker. Appends the info
+        as ReturnedMessage to self._returned_messages.
+
+        :param pika.Channel channel: our self._impl channel
+        :param pika.spec.Basic.Return method:
+        :param pika.spec.BasicProperties properties: message properties
+        :param body: returned message body; may be None if no body
+        :type body: str, unicode or None
+
+        """
+        assert channel is self._impl, (
+            channel.channel_number, self._impl.channel_number)
+
+        assert isinstance(method, pika.spec.Basic.Return), method
+        assert isinstance(properties, pika.spec.BasicProperties), (
+            properties)
+
+        LOGGER.warn(
+            "Published message was returned: _delivery_confirmation=%s; "
+            "channel=%s; method=%r; properties=%r; body_size=%d; "
+            "body_prefix=%.255r", self._delivery_confirmation,
+            channel.channel_number, method, properties,
+            len(body) if body is not None else None, body)
+
+        self._returned_messages.append(
+            ReturnedMessage(method, properties, body))
+
+    def _raiseAndClearIfReturnedMessagesPending(self):
+        """If there are returned messages, raise UnroutableError exception and
+        empty the returned messages list
+
+        :raises UnroutableError: if returned messages are present
+        """
+        if self._returned_messages:
+            messages = self._returned_messages
+            self._returned_messages = []
+
+            raise UnroutableError(messages)
+
+    def close(self, reply_code=0, reply_text="Normal Shutdown"):
+        """Will invoke a clean shutdown of the channel with the AMQP Broker.
+
+        :param int reply_code: The reply code to close the channel with
+        :param str reply_text: The reply text to close the channel with
+
+        """
+        LOGGER.info('Channel.close(%s, %s)', reply_code, reply_text)
+        try:
+            with _CallbackResult() as close_ok_result:
+                self._impl.add_callback(callback=close_ok_result.signal_once,
+                                        replies=[pika.spec.Channel.CloseOk],
+                                        one_shot=True)
+
+                self._impl.close(reply_code=reply_code, reply_text=reply_text)
+                self._flush_output(close_ok_result.is_ready)
+        finally:
+            # Clean up members that might inhibit garbage collection
+            self._message_confirmation_result.reset()
+
+    def basic_ack(self, delivery_tag=0, multiple=False):
+        """Acknowledge one or more messages. When sent by the client, this
+        method acknowledges one or more messages delivered via the Deliver or
+        Get-Ok methods. When sent by server, this method acknowledges one or
+        more messages published with the Publish method on a channel in
+        confirm mode. The acknowledgement can be for a single message or a
+        set of messages up to and including a specific message.
+
+        :param int delivery-tag: The server-assigned delivery tag
+        :param bool multiple: If set to True, the delivery tag is treated as
+                              "up to and including", so that multiple messages
+                              can be acknowledged with a single method. If set
+                              to False, the delivery tag refers to a single
+                              message. If the multiple field is 1, and the
+                              delivery tag is zero, this indicates
+                              acknowledgement of all outstanding messages.
+        """
+        self._impl.basic_ack(delivery_tag=delivery_tag, multiple=multiple)
+        self._flush_output()
+
+    def basic_nack(self, delivery_tag=None, multiple=False, requeue=True):
+        """This method allows a client to reject one or more incoming messages.
+        It can be used to interrupt and cancel large incoming messages, or
+        return untreatable messages to their original queue.
+
+        :param int delivery-tag: The server-assigned delivery tag
+        :param bool multiple: If set to True, the delivery tag is treated as
+                              "up to and including", so that multiple messages
+                              can be acknowledged with a single method. If set
+                              to False, the delivery tag refers to a single
+                              message. If the multiple field is 1, and the
+                              delivery tag is zero, this indicates
+                              acknowledgement of all outstanding messages.
+        :param bool requeue: If requeue is true, the server will attempt to
+                             requeue the message. If requeue is false or the
+                             requeue attempt fails the messages are discarded or
+                             dead-lettered.
+
+        """
+        self._impl.basic_nack(delivery_tag=delivery_tag, multiple=multiple,
+                              requeue=requeue)
+        self._flush_output()
+
+    def create_consumer(self, queue='', no_ack=False, exclusive=False,
+                        arguments=None):
+        """Sends the AMQP command Basic.Consume to the broker.
+
+        For more information on basic_consume, see:
+        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
+
+        :param queue: The queue to consume from
+        :type queue: str or unicode
+        :param bool no_ack: Tell the broker to not expect a response
+        :param bool exclusive: Don't allow other consumers on the queue
+        :param dict arguments: Custom key/value pair arguments for the consume
+        :returns: consumer tag
+        :rtype: str
+
+        """
+        with self._basic_consume_ok_result as ok_result:
+            ok_result.reset()
+            consumer_tag = self._impl.basic_consume(
+                consumer_callback=lambda channel, method, properties, body:
+                    self._pending_events.append(
+                        ConsumerDeliveryEvt(method, properties, body)),
+                queue=queue,
+                no_ack=no_ack,
+                exclusive=exclusive,
+                arguments=arguments)
+
+            self._flush_output(ok_result.is_ready)
+
+        return consumer_tag
+
+    def cancel_consumer(self, consumer_tag):
+        """ Cancel consumer with the given consumer_tag
+
+        :param str consumer_tag: consumer tag
+        :returns: a (possibly empty) sequence of BlockingChannel.Message
+            objects corresponding to messages delivered for the given consumer
+            before the cancel operation completed that were not yet yielded by
+            `BlockingChannel.consume_messages()` generator.
+        """
+        was_active = (consumer_tag in self._impl._consumers)
+        if was_active:
+            with _CallbackResult() as cancel_ok_result:
+                self._impl.basic_cancel(
+                    callback=cancel_ok_result.signal_once,
+                    consumer_tag=consumer_tag,
+                    nowait=False)
+
+                # Flush output and wait for Basic.CancelOk or broker-initiated
+                # Basic.Cancel
+                self._flush_output(
+                    cancel_ok_result.is_ready,
+                    lambda: consumer_tag not in self._impl._consumers)
+        else:
+            LOGGER.warn("User is attempting to cancel an unknown consumer=%s; "
+                        "already cancelled by user or broker?", consumer_tag)
+
+        # NOTE: new events may have arrived for this consumer while we were
+        # waiting for Basic.CancelOk
+
+        # Remove pending events destined for this consumer
+        remaining_events = deque()
+        unprocessed_messages = []
+        while self._pending_events:
+            evt = self._pending_events.popleft()
+            if evt.consumer_tag == consumer_tag:
+                if type(evt) is ConsumerDeliveryEvt:
+                    unprocessed_messages.append(evt)
+                else:
+                    # A broker-initiated Basic.Cancel must have arrived before
+                    # our cancel request completed
+                    assert type(evt) is ConsumerCancellationEvt, type(evt)
+                    LOGGER.warn("cancel_consumer: discarding evt=%s", evt)
+            else:
+                remaining_events.append(evt)
+
+        self._pending_events = remaining_events
+
+        return unprocessed_messages
+
+    def has_event(self):
+        """Check if at least one event is available to be returned by
+        `BlockingChannel.get_event` without blocking.
+
+        :returns: True if at least one event is available and may be retrieved
+          by calling `BlockingChannel.get_event()` without blocking; False if no
+          events are available.
+        :rtype: bool
+        """
+        return bool(self._pending_events)
+
+    def get_event(self, inactivity_timeout=None):
+        """Returns the next event; if an event is not available immediately,
+        blocks and waits for an incoming event.
+
+        :param float inactivity_timeout: if a number is given (in seconds), will
+            cause the method to return None after the given period of
+            inactivity; this permits for pseudo-regular maintenance activities
+            to be carried out by the user while waiting for messages to arrive.
+            If None is given (default), then the method blocks until the next
+            event arrives. NOTE that timing granularity is limited by the timer
+            resolution of the underlying implementation.
+
+        :returns: May return one of the following
+            `ConsumerDeliveryEvt` - message delivered for one of the active
+                consumers
+            `ConsumerCancellationEvt` - broker-initiated consumer cancellation.
+            None - upon expiration of inactivity timeout, if one was specified.
+            NOTE: other events types may be added in the future (e.g.,
+            flow-control)
+
+
+        Blocking example with inactivity timeout ::
+
+            cons1_id = channel.create_consumer(queue="apples")
+            cons2_id = channel.create_consumer(queue="oranges")
+
+            num_consumers = 2
+
+            while True:
+                evt = channel.get_event(inactivity_timeout=10)
+                if type(evt) is ConsumerDeliveryEvt:
+                    channel.basic_ack(evt.method.delivery_tag)
+                    print "Acked:", evt
+                elif type(evt) is ConsumerCancellationEvt:
+                    print "ERROR: Consumer cancelled by broker:", evt
+                    num_consumers -= 1
+                    if num_consumers <= 0:
+                        break
+                elif evt is None:
+                    print "INACTIVITY TIMEOUT"
+                else:
+                    print "WARNING: unexpected evt=", evt
+
+        """
+        if self.has_event():
+            return self._pending_events.popleft()
+
+        # Wait for an event
+        with _CallbackResult() as timeoutResult:
+            if inactivity_timeout is None:
+                waiters = (self.has_event,)
+            else:
+                waiters = (self.has_event, timeoutResult.is_ready)
+                # Start inactivity timer
+                timeout_id = self._connection.add_timeout(
+                    inactivity_timeout,
+                    timeoutResult.signal_once)
+
+            # Wait for message delivery or inactivity timeout, whichever
+            # occurs first
+            try:
+                self._flush_output(*waiters)
+            finally:
+                if inactivity_timeout is not None:
+                    # Reset timer
+                    if not timeoutResult:
+                        self._connection.remove_timeout(timeout_id)
+                    else:
+                        timeoutResult.reset()
+
+
+        if self.has_event():
+            # Got an event
+            return self._pending_events.popleft()
+        else:
+            # Inactivity timeout
+            return None
+
+
+    def read_events(self, inactivity_timeout=None):
+        """A blocking generator iterator that wraps `BlockingChanel.get_event`
+        and yields its results.
+
+        See `BlockingChanel.get_event` for more information about events.
+
+        :param float inactivity_timeout: if a number is given (in seconds), will
+            cause the generator to yield None after the given period of
+            inactivity; this permits for pseudo-regular maintenance activities
+            to be carried out by the user while waiting for messages to arrive.
+            NOTE that the underlying implementation doesn't permit a high level
+            of timing granularity.
+
+        Example with inactivity timeout ::
+
+            cons1_id = create_consumer(queue="apples")
+            cons2_id = create_consumer(queue="oranges")
+
+            num_consumers = 2
+
+            for evt in read_events(inactivity_timeout=10):
+                if type(evt) is ConsumerDeliveryEvt:
+                    channel.basic_ack(evt.delivery_tag)
+                    print "Acked:", evt
+                elif type(evt) is ConsumerCancellationEvt:
+                    print "ERROR: Consumer cancelled by broker:", evt
+                    num_consumers -= 1
+                    if num_consumers <= 0:
+                        break
+                elif evt is None:
+                    print "INACTIVITY TIMEOUT"
+                else:
+                    print "WARNING: unexpected evt=", evt
+
+        """
+        while True:
+            yield self.get_event(inactivity_timeout)
 
     def basic_get(self, queue=None, no_ack=False):
-        """Get a single message from the AMQP broker. Returns a set with the
-        method frame, header frame and body.
+        """Get a single message from the AMQP broker. Returns a sequence with
+        the method frame, message properties, and body.
 
-        :param queue: The queue to get a message from
+        :param queue: Name of queue to get a message from
         :type queue: str or unicode
         :param bool no_ack: Tell the broker to not expect a reply
-        :rtype: (None, None, None)|(spec.Basic.Get,
-                                    spec.Basic.Properties,
-                                    str or unicode)
-
+        :returns: a three-tuple; (None, None, None) if the queue was empty;
+            otherwise (method, properties, body); NOTE: body may be None
+        :rtype: (None, None, None)|(spec.Basic.GetOk,
+                                    spec.BasicProperties,
+                                    str or unicode or None)
         """
-        self._response = None
-        self._send_method(spec.Basic.Get(queue=queue, no_ack=no_ack))
-        while not self._response:
-            self.connection.process_data_events()
-        if isinstance(self._response[0], spec.Basic.GetEmpty):
-            return None, None, None
-        return self._response[0], self._response[1], self._response[2]
+        get_ok_result = _CallbackResult(self._RxMessageArgs)
+        assert not self._basic_getempty_result
+        with get_ok_result, self._basic_getempty_result:
+            self._impl.basic_get(callback=get_ok_result.set_value_once,
+                                 queue=queue,
+                                 no_ack=no_ack)
+            self._flush_output(get_ok_result.is_ready,
+                               self._basic_getempty_result.is_ready)
+            if get_ok_result:
+                evt = get_ok_result.value
+                return (evt.method, evt.properties, evt.body)
+            else:
+                assert self._basic_getempty_result, (
+                    "wait completed without GetOk and GetEmpty")
+                return None, None, None
 
     def basic_publish(self, exchange, routing_key, body,
-                      properties=None,
-                      mandatory=False,
-                      immediate=False):
+                      properties=None, mandatory=False, immediate=False):
         """Publish to the channel with the given exchange, routing key and body.
-        Returns a boolean value indicating the success of the operation. For
-        more information on basic_publish and what the parameters do, see:
+        Returns a boolean value indicating the success of the operation.
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
+        This is the legacy BlockingChannel method for publishing. See also
+        `BasicChannel.publish` that provides more information about failures.
+
+        For more information on basic_publish and what the parameters do, see:
+
+            http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
+
+        NOTE: mandatory and immediate may be enabled even without delivery
+          confirmation, but in the absence of delivery confirmation the
+          synchronous implementation has no way to know how long to wait for
+          the return.
 
         :param exchange: The exchange to publish to
         :type exchange: str or unicode
         :param routing_key: The routing key to bind on
         :type routing_key: str or unicode
-        :param body: The message body
-        :type body: str or unicode
-        :param pika.spec.Properties properties: Basic.properties
+        :param body: The message body; None if no body
+        :type body: str or unicode or None
+        :param pika.spec.BasicProperties properties: message properties
         :param bool mandatory: The mandatory flag
         :param bool immediate: The immediate flag
 
+        :returns: None if delivery confirmation is not enabled; otherwise
+                  returns False if the message could not be deliveved (
+                  Basic.nack or msg return) and True if the message was
+                  delivered (Basic.ack and no msg return)
         """
-        if not self.is_open:
-            raise exceptions.ChannelClosed()
-        if immediate:
-            LOGGER.warning('The immediate flag is deprecated in RabbitMQ')
-        properties = properties or spec.BasicProperties()
-
-        if mandatory:
-            self._response = None
-
-        if isinstance(body, unicode_type):
-            body = body.encode('utf-8')
-
-        if self._confirmation:
-            response = self._rpc(spec.Basic.Publish(exchange=exchange,
-                                                    routing_key=routing_key,
-                                                    mandatory=mandatory,
-                                                    immediate=immediate), None,
-                                 [spec.Basic.Ack,
-                                  spec.Basic.Nack], (properties, body))
-            if mandatory and self._response:
-                response = self._response[0]
-                LOGGER.warning('Message was returned (%s): %s',
-                               response.reply_code, response.reply_text)
-                return False
-
-            if isinstance(response.method, spec.Basic.Ack):
-                return True
-            elif isinstance(response.method, spec.Basic.Nack):
+        if self._delivery_confirmation:
+            # In publisher-acknowledgments mode
+            try:
+                self.publish(exchange, routing_key, body, properties,
+                             mandatory, immediate)
+            except (NackError, UnroutableError):
                 return False
             else:
-                raise ValueError('Unexpected frame type: %r', response)
-        else:
-            self._send_method(spec.Basic.Publish(exchange=exchange,
-                                                 routing_key=routing_key,
-                                                 mandatory=mandatory,
-                                                 immediate=immediate),
-                              (properties, body), False)
-            if mandatory:
-                if self._response:
-                    response = self._response[0]
-                    LOGGER.warning('Message was returned (%s): %s',
-                                   response.reply_code, response.reply_text)
-                    return False
                 return True
+        else:
+            # In non-publisher-acknowledgments mode
+            try:
+                self.publish(exchange, routing_key, body, properties,
+                             mandatory, immediate)
+            except UnroutableError:
+                # Suppress the error as it applies to previously-published
+                # messages (it's beein logged already), and repeat the publish
+                # call
+                self.publish(exchange, routing_key, body, properties,
+                             mandatory, immediate)
+            return None
+
+    def publish(self, exchange, routing_key, body,
+                properties=None, mandatory=False, immediate=False):
+        """Publish to the channel with the given exchange, routing key, and
+        body. Unlike the legacy `BlockingChannel.basic_publish`, this method
+        provides more information about failures via exceptions.
+
+        For more information on basic_publish and what the parameters do, see:
+
+            http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
+
+        NOTE: mandatory and immediate may be enabled even without delivery
+          confirmation, but in the absence of delivery confirmation the
+          synchronous implementation has no way to know how long to wait for
+          the Basic.Return.
+
+        :param exchange: The exchange to publish to
+        :type exchange: str or unicode
+        :param routing_key: The routing key to bind on
+        :type routing_key: str or unicode
+        :param body: The message body; None if no body
+        :type body: str or unicode or None
+        :param pika.spec.BasicProperties properties: message properties
+        :param bool mandatory: The mandatory flag
+        :param bool immediate: The immediate flag
+
+        :raises UnroutableError: In publisher-acknowledgments mode (see
+            `BlockingChannel.confirm_delivery`), raised if the given message
+            message is returned via Basic.Return. In
+            non-publisher-acknowledgements mode, raised before attempting to
+            publish the given message if there are pending unroutable messages.
+
+        :raises NackError: raised when a message published in
+            publisher-acknowledgements mode is Nack'ed by the broker. See
+            `BlockingChannel.confirm_delivery`.
+
+        """
+        if self._delivery_confirmation:
+            # In publisher-acknowledgments mode
+            with self._message_confirmation_result:
+                self._impl.basic_publish(exchange=exchange,
+                                         routing_key=routing_key,
+                                         body=body,
+                                         properties=properties,
+                                         mandatory=mandatory,
+                                         immediate=immediate)
+
+                self._flush_output(self._message_confirmation_result.is_ready)
+                conf_method = (self._message_confirmation_result.value
+                               .method_frame
+                               .method)
+                if isinstance(conf_method, pika.spec.Basic.Nack):
+                    # Broker was unable to process the message due to internal
+                    # error
+                    LOGGER.warn(
+                        "Message was Nack'ed by broker: nack=%r; channel=%s; "
+                        "exchange=%s; routing_key=%s; mandatory=%r; "
+                        "immediate=%r", conf_method, self._impl.channel_number,
+                        exchange, routing_key, mandatory, immediate)
+                    returned_messages = self._returned_messages
+                    self._returned_messages = []
+                    raise NackError(returned_messages)
+                elif isinstance(conf_method, pika.spec.Basic.Ack):
+                    self._raiseAndClearIfReturnedMessagesPending()
+                else:
+                    # Should never happen
+                    raise TypeError('Unexpected method type: %r', conf_method)
+        else:
+            # In non-publisher-acknowledgments mode
+
+            # Raise UnroutableError before publishing if returned messages are
+            # pending
+            self._raiseAndClearIfReturnedMessagesPending()
+
+            # Publish
+            self._impl.basic_publish(exchange=exchange,
+                                     routing_key=routing_key,
+                                     body=body,
+                                     properties=properties,
+                                     mandatory=mandatory,
+                                     immediate=immediate)
+
+            self._flush_output()
 
     def basic_qos(self, prefetch_size=0, prefetch_count=0, all_channels=False):
         """Specify quality of service. This method requests a specific quality
@@ -613,8 +1179,12 @@ class BlockingChannel(channel.Channel):
         :param bool all_channels: Should the QoS apply to all channels
 
         """
-        self._rpc(spec.Basic.Qos(prefetch_size, prefetch_count, all_channels),
-                  None, [spec.Basic.QosOk])
+        with _CallbackResult() as qos_ok_result:
+            self._impl.basic_qos(callback=qos_ok_result.signal_once,
+                                 prefetch_size=prefetch_size,
+                                 prefetch_count=prefetch_count,
+                                 all_channels=all_channels)
+            self._flush_output(qos_ok_result.is_ready)
 
     def basic_recover(self, requeue=False):
         """This method asks the server to redeliver all unacknowledged messages
@@ -627,116 +1197,56 @@ class BlockingChannel(channel.Channel):
                              delivering it to an alternative subscriber.
 
         """
-        self._rpc(spec.Basic.Recover(requeue), None, [spec.Basic.RecoverOk])
+        with _CallbackResult() as recover_ok_result:
+            self._impl.basic_recover(callback=recover_ok_result.signal_once,
+                                     requeue=requeue)
+            self._flush_output(recover_ok_result.is_ready)
 
-    def confirm_delivery(self, nowait=False):
-        """Turn on Confirm mode in the channel.
+    def basic_reject(self, delivery_tag=None, requeue=True):
+        """Reject an incoming message. This method allows a client to reject a
+        message. It can be used to interrupt and cancel large incoming messages,
+        or return untreatable messages to their original queue.
+
+        :param int delivery-tag: The server-assigned delivery tag
+        :param bool requeue: If requeue is true, the server will attempt to
+                             requeue the message. If requeue is false or the
+                             requeue attempt fails the messages are discarded or
+                             dead-lettered.
+
+        """
+        self._impl.basic_reject(delivery_tag=delivery_tag, requeue=requeue)
+        self._flush_output()
+
+    def confirm_delivery(self):
+        """Turn on RabbitMQ-proprietary Confirm mode in the channel.
 
         For more information see:
             http://www.rabbitmq.com/extensions.html#confirms
 
-        :param bool nowait: Do not send a reply frame (Confirm.SelectOk)
-
+        :raises UnroutableError: when unroutable messages that were sent prior
+            to this call are returned before we receive Confirm.Select-ok
         """
-        if (not self.connection.publisher_confirms or
-            not self.connection.basic_nack):
-            raise exceptions.MethodNotImplemented('Not Supported on Server')
-        self._confirmation = True
-        replies = [spec.Confirm.SelectOk] if nowait is False else []
-        self._rpc(spec.Confirm.Select(nowait), None, replies)
-        self.connection.process_data_events()
+        if self._delivery_confirmation:
+            LOGGER.error('confirm_delivery: confirmation was already enabled '
+                         'on channel=%s', self._impl.channel_number)
+            return
 
-    def cancel(self):
-        """Cancel the consumption of a queue, rejecting all pending messages.
-        This should only work with the generator based BlockingChannel.consume
-        method. If you're looking to cancel a consumer issues with
-        BlockingChannel.basic_consume then you should call
-        BlockingChannel.basic_cancel.
+        with _CallbackResult() as select_ok_result:
+            self._impl.add_callback(callback=select_ok_result.signal_once,
+                                    replies=[pika.spec.Confirm.SelectOk],
+                                    one_shot=True)
 
-        :return int: The number of messages requeued by Basic.Nack
+            self._impl.confirm_delivery(
+                callback=self._message_confirmation_result.set_value_once,
+                nowait=False)
 
-        """
-        messages = 0
-        self.basic_cancel(self._generator)
-        if self._generator_messages:
-            # Get the last item
-            (method, properties, body) = self._generator_messages.pop()
-            messages = len(self._generator_messages)
-            LOGGER.info('Requeueing %i messages with delivery tag %s', messages,
-                        method.delivery_tag)
-            self.basic_nack(method.delivery_tag, multiple=True, requeue=True)
-            self.connection.process_data_events()
-        self._generator = None
-        self._generator_messages = list()
-        return messages
+            self._flush_output(select_ok_result.is_ready)
 
-    def close(self, reply_code=0, reply_text="Normal Shutdown"):
-        """Will invoke a clean shutdown of the channel with the AMQP Broker.
+        self._delivery_confirmation = True
 
-        :param int reply_code: The reply code to close the channel with
-        :param str reply_text: The reply text to close the channel with
-
-        """
-
-        LOGGER.info('Channel.close(%s, %s)', reply_code, reply_text)
-        if not self.is_open:
-            raise exceptions.ChannelClosed()
-
-        # Cancel the generator if it's running
-        if self._generator:
-            self.cancel()
-
-        # If there are any consumers, cancel them as well
-        if self._consumers:
-            LOGGER.debug('Cancelling %i consumers', len(self._consumers))
-            for consumer_tag in dictkeys(self._consumers):
-                self.basic_cancel(consumer_tag=consumer_tag)
-        self._set_state(self.CLOSING)
-        self._rpc(spec.Channel.Close(reply_code, reply_text, 0, 0), None,
-                  [spec.Channel.CloseOk])
-        self._set_state(self.CLOSED)
-        self._cleanup()
-
-    def consume(self, queue, no_ack=False, exclusive=False):
-        """Blocking consumption of a queue instead of via a callback. This
-        method is a generator that returns messages a tuple of method,
-        properties, and body.
-
-        Example:
-
-            for method, properties, body in channel.consume('queue'):
-                print(body)
-                channel.basic_ack(method.delivery_tag)
-
-        You should call BlockingChannel.cancel() when you escape out of the
-        generator loop. Also note this turns on forced data events to make
-        sure that any acked messages actually get acked.
-
-        :param queue: The queue name to consume
-        :type queue: str or unicode
-        :param no_ack: Tell the broker to not expect a response
-        :type no_ack: bool
-        :param exclusive: Don't allow other consumers on the queue
-        :type exclusive: bool
-        :rtype: tuple(spec.Basic.Deliver, spec.BasicProperties, str or unicode)
-
-        """
-        LOGGER.debug('Forcing data events on')
-        if not self._generator:
-            LOGGER.debug('Issuing Basic.Consume')
-            self._generator = self.basic_consume(self._generator_callback,
-                                                 queue, no_ack, exclusive)
-        while True:
-            if self._generator_messages:
-                yield self._generator_messages.pop(0)
-            self.connection.process_data_events()
-
-    def get_waiting_message_count(self):
-        """Returns the amount of messages waiting in the generator messages list.
-
-        :rtype: int
-        """
-        return len(self._generator_messages)
+        # Unroutable messages returned after this point will be in the context
+        # of publisher acknowledgments
+        self._raiseAndClearIfReturnedMessagesPending()
 
     def force_data_events(self, enable):
         """Turn on and off forcing the blocking adapter to stop and look to see
@@ -744,6 +1254,9 @@ class BlockingChannel(channel.Channel):
         the BlockingChannel will check for a read after every RPC command which
         can cause performance to degrade in scenarios where you do not care if
         RabbitMQ is trying to send RPC commands to your client connection.
+
+        NOTE: This is a NO-OP here, since we're fixing the performance issue;
+        provided for API compatibility with BlockingChannel
 
         Examples of RPC commands of this sort are:
 
@@ -767,13 +1280,12 @@ class BlockingChannel(channel.Channel):
         :param bool enable: Set to False to disable
 
         """
-        self._force_data_events_override = enable
+        # This is a NO-OP here, since we're fixing the performance issue
+        LOGGER.warn("%s.force_data_events() is a NO-OP",
+                    self.__class__.__name__)
+        pass
 
-    def exchange_bind(self,
-                      destination=None,
-                      source=None,
-                      routing_key='',
-                      nowait=False,
+    def exchange_bind(self, destination=None, source=None, routing_key='',
                       arguments=None):
         """Bind an exchange to another exchange.
 
@@ -783,25 +1295,24 @@ class BlockingChannel(channel.Channel):
         :type source: str or unicode
         :param routing_key: The routing key to bind on
         :type routing_key: str or unicode
-        :param bool nowait: Do not wait for an Exchange.BindOk
         :param dict arguments: Custom key/value pair arguments for the binding
 
         """
-        replies = [spec.Exchange.BindOk] if nowait is False else []
-        return self._rpc(spec.Exchange.Bind(0, destination, source, routing_key,
-                                            nowait, arguments or dict()), None,
-                         replies)
+        with _CallbackResult() as bind_ok_result:
+            self._impl.exchange_bind(
+                callback=bind_ok_result.signal_once,
+                destination=destination,
+                source=source,
+                routing_key=routing_key,
+                nowait=False,
+                arguments=arguments)
 
-    def exchange_declare(self,
-                         exchange=None,
-                         exchange_type='direct',
-                         passive=False,
-                         durable=False,
-                         auto_delete=False,
-                         internal=False,
-                         nowait=False,
-                         arguments=None,
-                         type=None):
+            self._flush_output(bind_ok_result.is_ready)
+
+    def exchange_declare(self, exchange=None,
+                         exchange_type='direct', passive=False, durable=False,
+                         auto_delete=False, internal=False,
+                         arguments=None, **kwargs):
         """This method creates an exchange if it does not already exist, and if
         the exchange exists, verifies that it is of the correct and expected
         class.
@@ -820,41 +1331,45 @@ class BlockingChannel(channel.Channel):
         :param bool durable: Survive a reboot of RabbitMQ
         :param bool auto_delete: Remove when no more queues are bound to it
         :param bool internal: Can only be published to by other exchanges
-        :param bool nowait: Do not expect an Exchange.DeclareOk response
         :param dict arguments: Custom key/value pair arguments for the exchange
-        :param str type: The deprecated exchange type parameter
+        :param str type: via kwargs: the deprecated exchange type parameter
 
         """
-        if type is not None:
-            warnings.warn('type is deprecated, use exchange_type instead',
-                          DeprecationWarning)
-            if exchange_type == 'direct' and type != exchange_type:
-                exchange_type = type
-        replies = [spec.Exchange.DeclareOk] if nowait is False else []
-        return self._rpc(spec.Exchange.Declare(0, exchange, exchange_type,
-                                               passive, durable, auto_delete,
-                                               internal, nowait,
-                                               arguments or dict()), None,
-                         replies)
+        assert len(kwargs) <= 1, kwargs
 
-    def exchange_delete(self, exchange=None, if_unused=False, nowait=False):
+        with _CallbackResult() as declare_ok_result:
+            self._impl.exchange_declare(
+                callback=declare_ok_result.signal_once,
+                exchange=exchange,
+                exchange_type=exchange_type,
+                passive=passive,
+                durable=durable,
+                auto_delete=auto_delete,
+                internal=internal,
+                nowait=False,
+                arguments=arguments,
+                type=kwargs["type"] if kwargs else None)
+
+            self._flush_output(declare_ok_result.is_ready)
+
+    def exchange_delete(self, exchange=None, if_unused=False):
         """Delete the exchange.
 
         :param exchange: The exchange name
         :type exchange: str or unicode
         :param bool if_unused: only delete if the exchange is unused
-        :param bool nowait: Do not wait for an Exchange.DeleteOk
 
         """
-        replies = [spec.Exchange.DeleteOk] if nowait is False else []
-        return self._rpc(spec.Exchange.Delete(0, exchange, if_unused, nowait),
-                         None, replies)
+        with _CallbackResult() as delete_ok_result:
+            self._impl.exchange_delete(
+                callback=delete_ok_result.signal_once,
+                exchange=exchange,
+                if_unused=if_unused,
+                nowait=False)
 
-    def exchange_unbind(self,
-                        destination=None,
-                        source=None,
-                        routing_key='',
-                        nowait=False,
+            self._flush_output(delete_ok_result.is_ready)
+
+    def exchange_unbind(self, destination=None, source=None, routing_key='',
                         arguments=None):
         """Unbind an exchange from another exchange.
 
@@ -864,24 +1379,21 @@ class BlockingChannel(channel.Channel):
         :type source: str or unicode
         :param routing_key: The routing key to unbind
         :type routing_key: str or unicode
-        :param bool nowait: Do not wait for an Exchange.UnbindOk
         :param dict arguments: Custom key/value pair arguments for the binding
 
         """
-        replies = [spec.Exchange.UnbindOk] if nowait is False else []
-        return self._rpc(spec.Exchange.Unbind(0, destination, source,
-                                              routing_key, nowait, arguments),
-                         None, replies)
+        with _CallbackResult() as unbind_ok_result:
+            self._impl.exchange_unbind(
+                callback=unbind_ok_result.signal_once,
+                destination=destination,
+                source=source,
+                routing_key=routing_key,
+                nowait=False,
+                arguments=arguments)
 
-    def open(self):
-        """Open the channel"""
-        self._set_state(self.OPENING)
-        self._add_callbacks()
-        self._rpc(spec.Channel.Open(), self._on_openok, [spec.Channel.OpenOk])
+            self._flush_output(unbind_ok_result.is_ready)
 
-    def queue_bind(self, queue, exchange,
-                   routing_key=None,
-                   nowait=False,
+    def queue_bind(self, queue, exchange, routing_key=None,
                    arguments=None):
         """Bind the queue to the specified exchange
 
@@ -891,24 +1403,21 @@ class BlockingChannel(channel.Channel):
         :type exchange: str or unicode
         :param routing_key: The routing key to bind on
         :type routing_key: str or unicode
-        :param bool nowait: Do not wait for a Queue.BindOk
         :param dict arguments: Custom key/value pair arguments for the binding
 
         """
-        replies = [spec.Queue.BindOk] if nowait is False else []
-        if routing_key is None:
-            routing_key = queue
-        return self._rpc(spec.Queue.Bind(0, queue, exchange, routing_key,
-                                         nowait, arguments or dict()), None,
-                         replies)
+        with _CallbackResult() as bind_ok_result:
+            self._impl.queue_bind(callback=bind_ok_result.signal_once,
+                                  queue=queue,
+                                  exchange=exchange,
+                                  routing_key=routing_key,
+                                  nowait=False,
+                                  arguments=arguments)
 
-    def queue_declare(self,
-                      queue='',
-                      passive=False,
-                      durable=False,
-                      exclusive=False,
-                      auto_delete=False,
-                      nowait=False,
+            self._flush_output(bind_ok_result.is_ready)
+
+    def queue_declare(self, queue='', passive=False, durable=False,
+                      exclusive=False, auto_delete=False,
                       arguments=None):
         """Declare queue, create if needed. This method creates or checks a
         queue. When creating a new queue the client can specify various
@@ -923,50 +1432,55 @@ class BlockingChannel(channel.Channel):
         :param bool durable: Survive reboots of the broker
         :param bool exclusive: Only allow access by the current connection
         :param bool auto_delete: Delete after consumer cancels or disconnects
-        :param bool nowait: Do not wait for a Queue.DeclareOk
         :param dict arguments: Custom key/value arguments for the queue
 
         """
-        condition = (spec.Queue.DeclareOk,
-                     {'queue': queue}) if queue else spec.Queue.DeclareOk
-        replies = [condition] if nowait is False else []
-        return self._rpc(spec.Queue.Declare(0, queue, passive, durable,
-                                            exclusive, auto_delete, nowait,
-                                            arguments or dict()), None, replies)
+        with _CallbackResult() as declare_ok_result:
+            self._impl.queue_declare(
+                callback=declare_ok_result.signal_once,
+                queue=queue,
+                passive=passive,
+                durable=durable,
+                exclusive=exclusive,
+                auto_delete=auto_delete,
+                nowait=False,
+                arguments=arguments)
 
-    def queue_delete(self,
-                     queue='',
-                     if_unused=False,
-                     if_empty=False,
-                     nowait=False):
+            self._flush_output(declare_ok_result.is_ready)
+
+    def queue_delete(self, queue='', if_unused=False, if_empty=False):
         """Delete a queue from the broker.
 
         :param queue: The queue to delete
         :type queue: str or unicode
         :param bool if_unused: only delete if it's unused
         :param bool if_empty: only delete if the queue is empty
-        :param bool nowait: Do not wait for a Queue.DeleteOk
 
         """
-        replies = [spec.Queue.DeleteOk] if nowait is False else []
-        return self._rpc(spec.Queue.Delete(0, queue, if_unused, if_empty,
-                                           nowait), None, replies)
+        with _CallbackResult() as delete_ok_result:
+            self._impl.queue_delete(callback=delete_ok_result.signal_once,
+                                    queue=queue,
+                                    if_unused=if_unused,
+                                    if_empty=if_empty,
+                                    nowait=False)
 
-    def queue_purge(self, queue='', nowait=False):
+            self._flush_output(delete_ok_result.is_ready)
+
+    def queue_purge(self, queue=''):
         """Purge all of the messages from the specified queue
 
         :param queue: The queue to purge
         :type  queue: str or unicode
-        :param bool nowait: Do not expect a Queue.PurgeOk response
 
         """
-        replies = [spec.Queue.PurgeOk] if nowait is False else []
-        return self._rpc(spec.Queue.Purge(0, queue, nowait), None, replies)
+        with _CallbackResult() as purge_ok_result:
+            self._impl.queue_purge(callback=purge_ok_result.signal_once,
+                                   queue=queue,
+                                   nowait=False)
 
-    def queue_unbind(self,
-                     queue='',
-                     exchange=None,
-                     routing_key=None,
+            self._flush_output(purge_ok_result.is_ready)
+
+    def queue_unbind(self, queue='', exchange=None, routing_key=None,
                      arguments=None):
         """Unbind a queue from an exchange.
 
@@ -979,36 +1493,13 @@ class BlockingChannel(channel.Channel):
         :param dict arguments: Custom key/value pair arguments for the binding
 
         """
-        if routing_key is None:
-            routing_key = queue
-        return self._rpc(spec.Queue.Unbind(0, queue, exchange, routing_key,
-                                           arguments or dict()), None,
-                         [spec.Queue.UnbindOk])
-
-    def start_consuming(self):
-        """Starts consuming from registered callbacks."""
-        while len(self._consumers):
-            self.connection.process_data_events()
-
-    def stop_consuming(self, consumer_tag=None):
-        """Sends off the Basic.Cancel to let RabbitMQ know to stop consuming and
-        sets our internal state to exit out of the basic_consume.
-
-        """
-        if consumer_tag:
-            self.basic_cancel(consumer_tag)
-        else:
-            for consumer_tag in dictkeys(self._consumers):
-                self.basic_cancel(consumer_tag)
-        self.wait = True
-
-    def tx_commit(self):
-        """Commit a transaction."""
-        return self._rpc(spec.Tx.Commit(), None, [spec.Tx.CommitOk])
-
-    def tx_rollback(self):
-        """Rollback a transaction."""
-        return self._rpc(spec.Tx.Rollback(), None, [spec.Tx.RollbackOk])
+        with _CallbackResult() as unbind_ok_result:
+            self._impl.queue_unbind(callback=unbind_ok_result.signal_once,
+                                    queue=queue,
+                                    exchange=exchange,
+                                    routing_key=routing_key,
+                                    arguments=arguments)
+            self._flush_output(unbind_ok_result.is_ready)
 
     def tx_select(self):
         """Select standard transaction mode. This method sets the channel to use
@@ -1016,217 +1507,18 @@ class BlockingChannel(channel.Channel):
         a channel before using the Commit or Rollback methods.
 
         """
-        return self._rpc(spec.Tx.Select(), None, [spec.Tx.SelectOk])
+        with _CallbackResult() as select_ok_result:
+            self._impl.tx_select(select_ok_result.signal_once)
+            self._flush_output(select_ok_result.is_ready)
 
-    # Internal methods
+    def tx_commit(self):
+        """Commit a transaction."""
+        with _CallbackResult() as commit_ok_result:
+            self._impl.tx_commit(commit_ok_result.signal_once)
+            self._flush_output(commit_ok_result.is_ready)
 
-    def _add_reply(self, reply):
-        reply = callback_manager.name_or_value(reply)
-        self._replies.append(reply)
-
-    def _add_callbacks(self):
-        """Add callbacks for when the channel opens and closes."""
-        self.connection.callbacks.add(self.channel_number, spec.Channel.Close,
-                                      self._on_close)
-        self.callbacks.add(self.channel_number, spec.Basic.GetEmpty,
-                           self._on_getempty, False)
-        self.callbacks.add(self.channel_number, spec.Basic.Cancel,
-                           self._on_cancel, False)
-        self.connection.callbacks.add(self.channel_number, spec.Channel.CloseOk,
-                                      self._on_rpc_complete)
-
-    def _generator_callback(self, unused, method, properties, body):
-        """Called when a message is received from RabbitMQ and appended to the
-        list of messages to be returned when a message is received by RabbitMQ.
-
-        :param pika.spec.Basic.Deliver: The method frame received
-        :param pika.spec.BasicProperties: The  message properties
-        :param body: The body received
-        :type body: str or unicode
-
-        """
-        self._generator_messages.append((method, properties, body))
-        LOGGER.debug('%i pending messages', len(self._generator_messages))
-
-    def _on_cancel(self, method_frame):
-        """Raises a ConsumerCanceled exception after processing the frame
-
-
-        :param pika.frame.Method method_frame: The method frame received
-
-        """
-        super(BlockingChannel, self)._on_cancel(method_frame)
-        raise exceptions.ConsumerCancelled(method_frame.method)
-
-    def _on_getok(self, method_frame, header_frame, body):
-        """Called in reply to a Basic.Get when there is a message.
-
-        :param pika.frame.Method method_frame: The method frame received
-        :param pika.frame.Header header_frame: The header frame received
-        :param body: The body received
-        :type body: str or unicode
-
-        """
-        self._received_response = True
-        self._response = method_frame.method, header_frame.properties, body
-
-    def _on_getempty(self, frame_value):
-        self._received_response = True
-        self._response = frame_value.method, None, None
-
-    def _on_close(self, method_frame):
-        LOGGER.warning('Received Channel.Close, closing: %r', method_frame)
-        if not self.connection.is_closed:
-            self._send_method(spec.Channel.CloseOk(), None, False)
-        self._set_state(self.CLOSED)
-        self._cleanup()
-        self._generator_messages = list()
-        self._generator = None
-        if method_frame is None:
-            raise exceptions.ChannelClosed(0, 'Not specified')
-        else:
-            raise exceptions.ChannelClosed(method_frame.method.reply_code,
-                                           method_frame.method.reply_text)
-
-    def _on_openok(self, method_frame):
-        """Open the channel by sending the RPC command and remove the reply
-        from the stack of replies.
-
-        """
-        super(BlockingChannel, self)._on_openok(method_frame)
-        self._remove_reply(method_frame)
-
-    def _on_return(self, method_frame, header_frame, body):
-        """Called when a Basic.Return is received from publishing
-
-        :param pika.frame.Method method_frame: The method frame received
-        :param pika.frame.Header header_frame: The header frame received
-        :param body: The body received
-        :type body: str or unicode
-
-        """
-        self._received_response = True
-        self._response = method_frame.method, header_frame.properties, body
-
-    def _on_rpc_complete(self, frame_value):
-        key = callback_manager.name_or_value(frame_value)
-        self._replies.append(key)
-        self._frames[key] = frame_value
-        self._received_response = True
-
-    def _process_replies(self, replies, callback):
-        """Process replies from RabbitMQ, looking in the stack of callback
-        replies for a match. Will optionally call callback prior to
-        returning the frame_value.
-
-        :param list replies: The reply handles to iterate
-        :param method callback: The method to optionally call
-        :rtype: pika.frame.Frame
-
-        """
-        for reply in self._replies:
-            if reply in replies:
-                frame_value = self._frames[reply]
-                self._received_response = True
-                if callback:
-                    callback(frame_value)
-                del (self._frames[reply])
-                return frame_value
-
-    def _remove_reply(self, frame_value):
-        key = callback_manager.name_or_value(frame_value)
-        if key in self._replies:
-            self._replies.remove(key)
-
-    def _rpc(self, method_frame,
-             callback=None,
-             acceptable_replies=None,
-             content=None,
-             force_data_events=True):
-        """Make an RPC call for the given callback, channel number and method.
-        acceptable_replies lists out what responses we'll process from the
-        server with the specified callback.
-
-        :param pika.amqp_object.Method method_frame: The method frame to call
-        :param method callback: The callback for the RPC response
-        :param list acceptable_replies: The replies this RPC call expects
-        :param tuple content: Properties and Body for content frames
-        :param bool force_data_events: Call process data events before reply
-        :rtype: pika.frame.Method
-
-        """
-        if self.is_closed:
-            raise exceptions.ChannelClosed
-        self._validate_acceptable_replies(acceptable_replies)
-        self._validate_callback(callback)
-        replies = list()
-        for reply in acceptable_replies or list():
-            if isinstance(reply, tuple):
-                reply, arguments = reply
-            else:
-                arguments = None
-            prefix, key = self.callbacks.add(self.channel_number, reply,
-                                             self._on_rpc_complete,
-                                             arguments=arguments)
-            replies.append(key)
-        self._send_method(method_frame, content,
-                          self._wait_on_response(method_frame))
-        if force_data_events and self._force_data_events_override is not False:
-            self.connection.process_data_events()
-        return self._process_replies(replies, callback)
-
-    def _send_method(self, method_frame, content=None, wait=False):
-        """Shortcut wrapper to send a method through our connection, passing in
-        our channel number.
-
-        :param pika.amqp_object.Method method_frame: The method frame to send
-        :param content: The content to send
-        :type content: tuple
-        :param bool wait: Wait for a response
-
-        """
-        self.wait = wait
-        prev_received_response = self._received_response
-        self._received_response = False
-        self.connection.send_method(self.channel_number, method_frame, content)
-        while wait and not self._received_response:
-            try:
-                self.connection.process_data_events()
-            except exceptions.ConnectionClosed:
-                # No further I/O is possible, so propagate exception
-                raise
-            except exceptions.AMQPConnectionError:
-                break
-        self._received_response = prev_received_response
-
-    @staticmethod
-    def _validate_acceptable_replies(acceptable_replies):
-        """Validate the list of acceptable replies
-
-        :param acceptable_replies:
-        :raises: TypeError
-
-        """
-        if acceptable_replies and not isinstance(acceptable_replies, list):
-            raise TypeError("acceptable_replies should be list or None, is %s",
-                            type(acceptable_replies))
-
-    @staticmethod
-    def _validate_callback(callback):
-        """Validate the value passed in is a method or function.
-
-        :param method callback: The method to validate
-        :raises: TypeError
-
-        """
-        if callback is not None and not utils.is_callable(callback):
-            raise TypeError("Callback should be a function or method, is %s",
-                            type(callback))
-
-    def _wait_on_response(self, method_frame):
-        """Returns True if the rpc call should wait on a response.
-
-        :param pika.frame.Method method_frame: The frame to check
-
-        """
-        return method_frame.NAME not in self.NO_RESPONSE_FRAMES
+    def tx_rollback(self):
+        """Rollback a transaction."""
+        with _CallbackResult() as rollback_ok_result:
+            self._impl.tx_rollback(rollback_ok_result.signal_once)
+            self._flush_output(rollback_ok_result.is_ready)


### PR DESCRIPTION
Copied synchronous_connection.py from pika-synchronous branch
Fixed pylint findings
Integrated SynchronousConnection with the new ioloop in SelectConnection
Defined dedicated message classes PolledMessage and ConsumerMessage and moved from BlockingChannel to module-global scope.
Got rid of nowait args from BlockingChannel public API methods
Signal unroutable messages via UnroutableError exception. Signal Nack'ed messages via NackError exception. These expose more information about the failure than legacy basic_publich API.
Removed set_timeout and backpressure callback methods