### PR TITLE
Fixed BlockingConnection test that was failing with ConnectionClosed error

### DIFF
--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -90,7 +90,7 @@ class TestNoAccessToFileDescriptorAfterConnectionClosed(BlockingTestCase):
         # Attempt to operate on the connection once again after ConnectionClosed
         self.assertIsNone(self.connection._read_poller)
         self.assertIsNone(self.connection.socket)
-        with self.assertRaises(AttributeError):
+        with self.assertRaises(pika.exceptions.ConnectionClosed):
             channel = self.connection.channel()
 
 


### PR DESCRIPTION
@gmr, this fixes the BlockingConnection acceptance test TestNoAccessToFileDescriptorAfterConnectionClosed. I think it started failing after a recent change to raise ConnectionError that in the past would have resulted in AttributeError.