### PR TITLE
Added a '_send_frame' based '_send_message' method in twisted_connection.py

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -13,10 +13,13 @@ TwistedChannel class for details.
 
 """
 import functools
+import math
+
 from twisted.internet import defer, error, reactor
 from twisted.python import log
 
 from pika import exceptions
+from pika import frame
 from pika.adapters import base_connection
 
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -426,7 +426,6 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
         self._send_frame(frame.Header(channel_number, length, content[0]))
         
         if content[1]:
-            import math
             chunks = int(math.ceil(float(length) / self._body_max_length))
             for chunk in range(0, chunks):
                 s = chunk * self._body_max_length


### PR DESCRIPTION
Added a '_send_frame' based '_send_message' method to avoid the 'nonetype' error when using 'twisted_connection' to send_message to mq.