### PR TITLE
Allow passing exchange, queue and routing_key as text

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -812,7 +812,7 @@ class Connection(object):
         :rtype: bool
 
         """
-        return self.server_capabilities.get(b'basic.nack', False)
+        return self.server_capabilities.get('basic.nack', False)
 
     @property
     def consumer_cancel_notify(self):
@@ -822,7 +822,7 @@ class Connection(object):
         :rtype: bool
 
         """
-        return self.server_capabilities.get(b'consumer_cancel_notify', False)
+        return self.server_capabilities.get('consumer_cancel_notify', False)
 
     @property
     def exchange_exchange_bindings(self):
@@ -832,7 +832,7 @@ class Connection(object):
         :rtype: bool
 
         """
-        return self.server_capabilities.get(b'exchange_exchange_bindings', False)
+        return self.server_capabilities.get('exchange_exchange_bindings', False)
 
     @property
     def publisher_confirms(self):
@@ -841,7 +841,7 @@ class Connection(object):
         :rtype: bool
 
         """
-        return self.server_capabilities.get(b'publisher_confirms', False)
+        return self.server_capabilities.get('publisher_confirms', False)
 
     #
     # Internal methods for managing the communication process
@@ -1616,7 +1616,7 @@ class Connection(object):
 
         """
         self.server_properties = method_frame.method.server_properties
-        self.server_capabilities = self.server_properties.get(b'capabilities',
+        self.server_capabilities = self.server_properties.get('capabilities',
                                                               dict())
         if hasattr(self.server_properties, 'capabilities'):
             del self.server_properties['capabilities']

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -224,3 +224,10 @@ class RecursionError(Exception):
     Used by BlockingConnection/BlockingChannel
 
     """
+
+
+class ShortStringTooLong(AMQPError):
+
+    def __repr__(self):
+        return ('AMQP Short String can contain up to 255 bytes: '
+                '%.300s' % self.args[0])

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -126,14 +126,7 @@ class Connection(amqp_object.Class):
 
         def decode(self, encoded, offset=0):
             (self.client_properties, offset) = data.decode_table(encoded, offset)
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.mechanism = encoded[offset:offset + length]
-            try:
-                self.mechanism = str(self.mechanism)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.mechanism, offset = data.decode_short_string(encoded, offset)
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.response = encoded[offset:offset + length]
@@ -142,14 +135,7 @@ class Connection(amqp_object.Class):
             except UnicodeEncodeError:
                 pass
             offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.locale = encoded[offset:offset + length]
-            try:
-                self.locale = str(self.locale)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.locale, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
@@ -157,9 +143,7 @@ class Connection(amqp_object.Class):
             data.encode_table(pieces, self.client_properties)
             assert isinstance(self.mechanism, str_or_bytes),\
                    'A non-string value was supplied for self.mechanism'
-            value = self.mechanism.encode('utf-8') if isinstance(self.mechanism, unicode_type) else self.mechanism
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.mechanism)
             assert isinstance(self.response, str_or_bytes),\
                    'A non-string value was supplied for self.response'
             value = self.response.encode('utf-8') if isinstance(self.response, unicode_type) else self.response
@@ -167,9 +151,7 @@ class Connection(amqp_object.Class):
             pieces.append(value)
             assert isinstance(self.locale, str_or_bytes),\
                    'A non-string value was supplied for self.locale'
-            value = self.locale.encode('utf-8') if isinstance(self.locale, unicode_type) else self.locale
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.locale)
             return pieces
 
     class Secure(amqp_object.Method):
@@ -311,22 +293,8 @@ class Connection(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.virtual_host = encoded[offset:offset + length]
-            try:
-                self.virtual_host = str(self.virtual_host)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.capabilities = encoded[offset:offset + length]
-            try:
-                self.capabilities = str(self.capabilities)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.virtual_host, offset = data.decode_short_string(encoded, offset)
+            self.capabilities, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.insist = (bit_buffer & (1 << 0)) != 0
@@ -336,14 +304,10 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.virtual_host, str_or_bytes),\
                    'A non-string value was supplied for self.virtual_host'
-            value = self.virtual_host.encode('utf-8') if isinstance(self.virtual_host, unicode_type) else self.virtual_host
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.virtual_host)
             assert isinstance(self.capabilities, str_or_bytes),\
                    'A non-string value was supplied for self.capabilities'
-            value = self.capabilities.encode('utf-8') if isinstance(self.capabilities, unicode_type) else self.capabilities
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.capabilities)
             bit_buffer = 0
             if self.insist:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -363,23 +327,14 @@ class Connection(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.known_hosts = encoded[offset:offset + length]
-            try:
-                self.known_hosts = str(self.known_hosts)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.known_hosts, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.known_hosts, str_or_bytes),\
                    'A non-string value was supplied for self.known_hosts'
-            value = self.known_hosts.encode('utf-8') if isinstance(self.known_hosts, unicode_type) else self.known_hosts
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.known_hosts)
             return pieces
 
     class Close(amqp_object.Method):
@@ -400,14 +355,7 @@ class Connection(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.reply_text = encoded[offset:offset + length]
-            try:
-                self.reply_text = str(self.reply_text)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.reply_text, offset = data.decode_short_string(encoded, offset)
             self.class_id = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.method_id = struct.unpack_from('>H', encoded, offset)[0]
@@ -419,9 +367,7 @@ class Connection(amqp_object.Class):
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, str_or_bytes),\
                    'A non-string value was supplied for self.reply_text'
-            value = self.reply_text.encode('utf-8') if isinstance(self.reply_text, unicode_type) else self.reply_text
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.reply_text)
             pieces.append(struct.pack('>H', self.class_id))
             pieces.append(struct.pack('>H', self.method_id))
             return pieces
@@ -458,23 +404,14 @@ class Connection(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.reason = encoded[offset:offset + length]
-            try:
-                self.reason = str(self.reason)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.reason, str_or_bytes),\
                    'A non-string value was supplied for self.reason'
-            value = self.reason.encode('utf-8') if isinstance(self.reason, unicode_type) else self.reason
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.reason)
             return pieces
 
     class Unblocked(amqp_object.Method):
@@ -515,23 +452,14 @@ class Channel(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.out_of_band = encoded[offset:offset + length]
-            try:
-                self.out_of_band = str(self.out_of_band)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.out_of_band, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.out_of_band, str_or_bytes),\
                    'A non-string value was supplied for self.out_of_band'
-            value = self.out_of_band.encode('utf-8') if isinstance(self.out_of_band, unicode_type) else self.out_of_band
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.out_of_band)
             return pieces
 
     class OpenOk(amqp_object.Method):
@@ -636,14 +564,7 @@ class Channel(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.reply_text = encoded[offset:offset + length]
-            try:
-                self.reply_text = str(self.reply_text)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.reply_text, offset = data.decode_short_string(encoded, offset)
             self.class_id = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.method_id = struct.unpack_from('>H', encoded, offset)[0]
@@ -655,9 +576,7 @@ class Channel(amqp_object.Class):
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, str_or_bytes),\
                    'A non-string value was supplied for self.reply_text'
-            value = self.reply_text.encode('utf-8') if isinstance(self.reply_text, unicode_type) else self.reply_text
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.reply_text)
             pieces.append(struct.pack('>H', self.class_id))
             pieces.append(struct.pack('>H', self.method_id))
             return pieces
@@ -705,14 +624,7 @@ class Access(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.realm = encoded[offset:offset + length]
-            try:
-                self.realm = str(self.realm)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.realm, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.exclusive = (bit_buffer & (1 << 0)) != 0
@@ -726,9 +638,7 @@ class Access(amqp_object.Class):
             pieces = list()
             assert isinstance(self.realm, str_or_bytes),\
                    'A non-string value was supplied for self.realm'
-            value = self.realm.encode('utf-8') if isinstance(self.realm, unicode_type) else self.realm
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.realm)
             bit_buffer = 0
             if self.exclusive:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -794,22 +704,8 @@ class Exchange(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.type = encoded[offset:offset + length]
-            try:
-                self.type = str(self.type)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.type, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.passive = (bit_buffer & (1 << 0)) != 0
@@ -825,14 +721,10 @@ class Exchange(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.type, str_or_bytes),\
                    'A non-string value was supplied for self.type'
-            value = self.type.encode('utf-8') if isinstance(self.type, unicode_type) else self.type
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.type)
             bit_buffer = 0
             if self.passive:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -885,14 +777,7 @@ class Exchange(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.exchange, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.if_unused = (bit_buffer & (1 << 0)) != 0
@@ -904,9 +789,7 @@ class Exchange(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             bit_buffer = 0
             if self.if_unused:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -954,30 +837,9 @@ class Exchange(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.destination = encoded[offset:offset + length]
-            try:
-                self.destination = str(self.destination)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.source = encoded[offset:offset + length]
-            try:
-                self.source = str(self.source)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.destination, offset = data.decode_short_string(encoded, offset)
+            self.source, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -989,19 +851,13 @@ class Exchange(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, str_or_bytes),\
                    'A non-string value was supplied for self.destination'
-            value = self.destination.encode('utf-8') if isinstance(self.destination, unicode_type) else self.destination
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.destination)
             assert isinstance(self.source, str_or_bytes),\
                    'A non-string value was supplied for self.source'
-            value = self.source.encode('utf-8') if isinstance(self.source, unicode_type) else self.source
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.source)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             bit_buffer = 0
             if self.nowait:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1048,30 +904,9 @@ class Exchange(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.destination = encoded[offset:offset + length]
-            try:
-                self.destination = str(self.destination)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.source = encoded[offset:offset + length]
-            try:
-                self.source = str(self.source)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.destination, offset = data.decode_short_string(encoded, offset)
+            self.source, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -1083,19 +918,13 @@ class Exchange(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, str_or_bytes),\
                    'A non-string value was supplied for self.destination'
-            value = self.destination.encode('utf-8') if isinstance(self.destination, unicode_type) else self.destination
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.destination)
             assert isinstance(self.source, str_or_bytes),\
                    'A non-string value was supplied for self.source'
-            value = self.source.encode('utf-8') if isinstance(self.source, unicode_type) else self.source
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.source)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             bit_buffer = 0
             if self.nowait:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1150,14 +979,7 @@ class Queue(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.passive = (bit_buffer & (1 << 0)) != 0
@@ -1173,9 +995,7 @@ class Queue(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             bit_buffer = 0
             if self.passive:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1206,14 +1026,7 @@ class Queue(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.consumer_count = struct.unpack_from('>I', encoded, offset)[0]
@@ -1224,9 +1037,7 @@ class Queue(amqp_object.Class):
             pieces = list()
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             pieces.append(struct.pack('>I', self.message_count))
             pieces.append(struct.pack('>I', self.consumer_count))
             return pieces
@@ -1251,30 +1062,9 @@ class Queue(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -1286,19 +1076,13 @@ class Queue(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             bit_buffer = 0
             if self.nowait:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1342,14 +1126,7 @@ class Queue(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -1360,9 +1137,7 @@ class Queue(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             bit_buffer = 0
             if self.nowait:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1410,14 +1185,7 @@ class Queue(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.if_unused = (bit_buffer & (1 << 0)) != 0
@@ -1430,9 +1198,7 @@ class Queue(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             bit_buffer = 0
             if self.if_unused:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1484,30 +1250,9 @@ class Queue(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
@@ -1516,19 +1261,13 @@ class Queue(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -1632,22 +1371,8 @@ class Basic(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.consumer_tag = encoded[offset:offset + length]
-            try:
-                self.consumer_tag = str(self.consumer_tag)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.no_local = (bit_buffer & (1 << 0)) != 0
@@ -1662,14 +1387,10 @@ class Basic(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             assert isinstance(self.consumer_tag, str_or_bytes),\
                    'A non-string value was supplied for self.consumer_tag'
-            value = self.consumer_tag.encode('utf-8') if isinstance(self.consumer_tag, unicode_type) else self.consumer_tag
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.consumer_tag)
             bit_buffer = 0
             if self.no_local:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1696,23 +1417,14 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.consumer_tag = encoded[offset:offset + length]
-            try:
-                self.consumer_tag = str(self.consumer_tag)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, str_or_bytes),\
                    'A non-string value was supplied for self.consumer_tag'
-            value = self.consumer_tag.encode('utf-8') if isinstance(self.consumer_tag, unicode_type) else self.consumer_tag
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.consumer_tag)
             return pieces
 
     class Cancel(amqp_object.Method):
@@ -1729,14 +1441,7 @@ class Basic(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.consumer_tag = encoded[offset:offset + length]
-            try:
-                self.consumer_tag = str(self.consumer_tag)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -1746,9 +1451,7 @@ class Basic(amqp_object.Class):
             pieces = list()
             assert isinstance(self.consumer_tag, str_or_bytes),\
                    'A non-string value was supplied for self.consumer_tag'
-            value = self.consumer_tag.encode('utf-8') if isinstance(self.consumer_tag, unicode_type) else self.consumer_tag
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.consumer_tag)
             bit_buffer = 0
             if self.nowait:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1768,23 +1471,14 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.consumer_tag = encoded[offset:offset + length]
-            try:
-                self.consumer_tag = str(self.consumer_tag)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, str_or_bytes),\
                    'A non-string value was supplied for self.consumer_tag'
-            value = self.consumer_tag.encode('utf-8') if isinstance(self.consumer_tag, unicode_type) else self.consumer_tag
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.consumer_tag)
             return pieces
 
     class Publish(amqp_object.Method):
@@ -1806,22 +1500,8 @@ class Basic(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.mandatory = (bit_buffer & (1 << 0)) != 0
@@ -1833,14 +1513,10 @@ class Basic(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             bit_buffer = 0
             if self.mandatory:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -1867,30 +1543,9 @@ class Basic(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.reply_text = encoded[offset:offset + length]
-            try:
-                self.reply_text = str(self.reply_text)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.reply_text, offset = data.decode_short_string(encoded, offset)
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
@@ -1898,19 +1553,13 @@ class Basic(amqp_object.Class):
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, str_or_bytes),\
                    'A non-string value was supplied for self.reply_text'
-            value = self.reply_text.encode('utf-8') if isinstance(self.reply_text, unicode_type) else self.reply_text
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.reply_text)
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             return pieces
 
     class Deliver(amqp_object.Method):
@@ -1930,44 +1579,21 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.consumer_tag = encoded[offset:offset + length]
-            try:
-                self.consumer_tag = str(self.consumer_tag)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.redelivered = (bit_buffer & (1 << 0)) != 0
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, str_or_bytes),\
                    'A non-string value was supplied for self.consumer_tag'
-            value = self.consumer_tag.encode('utf-8') if isinstance(self.consumer_tag, unicode_type) else self.consumer_tag
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.consumer_tag)
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
             if self.redelivered:
@@ -1975,14 +1601,10 @@ class Basic(amqp_object.Class):
             pieces.append(struct.pack('B', bit_buffer))
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             return pieces
 
     class Get(amqp_object.Method):
@@ -2002,14 +1624,7 @@ class Basic(amqp_object.Class):
         def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.queue = encoded[offset:offset + length]
-            try:
-                self.queue = str(self.queue)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.queue, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.no_ack = (bit_buffer & (1 << 0)) != 0
@@ -2020,9 +1635,7 @@ class Basic(amqp_object.Class):
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, str_or_bytes),\
                    'A non-string value was supplied for self.queue'
-            value = self.queue.encode('utf-8') if isinstance(self.queue, unicode_type) else self.queue
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.queue)
             bit_buffer = 0
             if self.no_ack:
                 bit_buffer = bit_buffer | (1 << 0)
@@ -2051,22 +1664,8 @@ class Basic(amqp_object.Class):
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.redelivered = (bit_buffer & (1 << 0)) != 0
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.exchange = encoded[offset:offset + length]
-            try:
-                self.exchange = str(self.exchange)
-            except UnicodeEncodeError:
-                pass
-            offset += length
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.routing_key = encoded[offset:offset + length]
-            try:
-                self.routing_key = str(self.routing_key)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.exchange, offset = data.decode_short_string(encoded, offset)
+            self.routing_key, offset = data.decode_short_string(encoded, offset)
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
@@ -2080,14 +1679,10 @@ class Basic(amqp_object.Class):
             pieces.append(struct.pack('B', bit_buffer))
             assert isinstance(self.exchange, str_or_bytes),\
                    'A non-string value was supplied for self.exchange'
-            value = self.exchange.encode('utf-8') if isinstance(self.exchange, unicode_type) else self.exchange
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, str_or_bytes),\
                    'A non-string value was supplied for self.routing_key'
-            value = self.routing_key.encode('utf-8') if isinstance(self.routing_key, unicode_type) else self.routing_key
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.routing_key)
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
 
@@ -2104,23 +1699,14 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.cluster_id = encoded[offset:offset + length]
-            try:
-                self.cluster_id = str(self.cluster_id)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.cluster_id, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
             pieces = list()
             assert isinstance(self.cluster_id, str_or_bytes),\
                    'A non-string value was supplied for self.cluster_id'
-            value = self.cluster_id.encode('utf-8') if isinstance(self.cluster_id, unicode_type) else self.cluster_id
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.cluster_id)
             return pieces
 
     class Ack(amqp_object.Method):
@@ -2508,25 +2094,11 @@ class BasicProperties(amqp_object.Properties):
                 break
             flagword_index += 1
         if flags & BasicProperties.FLAG_CONTENT_TYPE:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.content_type = encoded[offset:offset + length]
-            try:
-                self.content_type = str(self.content_type)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.content_type, offset = data.decode_short_string(encoded, offset)
         else:
             self.content_type = None
         if flags & BasicProperties.FLAG_CONTENT_ENCODING:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.content_encoding = encoded[offset:offset + length]
-            try:
-                self.content_encoding = str(self.content_encoding)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.content_encoding, offset = data.decode_short_string(encoded, offset)
         else:
             self.content_encoding = None
         if flags & BasicProperties.FLAG_HEADERS:
@@ -2544,47 +2116,19 @@ class BasicProperties(amqp_object.Properties):
         else:
             self.priority = None
         if flags & BasicProperties.FLAG_CORRELATION_ID:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.correlation_id = encoded[offset:offset + length]
-            try:
-                self.correlation_id = str(self.correlation_id)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.correlation_id, offset = data.decode_short_string(encoded, offset)
         else:
             self.correlation_id = None
         if flags & BasicProperties.FLAG_REPLY_TO:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.reply_to = encoded[offset:offset + length]
-            try:
-                self.reply_to = str(self.reply_to)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.reply_to, offset = data.decode_short_string(encoded, offset)
         else:
             self.reply_to = None
         if flags & BasicProperties.FLAG_EXPIRATION:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.expiration = encoded[offset:offset + length]
-            try:
-                self.expiration = str(self.expiration)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.expiration, offset = data.decode_short_string(encoded, offset)
         else:
             self.expiration = None
         if flags & BasicProperties.FLAG_MESSAGE_ID:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.message_id = encoded[offset:offset + length]
-            try:
-                self.message_id = str(self.message_id)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.message_id, offset = data.decode_short_string(encoded, offset)
         else:
             self.message_id = None
         if flags & BasicProperties.FLAG_TIMESTAMP:
@@ -2593,47 +2137,19 @@ class BasicProperties(amqp_object.Properties):
         else:
             self.timestamp = None
         if flags & BasicProperties.FLAG_TYPE:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.type = encoded[offset:offset + length]
-            try:
-                self.type = str(self.type)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.type, offset = data.decode_short_string(encoded, offset)
         else:
             self.type = None
         if flags & BasicProperties.FLAG_USER_ID:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.user_id = encoded[offset:offset + length]
-            try:
-                self.user_id = str(self.user_id)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.user_id, offset = data.decode_short_string(encoded, offset)
         else:
             self.user_id = None
         if flags & BasicProperties.FLAG_APP_ID:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.app_id = encoded[offset:offset + length]
-            try:
-                self.app_id = str(self.app_id)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.app_id, offset = data.decode_short_string(encoded, offset)
         else:
             self.app_id = None
         if flags & BasicProperties.FLAG_CLUSTER_ID:
-            length = struct.unpack_from('B', encoded, offset)[0]
-            offset += 1
-            self.cluster_id = encoded[offset:offset + length]
-            try:
-                self.cluster_id = str(self.cluster_id)
-            except UnicodeEncodeError:
-                pass
-            offset += length
+            self.cluster_id, offset = data.decode_short_string(encoded, offset)
         else:
             self.cluster_id = None
         return self
@@ -2645,16 +2161,12 @@ class BasicProperties(amqp_object.Properties):
             flags = flags | BasicProperties.FLAG_CONTENT_TYPE
             assert isinstance(self.content_type, str_or_bytes),\
                    'A non-string value was supplied for self.content_type'
-            value = self.content_type.encode('utf-8') if isinstance(self.content_type, unicode_type) else self.content_type
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.content_type)
         if self.content_encoding is not None:
             flags = flags | BasicProperties.FLAG_CONTENT_ENCODING
             assert isinstance(self.content_encoding, str_or_bytes),\
                    'A non-string value was supplied for self.content_encoding'
-            value = self.content_encoding.encode('utf-8') if isinstance(self.content_encoding, unicode_type) else self.content_encoding
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.content_encoding)
         if self.headers is not None:
             flags = flags | BasicProperties.FLAG_HEADERS
             data.encode_table(pieces, self.headers)
@@ -2668,30 +2180,22 @@ class BasicProperties(amqp_object.Properties):
             flags = flags | BasicProperties.FLAG_CORRELATION_ID
             assert isinstance(self.correlation_id, str_or_bytes),\
                    'A non-string value was supplied for self.correlation_id'
-            value = self.correlation_id.encode('utf-8') if isinstance(self.correlation_id, unicode_type) else self.correlation_id
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.correlation_id)
         if self.reply_to is not None:
             flags = flags | BasicProperties.FLAG_REPLY_TO
             assert isinstance(self.reply_to, str_or_bytes),\
                    'A non-string value was supplied for self.reply_to'
-            value = self.reply_to.encode('utf-8') if isinstance(self.reply_to, unicode_type) else self.reply_to
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.reply_to)
         if self.expiration is not None:
             flags = flags | BasicProperties.FLAG_EXPIRATION
             assert isinstance(self.expiration, str_or_bytes),\
                    'A non-string value was supplied for self.expiration'
-            value = self.expiration.encode('utf-8') if isinstance(self.expiration, unicode_type) else self.expiration
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.expiration)
         if self.message_id is not None:
             flags = flags | BasicProperties.FLAG_MESSAGE_ID
             assert isinstance(self.message_id, str_or_bytes),\
                    'A non-string value was supplied for self.message_id'
-            value = self.message_id.encode('utf-8') if isinstance(self.message_id, unicode_type) else self.message_id
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.message_id)
         if self.timestamp is not None:
             flags = flags | BasicProperties.FLAG_TIMESTAMP
             pieces.append(struct.pack('>Q', self.timestamp))
@@ -2699,30 +2203,22 @@ class BasicProperties(amqp_object.Properties):
             flags = flags | BasicProperties.FLAG_TYPE
             assert isinstance(self.type, str_or_bytes),\
                    'A non-string value was supplied for self.type'
-            value = self.type.encode('utf-8') if isinstance(self.type, unicode_type) else self.type
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.type)
         if self.user_id is not None:
             flags = flags | BasicProperties.FLAG_USER_ID
             assert isinstance(self.user_id, str_or_bytes),\
                    'A non-string value was supplied for self.user_id'
-            value = self.user_id.encode('utf-8') if isinstance(self.user_id, unicode_type) else self.user_id
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.user_id)
         if self.app_id is not None:
             flags = flags | BasicProperties.FLAG_APP_ID
             assert isinstance(self.app_id, str_or_bytes),\
                    'A non-string value was supplied for self.app_id'
-            value = self.app_id.encode('utf-8') if isinstance(self.app_id, unicode_type) else self.app_id
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.app_id)
         if self.cluster_id is not None:
             flags = flags | BasicProperties.FLAG_CLUSTER_ID
             assert isinstance(self.cluster_id, str_or_bytes),\
                    'A non-string value was supplied for self.cluster_id'
-            value = self.cluster_id.encode('utf-8') if isinstance(self.cluster_id, unicode_type) else self.cluster_id
-            pieces.append(struct.pack('B', len(value)))
-            pieces.append(value)
+            data.encode_short_string(pieces, self.cluster_id)
         flag_pieces = list()
         while True:
             remainder = flags >> 16

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -89,8 +89,8 @@ class BoundQueueTestCase(AsyncTestCase):
 
     def start(self, adapter=None):
         # PY3 compat encoding
-        self.exchange = ('e' + str(id(self))).encode()
-        self.queue = ('q' + str(id(self))).encode()
+        self.exchange = 'e' + str(id(self))
+        self.queue = 'q' + str(id(self))
         self.routing_key = self.__class__.__name__
         super(BoundQueueTestCase, self).start(adapter)
 

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -218,7 +218,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_basic_consume_consumer_tag(self):
         self.obj._set_state(self.obj.OPEN)
-        expectation = b'ctag1.'
+        expectation = 'ctag1.'
         mock_callback = mock.Mock()
         self.assertEqual(
             self.obj.basic_consume(mock_callback, 'test-queue')[:6],
@@ -226,7 +226,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_basic_consume_consumer_tag_cancelled_full(self):
         self.obj._set_state(self.obj.OPEN)
-        expectation = b'ctag1.'
+        expectation = 'ctag1.'
         mock_callback = mock.Mock()
         for ctag in ['ctag1.%i' % ii for ii in range(11)]:
             self.obj._cancelled.add(ctag)

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -328,10 +328,10 @@ class ConnectionTests(unittest.TestCase):
         #This may be incorrectly mocked, or the code is wrong
         #TODO: Code does hasattr check, should this be a has_key/in check?
         method_frame.method.server_properties = {
-            b'capabilities': {
-                b'basic.nack': True,
-                b'consumer_cancel_notify': False,
-                b'exchange_exchange_bindings': False
+            'capabilities': {
+                'basic.nack': True,
+                'consumer_cancel_notify': False,
+                'exchange_exchange_bindings': False
             }
         }
         #This will be called, but shoudl not be implmented here, just mock it

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -39,17 +39,17 @@ class DataTests(unittest.TestCase):
     )
 
     FIELD_TBL_VALUE = OrderedDict([
-        (b'array', [1, 2, 3]),
-        (b'boolval', True),
-        (b'decimal', decimal.Decimal('3.14')),
-        (b'decimal_too', decimal.Decimal('100')),
-        (b'dictval', {b'foo': 'bar'}),
-        (b'intval', 1)	,
-        (b'longval', long(912598613)),
-        (b'null', None),
-        (b'strval', 'Test'),
-        (b'timestampval', datetime.datetime(2006, 11, 21, 16, 30, 10)),
-        (b'unicode', u'utf8=✓')
+        ('array', [1, 2, 3]),
+        ('boolval', True),
+        ('decimal', decimal.Decimal('3.14')),
+        ('decimal_too', decimal.Decimal('100')),
+        ('dictval', {'foo': 'bar'}),
+        ('intval', 1)	,
+        ('longval', long(912598613)),
+        ('null', None),
+        ('strval', 'Test'),
+        ('timestampval', datetime.datetime(2006, 11, 21, 16, 30, 10)),
+        ('unicode', u'utf8=✓')
     ])
 
     def test_encode_table(self):

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -89,16 +89,7 @@ def generate(specPath):
     def genSingleDecode(prefix, cLvalue, unresolved_domain):
         type = spec.resolveDomain(unresolved_domain)
         if type == 'shortstr':
-            print(
-                prefix + "length = struct.unpack_from('B', encoded, offset)[0]")
-            print(prefix + "offset += 1")
-            print(prefix + "%s = encoded[offset:offset + length]" % cLvalue)
-            # What is this trying to do???
-            print(prefix + "try:")
-            print(prefix + "    %s = str(%s)" % (cLvalue, cLvalue))
-            print(prefix + "except UnicodeEncodeError:")
-            print(prefix + "    pass")
-            print(prefix + "offset += length")
+            print(prefix + "%s, offset = data.decode_short_string(encoded, offset)" % cLvalue)
         elif type == 'longstr':
             print(prefix +
                   "length = struct.unpack_from('>I', encoded, offset)[0]")
@@ -143,12 +134,7 @@ def generate(specPath):
             print(prefix + \
                 "assert isinstance(%s, str_or_bytes),\\\n%s       'A non-string value was supplied for %s'" \
                 % (cValue, prefix, cValue))
-            print(
-                prefix +
-                "value = %s.encode('utf-8') if isinstance(%s, unicode_type) else %s"
-                % (cValue, cValue, cValue))
-            print(prefix + "pieces.append(struct.pack('B', len(value)))")
-            print(prefix + "pieces.append(value)")
+            print(prefix + "data.encode_short_string(pieces, %s)" % cValue)
         elif type == 'longstr':
             print(prefix + \
                 "assert isinstance(%s, str_or_bytes),\\\n%s       'A non-string value was supplied for %s'" \


### PR DESCRIPTION
It turned out that ``queue`` argument was the reason why methods like ``queue_declare`` etc. seemed to require ``bytes`` values. This was due to the callback handling that compares frames/methods and stored arguments.

With these changes channel methods accept text (``str``) arguments in python3.

+  No new tests failed, the 5 failures (that Travis doesn't seem to produce) were present in the pika/master.

ping @ztane 
