### PR TITLE
Restored BlockingConnection/BlockingChannel methods that were removed in initial SelectConnection wrapper implementation

### DIFF
--- a/pika/compat.py
+++ b/pika/compat.py
@@ -28,13 +28,23 @@ if not PY2:
         Returns a list of keys of dictionary
 
         dict.keys returns a view that works like .keys in Python 2
-       *except* any modifications in the dictionary will be visible
+        *except* any modifications in the dictionary will be visible
         (and will cause errors if the view is being iterated over while
         it is modified).
         """
 
         return list(dct.keys())
 
+    def dictvalues(dct):
+        """
+        Returns a list of values of a dictionary
+
+        dict.values returns a view that works like .values in Python 2
+        *except* any modifications in the dictionary will be visible
+        (and will cause errors if the view is being iterated over while
+        it is modified).
+        """
+        return list(dct.values())
 
     def byte(*args):
         """
@@ -48,7 +58,7 @@ if not PY2:
 
     class long(int):
         """
-        A marker class that signifies that the integer value should be 
+        A marker class that signifies that the integer value should be
         serialized as `l` instead of `I`
         """
 
@@ -71,6 +81,7 @@ else:
     xrange = xrange
     unicode_type = unicode
     dictkeys = dict.keys
+    dictvalues = dict.values
     byte = chr
     long = long
 

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -73,7 +73,7 @@ class TestExchangeDeclareAndDelete(AsyncTestCase, AsyncAdapters):
 
 
 class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "should close chan: re-declared queue w/ diff params"
+    DESCRIPTION = "should close chan: re-declared exchange w/ diff params"
 
     X_TYPE1 = 'direct'
     X_TYPE2 = 'topic'

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -17,7 +17,6 @@ from pika.adapters import blocking_connection
 import pika.connection
 import pika.exceptions
 
-
 # Disable warning about access to protected member
 # pylint: disable=W0212
 
@@ -48,7 +47,7 @@ def _p3_as_bytes(value):
         return value
 
 
-class BlockingTestCase(unittest.TestCase):
+class BlockingTestCaseBase(unittest.TestCase):
 
     TIMEOUT = DEFAULT_TIMEOUT
 
@@ -73,10 +72,10 @@ class BlockingTestCase(unittest.TestCase):
         self.fail('Test timed out')
 
 
-class TestCreateAndCloseConnection(BlockingTestCase):
+class TestCreateAndCloseConnection(BlockingTestCaseBase):
 
     def test(self):
-        """Create and close connection"""
+        """Create connection, channel, and consumer, then close connection"""
         connection = self._connect()
         self.assertIsInstance(connection, pika.BlockingConnection)
         self.assertTrue(connection.is_open)
@@ -89,7 +88,62 @@ class TestCreateAndCloseConnection(BlockingTestCase):
         self.assertFalse(connection.is_closing)
 
 
-class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCase):
+class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
+    def test(self):
+        """ConnectionClosed raised when creating exchange with invalid type"""
+        # This test exploits behavior specific to RabbitMQ whereby the broker
+        # closes the connection if an attempt is made to declare an exchange
+        # with an invalid exchange type
+        connection = self._connect()
+        ch = connection.channel()
+
+        exg_name = ("TestInvalidExchangeTypeRaisesConnectionClosed_" +
+                    uuid.uuid1().hex)
+
+        with self.assertRaises(pika.exceptions.ConnectionClosed) as ex_cm:
+            # Attempt to create an exchange with invalid exchange type
+            ch.exchange_declare(exg_name, exchange_type='ZZwwInvalid')
+
+        self.assertEqual(ex_cm.exception.args[0], 503)
+
+
+class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
+
+    def test(self):
+        """Create and close connection"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes(
+            'TestCreateAndCloseConnectionWithChannelAndConsumer_q' +
+            uuid.uuid1().hex)
+
+        body1 = _p3_as_bytes('a' * 1024)
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Publish the message to the queue by way of default exchange
+        ch.publish(exchange='', routing_key=q_name, body=body1)
+
+        # Create a non-ackable consumer
+        ch.basic_consume(lambda *x: None, q_name, no_ack=True,
+                         exclusive=False, arguments=None)
+
+        connection.close()
+        self.assertTrue(connection.is_closed)
+        self.assertFalse(connection.is_open)
+        self.assertFalse(connection.is_closing)
+
+        self.assertFalse(connection._impl._channels)
+
+        self.assertFalse(ch._consumer_infos)
+        self.assertFalse(ch._impl._consumers)
+
+
+class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
 
     def test(self):
         """BlockingConnection resets properly on TCP/IP drop during channel()
@@ -109,7 +163,7 @@ class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCase):
         self.assertIsNone(self.connection._impl.socket)
 
 
-class TestNoAccessToFileDescriptorAfterConnectionClosed(BlockingTestCase):
+class TestNoAccessToFileDescriptorAfterConnectionClosed(BlockingTestCaseBase):
 
     def test(self):
         """BlockingConnection no access file descriptor after ConnectionClosed
@@ -134,7 +188,7 @@ class TestNoAccessToFileDescriptorAfterConnectionClosed(BlockingTestCase):
             self.connection.channel()
 
 
-class TestConnectWithDownedBroker(BlockingTestCase):
+class TestConnectWithDownedBroker(BlockingTestCaseBase):
 
     def test(self):
         """ BlockingConnection to downed broker results in AMQPConnectionError
@@ -155,7 +209,7 @@ class TestConnectWithDownedBroker(BlockingTestCase):
                 PARAMS_URL_TEMPLATE % {"port": port})
 
 
-class TestDisconnectDuringConnectionStart(BlockingTestCase):
+class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
 
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_START
@@ -178,7 +232,7 @@ class TestDisconnectDuringConnectionStart(BlockingTestCase):
                 impl_class=MySelectConnection)
 
 
-class TestDisconnectDuringConnectionTune(BlockingTestCase):
+class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
 
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_TUNE
@@ -201,7 +255,7 @@ class TestDisconnectDuringConnectionTune(BlockingTestCase):
                 impl_class=MySelectConnection)
 
 
-class TestDisconnectDuringConnectionProtocol(BlockingTestCase):
+class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
 
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_PROTOCOL
@@ -223,7 +277,7 @@ class TestDisconnectDuringConnectionProtocol(BlockingTestCase):
                           impl_class=MySelectConnection)
 
 
-class TestProcessDataEvents(BlockingTestCase):
+class TestProcessDataEvents(BlockingTestCaseBase):
 
     def test(self):
         """BlockingConnection.process_data_events"""
@@ -243,7 +297,64 @@ class TestProcessDataEvents(BlockingTestCase):
         self.assertLess(elapsed, 0.25)
 
 
-class TestSleep(BlockingTestCase):
+class TestAddTimeoutRemoveTimeout(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingConnection.add_timeout and remove_timeout"""
+        connection = self._connect()
+
+        # Test timer completion
+        start_time = time.time()
+        rx_callback = []
+        timer_id = connection.add_timeout(
+            0.005,
+            lambda: rx_callback.append(time.time()))
+        while not rx_callback:
+            connection.process_data_events(time_limit=None)
+
+        self.assertEqual(len(rx_callback), 1)
+        elapsed = time.time() - start_time
+        self.assertLess(elapsed, 0.25)
+
+        # Test removing triggered timeout
+        connection.remove_timeout(timer_id)
+
+
+        # Test aborted timer
+        rx_callback = []
+        timer_id = connection.add_timeout(
+            0.001,
+            lambda: rx_callback.append(time.time()))
+        connection.remove_timeout(timer_id)
+        connection.process_data_events(time_limit=0.1)
+        self.assertFalse(rx_callback)
+
+
+class TestRemoveTimeoutFromTimeoutCallback(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingConnection.remove_timeout from timeout callback"""
+        connection = self._connect()
+
+        # Test timer completion
+        timer_id1 = connection.add_timeout(5, lambda: 0/0)
+
+        rx_timer2 = []
+        def on_timer2():
+            connection.remove_timeout(timer_id1)
+            connection.remove_timeout(timer_id2)
+            rx_timer2.append(1)
+
+        timer_id2 = connection.add_timeout(0, on_timer2)
+
+        while not rx_timer2:
+            connection.process_data_events(time_limit=None)
+
+        self.assertNotIn(timer_id1, connection._impl.ioloop._timeouts)
+        self.assertFalse(connection._pending_timers)
+
+
+class TestSleep(BlockingTestCaseBase):
 
     def test(self):
         """BlockingConnection.sleep"""
@@ -263,7 +374,7 @@ class TestSleep(BlockingTestCase):
         self.assertLess(elapsed, 0.25)
 
 
-class TestConnectionProperties(BlockingTestCase):
+class TestConnectionProperties(BlockingTestCaseBase):
 
     def test(self):
         """Test BlockingConnection properties"""
@@ -285,7 +396,7 @@ class TestConnectionProperties(BlockingTestCase):
 
 
 
-class TestCreateAndCloseChannel(BlockingTestCase):
+class TestCreateAndCloseChannel(BlockingTestCaseBase):
 
     def test(self):
         """Create and close channel"""
@@ -304,7 +415,7 @@ class TestCreateAndCloseChannel(BlockingTestCase):
         self.assertFalse(ch.is_closing)
 
 
-class TestExchangeDeclareAndDelete(BlockingTestCase):
+class TestExchangeDeclareAndDelete(BlockingTestCaseBase):
 
     def test(self):
         """Test exchange_declare and exchange_delete"""
@@ -335,7 +446,7 @@ class TestExchangeDeclareAndDelete(BlockingTestCase):
         self.assertEqual(cm.exception.args[0], 404)
 
 
-class TestQueueDeclareAndDelete(BlockingTestCase):
+class TestQueueDeclareAndDelete(BlockingTestCaseBase):
 
     def test(self):
         """Test queue_declare and queue_delete"""
@@ -343,30 +454,46 @@ class TestQueueDeclareAndDelete(BlockingTestCase):
 
         ch = connection.channel()
 
-        name = _p3_as_bytes('TestQueueDeclareAndDelete_' + uuid.uuid1().hex)
+        q_name = _p3_as_bytes('TestQueueDeclareAndDelete_' + uuid.uuid1().hex)
 
         # Declare a new queue
-        frame = ch.queue_declare(name, auto_delete=True)
-        self.addCleanup(connection.channel().queue_delete, name)
+        frame = ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         self.assertIsInstance(frame.method, pika.spec.Queue.DeclareOk)
 
         # Check if it exists by declaring it passively
-        frame = ch.queue_declare(name, passive=True)
+        frame = ch.queue_declare(q_name, passive=True)
         self.assertIsInstance(frame.method, pika.spec.Queue.DeclareOk)
 
         # Delete the queue
-        frame = ch.queue_delete(name)
+        frame = ch.queue_delete(q_name)
         self.assertIsInstance(frame.method, pika.spec.Queue.DeleteOk)
 
         # Verify that it's been deleted
         with self.assertRaises(pika.exceptions.ChannelClosed) as cm:
-            ch.queue_declare(name, passive=True)
+            ch.queue_declare(q_name, passive=True)
 
         self.assertEqual(cm.exception.args[0], 404)
 
 
-class TestQueueBindAndUnbindAndPurge(BlockingTestCase):
+class TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed(
+        BlockingTestCaseBase):
+    def test(self):
+        """ChannelClosed raised when passive-declaring unknown queue"""
+        connection = self._connect()
+        ch = connection.channel()
+
+        q_name = ("TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed_q_"
+                  + uuid.uuid1().hex)
+
+        with self.assertRaises(pika.exceptions.ChannelClosed) as ex_cm:
+            ch.queue_declare(q_name, passive=True)
+
+        self.assertEqual(ex_cm.exception.args[0], 404)
+
+
+class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
 
     def test(self):
         """Test queue_bind and queue_unbind"""
@@ -391,7 +518,7 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCase):
 
         # Declare a new queue
         ch.queue_declare(q_name, auto_delete=True)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         # Bind the queue to the exchange using routing key
         frame = ch.queue_bind(q_name, exchange=exg_name,
@@ -416,7 +543,7 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCase):
         self.assertIsInstance(frame.method, pika.spec.Queue.UnbindOk)
 
         # Verify that the queue is now unreachable via that binding
-        with self.assertRaises(blocking_connection.UnroutableError):
+        with self.assertRaises(pika.exceptions.UnroutableError):
             ch.publish(exg_name, routing_key,
                        body='TestQueueBindAndUnbindAndPurge-2',
                        mandatory=True)
@@ -431,7 +558,7 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCase):
         self.assertEqual(frame.method.message_count, 0)
 
 
-class TestBasicGet(BlockingTestCase):
+class TestBasicGet(BlockingTestCaseBase):
 
     def tearDown(self):
         LOGGER.info('%s TEARING DOWN (%s)', datetime.utcnow(), self)
@@ -456,7 +583,7 @@ class TestBasicGet(BlockingTestCase):
 
         # Declare a new queue
         ch.queue_declare(q_name, auto_delete=True)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
         LOGGER.info('%s DECLARED QUEUE (%s)', datetime.utcnow(), self)
 
         # Verify result of getting a message from an empty queue
@@ -495,10 +622,386 @@ class TestBasicGet(BlockingTestCase):
         self.assertEqual(frame.method.message_count, 0)
 
 
-class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCase):
+class TestBasicReject(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_publish, publish, get_event, has_event, QoS"""
+        """BlockingChannel.basic_reject"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestBasicReject_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that the message
+        # may be delivered synchronously to the queue by publishing it with
+        # mandatory=True
+        ch.confirm_delivery()
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicReject1'),
+                   mandatory=True)
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicReject2'),
+                   mandatory=True)
+
+        # Get the messages
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestBasicReject1'))
+
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestBasicReject2'))
+
+        # Nack the second message
+        ch.basic_reject(rx_method.delivery_tag, requeue=True)
+
+        # Verify that exactly one message is present in the queue, namely the
+        # second one
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 1)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestBasicReject2'))
+
+
+class TestBasicRejectNoRequeue(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.basic_reject with requeue=False"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestBasicRejectNoRequeue_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that the message
+        # may be delivered synchronously to the queue by publishing it with
+        # mandatory=True
+        ch.confirm_delivery()
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicRejectNoRequeue1'),
+                   mandatory=True)
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicRejectNoRequeue2'),
+                   mandatory=True)
+
+        # Get the messages
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicRejectNoRequeue1'))
+
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicRejectNoRequeue2'))
+
+        # Nack the second message
+        ch.basic_reject(rx_method.delivery_tag, requeue=False)
+
+        # Verify that no messages are present in the queue
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 0)
+
+
+class TestBasicNack(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.basic_nack single message"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestBasicNack_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that the message
+        # may be delivered synchronously to the queue by publishing it with
+        # mandatory=True
+        ch.confirm_delivery()
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicNack1'),
+                   mandatory=True)
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicNack2'),
+                   mandatory=True)
+
+        # Get the messages
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestBasicNack1'))
+
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestBasicNack2'))
+
+        # Nack the second message
+        ch.basic_nack(rx_method.delivery_tag, multiple=False, requeue=True)
+
+        # Verify that exactly one message is present in the queue, namely the
+        # second one
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 1)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestBasicNack2'))
+
+
+class TestBasicNackNoRequeue(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.basic_nack with requeue=False"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestBasicNackNoRequeue_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that the message
+        # may be delivered synchronously to the queue by publishing it with
+        # mandatory=True
+        ch.confirm_delivery()
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicNackNoRequeue1'),
+                   mandatory=True)
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicNackNoRequeue2'),
+                   mandatory=True)
+
+        # Get the messages
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicNackNoRequeue1'))
+
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicNackNoRequeue2'))
+
+        # Nack the second message
+        ch.basic_nack(rx_method.delivery_tag, requeue=False)
+
+        # Verify that no messages are present in the queue
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 0)
+
+
+class TestBasicNackMultiple(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.basic_nack multiple messages"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestBasicNackMultiple_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that the message
+        # may be delivered synchronously to the queue by publishing it with
+        # mandatory=True
+        ch.confirm_delivery()
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicNackMultiple1'),
+                   mandatory=True)
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicNackMultiple2'),
+                   mandatory=True)
+
+        # Get the messages
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicNackMultiple1'))
+
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicNackMultiple2'))
+
+        # Nack both messages via the "multiple" option
+        ch.basic_nack(rx_method.delivery_tag, multiple=True, requeue=True)
+
+        # Verify that both messages are present in the queue
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 2)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicNackMultiple1'))
+        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicNackMultiple2'))
+
+
+class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.basic_recover with requeue=True.
+
+        NOTE: the requeue=False option is not supported by RabbitMQ broker as
+        of this writing (using RabbitMQ 3.5.1)
+        """
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes(
+            'TestBasicRecoverWithRequeue_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that the message
+        # may be delivered synchronously to the queue by publishing it with
+        # mandatory=True
+        ch.confirm_delivery()
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicRecoverWithRequeue1'),
+                   mandatory=True)
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestBasicRecoverWithRequeue2'),
+                   mandatory=True)
+
+        rx_messages = []
+        num_messages = 0
+        for msg in ch.consume(q_name, no_ack=False):
+            num_messages += 1
+
+            if num_messages == 2:
+                ch.basic_recover(requeue=True)
+
+            if num_messages > 2:
+                rx_messages.append(msg)
+
+            if num_messages == 4:
+                break
+        else:
+            self.fail('consumer aborted prematurely')
+
+        # Get the messages
+        (_, _, rx_body) = rx_messages[0]
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicRecoverWithRequeue1'))
+
+        (_, _, rx_body) = rx_messages[1]
+        self.assertEqual(rx_body,
+                         pika.compat.as_bytes('TestBasicRecoverWithRequeue2'))
+
+
+class TestTxCommit(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.tx_commit"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestTxCommit_q' + uuid.uuid1().hex)
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Select standard transaction mode
+        frame = ch.tx_select()
+        self.assertIsInstance(frame.method, pika.spec.Tx.SelectOk)
+
+        # Deposit a message in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestTxCommit1'),
+                   mandatory=True)
+
+        # Verify that queue is still empty
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 0)
+
+        # Commit the transaction
+        ch.tx_commit()
+
+        # Verify that the queue has the expected message
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 1)
+
+        (_, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        self.assertEqual(rx_body, pika.compat.as_bytes('TestTxCommit1'))
+
+
+class TestTxRollback(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.tx_commit"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes('TestTxRollback_q' + uuid.uuid1().hex)
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Select standard transaction mode
+        frame = ch.tx_select()
+        self.assertIsInstance(frame.method, pika.spec.Tx.SelectOk)
+
+        # Deposit a message in the queue via default exchange
+        ch.publish(exchange='', routing_key=q_name,
+                   body=_p3_as_bytes('TestTxRollback1'),
+                   mandatory=True)
+
+        # Verify that queue is still empty
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 0)
+
+        # Roll back the transaction
+        ch.tx_rollback()
+
+        # Verify that the queue continues to be empty
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 0)
+
+
+class TestBasicConsumeFromUnknownQueueRaisesChannelClosed(BlockingTestCaseBase):
+    def test(self):
+        """ChannelClosed raised when consuming from unknown queue"""
+        connection = self._connect()
+        ch = connection.channel()
+
+        q_name = ("TestBasicConsumeFromUnknownQueueRaisesChannelClosed_q_" +
+                  uuid.uuid1().hex)
+
+        with self.assertRaises(pika.exceptions.ChannelClosed) as ex_cm:
+            ch.basic_consume(lambda *args: None, q_name)
+
+        self.assertEqual(ex_cm.exception.args[0], 404)
+
+
+class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
+
+    def test(self):  # pylint: disable=R0914
+        """BlockingChannel.basic_publish, publish, basic_consume, QoS, \
+        Basic.Cancel from broker
+        """
         connection = self._connect()
 
         ch = connection.channel()
@@ -520,7 +1023,7 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCase):
 
         # Declare a new queue
         ch.queue_declare(q_name, auto_delete=True)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         # Verify unroutable message handling using basic_publish
         res = ch.basic_publish(exg_name, routing_key=routing_key, body='',
@@ -528,7 +1031,7 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCase):
         self.assertEqual(res, False)
 
         # Verify unroutable message handling using publish
-        with self.assertRaises(blocking_connection.UnroutableError) as cm:
+        with self.assertRaises(pika.exceptions.UnroutableError) as cm:
             ch.publish(exg_name, routing_key=routing_key, body='',
                        mandatory=True)
         (msg,) = cm.exception.messages
@@ -562,70 +1065,304 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCase):
         ch.basic_qos(prefetch_size=0, prefetch_count=1, all_channels=False)
 
         # Create a consumer
-        consumer_tag = ch.create_consumer(q_name, no_ack=False,
-                                          exclusive=False,
-                                          arguments=None)
+        rx_messages = []
+        consumer_tag = ch.basic_consume(
+            lambda *args: rx_messages.append(args),
+            q_name,
+            no_ack=False,
+            exclusive=False,
+            arguments=None)
 
-        # Test has_event() by waiting for first message to arrive
-        while not ch.has_event():
-            connection.process_data_events(time_limit=0.0001)
+        # Wait for first message to arrive
+        while not rx_messages:
+            connection.process_data_events(time_limit=None)
 
-        # Get the first message
-        msg = ch.get_event()
-        self.assertIsInstance(msg, blocking_connection.ConsumerDeliveryEvt)
-        self.assertIsInstance(msg.method, pika.spec.Basic.Deliver)
-        self.assertEqual(msg.method.consumer_tag, consumer_tag)
-        self.assertEqual(msg.method.delivery_tag, 1)
-        self.assertFalse(msg.method.redelivered)
-        self.assertEqual(msg.method.exchange, exg_name)
-        self.assertEqual(msg.method.routing_key, routing_key)
+        self.assertEqual(len(rx_messages), 1)
 
-        self.assertIsInstance(msg.properties, pika.BasicProperties)
-        self.assertEqual(msg.body, _p3_as_bytes('via-basic_publish'))
+        # Check the first message
+        msg = rx_messages[0]
+        self.assertIsInstance(msg, tuple)
+        rx_ch, rx_method, rx_properties, rx_body = msg
+        self.assertIs(rx_ch, ch)
+        self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
+        self.assertEqual(rx_method.consumer_tag, consumer_tag)
+        self.assertEqual(rx_method.delivery_tag, 1)
+        self.assertFalse(rx_method.redelivered)
+        self.assertEqual(rx_method.exchange, exg_name)
+        self.assertEqual(rx_method.routing_key, routing_key)
+
+        self.assertIsInstance(rx_properties, pika.BasicProperties)
+        self.assertEqual(rx_body, _p3_as_bytes('via-basic_publish'))
 
         # There shouldn't be any more events now
-        self.assertFalse(ch.has_event())
+        self.assertFalse(ch._pending_events)
 
         # Ack the mesage so that the next one can arrive (we configured QoS with
         # prefetch_count=1)
-        ch.basic_ack(delivery_tag=msg.method.delivery_tag, multiple=False)
+        ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
 
         # Get the second message
-        msg = ch.get_event()
-        self.assertIsInstance(msg, blocking_connection.ConsumerDeliveryEvt)
-        self.assertIsInstance(msg.method, pika.spec.Basic.Deliver)
-        self.assertEqual(msg.method.consumer_tag, consumer_tag)
-        self.assertEqual(msg.method.delivery_tag, 2)
-        self.assertFalse(msg.method.redelivered)
-        self.assertEqual(msg.method.exchange, exg_name)
-        self.assertEqual(msg.method.routing_key, routing_key)
+        while len(rx_messages) < 2:
+            connection.process_data_events(time_limit=None)
 
-        self.assertIsInstance(msg.properties, pika.BasicProperties)
-        self.assertEqual(msg.body, _p3_as_bytes('via-publish'))
+        self.assertEqual(len(rx_messages), 2)
+
+        msg = rx_messages[1]
+        self.assertIsInstance(msg, tuple)
+        rx_ch, rx_method, rx_properties, rx_body = msg
+        self.assertIs(rx_ch, ch)
+        self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
+        self.assertEqual(rx_method.consumer_tag, consumer_tag)
+        self.assertEqual(rx_method.delivery_tag, 2)
+        self.assertFalse(rx_method.redelivered)
+        self.assertEqual(rx_method.exchange, exg_name)
+        self.assertEqual(rx_method.routing_key, routing_key)
+
+        self.assertIsInstance(rx_properties, pika.BasicProperties)
+        self.assertEqual(rx_body, _p3_as_bytes('via-publish'))
 
         # There shouldn't be any more events now
-        self.assertFalse(ch.has_event())
+        self.assertFalse(ch._pending_events)
 
-        ch.basic_ack(delivery_tag=msg.method.delivery_tag, multiple=False)
+        ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
 
         # Verify that the queue is now empty
         frame = ch.queue_declare(q_name, passive=True)
         self.assertEqual(frame.method.message_count, 0)
 
-        # Attempt get_event again with a short timeout
-        res = ch.get_event(inactivity_timeout=0.005)
-        self.assertIsNone(res)
+        # Attempt to cosume again with a short timeout
+        connection.process_data_events(time_limit=0.005)
+        self.assertEqual(len(rx_messages), 2)
 
-        # Delete the queue to force consumer cancellation
+        # Delete the queue and wait for consumer cancellation
+        rx_cancellations = []
+        ch.add_on_cancel_callback(lambda frame: rx_cancellations.append(frame))
         ch.queue_delete(q_name)
+        ch.start_consuming()
 
-        # Receive consumer cancellation
-        evt = ch.get_event(inactivity_timeout=None)
-        self.assertIsInstance(evt, blocking_connection.ConsumerCancellationEvt)
-        self.assertEqual(evt.method.consumer_tag, consumer_tag)
+        self.assertEqual(len(rx_cancellations), 1)
+        frame, = rx_cancellations
+        self.assertEqual(frame.method.consumer_tag, consumer_tag)
 
 
-class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCase):
+class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.basic_publish from basic_consume callback
+        """
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        src_q_name = _p3_as_bytes(
+            'TestPublishFromBasicConsumeCallback_src_q' + uuid.uuid1().hex)
+        dest_q_name = _p3_as_bytes(
+            'TestPublishFromBasicConsumeCallback_dest_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that publishing
+        # with mandatory=True will be synchronous
+        ch.confirm_delivery()
+
+        # Declare source and destination queues
+        ch.queue_declare(src_q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, src_q_name)
+        ch.queue_declare(dest_q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, dest_q_name)
+
+        # Deposit a message in the source queue
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=src_q_name,
+                   body='via-publish',
+                   mandatory=True)
+
+        # Create a consumer
+        def on_consume(channel, method, props, body):
+            channel.publish(
+                _p3_as_bytes(''), routing_key=dest_q_name, body=body,
+                properties=props, mandatory=True)
+            channel.basic_ack(method.delivery_tag)
+
+        ch.basic_consume(on_consume,
+                         src_q_name,
+                         no_ack=False,
+                         exclusive=False,
+                         arguments=None)
+
+        # Consume from destination queue
+        for _, _, rx_body in ch.consume(dest_q_name,
+                                                       no_ack=True):
+            self.assertEqual(rx_body, pika.compat.as_bytes('via-publish'))
+            break
+        else:
+            self.fail('failed to consume a messages from destination q')
+
+
+class TestStopConsumingFromBasicConsumeCallback(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.stop_consuming from basic_consume callback
+        """
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes(
+            'TestStopConsumingFromBasicConsumeCallback_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that publishing
+        # with mandatory=True will be synchronous
+        ch.confirm_delivery()
+
+        # Declare the queue
+        ch.queue_declare(q_name, auto_delete=False)
+        self.addCleanup(connection.channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=q_name,
+                   body='via-publish1',
+                   mandatory=True)
+
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=q_name,
+                   body='via-publish2',
+                   mandatory=True)
+
+        # Create a consumer
+        def on_consume(channel, method, props, body):  # pylint: disable=W0613
+            channel.stop_consuming()
+            channel.basic_ack(method.delivery_tag)
+
+        ch.basic_consume(on_consume,
+                         q_name,
+                         no_ack=False,
+                         exclusive=False,
+                         arguments=None)
+
+        ch.start_consuming()
+
+        ch.close()
+
+        ch = connection.channel()
+
+        # Verify that only the second message is present in the queue
+        _, _, rx_body = ch.basic_get(q_name)
+        self.assertEqual(rx_body, pika.compat.as_bytes('via-publish2'))
+
+        msg = ch.basic_get(q_name)
+        self.assertTupleEqual(msg, (None, None, None))
+
+
+class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel.close from basic_consume callback
+        """
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes(
+            'TestCloseChannelFromBasicConsumeCallback_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that publishing
+        # with mandatory=True will be synchronous
+        ch.confirm_delivery()
+
+        # Declare the queue
+        ch.queue_declare(q_name, auto_delete=False)
+        self.addCleanup(connection.channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=q_name,
+                   body='via-publish1',
+                   mandatory=True)
+
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=q_name,
+                   body='via-publish2',
+                   mandatory=True)
+
+        # Create a consumer
+        def on_consume(channel, method, props, body):  # pylint: disable=W0613
+            channel.close()
+
+        ch.basic_consume(on_consume,
+                         q_name,
+                         no_ack=False,
+                         exclusive=False,
+                         arguments=None)
+
+        ch.start_consuming()
+
+        self.assertTrue(ch.is_closed)
+
+
+        # Verify that both messages are present in the queue
+        ch = connection.channel()
+        _, _, rx_body = ch.basic_get(q_name)
+        self.assertEqual(rx_body, pika.compat.as_bytes('via-publish1'))
+        _, _, rx_body = ch.basic_get(q_name)
+        self.assertEqual(rx_body, pika.compat.as_bytes('via-publish2'))
+
+
+class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingConnection.close from basic_consume callback
+        """
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes(
+            'TestCloseConnectionFromBasicConsumeCallback_q' + uuid.uuid1().hex)
+
+        # Place channel in publisher-acknowledgments mode so that publishing
+        # with mandatory=True will be synchronous
+        ch.confirm_delivery()
+
+        # Declare the queue
+        ch.queue_declare(q_name, auto_delete=False)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Deposit two messages in the queue
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=q_name,
+                   body='via-publish1',
+                   mandatory=True)
+
+        ch.publish(_p3_as_bytes(''),
+                   routing_key=q_name,
+                   body='via-publish2',
+                   mandatory=True)
+
+        # Create a consumer
+        def on_consume(channel, method, props, body):  # pylint: disable=W0613
+            connection.close()
+
+        ch.basic_consume(on_consume,
+                         q_name,
+                         no_ack=False,
+                         exclusive=False,
+                         arguments=None)
+
+        ch.start_consuming()
+
+        self.assertTrue(ch.is_closed)
+        self.assertTrue(connection.is_closed)
+
+
+        # Verify that both messages are present in the queue
+        ch = self._connect().channel()
+        _, _, rx_body = ch.basic_get(q_name)
+        self.assertEqual(rx_body, pika.compat.as_bytes('via-publish1'))
+        _, _, rx_body = ch.basic_get(q_name)
+        self.assertEqual(rx_body, pika.compat.as_bytes('via-publish2'))
+
+
+class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
 
     def test(self):
         """BlockingChannel publish/consume huge message"""
@@ -639,43 +1376,42 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCase):
         body = _p3_as_bytes('a' * 1000000)
 
         # Declare a new queue
-        ch.queue_declare(q_name, auto_delete=True)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        ch.queue_declare(q_name, auto_delete=False)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         # Publish a message to the queue by way of default exchange
         ch.publish(exchange='', routing_key=q_name, body=body)
         LOGGER.info('Published message body size=%s', len(body))
 
-        # Create a consumer
-        consumer_tag = ch.create_consumer(q_name, no_ack=False,
-                                          exclusive=False,
-                                          arguments=None)
+        # Consume the message
+        for rx_method, rx_props, rx_body in ch.consume(q_name, no_ack=False,
+                                                       exclusive=False,
+                                                       arguments=None):
+            self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
+            self.assertEqual(rx_method.delivery_tag, 1)
+            self.assertFalse(rx_method.redelivered)
+            self.assertEqual(rx_method.exchange, _p3_as_bytes(''))
+            self.assertEqual(rx_method.routing_key, q_name)
 
-        # Get the message
-        msg = ch.get_event()
-        self.assertIsInstance(msg, blocking_connection.ConsumerDeliveryEvt)
-        self.assertIsInstance(msg.method, pika.spec.Basic.Deliver)
-        self.assertEqual(msg.method.consumer_tag, consumer_tag)
-        self.assertEqual(msg.method.delivery_tag, 1)
-        self.assertFalse(msg.method.redelivered)
-        self.assertEqual(msg.method.exchange, _p3_as_bytes(''))
-        self.assertEqual(msg.method.routing_key, q_name)
+            self.assertIsInstance(rx_props, pika.BasicProperties)
+            self.assertEqual(rx_body, body)
 
-        self.assertIsInstance(msg.properties, pika.BasicProperties)
-        self.assertEqual(msg.body, body)
+            # Ack the mesage
+            ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
 
-        # Ack the mesage
-        ch.basic_ack(delivery_tag=msg.method.delivery_tag, multiple=False)
+            break
 
         # There shouldn't be any more events now
-        self.assertFalse(ch.has_event())
+        self.assertFalse(ch._queue_consumer_generator.pending_events)
 
         # Verify that the queue is now empty
+        ch.close()
+        ch = connection.channel()
         frame = ch.queue_declare(q_name, passive=True)
         self.assertEqual(frame.method.message_count, 0)
 
 
-class TestNonPubackPublishAndConsumeManyMessages(BlockingTestCase):
+class TestNonPubackPublishAndConsumeManyMessages(BlockingTestCaseBase):
 
     def test(self):
         """BlockingChannel non-pub-ack publish/consume many messages"""
@@ -691,84 +1427,85 @@ class TestNonPubackPublishAndConsumeManyMessages(BlockingTestCase):
         num_messages_to_publish = 500
 
         # Declare a new queue
-        ch.queue_declare(q_name, auto_delete=True)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        ch.queue_declare(q_name, auto_delete=False)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
-        for i in pika.compat.xrange(num_messages_to_publish):
+        for _ in pika.compat.xrange(num_messages_to_publish):
             # Publish a message to the queue by way of default exchange
             ch.publish(exchange='', routing_key=q_name, body=body)
 
-        # Create a consumer
-        consumer_tag = ch.create_consumer(q_name, no_ack=False,
-                                          exclusive=False,
-                                          arguments=None)
-
         # Consume the messages
-        for i in pika.compat.xrange(num_messages_to_publish):
-            msg = ch.get_event()
-            self.assertIsInstance(msg, blocking_connection.ConsumerDeliveryEvt)
-            self.assertIsInstance(msg.method, pika.spec.Basic.Deliver)
-            self.assertEqual(msg.method.consumer_tag, consumer_tag)
-            self.assertEqual(msg.method.delivery_tag, i+1)
-            self.assertFalse(msg.method.redelivered)
-            self.assertEqual(msg.method.exchange, _p3_as_bytes(''))
-            self.assertEqual(msg.method.routing_key, q_name)
+        num_consumed = 0
+        for rx_method, rx_props, rx_body in ch.consume(q_name,
+                                                       no_ack=False,
+                                                       exclusive=False,
+                                                       arguments=None):
+            num_consumed += 1
+            self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
+            self.assertEqual(rx_method.delivery_tag, num_consumed)
+            self.assertFalse(rx_method.redelivered)
+            self.assertEqual(rx_method.exchange, _p3_as_bytes(''))
+            self.assertEqual(rx_method.routing_key, q_name)
 
-            self.assertIsInstance(msg.properties, pika.BasicProperties)
-            self.assertEqual(msg.body, body)
+            self.assertIsInstance(rx_props, pika.BasicProperties)
+            self.assertEqual(rx_body, body)
 
             # Ack the mesage
-            ch.basic_ack(delivery_tag=msg.method.delivery_tag, multiple=False)
+            ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
+
+            if num_consumed >= num_messages_to_publish:
+                break
+
+        # There shouldn't be any more events now
+        self.assertFalse(ch._queue_consumer_generator.pending_events)
+
+        ch.close()
+
+        self.assertIsNone(ch._queue_consumer_generator)
 
         # Verify that the queue is now empty
+        ch = connection.channel()
         frame = ch.queue_declare(q_name, passive=True)
         self.assertEqual(frame.method.message_count, 0)
 
-        # There shouldn't be any more events now
-        self.assertFalse(ch.has_event())
 
-
-class TestUserCancelsConsumer(BlockingTestCase):
+class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel user cancels consumer"""
+        """BlockingChannel user cancels non-ackable consumer via basic_cancel"""
         connection = self._connect()
 
         ch = connection.channel()
 
         q_name = _p3_as_bytes(
-            'TestUserCancelsConsumer_q' + uuid.uuid1().hex)
+            'TestBasicCancelWithNonAckableConsumer_q' + uuid.uuid1().hex)
 
         body1 = _p3_as_bytes('a' * 1024)
         body2 = _p3_as_bytes('b' * 2048)
 
         # Declare a new queue
         ch.queue_declare(q_name, auto_delete=False)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         # Publish two messages to the queue by way of default exchange
         ch.publish(exchange='', routing_key=q_name, body=body1)
         ch.publish(exchange='', routing_key=q_name, body=body2)
 
-        # Create a consumer
-        consumer_tag = ch.create_consumer(q_name, no_ack=False,
-                                          exclusive=False,
-                                          arguments=None)
+        # Create a non-ackable consumer
+        consumer_tag = ch.basic_consume(lambda *x: None, q_name, no_ack=True,
+                                        exclusive=False, arguments=None)
 
         # Cancel the consumer
-        events = ch.cancel_consumer(consumer_tag)
-
-        # There shouldn't be any more events now
-        self.assertFalse(ch.has_event())
+        messages = ch.basic_cancel(consumer_tag)
 
         # Both messages should have been on their way when we cancelled
-        self.assertEqual(len(events), 2)
+        self.assertEqual(len(messages), 2)
 
-        self.assertEqual(events[0].body, body1)
-        self.assertEqual(events[1].body, body2)
+        _, _, rx_body1 = messages[0]
+        self.assertEqual(rx_body1, body1)
 
-        # Ack both messages via multiple=True
-        ch.basic_ack(delivery_tag=events[-1].method.delivery_tag, multiple=True)
+        _, _, rx_body2 = messages[1]
+        self.assertEqual(rx_body2, body2)
 
         ch.close()
 
@@ -779,7 +1516,48 @@ class TestUserCancelsConsumer(BlockingTestCase):
         self.assertEqual(frame.method.message_count, 0)
 
 
-class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCase):
+class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingChannel user cancels ackable consumer via basic_cancel"""
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = _p3_as_bytes(
+            'TestBasicCancelWithAckableConsumer_q' + uuid.uuid1().hex)
+
+        body1 = _p3_as_bytes('a' * 1024)
+        body2 = _p3_as_bytes('b' * 2048)
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=False)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Publish two messages to the queue by way of default exchange
+        ch.publish(exchange='', routing_key=q_name, body=body1)
+        ch.publish(exchange='', routing_key=q_name, body=body2)
+
+        # Create an ackable consumer
+        consumer_tag = ch.basic_consume(lambda *x: None, q_name, no_ack=False,
+                                        exclusive=False, arguments=None)
+
+        # Cancel the consumer
+        messages = ch.basic_cancel(consumer_tag)
+
+        # Both messages should have been on their way when we cancelled
+        self.assertEqual(len(messages), 0)
+
+        ch.close()
+
+        ch = connection.channel()
+
+        # Verify that the queue is now empty; this validates the multi-ack
+        frame = ch.queue_declare(q_name, passive=True)
+        self.assertEqual(frame.method.message_count, 2)
+
+
+class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
     def test(self):
         """BlockingChannel unacked message restored to q on channel close """
@@ -796,21 +1574,24 @@ class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCase):
 
         # Declare a new queue
         ch.queue_declare(q_name, auto_delete=False)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         # Publish two messages to the queue by way of default exchange
         ch.publish(exchange='', routing_key=q_name, body=body1)
         ch.publish(exchange='', routing_key=q_name, body=body2)
 
         # Consume the events, but don't ack
-        ch.create_consumer(q_name, no_ack=False,
-                           exclusive=False,
-                           arguments=None)
+        rx_messages = []
+        ch.basic_consume(lambda *args: rx_messages.append(args),
+                         q_name,
+                         no_ack=False,
+                         exclusive=False,
+                         arguments=None)
+        while len(rx_messages) != 2:
+            connection.process_data_events(time_limit=None)
 
-        evt1 = ch.get_event()
-        self.assertEqual(evt1.method.delivery_tag, 1)
-        evt2 = ch.get_event()
-        self.assertEqual(evt2.method.delivery_tag, 2)
+        self.assertEqual(rx_messages[0][1].delivery_tag, 1)
+        self.assertEqual(rx_messages[1][1].delivery_tag, 2)
 
         # Verify no more ready messages in queue
         frame = ch.queue_declare(q_name, passive=True)
@@ -826,7 +1607,7 @@ class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCase):
         self.assertEqual(frame.method.message_count, 2)
 
 
-class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCase):
+class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
     def test(self):
         """BlockingChannel unacked message restored to q on channel close """
@@ -843,21 +1624,25 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCase):
 
         # Declare a new queue
         ch.queue_declare(q_name, auto_delete=False)
-        self.addCleanup(connection.channel().queue_delete, q_name)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
 
         # Publish two messages to the queue by way of default exchange
         ch.publish(exchange='', routing_key=q_name, body=body1)
         ch.publish(exchange='', routing_key=q_name, body=body2)
 
-        # Consume the events, but don't ack
-        ch.create_consumer(q_name, no_ack=True,
-                           exclusive=False,
-                           arguments=None)
+        # Consume, but don't ack
+        num_messages = 0
+        for rx_method, _, _ in ch.consume(q_name,
+                                                       no_ack=True,
+                                                       exclusive=False):
+            num_messages += 1
 
-        evt1 = ch.get_event()
-        self.assertEqual(evt1.method.delivery_tag, 1)
-        evt2 = ch.get_event()
-        self.assertEqual(evt2.method.delivery_tag, 2)
+            self.assertEqual(rx_method.delivery_tag, num_messages)
+
+            if num_messages == 2:
+                break
+        else:
+            self.fail('expected 2 messages, but consumed %i' % (num_messages,))
 
         # Verify no more ready messages in queue
         frame = ch.queue_declare(q_name, passive=True)
@@ -868,6 +1653,9 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCase):
 
         # Verify that there are no messages in q now
         ch = connection.channel()
-
         frame = ch.queue_declare(q_name, passive=True)
         self.assertEqual(frame.method.message_count, 0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -57,18 +57,12 @@ class BlockingChannelTests(unittest.TestCase):
     def test_init_initial_value_returned_messages(self):
         self.assertListEqual(self.obj._returned_messages, list())
 
-    def test_has_event_and_get_event(self):
-        self.obj.create_consumer("queue")
-        self.assertFalse(self.obj.has_event())
+    def test_basic_consume(self):
+        with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
+            self.obj._impl._generate_consumer_tag.return_value = 'ctag0'
+            self.obj._impl.basic_consume.return_value = 'ctag0'
 
-        self.obj._pending_events.append("test1")
-        self.assertTrue(self.obj.has_event())
+            self.obj.basic_consume(mock.Mock(), "queue")
 
-        self.obj._pending_events.append("test2")
-        self.assertTrue(self.obj.has_event())
-
-        self.assertEqual(self.obj.get_event(), "test1")
-        self.assertTrue(self.obj.has_event())
-
-        self.assertEqual(self.obj.get_event(), "test2")
-        self.assertFalse(self.obj.has_event())
+            self.assertEqual(self.obj._consumer_infos['ctag0'].state,
+                             blocking_connection._ConsumerInfo.ACTIVE)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -76,7 +76,7 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(self.obj._state, channel.Channel.CLOSED)
 
     def test_init_cancelled(self):
-        self.assertIsInstance(self.obj._cancelled, collections.deque)
+        self.assertIsInstance(self.obj._cancelled, set)
 
     def test_init_consumers(self):
         self.assertEqual(self.obj._consumers, dict())
@@ -229,7 +229,7 @@ class ChannelTests(unittest.TestCase):
         expectation = b'ctag1.'
         mock_callback = mock.Mock()
         for ctag in ['ctag1.%i' % ii for ii in range(11)]:
-            self.obj._cancelled.append(ctag)
+            self.obj._cancelled.add(ctag)
         self.assertEqual(
             self.obj.basic_consume(mock_callback, 'test-queue')[:6],
             expectation)
@@ -936,11 +936,11 @@ class ChannelTests(unittest.TestCase):
     def test_has_content_false(self):
         self.assertFalse(self.obj._has_content(spec.Basic.Ack))
 
-    def test_on_cancel_appended_cancelled(self):
+    def test_on_cancel_not_appended_cancelled(self):
         consumer_tag = 'ctag0'
         frame_value = frame.Method(1, spec.Basic.Cancel(consumer_tag))
         self.obj._on_cancel(frame_value)
-        self.assertIn(consumer_tag, self.obj._cancelled)
+        self.assertNotIn(consumer_tag, self.obj._cancelled)
 
     def test_on_cancel_removed_consumer(self):
         consumer_tag = 'ctag0'

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -71,7 +71,7 @@ class ConnectionTests(unittest.TestCase):
                         '_on_close_ready should have been called')
 
     @mock.patch('pika.connection.Connection._on_close_ready')
-    def test_on_channel_closeok_no_open_channels(self, on_close_ready):
+    def test_on_channel_cleanup_no_open_channels(self, on_close_ready):
         """Should call _on_close_ready if connection is closing and there are
         no open channels
 
@@ -82,7 +82,7 @@ class ConnectionTests(unittest.TestCase):
                         '_on_close_ready should been called')
 
     @mock.patch('pika.connection.Connection._on_close_ready')
-    def test_on_channel_closeok_open_channels(self, on_close_ready):
+    def test_on_channel_cleanup_open_channels(self, on_close_ready):
         """if connection is closing but channels remain open do not call
         _on_close_ready
 
@@ -92,9 +92,9 @@ class ConnectionTests(unittest.TestCase):
                          '_on_close_ready should not have been called')
 
     @mock.patch('pika.connection.Connection._on_close_ready')
-    def test_on_channel_closeok_non_closing_state(self, on_close_ready):
+    def test_on_channel_cleanup_non_closing_state(self, on_close_ready):
         """if connection isn't closing _on_close_ready should not be called"""
-        self.connection._on_channel_closeok(mock.Mock())
+        self.connection._on_channel_cleanup(mock.Mock())
         self.assertFalse(on_close_ready.called,
                          '_on_close_ready should not have been called')
 


### PR DESCRIPTION
Removed the new BlockingChannel.has_event and get_event.

Implemented majority of the balance of the BlockingConnection/BlockingChannel acceptance tests except `BlockingChannel.exchange_bind/exchange_unbind` and validation of `BasicProperties`