### PR TITLE
Return True from basic_publish when pubacks is off.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -82,11 +82,15 @@ changes:
   * `BlockingChannel.confirm_delivery`: raises UnroutableError when unroutable
     messages that were sent prior to this call are returned before we receive
     Confirm.Select-ok.
-  * `BlockingChannel.basic_publish: always returns None if delivery confirmation
-    is not enabled (bulisher acks = off); the legacy implementation returned a
-    bool in this case to indicate whether the messges was returned; however,
-    this was non-deterministic, because Basic.Return is asynchronous. The new
-    implementation returns a bool only when delivery confirmation is enabled.
+  * `BlockingChannel.basic_publish: always returns True when delivery
+    confirmation is not enabled (publisher-acks = off); the legacy implementation
+    returned a bool in this case if `mandatory=True` to indicate whether the
+    message was delivered; however, this was non-deterministic, because
+    Basic.Return is asynchronous and there is no way to know how long to wait
+    for it or its absence. The legacy implementation returned None when
+    publishing with publisher-acks = off and `mandatory=False`. The new
+    implementation always returns True when publishing while
+    publisher-acks = off.
   * `BlockingChannel.publish`: a new alternate method (vs. `basic_publish`) for
      publishing a message with more detailed error reporting via UnroutableError
      and NackError exceptions.

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1746,7 +1746,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         NOTE: mandatory and immediate may be enabled even without delivery
           confirmation, but in the absence of delivery confirmation the
           synchronous implementation has no way to know how long to wait for
-          the return.
+          the Basic.Return or lack thereof.
 
         :param exchange: The exchange to publish to
         :type exchange: str or unicode
@@ -1758,10 +1758,10 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         :param bool mandatory: The mandatory flag
         :param bool immediate: The immediate flag
 
-        :returns: None if delivery confirmation is not enabled; otherwise
-                  returns False if the message could not be deliveved (
-                  Basic.nack or msg return) and True if the message was
-                  delivered (Basic.ack and no msg return)
+        :returns: True if delivery confirmation is not enabled (NEW in pika
+            0.10.0); otherwise returns False if the message could not be
+            deliveved (Basic.nack and/or Basic.Return) and True if the message
+            was delivered (Basic.ack and no Basic.Return)
         """
         if self._delivery_confirmation:
             # In publisher-acknowledgments mode
@@ -1784,7 +1784,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
                 # already), and repeat the publish call
                 self.publish(exchange, routing_key, body, properties,
                              mandatory, immediate)
-            return None
+            return True
 
     def publish(self, exchange, routing_key, body,  # pylint: disable=R0913
                 properties=None, mandatory=False, immediate=False):


### PR DESCRIPTION
Return True from basic_publish when pubacks is off; this provides better compatibility with legacy implementation.
Implemented more blocking adapter acceptance tests.
Fixed spelling mistake.