### PR TITLE
temporary solution for nonetype error when using twisted-pika to send message.

### DIFF
--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -175,9 +175,8 @@ class TestService(service.Service):
 
     def startService(self):
         self.amqp = self.parent.getServiceNamed("amqp").getFactory()
-        self.amqp.read_messages("foobar", "request1", self.respond)
-        self.amqp.read_messages("foobar", "request2", self.respond)
-        self.amqp.read_messages("foobar", "request3", self.respond)
+        self.amqp.send_message('foobar', 'message1', 'hello pika!')
+        self.amqp.read_messages("foobar", "message1", self.respond)
 
 ts = TestService()
 ts.setServiceParent(application)

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -380,6 +380,13 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
         # The connection is open asynchronously by Twisted, so skip the whole
         # connect() part, except for setting the connection state
         self._set_connection_state(self.CONNECTION_INIT)
+        
+    def _flush_outbound(self):
+        while self.outbound_buffer:
+            marshaled_frame = self.outbound_buffer.popleft()
+            self.bytes_sent += len(marshaled_frame)
+            self.frames_sent += 1
+            self.transport.write(marshaled_frame)
 
     def _adapter_connect(self):
         # Should never be called, as we override connect() and leave the


### PR DESCRIPTION
send->read->send which is able to show the bug. And then override
BaseConnection._flush_outbound(self) in TwistedProtocolConnection.
@vitaly-krugl Thanks for your work on my PR, it's my first PR to pika and i am very happy for all your answers. To this PR, maybe we should not only use transport() (or other socket function) from twisted, but also  utilize other native and graceful facilities such as buffering and defer. To be more precise, and for example, like the comments in TwistedProtocolConnection._send_frame say, send data the Twisted way, and no need for buffering, because twisted handles that by itself, we may also '_send_message' the Twisted way. I will check other details in twisted-pika later and I suppose to give more PRs.  