### PR TITLE
TwistedProtocolConnection fix example for @gaochunzy's PR 613

### DIFF
--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -1,3 +1,4 @@
+"""
 # -*- coding:utf-8 -*-
 # based on:
 #  - txamqp-helpers by Dan Siemon <dan@coverfire.com> (March 2010)
@@ -6,6 +7,14 @@
 #    https://groups.google.com/forum/#!topic/pika-python/o_deVmGondk
 #  - Pika Documentation
 #    http://pika.readthedocs.org/en/latest/examples/twisted_example.html
+
+
+Fire up this test application via `twistd -ny twisted_service.py`
+
+The application will answer to requests to exchange "foobar" and any of the
+routing_key values: "request1", "request2", or "request3"
+with messages to the same exchange, but with routing_key "response"
+"""
 
 import pika
 from pika import spec
@@ -158,15 +167,12 @@ class PikaFactory(protocol.ReconnectingClientFactory):
         if self.client is not None:
             self.client.read(exchange, routing_key, callback)
 
-## Fire up test application with
-# twistd -ny twisted_service.py
-## application will answer to requests to exchange "foobar" and routing_key "request"
-## with messages to the same exchange but with routing_key "response"
 
 application = service.Application("pikaapplication")
 
 ps = PikaService(pika.ConnectionParameters(host="localhost", virtual_host="/", credentials=pika.PlainCredentials("guest", "guest")))
 ps.setServiceParent(application)
+
 
 class TestService(service.Service):
 


### PR DESCRIPTION
@gaochunzy, I reviewed your PR #613. It still had one conflicting method `_send_frame` that needed to be removed and it turns out that `_flush_outbound` can even be simpler than I thought initially. I submitted this PR as an example of what I had in mind. Please start with this and also add a basic acceptance test in `tests/acceptance/twisted_protocol_connection_test.py` (new test script) for TwistedProtocolConnection that at least connects, creates a channel, creates a queue, publishes a message to that queue, consumes the message from the queue and validates its contents, deletes the queue.