### PR TITLE
Fixed failure to purge _ConsumerCancellationEvt from BlockingChannel._pending_events during basic_cancel and restored BlockingChannel.add_on_return_callback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -90,9 +90,6 @@ changes:
   - `BlockingChannel.open`: removed in favor of having a single mechanism for
     creating a channel (`BlockingConnection.channel`); this reduces maintenance
     burden, while improving reliability of the adapter.
-  - `BlockingChannel.confirm_delivery`: raises UnroutableError when unroutable
-    messages that were sent prior to this call are returned before we receive
-    Confirm.Select-ok.
   - `BlockingChannel.basic_publish: always returns True when delivery
     confirmation is not enabled (publisher-acks = off); the legacy implementation
     returned a bool in this case if `mandatory=True` to indicate whether the

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -54,8 +54,8 @@ class BlockingChannelTests(unittest.TestCase):
     def test_init_initial_value_pending_events(self):
         self.assertEqual(self.obj._pending_events, deque())
 
-    def test_init_initial_value_returned_messages(self):
-        self.assertListEqual(self.obj._returned_messages, list())
+    def test_init_initial_value_buback_return(self):
+        self.assertIsNone(self.obj._puback_return)
 
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):


### PR DESCRIPTION
Implemented acceptance tests to validate the changes.