### PR TITLE
Check the existence of a timeout-handler key before removing as the h…

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -28,22 +28,6 @@ WRITE = 0x0004
 ERROR = 0x0008
 
 
-if pika.compat.PY2:
-    _SELECT_ERROR = select.error
-else:
-    # select.error was deprecated and replaced by OSError in python 3.3
-    _SELECT_ERROR = OSError
-
-
-def _get_select_errno(error):
-    if pika.compat.PY2:
-        assert isinstance(error, select.error), repr(error)
-        return error.args[0]
-    else:
-        assert isinstance(error, OSError), repr(error)
-        return error.errno
-
-
 class SelectConnection(BaseConnection):
     """An asynchronous connection adapter that attempts to use the fastest
     event loop adapter for the given platform.
@@ -392,8 +376,8 @@ class SelectPoller(object):
                                                    self._fd_events[ERROR],
                                                    self.get_next_deadline())
                 break
-            except _SELECT_ERROR as error:
-                if _get_select_errno(error) == errno.EINTR:
+            except pika.compat._SELECT_ERROR as error:
+                if pika.compat._is_resumable_error(error):
                     continue
                 else:
                     raise
@@ -507,8 +491,8 @@ class KQueuePoller(SelectPoller):
                 kevents = self._kqueue.control(None, 1000,
                                                self.get_next_deadline())
                 break
-            except _SELECT_ERROR as error:
-                if _get_select_errno(error) == errno.EINTR:
+            except pika.compat._SELECT_ERROR as error:
+                if pika.compat._is_resumable_error(error):
                     continue
                 else:
                     raise
@@ -582,8 +566,8 @@ class PollPoller(SelectPoller):
             try:
                 events = self._poll.poll(self.get_next_deadline())
                 break
-            except _SELECT_ERROR as error:
-                if _get_select_errno(error) == errno.EINTR:
+            except pika.compat._SELECT_ERROR as error:
+                if pika.compat._is_resumable_error(error):
                     continue
                 else:
                     raise

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -276,7 +276,9 @@ class SelectPoller(object):
         # were only run periodically.
         for t in sorted(to_run, key=itemgetter('deadline')):
             t['callback']()
-            del self._timeouts[hash(frozenset(t.items()))]
+            k = hash(frozenset(t.items()))
+            if k in self._timeouts:
+                    del self._timeouts[k]
             self._next_timeout = None
 
     def add_handler(self, fileno, handler, events):

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -1,5 +1,5 @@
 import sys as _sys
-
+import errno
 
 PY2 = _sys.version_info < (3,)
 PY3 = not PY2
@@ -73,6 +73,9 @@ if not PY2:
 
         return str(value)
 
+    _SELECT_ERROR = OSError
+    def _is_resumable_error(x): return x.errno==errno.EINTR
+
 else:
     from urllib import unquote as url_unquote, urlencode
 
@@ -96,6 +99,12 @@ else:
             return str(value)
         except UnicodeEncodeError:
             return str(value.encode('utf-8'))
+
+
+    import select
+    _SELECT_ERROR = _sys.version.startswith('2.7.') and IOError \
+                    or select.error
+    def _is_resumable_error(x): return x.args[0]==errno.EINTR
 
 
 def as_bytes(value):


### PR DESCRIPTION
…andler may have deleted the key. (E.g. heartbeat checker)

Running the program below against pika@91a5f45bbff666754dd18f11d8a48ffa296e1824 to connect to a rabbitmq server running under VirtualBox and then suspending the VM will generate the following stack trace.

import pika
print pika.__file__

connection = pika.BlockingConnection(pika.ConnectionParameters(
    heartbeat_interval = 10,
    host='suzuki-VirtualBox'))
channel = connection.channel()

channel.queue_declare(queue='hello')

print ' [*] Waiting for messages. To exit press CTRL+C'

def callback(ch, method, properties, body):
    print " [x] Received %r" % (body,)

channel.basic_consume(callback,
                      queue='hello',
                      no_ack=True)

channel.start_consuming()

Traceback (most recent call last):
  File "test.py", line 26, in <module>
    channel.start_consuming()
  File "../pika/adapters/blocking_connection.py", line 1681, in start_consumin\
g
    self.connection.process_data_events(time_limit=None)
  File "../pika/adapters/blocking_connection.py", line 647, in process_data_ev\
ents
    self._flush_output(common_terminator)
  File "../pika/adapters/blocking_connection.py", line 411, in _flush_output
    self._impl.ioloop.process_timeouts()
  File "../pika/adapters/select_connection.py", line 279, in process_timeouts
    del self._timeouts[hash(frozenset(t.items()))]
KeyError: 5302635927768386976

This is because the timer is deleted at:

Traceback (most recent call last):
  File "test.py", line 26, in <module>
    channel.start_consuming()
  File "../pika/adapters/blocking_connection.py", line 1681, in start_consuming
    self.connection.process_data_events(time_limit=None)
  File "../pika/adapters/blocking_connection.py", line 647, in process_data_events
    self._flush_output(common_terminator)
  File "../pika/adapters/blocking_connection.py", line 411, in _flush_output
    self._impl.ioloop.process_timeouts()
  File "../pika/adapters/select_connection.py", line 278, in process_timeouts
    t['callback']()
  File "../pika/heartbeat.py", line 88, in send_and_check
    return self._close_connection()
  File "../pika/heartbeat.py", line 120, in _close_connection
    self._connection._adapter_disconnect()
  File "../pika/adapters/select_connection.py", line 96, in _adapter_disconnect
    super(SelectConnection, self)._adapter_disconnect()
  File "../pika/adapters/base_connection.py", line 152, in _adapter_disconnect
    self._remove_heartbeat()
  File "../pika/connection.py", line 1011, in _remove_heartbeat
    self.heartbeat.stop()
  File "../pika/heartbeat.py", line 110, in stop
    raise Exception('self._connection.remove_timeout(self._timer)')
Exception: self._connection.remove_timeout(self._timer)
