### PR TITLE
Fix KeyError exception caused by timeout handler(s) that remove thems…

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -264,20 +264,37 @@ class SelectPoller(object):
         timeout = min((timeout, SelectPoller.POLL_TIMEOUT))
         return timeout * SelectPoller.POLL_TIMEOUT_MULT
 
+    @staticmethod
+    def is_ready_to_fire(to_run):
+        """For patching by unittest"""
+        return True
+
     def process_timeouts(self):
         """Process the self._timeouts event stack"""
 
         now = time.time()
-        to_run = [timer for timer in self._timeouts.values()
-                  if timer['deadline'] <= now]
-
         # Run the timeouts in order of deadlines. Although this shouldn't
         # be strictly necessary it preserves old behaviour when timeouts
         # were only run periodically.
-        for t in sorted(to_run, key=itemgetter('deadline')):
-            t['callback']()
-            del self._timeouts[hash(frozenset(t.items()))]
+        to_run = sorted([(k,timer) for (k,timer) in self._timeouts.items()
+                         if timer['deadline'] <= now],
+                        key = lambda (k,timer) : timer['deadline'])
+
+        if self.is_ready_to_fire(to_run):
+            # Force recalculation as the oldest timer is going to be removed.
             self._next_timeout = None
+
+            for k, timer in to_run:
+                if k not in self._timeouts:
+                    # Previous invocation(s) should have deleted the timer.
+                    continue
+                try :
+                    timer['callback']()
+                finally:
+                    # Don't do 'del self._timeout[k]' as the key might
+                    # have been deleted just now.
+                    self._timeouts.pop(k, None)
+
 
     def add_handler(self, fileno, handler, events):
         """Add a new fileno to the set to be monitored

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -8,7 +8,6 @@ import socket
 import select
 import errno
 import time
-from operator import itemgetter
 from collections import defaultdict
 import threading
 
@@ -272,15 +271,15 @@ class SelectPoller(object):
         # Run the timeouts in order of deadlines. Although this shouldn't
         # be strictly necessary it preserves old behaviour when timeouts
         # were only run periodically.
-        to_run = sorted([(k,timer) for (k,timer) in self._timeouts.items()
+        to_run = sorted([(k, timer) for (k, timer) in self._timeouts.items()
                          if timer['deadline'] <= now],
-                        key = lambda item : item[1]['deadline'])
+                        key=lambda item: item[1]['deadline'])
 
         for k, timer in to_run:
             if k not in self._timeouts:
                 # Previous invocation(s) should have deleted the timer.
                 continue
-            try :
+            try:
                 timer['callback']()
             finally:
                 # Don't do 'del self._timeout[k]' as the key might

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -278,7 +278,7 @@ class SelectPoller(object):
         # were only run periodically.
         to_run = sorted([(k,timer) for (k,timer) in self._timeouts.items()
                          if timer['deadline'] <= now],
-                        key = lambda (k,timer) : timer['deadline'])
+                        key = lambda item : item[1]['deadline'])
 
         if self.is_ready_to_fire(to_run):
             # Force recalculation as the oldest timer is going to be removed.

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -106,12 +106,12 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         handle_holder = []
         self.timer_got_fired = False
         self.handle = self.ioloop.add_timeout(
-            0.1, partial(self._on_timer_deletes_itself, handle_holder))
+            0.1, partial(self._on_timer_delete_itself, handle_holder))
         handle_holder.append(self.handle)
         self.start()
         self.assertTrue(self.timer_got_called)
 
-    def _on_timer_deletes_itself(self, handle_holder):
+    def _on_timer_delete_itself(self, handle_holder):
         """ A timeout hanlder that tries to remove itself. """
         self.assertEqual(self.handle, handle_holder.pop())
         # This removal here should not raise exception by itself nor

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -120,7 +120,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.ioloop.remove_timeout(self.handle)
         self.ioloop.stop()
 
-    def test_timer_delete_anothoer(self):
+    def test_timer_delete_another(self):
         """Verifies that an attempt by a timeout handler to delete another,
         that  is ready to run, cancels the execution of the latter without
         generating an exception. This should pose no issues."""

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -129,7 +129,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.start( self.check_none_is_left )
 
     def check_none_is_left(self):
-        self.assertEquals(self.timer_stack, [None])
+        self.assertEqual(self.timer_stack, [None])
         self.ioloop.stop()
 
     def on_timer_murder(self, another_timeout):

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -89,7 +89,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.start()
 
     def on_timer(self, val):
-        self.assertEquals(val, self.timer_stack.pop())
+        self.assertEqual(val, self.timer_stack.pop())
         if not self.timer_stack:
             self.ioloop.stop()
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -86,11 +86,12 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
             self.ioloop.stop()
 
     def test_normal(self):
+        """Setup 5 timeout handlers and observe them get invoked one by one."""
         self.start_test()
 
     def test_timer_for_deleting_itself(self):
-        """This test verifies that an attempt to delete that timeout by
-        the corresponding handler generates no exceptions."""
+        """Verify that an attempt to delete a timeout within the
+        corresponding handler generates no exceptions."""
         self.timer_stack = list()
         handle_holder = []
         self.timer_got_fired = False
@@ -109,9 +110,9 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.ioloop.stop()
 
     def test_timers_for_deleting_anothoer(self):
-        """This test verifies that an attempt by a timeout handler to
-        delete another, that  is ready to run, cancels the execution
-        of the latter without generating an exception."""
+        """Verify that an attempt by a timeout handler to delete another,
+        that  is ready to run, cancels the execution of the latter without
+        generating an exception."""
         holder_for_target_timer = []
         self.ioloop.add_timeout(
             0.01, partial(self.on_timer_that_deletes_another_ready_timer,


### PR DESCRIPTION
…elves during execution. (Notably the heartbeat checker.)