### PR TITLE
More comprehensive/relaxed handling of EINTR exception.

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -27,21 +27,36 @@ WRITE = 0x0004
 ERROR = 0x0008
 
 
-if pika.compat.PY2:
-    _SELECT_ERROR = select.error
-else:
-    # select.error was deprecated and replaced by OSError in python 3.3
-    _SELECT_ERROR = OSError
+# Reason for this unconventional dict initialization is the fact that on some
+# platforms select.error is an aliases for OSError. We don't want the lambda
+# for select.error to win over one for OSError.
+_SELECT_ERROR_CHECKERS = {}
+if pika.compat.PY3:
+    #InterruptedError is undefined in PY2
+    #pylint: disable=E0602
+    _SELECT_ERROR_CHECKERS[InterruptedError] = lambda e: True
+_SELECT_ERROR_CHECKERS[select.error] = lambda e: e.args[0] == errno.EINTR
+_SELECT_ERROR_CHECKERS[IOError] = lambda e: e.errno == errno.EINTR
+_SELECT_ERROR_CHECKERS[OSError] = lambda e: e.errno == errno.EINTR
 
 
-def _get_select_errno(error):
-    if pika.compat.PY2:
-        assert isinstance(error, select.error), repr(error)
-        return error.args[0]
+# We can reduce the number of elements in the list by looking at super-sub
+# class relationship because only the most generic ones needs to be caught.
+# For now the optimization is left out.
+# Following is better but still incomplete.
+#_SELECT_ERRORS = tuple(filter(lambda e: not isinstance(e, OSError),
+#                              _SELECT_ERROR_CHECKERS.keys())
+#                       + [OSError])
+_SELECT_ERRORS = tuple(_SELECT_ERROR_CHECKERS.keys())
+
+def _is_resumable(exc):
+    ''' Check if caught exception represents EINTR error.
+    :param exc: exception; must be one of classes in _SELECT_ERRORS '''
+    checker = _SELECT_ERROR_CHECKERS.get(exc.__class__, None)
+    if checker is not None:
+        return checker(exc)
     else:
-        assert isinstance(error, OSError), repr(error)
-        return error.errno
-
+        return False
 
 class SelectConnection(BaseConnection):
     """An asynchronous connection adapter that attempts to use the fastest
@@ -261,7 +276,7 @@ class SelectPoller(object):
             timeout = SelectPoller.POLL_TIMEOUT
 
         timeout = min((timeout, SelectPoller.POLL_TIMEOUT))
-        return timeout * SelectPoller.POLL_TIMEOUT_MULT
+        return timeout * self.POLL_TIMEOUT_MULT
 
 
     def process_timeouts(self):
@@ -399,8 +414,8 @@ class SelectPoller(object):
                                                    self._fd_events[ERROR],
                                                    self.get_next_deadline())
                 break
-            except _SELECT_ERROR as error:
-                if _get_select_errno(error) == errno.EINTR:
+            except _SELECT_ERRORS as error:
+                if _is_resumable(error):
                     continue
                 else:
                     raise
@@ -514,8 +529,8 @@ class KQueuePoller(SelectPoller):
                 kevents = self._kqueue.control(None, 1000,
                                                self.get_next_deadline())
                 break
-            except _SELECT_ERROR as error:
-                if _get_select_errno(error) == errno.EINTR:
+            except _SELECT_ERRORS as error:
+                if _is_resumable(error):
                     continue
                 else:
                     raise
@@ -589,8 +604,8 @@ class PollPoller(SelectPoller):
             try:
                 events = self._poll.poll(self.get_next_deadline())
                 break
-            except _SELECT_ERROR as error:
-                if _get_select_errno(error) == errno.EINTR:
+            except _SELECT_ERRORS as error:
+                if _is_resumable(error):
                     continue
                 else:
                     raise

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -1,5 +1,5 @@
+import os
 import sys as _sys
-
 
 PY2 = _sys.version_info < (3,)
 PY3 = not PY2
@@ -103,3 +103,7 @@ def as_bytes(value):
         return value.encode('UTF-8')
     return value
 
+
+HAVE_SIGNAL = os.name == 'posix'
+
+EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3,4)

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -8,24 +8,34 @@ Tests for SelectConnection IOLoops
 # Disable warnings about too many public methods as they are in base classes
 # pylint: disable=R0904
 
-import logging
 try:
+    #pylint: disable=F0401
     import unittest2 as unittest
 except ImportError:
+    #pylint: disable=W0404
     import unittest
 
-import os
-import socket
+try:
+    #pylint: disable=F0401,E0611
+    from unittest.mock import patch as PATCH_
+except ImportError:
+    #pylint: disable=W0404
+    from mock import patch as PATCH_
+
 import errno
+import os
+import signal
+import socket
 import time
 import threading
 
 import pika
 from pika.adapters import select_connection
-from pika.adapters.select_connection import READ, WRITE, ERROR
+from pika.adapters.select_connection import READ, WRITE
 from functools import partial
 
 class IOLoopBaseTest(unittest.TestCase):
+    ''' Base for test classes in this uit. '''
 
     SELECT_POLLER = None
     TIMEOUT = 1.0
@@ -35,34 +45,43 @@ class IOLoopBaseTest(unittest.TestCase):
         self.ioloop = select_connection.IOLoop()
 
     def tearDown(self):
-        self.ioloop.remove_timeout(self.fail_timer)
         self.ioloop = None
 
     def start(self):
-        self.fail_timer = self.ioloop.add_timeout(self.TIMEOUT, self.on_timeout)
+        ''' Setup timeout handler for detecting 'no-activity'
+            and start polling. '''
+        fail_timer = self.ioloop.add_timeout(self.TIMEOUT, self.on_timeout)
+        self.addCleanup(self.ioloop.remove_timeout, fail_timer)
         self.ioloop.start()
 
     def on_timeout(self):
         """called when stuck waiting for connection to close"""
         # force the ioloop to stop
         self.ioloop.stop()
-        raise AssertionError('Test timed out')
+        self.fail('Test timed out')
 
 
 class IOLoopThreadStopTestSelect(IOLoopBaseTest):
+    ''' Test ioloop being stopped by another Thread. '''
     SELECT_POLLER = 'select'
     def start_test(self):
-        t = threading.Timer(0.1, self.ioloop.stop)
-        t.start()
+        ''' Starts a thread that stops ioloop after a while
+            and start polling '''
+        timer = threading.Timer(0.1, self.ioloop.stop)
+        self.addCleanup(timer.cancel)
+        timer.start()
         self.start()
 
 class IOLoopThreadStopTestPoll(IOLoopThreadStopTestSelect):
+    ''' Same as IOLoopThreadStopTestSelect but uses 'poll' syscall. '''
     SELECT_POLLER = 'poll'
 
 class IOLoopThreadStopTestEPoll(IOLoopThreadStopTestSelect):
+    ''' Same as IOLoopThreadStopTestSelect but uses 'epoll' syscall. '''
     SELECT_POLLER = 'epoll'
 
 class IOLoopThreadStopTestKqueue(IOLoopThreadStopTestSelect):
+    ''' Same as IOLoopThreadStopTestSelect but uses 'kqueue' syscall. '''
     SELECT_POLLER = 'kqueue'
 
 
@@ -160,12 +179,15 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
 
 
 class IOLoopTimerTestPoll(IOLoopTimerTestSelect):
+    ''' Same as IOLoopTimerTestSelect but uses 'poll' syscall '''
     SELECT_POLLER = 'poll'
 
 class IOLoopTimerTestEPoll(IOLoopTimerTestSelect):
+    ''' Same as IOLoopTimerTestSelect but uses 'epoll' syscall '''
     SELECT_POLLER = 'epoll'
 
 class IOLoopTimerTestKqueue(IOLoopTimerTestSelect):
+    ''' Same as IOLoopTimerTestSelect but uses 'kqueue' syscall '''
     SELECT_POLLER = 'kqueue'
 
 
@@ -174,29 +196,34 @@ class IOLoopSleepTimerTestSelect(IOLoopTimerTestSelect):
         fire in deadline order"""
 
     def start_test(self):
+        ''' Setup timers, sleep and start polling '''
         self.set_timers()
         time.sleep(self.NUM_TIMERS * self.TIMER_INTERVAL)
         self.start()
 
 
 class IOLoopSleepTimerTestPoll(IOLoopSleepTimerTestSelect):
+    ''' Same as IOLoopSleepTimerTestSelect but uses 'poll' syscall '''
     SELECT_POLLER = 'poll'
 
 class IOLoopSleepTimerTestEPoll(IOLoopSleepTimerTestSelect):
+    ''' Same as IOLoopSleepTimerTestSelect but uses 'epoll' syscall '''
     SELECT_POLLER = 'epoll'
 
 class IOLoopSleepTimerTestKqueue(IOLoopSleepTimerTestSelect):
+    ''' Same as IOLoopSleepTimerTestSelect but uses 'kqueue' syscall '''
     SELECT_POLLER = 'kqueue'
 
 class IOLoopSocketBaseSelect(IOLoopBaseTest):
-
+    ''' A base class for setting up a communicating pair of sockets. '''
     SELECT_POLLER = 'select'
     READ_SIZE = 1024
 
     def save_sock(self, sock):
-        fd = sock.fileno()
-        self.sock_map[fd] = sock
-        return fd
+        ''' Store 'sock' in self.sock_map and return the fileno.'''
+        fd_ = sock.fileno()
+        self.sock_map[fd_] = sock
+        return fd_
 
     def setUp(self):
         super(IOLoopSocketBaseSelect, self).setUp()
@@ -204,87 +231,181 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         self.create_accept_socket()
 
     def tearDown(self):
-        for fd in self.sock_map:
-            self.ioloop.remove_handler(fd)
-            self.sock_map[fd].close()
+        for fd_ in self.sock_map:
+            self.ioloop.remove_handler(fd_)
+            self.sock_map[fd_].close()
         super(IOLoopSocketBaseSelect, self).tearDown()
 
 
     def create_accept_socket(self):
+        ''' Create a socket and setup 'accept' handler '''
         listen_sock = socket.socket()
         listen_sock.setblocking(0)
         listen_sock.bind(('localhost', 0))
         listen_sock.listen(1)
-        fd = self.save_sock(listen_sock)
+        fd_ = self.save_sock(listen_sock)
         self.listen_addr = listen_sock.getsockname()
-        self.ioloop.add_handler(fd, self.do_accept, READ)
+        self.ioloop.add_handler(fd_, self.do_accept, READ)
 
     def create_write_socket(self, on_connected):
+        ''' Create a pair of socket and setup 'connected' handler '''
         write_sock = socket.socket()
         write_sock.setblocking(0)
         err = write_sock.connect_ex(self.listen_addr)
         self.assertEqual(err, errno.EINPROGRESS)
-        fd = self.save_sock(write_sock)
-        self.ioloop.add_handler(fd, on_connected, WRITE)
+        fd_ = self.save_sock(write_sock)
+        self.ioloop.add_handler(fd_, on_connected, WRITE)
         return write_sock
 
-    def do_accept(self, fd, events, write_only):
+    def do_accept(self, fd_, events, write_only): # pylint: disable=W0613
+        ''' Create socket from the given fd_ and setup 'read' handler '''
         self.assertEqual(events, READ)
-        listen_sock = self.sock_map[fd]
+        listen_sock = self.sock_map[fd_]
         read_sock, _ = listen_sock.accept()
-        fd = self.save_sock(read_sock)
-        self.ioloop.add_handler(fd, self.do_read, READ)
+        fd_ = self.save_sock(read_sock)
+        self.ioloop.add_handler(fd_, self.do_read, READ)
 
-    def connected(self, fd, events, write_only):
-        raise AssertionError("IOLoopSocketBase.connected not extended")
+    def connected(self, _fd, _events, write_only): # pylint: disable=W0613,R0201
+        ''' Create socket from given _fd and respond to 'connected'.
+            Implemenation is subclass's responsibility. '''
+        self.fail("IOLoopSocketBase.connected not extended")
 
-    def do_read(self, fd, events, write_only):
+    def do_read(self, fd_, events, write_only): # pylint: disable=W0613
+        ''' read from fd and check the received content '''
         self.assertEqual(events, READ)
-        self.verify_message(os.read(fd, self.READ_SIZE))
+        self.verify_message(os.read(fd_, self.READ_SIZE))
 
-    def verify_message(self, msg):
-        raise AssertionError("IOLoopSocketBase.verify_message not extended")
+    def verify_message(self, _msg): # pylint: disable=W0613,R0201
+        ''' See if 'msg' matches what is expected. This is a stub.
+            Real implementation is subclass's responsibility '''
+        self.fail("IOLoopSocketBase.verify_message not extended")
 
     def on_timeout(self):
         """called when stuck waiting for connection to close"""
         # force the ioloop to stop
         self.ioloop.stop()
-        raise AssertionError('Test timed out')
+        self.fail('Test timed out')
 
 class IOLoopSocketBasePoll(IOLoopSocketBaseSelect):
+    ''' Same as IOLoopSocketBaseSelect but uses 'poll' syscall '''
     SELECT_POLLER = 'poll'
 
 class IOLoopSocketBaseEPoll(IOLoopSocketBaseSelect):
+    ''' Same as IOLoopSocketBaseSelect but uses 'epoll' syscall '''
     SELECT_POLLER = 'epoll'
 
 class IOLoopSocketBaseKqueue(IOLoopSocketBaseSelect):
+    ''' Same as IOLoopSocketBaseSelect but uses 'kqueue' syscall '''
     SELECT_POLLER = 'kqueue'
 
 
 class IOLoopSimpleMessageTestCaseSelect(IOLoopSocketBaseSelect):
-
+    ''' Test read/write by creating a pair of sockets, writing to one
+        end and reading from the other '''
     def start(self):
+        ''' Create a pair of sockets and poll '''
         self.create_write_socket(self.connected)
         super(IOLoopSimpleMessageTestCaseSelect, self).start()
 
     def connected(self, fd, events, write_only):
+        ''' Respond to 'connected' event by writing to the write-side. '''
         self.assertEqual(events, WRITE)
-        logging.debug("Writing to %d message: %s", fd, 'X')
         os.write(fd, b'X')
         self.ioloop.update_handler(fd, 0)
 
     def verify_message(self, msg):
+        ''' Make sure we get what is expected and stop polling '''
         self.assertEqual(msg, b'X')
         self.ioloop.stop()
 
     def start_test(self):
+        ''' Simple message Test'''
         self.start()
 
 class IOLoopSimpleMessageTestCasetPoll(IOLoopSimpleMessageTestCaseSelect):
+    ''' Same as IOLoopSimpleMessageTestCaseSelect but uses 'poll' syscall '''
     SELECT_POLLER = 'poll'
 
 class IOLoopSimpleMessageTestCasetEPoll(IOLoopSimpleMessageTestCaseSelect):
+    ''' Same as IOLoopSimpleMessageTestCaseSelect but uses 'epoll' syscall '''
     SELECT_POLLER = 'epoll'
 
 class IOLoopSimpleMessageTestCasetKqueue(IOLoopSimpleMessageTestCaseSelect):
+    ''' Same as IOLoopSimpleMessageTestCaseSelect but uses 'kqueue' syscall '''
+    SELECT_POLLER = 'kqueue'
+
+
+class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
+    ''' Tests if EINTR is properly caught and polling gets resumed. '''
+    SELECT_POLLER = 'select'
+    MSG_CONTENT = b'hello'
+
+    @staticmethod
+    def signal_handler(signum, interrupted_stack):
+        '''A signal handler that gets called in response to
+           os.kill(signal.SIGUSR1).'''
+        pass
+
+    def _eintr_read_handler(self, fileno, events, write_only):
+        '''Read from within poll loop that gets receives eintr error.'''
+        self.assertFalse(write_only)
+        self.assertEqual(events, READ)
+        sock = socket.fromfd(fileno, socket.AF_INET, socket.SOCK_STREAM)
+        mesg = sock.recv(256)
+        self.assertEqual(mesg, self.MSG_CONTENT)
+        self.poller.stop()
+        self._eintr_read_handler_is_called = True
+
+    def _eintr_test_fail(self):
+        '''This function gets called when eintr-test failed to get
+           _eintr_read_handler called.'''
+        self.poller.stop()
+        self.fail('Eintr-test timed out')
+
+    @unittest.skipUnless(pika.compat.HAVE_SIGNAL,
+                         "This platform doesn't support posix signals")
+    @PATCH_('pika.adapters.select_connection._is_resumable')
+    def test_eintr(self, is_resumable_mock, is_resumable_raw=pika.adapters
+                   .select_connection._is_resumable #pylint: disable=W0212
+                   ):
+        '''Test that poll() is properly restarted after receiving EINTR error.
+           Class of an exception raised to signal the error differs in one
+           implementation of polling mechanism and another.'''
+        is_resumable_mock.side_effect = is_resumable_raw
+        self.poller = self.ioloop._get_poller() #pylint: disable=W0212
+        sockpair = self.poller.get_interrupt_pair()
+        self._eintr_read_handler_is_called = False
+        self.poller.add_handler(sockpair[0].fileno(), self._eintr_read_handler,
+                                READ)
+        self.poller.add_timeout(self.TIMEOUT, self._eintr_test_fail)
+        original_signal_handler = \
+            signal.signal(signal.SIGUSR1, self.signal_handler)
+        self.addCleanup(signal.signal, signal.SIGUSR1, original_signal_handler)
+
+        tmr_k = threading.Timer(
+            0.1, lambda: os.kill(os.getpid(), signal.SIGUSR1))
+        self.addCleanup(tmr_k.cancel)
+        tmr_w = threading.Timer(
+            0.2, lambda: sockpair[1].send(self.MSG_CONTENT))
+        self.addCleanup(tmr_w.cancel)
+        tmr_k.start()
+        tmr_w.start()
+        self.poller.start()
+        self.assertTrue(self._eintr_read_handler_is_called)
+        if pika.compat.EINTR_IS_EXPOSED:
+            self.assertTrue(is_resumable_mock.call_count == 1)
+        else:
+            self.assertFalse(is_resumable_mock.call_count == 0)
+
+
+class IOLoopEintrTestCasePoll(IOLoopEintrTestCaseSelect):
+    ''' Same as IOLoopEintrTestCaseSelect but uses poll syscall '''
+    SELECT_POLLER = 'poll'
+
+class IOLoopEintrTestCaseEPoll(IOLoopEintrTestCaseSelect):
+    ''' Same as IOLoopEINTRrTestCaseSelect but uses epoll syscall '''
+    SELECT_POLLER = 'epoll'
+
+class IOLoopEintrTestCaseKqueue(IOLoopEintrTestCaseSelect):
+    ''' Same as IOLoopEINTRTestCaseSelect but uses kqueue syscall '''
     SELECT_POLLER = 'kqueue'


### PR DESCRIPTION
Some polling mechanism on some platform (epoll on python2.7 on ubuntu14.04LTS) generates IOError rather than select.error or OSError.
Advice is needed as this patch lacks unit test and I can't figure out how I write test code that generates EINTR.
