### PR TITLE
Add constants for delivery mode options

### DIFF
--- a/pika/spec.py
+++ b/pika/spec.py
@@ -2067,6 +2067,9 @@ class BasicProperties(amqp_object.Properties):
     FLAG_APP_ID = (1 << 3)
     FLAG_CLUSTER_ID = (1 << 2)
 
+    DELIVERY_MODE_NON_PERSISTENT = 1
+    DELIVERY_MODE_PERSISTENT = 2
+
     def __init__(self, content_type=None, content_encoding=None, headers=None, delivery_mode=None, priority=None, correlation_id=None, reply_to=None, expiration=None, message_id=None, timestamp=None, type=None, user_id=None, app_id=None, cluster_id=None):
         self.content_type = content_type
         self.content_encoding = content_encoding


### PR DESCRIPTION
I know this is a small change, but I sometimes forget what `delivery_mode=2` means, and I have definitely been asked more time than I care to mention.

I think these constants would make things a lot clearer to those who don't visit their queue managers often, and newcomers alike.