### PR TITLE
Enh: Process _open_error_result before _flush_output

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -370,8 +370,9 @@ class BlockingConnection(object):  # pylint: disable=R0902
 
         :raises AMQPConnectionError: on connection open error
         """
-        self._flush_output(self._opened_result.is_ready,
-                           self._open_error_result.is_ready)
+        if not self._open_error_result.ready:
+            self._flush_output(self._opened_result.is_ready,
+                               self._open_error_result.is_ready)
 
         if self._open_error_result.ready:
             exception_or_message = self._open_error_result.value.error


### PR DESCRIPTION
This permit to correctly handle a timeout error (whatever is the connection_attemps parameter value), or, normally, any other kind of connection error.

This should fix #655 
