### PR TITLE
Fix: Improper KeyError when channel created on a BlockingConnection whose server was shutdown

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -726,11 +726,15 @@ class Connection(object):
         """
         if not channel_number:
             channel_number = self._next_channel_number()
-        self._channels[channel_number] = self._create_channel(channel_number,
-                                                              on_open_callback)
+        channel = self._create_channel(channel_number, on_open_callback)
+        # we have to retain the channel locally,
+        # and not only use self._channels[channel_number]
+        self._channels[channel_number] = channel
         self._add_channel_callbacks(channel_number)
-        self._channels[channel_number].open()
-        return self._channels[channel_number]
+        channel.open()
+        # because otherwise open() might clear self._channels entirely
+        # when the connection was closed previously (by the server).
+        return channel
 
     def close(self, reply_code=200, reply_text='Normal shutdown'):
         """Disconnect from RabbitMQ. If there are any open channels, it will

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -3,7 +3,15 @@
 Tests for pika.adapters.blocking_connection.BlockingConnection
 
 """
+import errno
 import socket
+import struct
+try:
+    import socketserver
+except ImportError:
+    import SocketServer as socketserver
+
+import threading
 
 try:
     from unittest import mock
@@ -17,11 +25,15 @@ except ImportError:
     import unittest
 
 import pika
+import pika.adapters.base_connection
+import pika.connection
+import pika.exceptions
 from pika.adapters import blocking_connection
 
 
 class BlockingConnectionMockTemplate(blocking_connection.BlockingConnection):
     pass
+
 
 class SelectConnectionTemplate(blocking_connection.SelectConnection):
     is_closed = False
@@ -204,3 +216,149 @@ class BlockingConnectionTests(unittest.TestCase):
             connection.sleep(0.00001)
 
 
+HAS_SO_LINGER = hasattr(socket, 'SO_LINGER')
+
+
+class ThreadedTCPRequestHandler(socketserver.BaseRequestHandler):
+
+    def log(self, m):
+        self.server.log(m)
+
+    TO_RECEIVE = b''.join([
+        b'AMQP\x00\x00\t\x01',
+        b'\x01\x00\x00\x00\x00\x01"\x00\n\x00\x0b\x00\x00\x00\xfe\x07versionS\x00\x00\x00\x060.10.0\x08platformS\x00\x00\x00\x0cPython 3.4.3\x07productS\x00\x00\x00\x1aPika Python Client Library\x0ccapabilitiesF\x00\x00\x00o\x12connection.blockedt\x01\nbasic.nackt\x01\x12publisher_confirmst\x01\x16consumer_cancel_notifyt\x01\x1cauthentication_failure_closet\x01\x0binformationS\x00\x00\x00\x18See http://pika.rtfd.org\x05PLAIN\x00\x00\x00\x0c\x00guest\x00guest\x05en_US\xce',
+        b'\x01\x00\x00\x00\x00\x00\x0c\x00\n\x00\x1f\x00\x00\x00\x02\x00\x00\x02D\xce',
+        b'\x01\x00\x00\x00\x00\x00\x08\x00\n\x00(\x01/\x00\x01\xce'
+    ])
+
+    TO_SEND = [
+        b"\x01\x00\x00\x00\x00\x01\xc3\x00\n\x00\n\x00\t\x00\x00\x01\x9e\x0ccapabilitiesF\x00\x00\x00\xb5\x12publisher_confirmst\x01\x1aexchange_exchange_bindingst\x01\nbasic.nackt\x01\x16consumer_cancel_notifyt\x01\x12connection.blockedt\x01\x13consumer_prioritiest\x01\x1cauthentication_failure_closet\x01\x10per_consumer_qost\x01\x0ccluster_nameS\x00\x00\x00\nrabbit@taf\tcopyrightS\x00\x00\x00'Copyright (C) 2007-2014 GoPivotal, Inc.\x0binformationS\x00\x00\x005Licensed under the MPL.  See http://www.rabbitmq.com/\x08platformS\x00\x00\x00\nErlang/OTP\x07productS\x00\x00\x00\x08RabbitMQ\x07versionS\x00\x00\x00\x053.5.3\x00\x00\x00\x0eAMQPLAIN PLAIN\x00\x00\x00\x05en_US\xce",
+        b'\x01\x00\x00\x00\x00\x00\x0c\x00\n\x00\x1e\x00\x00\x00\x02\x00\x00\x02D\xce',
+        b'\x01\x00\x00\x00\x00\x00\x05\x00\n\x00)\x00\xce'
+    ]
+
+    def __init__(self, *args, **kwargs):
+        self.already_received = b''
+        socketserver.BaseRequestHandler.__init__(self, *args, **kwargs)
+
+    def recv(self, n):
+        if len(self.already_received) >= len(self.TO_RECEIVE):
+            # important: some packets may arrive combined,
+            # so we have to count what we already have received,
+            # in order to not try to receive more than what we expect to..
+            # which otherwise would make us to possibly block forever
+            return
+        self.log('reading %s ..' % n)
+        data = self.request.recv(n)
+        self.log('received = %r' % data)
+        self.already_received += data
+
+    def send(self, data):
+        self.log('sending %r' % data)
+        self.request.send(data)
+        self.log('sent ok')
+
+    def handle(self):
+        self.log('handling new connection..')
+        server = self.server
+        self.recv(1024)
+        for d in self.TO_SEND:
+            self.send(d)
+            self.recv(1024)
+        self.log("waiting ev1")
+        server.ev1.wait()
+        self.log("got ev1")
+
+        if HAS_SO_LINGER:
+            # the following setsockopt should make the trick to have
+            # the connection get a RST packet at the tcp level..
+            l_onoff = 1
+            l_linger = 0
+            self.request.setsockopt(socket.SOL_SOCKET, socket.SO_LINGER,
+                                    struct.pack('ii', l_onoff, l_linger))
+        self.log('closing connection ..')
+        self.request.close()  # ..once we close it here.
+        server.connections_received += 1
+        server.ev2.set()
+        self.log('ev2 set')
+
+
+class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):
+    allow_reuse_address = True
+
+    def __init__(self, *args, **kwargs):
+        verbose = kwargs.pop('verbose', 0)
+        socketserver.TCPServer.__init__(self, *args, **kwargs)
+        self.ev1 = threading.Event()
+        self.ev2 = threading.Event()
+        self.connections_received = 0
+        self.verbose = verbose
+
+    def log(self, *args):
+        if self.verbose:
+            new_args = [
+                '%s> %s' % (threading.current_thread().name, args[0])]
+            new_args.extend(args[1:])
+            print(''.join(map(str, new_args)))
+
+
+class TestChannelCreationOnBrokenConnection(unittest.TestCase):
+
+    def test_that_it_raise_closed_connection(self):
+
+        expected_error = errno.ECONNRESET
+
+        tcp_server = ThreadedTCPServer(('127.0.0.1', 0), ThreadedTCPRequestHandler, verbose=1)
+        _, port = tcp_server.server_address
+
+        log = tcp_server.log
+
+        log("port=", port)
+
+        server_thread = threading.Thread(target=tcp_server.serve_forever)
+        # Exit the server thread when the main thread terminates
+        server_thread.daemon = True
+        server_thread.start()
+        try:
+
+            params = pika.connection.ConnectionParameters(host='127.0.0.1', port=port)
+
+            # initiate a connection:
+            log('initiating connection..')
+            conn = blocking_connection.BlockingConnection(parameters=params)
+            log("connection done")
+            tcp_server.ev1.set()
+            log("set ev1 and wait ev2")
+            tcp_server.ev2.wait()
+            log("got ev2")
+
+            if not HAS_SO_LINGER:
+                # without SO_LINGER we can't be sure that we'll get a RST a the tcp-level.
+                # but we can still trigger/force manually the right error
+
+                class _Proxy(object):
+                    def __init__(self, obj):
+                        self._obj = obj
+
+                    def __getattribute__(self, item):
+                        if item in ('_obj', 'send'):
+                            return object.__getattribute__(self, item)
+                        return getattr(self._obj, item)
+
+                    def send(self, *args):
+                        raise socket.error(expected_error, "douh")
+
+                conn._impl.socket = _Proxy(conn._impl.socket)
+
+            log('now creating new channel ..')
+            with mock.patch.object(
+                    pika.adapters.base_connection,
+                    'LOGGER') as logger_mock:
+                with self.assertRaises(pika.exceptions.ConnectionClosed):
+                    conn.channel()
+
+            self.assertEqual(1, tcp_server.connections_received)
+            logger_mock.error.assert_called_with("Socket Error: %s", expected_error)
+        finally:
+            tcp_server.shutdown()
+            tcp_server.server_close()


### PR DESCRIPTION

More specifically:

    return self._channels[channel_number]

will raise KeyError in such case because the channel will have already been removed from the connection _channels dict.

Using this fix you'll more correctly get ConnectionClosed exception.