### PR TITLE
Fixed EINTR unittest failure on Python3.5

### DIFF
--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -393,9 +393,9 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         self.poller.start()
         self.assertTrue(self._eintr_read_handler_is_called)
         if pika.compat.EINTR_IS_EXPOSED:
-            self.assertTrue(is_resumable_mock.call_count == 1)
+            self.assertEqual(is_resumable_mock.call_count, 1)
         else:
-            self.assertFalse(is_resumable_mock.call_count == 0)
+            self.assertEqual(is_resumable_mock.call_count, 0)
 
 
 class IOLoopEintrTestCasePoll(IOLoopEintrTestCaseSelect):


### PR DESCRIPTION
Fixed True<=>False typo in the eintr unittest that had caused failure on Python 3.5, replacing assertTrue(a==b) with assertEqual(a,b).