### PR TITLE
Call on open error callback for probable auth/access failures

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -1,6 +1,13 @@
 Version History
 ===============
 
+Next Release
+------------
+
+ - Connection failures that occur after the socket is opened and before the
+   AMQP connection is ready to go are now reported by calling the connection
+   error callback.  Previously these were not consistently reported.
+
 0.10.0 2015-09-02
 -----------------
 
@@ -14,7 +21,7 @@ Version History
  - f72b58f - Fixed failure to purge _ConsumerCancellationEvt from BlockingChannel._pending_events during basic_cancel. (Vitaly Kruglikov)
 
 0.10.0b1 2015-07-10
----------------------
+-------------------
 
 High-level summary of notable changes:
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -285,7 +285,16 @@ class BaseConnection(connection.Connection):
     def _handle_disconnect(self):
         """Called internally when the socket is disconnected already
         """
-        self._adapter_disconnect()
+        try:
+            self._adapter_disconnect()
+        except (exceptions.ProbableAccessDeniedError,
+                exceptions.ProbableAuthenticationError) as error:
+            LOGGER.error('disconnected due to %r', error)
+            self.callbacks.process(0,
+                                   self.ON_CONNECTION_ERROR,
+                                   self,
+                                   self, error)
+
         self._on_connection_closed(None, True)
 
     def _handle_ioloop_stop(self):

--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -158,7 +158,7 @@ class LibevConnection(BaseConnection):
         be wiped.
 
         """
-        active_timers = self._active_timers.keys()
+        active_timers = list(self._active_timers.keys())
         for timer in active_timers:
             self.remove_timeout(timer)
         if global_sigint_watcher:

--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -158,7 +158,8 @@ class LibevConnection(BaseConnection):
         be wiped.
 
         """
-        for timer in self._active_timers.keys():
+        active_timers = self._active_timers.keys()
+        for timer in active_timers:
             self.remove_timeout(timer)
         if global_sigint_watcher:
             global_sigint_watcher.stop()
@@ -196,7 +197,7 @@ class LibevConnection(BaseConnection):
 
     def _reset_io_watcher(self):
         """Reset the IO watcher; retry as necessary
-        
+
         """
         self._io_watcher.stop()
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,4 +3,4 @@ codecov
 mock
 nose
 tornado
-twisted
+twisted<15.4.0

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -13,15 +13,17 @@ from pika import adapters
 from pika.adapters import select_connection
 
 LOGGER = logging.getLogger(__name__)
-PARAMETERS = pika.URLParameters('amqp://guest:guest@localhost:5672/%2f')
-DEFAULT_TIMEOUT = 15
 
 
 class AsyncTestCase(unittest.TestCase):
     DESCRIPTION = ""
     ADAPTER = None
-    TIMEOUT = DEFAULT_TIMEOUT
+    TIMEOUT = 15
 
+    def setUp(self):
+        self.parameters = pika.URLParameters(
+            'amqp://guest:guest@localhost:5672/%2F')
+        super(AsyncTestCase, self).setUp()
 
     def shortDescription(self):
         method_desc = super(AsyncTestCase, self).shortDescription()
@@ -37,7 +39,7 @@ class AsyncTestCase(unittest.TestCase):
     def start(self, adapter=None):
         self.adapter = adapter or self.ADAPTER
 
-        self.connection = self.adapter(PARAMETERS, self.on_open,
+        self.connection = self.adapter(self.parameters, self.on_open,
                                        self.on_open_error, self.on_closed)
         self.timeout = self.connection.add_timeout(self.TIMEOUT,
                                                    self.on_timeout)
@@ -84,7 +86,7 @@ class BoundQueueTestCase(AsyncTestCase):
 
     def tearDown(self):
         """Cleanup auto-declared queue and exchange"""
-        self._cconn = self.adapter(PARAMETERS, self._on_cconn_open,
+        self._cconn = self.adapter(self.parameters, self._on_cconn_open,
                                    self._on_cconn_error, self._on_cconn_closed)
 
     def start(self, adapter=None):

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -71,7 +71,7 @@ class AsyncTestCase(unittest.TestCase):
     def on_open(self, connection):
         self.channel = connection.channel(self.begin)
 
-    def on_open_error(self, connection):
+    def on_open_error(self, connection, error):
         connection.ioloop.stop()
         raise AssertionError('Error connecting to RabbitMQ')
 

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -72,9 +72,9 @@ class BlockingConnectionTests(unittest.TestCase):
                                '_process_io_for_connection_setup'):
             connection = blocking_connection.BlockingConnection('params')
 
+        exc_value = pika.exceptions.AMQPConnectionError('failed')
         connection._open_error_result.set_value_once(
-            select_connection_class_mock.return_value,
-            'failed')
+            select_connection_class_mock.return_value, exc_value)
 
         with mock.patch.object(
                 blocking_connection.BlockingConnection,
@@ -83,7 +83,7 @@ class BlockingConnectionTests(unittest.TestCase):
             with self.assertRaises(pika.exceptions.AMQPConnectionError) as cm:
                 connection._process_io_for_connection_setup()
 
-            self.assertEqual(cm.exception.args[0], 'failed')
+            self.assertEqual(cm.exception, exc_value)
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate,


### PR DESCRIPTION
This PR invokes the `on_open_error_callback` when the broker connection is lost between the time that the socket connection is established and the OpenOK comes back.  The current implementation does not invoke any of the connection related callbacks.  I ran into this using the Tornado async adapter which exhibits itself as creating the `TornadoConnection` object and never receiving a callback until my application was closing.