### PR TITLE
Connection._next_channel_number optimization

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1207,13 +1207,10 @@ class Connection(object):
         if len(self._channels) >= limit:
             raise exceptions.NoFreeChannels()
 
-        if self._channels:
-            n = min(self._channels)
-            if n <= 1:
-                for n in xrange(n + 1, n + len(self._channels) + 1):
-                    if n not in self._channels:
-                        return n
-        return 1
+        for n in xrange(1, len(self._channels) + 1):
+            if n not in self._channels:
+                return n
+        return len(self._channels) + 1
 
     def _on_channel_cleanup(self, channel):
         """Remove the channel from the dict of channels when Channel.CloseOk is

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -24,7 +24,7 @@ from pika import utils
 
 from pika import spec
 
-from pika.compat import basestring, url_unquote, dictkeys
+from pika.compat import xrange, basestring, url_unquote, dictkeys
 
 
 BACKPRESSURE_WARNING = ("Pika: Write buffer exceeded warning threshold at "

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1204,13 +1204,16 @@ class Connection(object):
 
         """
         limit = self.params.channel_max or channel.MAX_CHANNELS
-        if len(self._channels) == limit:
+        if len(self._channels) >= limit:
             raise exceptions.NoFreeChannels()
 
-        ckeys = set(self._channels.keys())
-        if not ckeys:
-            return 1
-        return [x + 1 for x in sorted(ckeys) if x + 1 not in ckeys][0]
+        if self._channels:
+            n = min(self._channels)
+            if n <= 1:
+                for n in xrange(n + 1, n + len(self._channels) + 1):
+                    if n not in self._channels:
+                        return n
+        return 1
 
     def _on_channel_cleanup(self, channel):
         """Remove the channel from the dict of channels when Channel.CloseOk is


### PR DESCRIPTION
When we have many (hundreds) channels opened within a connection, the current `Connection._next_channel_number` implementation may become a bottleneck sometimes.
```Python
        ckeys = set(self._channels.keys())
        if not ckeys:
            return 1
        return [x + 1 for x in sorted(ckeys) if x + 1 not in ckeys][0]
```
I see 3 problems with this code.
1. This `ckeys = set(self._channels.keys())` call is effectively useless here. The rest of the code would work just as fine if there was simply `ckeys = self._channels`
2. Not the best idea to use a `[list-comprehension][0]` when we only need to find a first item of the resulting list
3. The `x + 1` part is all right, but why don't we allow to reuse `x - 1` numbers too?