### PR TITLE
Fix issue 663: don't block channel when making RPC call for nowait=True

### DIFF
--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -127,7 +127,7 @@ class LibevConnection(BaseConnection):
             if self._on_signal_callback and not global_sigterm_watcher:
                 global_sigterm_watcher = \
                     self.ioloop.signal(signal.SIGTERM,
-                                                                                  self._handle_sigterm)
+                                       self._handle_sigterm)
 
             if self._on_signal_callback and not global_sigint_watcher:
                 global_sigint_watcher = self.ioloop.signal(signal.SIGINT,
@@ -136,8 +136,8 @@ class LibevConnection(BaseConnection):
             if not self._io_watcher:
                 self._io_watcher = \
                     self.ioloop.io(self.socket.fileno(),
-                                                                        self._PIKA_TO_LIBEV_ARRAY[self.event_state],
-                                                                        self._handle_events)
+                                   self._PIKA_TO_LIBEV_ARRAY[self.event_state],
+                                   self._handle_events)
 
             self.async = pyev.Async(self.ioloop, self._noop_callable)
             self.async.start()
@@ -209,8 +209,9 @@ class LibevConnection(BaseConnection):
                     self._PIKA_TO_LIBEV_ARRAY[self.event_state])
 
                 break
-            except:  # sometimes the stop() doesn't complete in time
-                if retries > 5: raise
+            except Exception:  # sometimes the stop() doesn't complete in time
+                if retries > 5:
+                    raise
                 self._io_watcher.stop()  # so try it again
                 retries += 1
 
@@ -268,7 +269,7 @@ class LibevConnection(BaseConnection):
         :rtype: timer instance handle.
 
         """
-        LOGGER.debug('deadline: {0}'.format(deadline))
+        LOGGER.debug('deadline: %s', deadline)
         timer = self._get_timer(deadline)
         self._active_timers[timer] = (callback_method, callback_timeout,
                                       callback_kwargs)

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -1,13 +1,25 @@
+# Suppress pylint messages concerning missing class and method docstrings
+# pylint: disable=C0111
+
+# Suppress pylint warning about attribute defined outside __init__
+# pylint: disable=W0201
+
+# Suppress pylint warning about access to protected member
+# pylint: disable=W0212
+
+# Suppress pylint warning about unused argument
+# pylint: disable=W0613
+
 import time
 import uuid
 
-from pika import spec, URLParameters
+from pika import spec
 from pika.compat import as_bytes
 
 from async_test_base import (AsyncTestCase, BoundQueueTestCase, AsyncAdapters)
 
 
-class TestA_Connect(AsyncTestCase, AsyncAdapters):
+class TestA_Connect(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Connect, open channel and disconnect"
 
     def begin(self, channel):
@@ -26,11 +38,49 @@ class TestConfirmSelect(AsyncTestCase, AsyncAdapters):
         self.stop()
 
 
+class TestBlockingNonBlockingBlockingRPCWontStall(AsyncTestCase, AsyncAdapters):
+    DESCRIPTION = ("Verify that a sequence of blocking, non-blocking, blocking "
+                   "RPC requests won't stall")
+
+    def begin(self, channel):
+        # Queue declaration params table: queue name, nowait value
+        self._expected_queue_params = (
+            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, False),
+            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, True),
+            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, False)
+        )
+
+        self._declared_queue_names = []
+
+        for queue, nowait in self._expected_queue_params:
+            channel.queue_declare(callback=self._queue_declare_ok_cb
+                                  if not nowait else None,
+                                  queue=queue,
+                                  auto_delete=True,
+                                  nowait=nowait,
+                                  arguments={'x-expires': self.TIMEOUT * 1000})
+
+    def _queue_declare_ok_cb(self, declare_ok_frame):
+        self._declared_queue_names.append(declare_ok_frame.method.queue)
+
+        if len(self._declared_queue_names) == 2:
+            # Initiate check for creation of queue declared with nowait=True
+            self.channel.queue_declare(callback=self._queue_declare_ok_cb,
+                                       queue=self._expected_queue_params[1][0],
+                                       passive=True,
+                                       nowait=False)
+        elif len(self._declared_queue_names) == 3:
+            self.assertSequenceEqual(
+                sorted(self._declared_queue_names),
+                sorted(item[0] for item in self._expected_queue_params))
+            self.stop()
+
+
 class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Consume and cancel"
 
     def begin(self, channel):
-        self.queue_name = str(uuid.uuid4())
+        self.queue_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         channel.queue_declare(self.on_queue_declared, queue=self.queue_name)
 
     def on_queue_declared(self, frame):
@@ -58,7 +108,7 @@ class TestExchangeDeclareAndDelete(AsyncTestCase, AsyncAdapters):
     X_TYPE = 'direct'
 
     def begin(self, channel):
-        self.name = self.__class__.__name__ + ':' + str(id(self))
+        self.name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         channel.exchange_declare(self.on_exchange_declared, self.name,
                                  exchange_type=self.X_TYPE,
                                  passive=False,
@@ -81,7 +131,7 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
     X_TYPE2 = 'topic'
 
     def begin(self, channel):
-        self.name = self.__class__.__name__ + ':' + str(id(self))
+        self.name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.channel.add_on_close_callback(self.on_channel_closed)
         channel.exchange_declare(self.on_exchange_declared, self.name,
                                  exchange_type=self.X_TYPE1,
@@ -97,7 +147,7 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
         self.connection.channel(self.on_cleanup_channel)
 
     def on_exchange_declared(self, frame):
-        self.channel.exchange_declare(self.on_exchange_declared, self.name,
+        self.channel.exchange_declare(self.on_bad_result, self.name,
                                       exchange_type=self.X_TYPE2,
                                       passive=False,
                                       durable=False,
@@ -134,7 +184,8 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Create and delete a named queue"
 
     def begin(self, channel):
-        channel.queue_declare(self.on_queue_declared, str(id(self)),
+        self._q_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
+        channel.queue_declare(self.on_queue_declared, self._q_name,
                               passive=False,
                               durable=False,
                               exclusive=True,
@@ -143,10 +194,9 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase, AsyncAdapters):
                               arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
-        queue = str(id(self))
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
         # Frame's method's queue is encoded (impl detail)
-        self.assertEqual(frame.method.queue, queue)
+        self.assertEqual(frame.method.queue, self._q_name)
         self.channel.queue_delete(self.on_queue_delete, frame.method.queue)
 
     def on_queue_delete(self, frame):
@@ -159,8 +209,9 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Should close chan: re-declared queue w/ diff params"
 
     def begin(self, channel):
+        self._q_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.channel.add_on_close_callback(self.on_channel_closed)
-        channel.queue_declare(self.on_queue_declared, str(id(self)),
+        channel.queue_declare(self.on_queue_declared, self._q_name,
                               passive=False,
                               durable=False,
                               exclusive=True,
@@ -172,7 +223,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
         self.stop()
 
     def on_queue_declared(self, frame):
-        self.channel.queue_declare(self.on_bad_result, str(id(self)),
+        self.channel.queue_declare(self.on_bad_result, self._q_name,
                                    passive=False,
                                    durable=True,
                                    exclusive=False,
@@ -181,13 +232,13 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
                                    arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_bad_result(self, frame):
-        self.channel.queue_delete(None, str(id(self)), nowait=True)
+        self.channel.queue_delete(None, self._q_name, nowait=True)
         raise AssertionError("Should not have received a Queue.DeclareOk")
 
 
 
-class TestTX1_Select(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION="Receive confirmation of Tx.Select"
+class TestTX1_Select(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
+    DESCRIPTION = "Receive confirmation of Tx.Select"
 
     def begin(self, channel):
         channel.tx_select(self.on_complete)
@@ -198,8 +249,8 @@ class TestTX1_Select(AsyncTestCase, AsyncAdapters):
 
 
 
-class TestTX2_Commit(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION="Start a transaction, and commit it"
+class TestTX2_Commit(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
+    DESCRIPTION = "Start a transaction, and commit it"
 
     def begin(self, channel):
         channel.tx_select(self.on_selectok)
@@ -213,7 +264,7 @@ class TestTX2_Commit(AsyncTestCase, AsyncAdapters):
         self.stop()
 
 
-class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):
+class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Close the channel: commit without a TX"
 
     def begin(self, channel):
@@ -226,11 +277,12 @@ class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):
     def on_selectok(self, frame):
         self.assertIsInstance(frame.method, spec.Tx.SelectOk)
 
-    def on_commitok(self, frame):
+    @staticmethod
+    def on_commitok(frame):
         raise AssertionError("Should not have received a Tx.CommitOk")
 
 
-class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):
+class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Start a transaction, then rollback"
 
     def begin(self, channel):
@@ -246,7 +298,7 @@ class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):
 
 
 
-class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):
+class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Close the channel: rollback without a TX"
 
     def begin(self, channel):
@@ -256,12 +308,12 @@ class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):
     def on_channel_closed(self, channel, reply_code, reply_text):
         self.stop()
 
-    def on_commitok(self, frame):
+    @staticmethod
+    def on_commitok(frame):
         raise AssertionError("Should not have received a Tx.RollbackOk")
 
 
-
-class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):
+class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Publish a message and consume it"
 
     def on_ready(self, frame):
@@ -282,10 +334,11 @@ class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):
 
 
 
-class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
+class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Publish a big message and consume it"
 
-    def _get_msg_body(self):
+    @staticmethod
+    def _get_msg_body():
         return '\n'.join(["%s" % i for i in range(0, 2097152)])
 
     def on_ready(self, frame):
@@ -305,7 +358,7 @@ class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
         self.channel.basic_cancel(self.on_cancelled, self.ctag)
 
 
-class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):
+class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Publish a message and get it"
 
     def on_ready(self, frame):
@@ -321,13 +374,14 @@ class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):
         self.stop()
 
 
-class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):
+class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Verify that access denied invokes on open error callback"
 
     def start(self, *args, **kwargs):
         self.parameters.virtual_host = str(uuid.uuid4())
         self.error_captured = False
         super(TestZ_AccessDenied, self).start(*args, **kwargs)
+        self.assertTrue(self.error_captured)
 
     def on_open_error(self, connection, error):
         self.error_captured = True
@@ -336,7 +390,3 @@ class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):
     def on_open(self, connection):
         super(TestZ_AccessDenied, self).on_open(connection)
         self.stop()
-
-    def tearDown(self):
-        self.assertTrue(self.error_captured)
-        super(TestZ_AccessDenied, self).tearDown()

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -1,3 +1,10 @@
+# Suppress pylint warnings concerning attribute defined outside __init__
+# pylint: disable=W0201
+
+# Suppress pylint messages concerning missing docstrings
+# pylint: disable=C0111
+
+from datetime import datetime
 import select
 import logging
 try:
@@ -6,7 +13,9 @@ except ImportError:
     import unittest
 
 import platform
-target = platform.python_implementation()
+_TARGET = platform.python_implementation()
+
+import uuid
 
 import pika
 from pika import adapters
@@ -24,6 +33,9 @@ class AsyncTestCase(unittest.TestCase):
             'amqp://guest:guest@localhost:5672/%2F')
         super(AsyncTestCase, self).setUp()
 
+    def tearDown(self):
+        self._stop()
+
     def shortDescription(self):
         method_desc = super(AsyncTestCase, self).shortDescription()
         if self.DESCRIPTION:
@@ -31,11 +43,12 @@ class AsyncTestCase(unittest.TestCase):
         else:
             return method_desc
 
-    def begin(self, channel):
+    def begin(self, channel):  # pylint: disable=R0201,W0613
         """Extend to start the actual tests on the channel"""
-        raise AssertionError("AsyncTestCase.begin_test not extended")
+        self.fail("AsyncTestCase.begin_test not extended")
 
     def start(self, adapter=None):
+        self.logger.info('start at %s', datetime.utcnow())
         self.adapter = adapter or self.ADAPTER
 
         self.connection = self.adapter(self.parameters, self.on_open,
@@ -53,19 +66,18 @@ class AsyncTestCase(unittest.TestCase):
 
     def _stop(self):
         if hasattr(self, 'timeout') and self.timeout:
+            self.logger.info("Removing timeout")
             self.connection.remove_timeout(self.timeout)
             self.timeout = None
         if hasattr(self, 'connection') and self.connection:
+            self.logger.info("Stopping ioloop")
             self.connection.ioloop.stop()
             self.connection = None
 
-    def tearDown(self):
-        self._stop()
-
     def on_closed(self, connection, reply_code, reply_text):
         """called when the connection has finished closing"""
-        self.logger.debug('on_closed: %r %r %r', connection,
-                          reply_code, reply_text)
+        self.logger.info('on_closed: %r %r %r', connection,
+                         reply_code, reply_text)
         self._stop()
 
     def on_open(self, connection):
@@ -73,29 +85,25 @@ class AsyncTestCase(unittest.TestCase):
         self.channel = connection.channel(self.begin)
 
     def on_open_error(self, connection, error):
-        self.logger.debug('on_open_error: %r %r', connection, error)
+        self.logger.error('on_open_error: %r %r', connection, error)
         connection.ioloop.stop()
         raise AssertionError('Error connecting to RabbitMQ')
 
     def on_timeout(self):
         """called when stuck waiting for connection to close"""
+        self.logger.info('on_timeout at %s', datetime.utcnow())
         # force the ioloop to stop
-        self.logger.debug('on_timeout')
+        self.logger.debug('on_timeout called')
         self.connection.ioloop.stop()
         raise AssertionError('Test timed out')
 
 
 class BoundQueueTestCase(AsyncTestCase):
 
-    def tearDown(self):
-        """Cleanup auto-declared queue and exchange"""
-        self._cconn = self.adapter(self.parameters, self._on_cconn_open,
-                                   self._on_cconn_error, self._on_cconn_closed)
-
     def start(self, adapter=None):
         # PY3 compat encoding
-        self.exchange = 'e' + str(id(self))
-        self.queue = 'q' + str(id(self))
+        self.exchange = 'e-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
+        self.queue = 'q-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.routing_key = self.__class__.__name__
         super(BoundQueueTestCase, self).start(adapter)
 
@@ -106,82 +114,70 @@ class BoundQueueTestCase(AsyncTestCase):
                                       durable=False,
                                       auto_delete=True)
 
-    def on_exchange_declared(self, frame):
+    def on_exchange_declared(self, frame):  # pylint: disable=W0613
         self.channel.queue_declare(self.on_queue_declared, self.queue,
                                    passive=False,
                                    durable=False,
                                    exclusive=True,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT * 1000}
-                                   )
+                                   arguments={'x-expires': self.TIMEOUT * 1000})
 
-    def on_queue_declared(self, frame):
+    def on_queue_declared(self, frame):  # pylint: disable=W0613
         self.channel.queue_bind(self.on_ready, self.queue, self.exchange,
                                 self.routing_key)
 
     def on_ready(self, frame):
         raise NotImplementedError
 
-    def _on_cconn_closed(self, cconn, *args, **kwargs):
-        cconn.ioloop.stop()
-        self._cconn = None
-
-    def _on_cconn_error(self, connection):
-        connection.ioloop.stop()
-        raise AssertionError('Error connecting to RabbitMQ')
-
-    def _on_cconn_open(self, connection):
-        connection.channel(self._on_cconn_channel)
-
-    def _on_cconn_channel(self, channel):
-        channel.exchange_delete(None, self.exchange, nowait=True)
-        channel.queue_delete(None, self.queue, nowait=True)
-        self._cconn.close()
 
 #
 # In order to write test cases that will tested using all the Async Adapters
-# write a class that inherits both from one of TestCase classes above and 
+# write a class that inherits both from one of TestCase classes above and
 # from the AsyncAdapters class below. This allows you to avoid duplicating the
 # test methods for each adapter in each test class.
 #
 
 class AsyncAdapters(object):
 
+    def start(self, adapter_class):
+        raise NotImplementedError
+
     def select_default_test(self):
         "SelectConnection:DefaultPoller"
-        select_connection.POLLER_TYPE=None
+        select_connection.POLLER_TYPE = None
         self.start(adapters.SelectConnection)
 
     def select_select_test(self):
         "SelectConnection:select"
-        select_connection.POLLER_TYPE='select'
+        select_connection.POLLER_TYPE = 'select'
         self.start(adapters.SelectConnection)
 
-    @unittest.skipIf(not hasattr(select, 'poll') 
-        or not hasattr(select.poll(), 'modify'), "poll not supported")
+    @unittest.skipIf(
+        not hasattr(select, 'poll') or
+        not hasattr(select.poll(), 'modify'), "poll not supported")  # pylint: disable=E1101
     def select_poll_test(self):
         "SelectConnection:poll"
-        select_connection.POLLER_TYPE='poll'
+        select_connection.POLLER_TYPE = 'poll'
         self.start(adapters.SelectConnection)
 
     @unittest.skipIf(not hasattr(select, 'epoll'), "epoll not supported")
     def select_epoll_test(self):
         "SelectConnection:epoll"
-        select_connection.POLLER_TYPE='epoll'
+        select_connection.POLLER_TYPE = 'epoll'
         self.start(adapters.SelectConnection)
 
     @unittest.skipIf(not hasattr(select, 'kqueue'), "kqueue not supported")
     def select_kqueue_test(self):
         "SelectConnection:kqueue"
-        select_connection.POLLER_TYPE='kqueue'
+        select_connection.POLLER_TYPE = 'kqueue'
         self.start(adapters.SelectConnection)
 
     def tornado_test(self):
         "TornadoConnection"
         self.start(adapters.TornadoConnection)
 
-    @unittest.skipIf(target == 'PyPy', 'PyPy is not supported')
+    @unittest.skipIf(_TARGET == 'PyPy', 'PyPy is not supported')
     @unittest.skipIf(adapters.LibevConnection is None, 'pyev is not installed')
     def libev_test(self):
         "LibevConnection"


### PR DESCRIPTION
Fixes #663
Fix Channel._rpc to place channel in blocking state only if acceptable_replies arg is not empty to ensure that _on_synchronous_complete will be called to process subsequently blocked requests.