### PR TITLE
Both int and long are valid types for delivery_tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install pyev; fi
   - pip install -r test-requirements.txt
+  - pip freeze
 services:
   - rabbitmq
 script: nosetests

--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -12,6 +12,10 @@ Next Release
    gracefully.
  - Pass error information from failed socket connection to user callbacks
    on_open_error_callback and on_close_callback with result_code=-1.
+ - ValueError is raised when a completion callback is passed to an asynchronous
+   (nowait) Channel operation. It's an application error to pass a non-None
+   completion callback with an asynchronous request, because this callback can
+   never be serviced in the asynchronous scenario.
 
 0.10.0 2015-09-02
 -----------------

--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -10,6 +10,8 @@ Next Release
  - In BaseConnection.close, call _handle_ioloop_stop only if the connection is
    already closed to allow the asynchronous close operation to complete
    gracefully.
+ - Pass error information from failed socket connection to user callbacks
+   on_open_error_callback and on_close_callback with result_code=-1.
 
 0.10.0 2015-09-02
 -----------------

--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -7,6 +7,9 @@ Next Release
  - Connection failures that occur after the socket is opened and before the
    AMQP connection is ready to go are now reported by calling the connection
    error callback.  Previously these were not consistently reported.
+ - In BaseConnection.close, call _handle_ioloop_stop only if the connection is
+   already closed to allow the asynchronous close operation to complete
+   gracefully.
 
 0.10.0 2015-09-02
 -----------------

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -123,7 +123,8 @@ class BaseConnection(connection.Connection):
         # Get the addresses for the socket, supporting IPv4 & IPv6
         while True:
             try:
-                addresses = socket.getaddrinfo(self.params.host, self.params.port,
+                addresses = socket.getaddrinfo(self.params.host,
+                                               self.params.port,
                                                0, socket.SOCK_STREAM,
                                                socket.IPPROTO_TCP)
                 break

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -10,7 +10,6 @@ import ssl
 
 import pika.compat
 from pika import connection
-from pika import exceptions
 
 try:
     SOL_TCP = socket.SOL_TCP
@@ -52,10 +51,10 @@ class BaseConnection(connection.Connection):
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param method on_open_callback: Method to call on connection open
-        :param on_open_error_callback: Method to call if the connection cant
-                                       be opened
-        :type on_open_error_callback: method
-        :param method on_close_callback: Method to call on connection close
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param object ioloop: IOLoop object to use
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :raises: RuntimeError
@@ -152,38 +151,9 @@ class BaseConnection(connection.Connection):
     def _adapter_disconnect(self):
         """Invoked if the connection is being told to disconnect"""
         try:
-            self._remove_heartbeat()
             self._cleanup_socket()
-            self._check_state_on_disconnect()
         finally:
-            # Ensure proper cleanup since _check_state_on_disconnect may raise
-            # an exception
             self._handle_ioloop_stop()
-            self._init_connection_state()
-
-    def _check_state_on_disconnect(self):
-        """Checks to see if we were in opening a connection with RabbitMQ when
-        we were disconnected and raises exceptions for the anticipated
-        exception types.
-
-        """
-        if self.connection_state == self.CONNECTION_PROTOCOL:
-            LOGGER.error('Incompatible Protocol Versions')
-            raise exceptions.IncompatibleProtocolError
-        elif self.connection_state == self.CONNECTION_START:
-            LOGGER.error("Socket closed while authenticating indicating a "
-                         "probable authentication error")
-            raise exceptions.ProbableAuthenticationError
-        elif self.connection_state == self.CONNECTION_TUNE:
-            LOGGER.error("Socket closed while tuning the connection indicating "
-                         "a probable permission error when accessing a virtual "
-                         "host")
-            raise exceptions.ProbableAccessDeniedError
-        elif self.is_open:
-            LOGGER.warning("Socket closed when connection was open")
-        elif not self.is_closed and not self.is_closing:
-            LOGGER.warning('Unknown state on disconnect: %i',
-                           self.connection_state)
 
     def _cleanup_socket(self):
         """Close the socket cleanly"""
@@ -272,11 +242,14 @@ class BaseConnection(connection.Connection):
         """
         if not error_value:
             return None
+
         if hasattr(error_value, 'errno'):  # Python >= 2.6
             return error_value.errno
-        elif error_value is not None:
+        else:
+            # TODO: this doesn't look right; error_value.args[0] ??? Could
+            # probably remove this code path since pika doesn't test against
+            # Python 2.5
             return error_value[0]  # Python <= 2.5
-        return None
 
     def _flush_outbound(self):
         """Have the state manager schedule the necessary I/O.
@@ -290,21 +263,6 @@ class BaseConnection(connection.Connection):
         # detected in _send_connection_tune_ok, before _send_connection_open is
         # called), etc., etc., etc.
         self._manage_event_state()
-
-    def _handle_disconnect(self):
-        """Called internally when the socket is disconnected already
-        """
-        try:
-            self._adapter_disconnect()
-        except (exceptions.ProbableAccessDeniedError,
-                exceptions.ProbableAuthenticationError) as error:
-            LOGGER.error('disconnected due to %r', error)
-            self.callbacks.process(0,
-                                   self.ON_CONNECTION_ERROR,
-                                   self,
-                                   self, error)
-
-        self._on_connection_closed(None, True)
 
     def _handle_ioloop_stop(self):
         """Invoked when the connection is closed to determine if the IOLoop
@@ -323,9 +281,10 @@ class BaseConnection(connection.Connection):
         :param int|object error_value: The inbound error
 
         """
-        if 'timed out' in str(error_value):
-            raise socket.timeout
+        # TODO: doesn't seem right: docstring defines error_value as int|object,
+        # but _get_error_code expects a falsie or an exception-like object
         error_code = self._get_error_code(error_value)
+
         if not error_code:
             LOGGER.critical("Tried to handle an error where no error existed")
             return
@@ -342,6 +301,8 @@ class BaseConnection(connection.Connection):
         elif self.params.ssl and isinstance(error_value, ssl.SSLError):
 
             if error_value.args[0] == ssl.SSL_ERROR_WANT_READ:
+                # TODO: doesn't seem right: this logic updates event state, but
+                # the logic at the bottom unconditionaly disconnects anyway.
                 self.event_state = self.READ
             elif error_value.args[0] == ssl.SSL_ERROR_WANT_WRITE:
                 self.event_state = self.WRITE
@@ -353,20 +314,21 @@ class BaseConnection(connection.Connection):
             LOGGER.error("Socket Error: %s", error_code)
 
         # Disconnect from our IOLoop and let Connection know what's up
-        self._handle_disconnect()
+        self._on_terminate(-1, repr(error_value))
 
     def _handle_timeout(self):
         """Handle a socket timeout in read or write.
         We don't do anything in the non-blocking handlers because we
         only have the socket in a blocking state during connect."""
-        pass
+        LOGGER.warning("Unexpected socket timeout")
 
     def _handle_events(self, fd, events, error=None, write_only=False):
         """Handle IO/Event loop events, processing them.
 
         :param int fd: The file descriptor for the events
         :param int events: Events from the IO/Event loop
-        :param int error: Was an error specified
+        :param int error: Was an error specified; TODO none of the current
+          adapters appear to be able to pass the `error` arg - is it needed?
         :param bool write_only: Only handle write events
 
         """
@@ -382,10 +344,11 @@ class BaseConnection(connection.Connection):
             self._handle_read()
 
         if (self.socket and write_only and (events & self.READ) and
-            (events & self.ERROR)):
-            LOGGER.error('BAD libc:  Write-Only but Read+Error. '
+                (events & self.ERROR)):
+            error_msg = ('BAD libc:  Write-Only but Read+Error. '
                          'Assume socket disconnected.')
-            self._handle_disconnect()
+            LOGGER.error(error_msg)
+            self._on_terminate(-1, error_msg)
 
         if self.socket and (events & self.ERROR):
             LOGGER.error('Error event %r, %r', events, error)
@@ -427,7 +390,7 @@ class BaseConnection(connection.Connection):
         # Empty data, should disconnect
         if not data or data == 0:
             LOGGER.error('Read empty data, calling disconnect')
-            return self._handle_disconnect()
+            return self._on_terminate(-1, "EOF")
 
         # Pass the data into our top level frame dispatching method
         self._on_data_available(data)

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -100,8 +100,11 @@ class BaseConnection(connection.Connection):
         :param str reply_text: The text reason for the close
 
         """
-        super(BaseConnection, self).close(reply_code, reply_text)
-        self._handle_ioloop_stop()
+        try:
+            super(BaseConnection, self).close(reply_code, reply_text)
+        finally:
+            if self.is_closed:
+                self._handle_ioloop_stop()
 
     def remove_timeout(self, timeout_id):
         """Remove the timeout from the IOLoop by the ID returned from

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -370,8 +370,9 @@ class BlockingConnection(object):  # pylint: disable=R0902
 
         :raises AMQPConnectionError: on connection open error
         """
-        self._flush_output(self._opened_result.is_ready,
-                           self._open_error_result.is_ready)
+        if not self._open_error_result.ready:
+            self._flush_output(self._opened_result.is_ready,
+                               self._open_error_result.is_ready)
 
         if self._open_error_result.ready:
             exception_or_message = self._open_error_result.value.error

--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -84,9 +84,10 @@ class LibevConnection(BaseConnection):
         :param pika.connection.Parameters parameters: Connection parameters
         :param on_open_callback: The method to call when the connection is open
         :type on_open_callback: method
-        :param on_open_error_callback: Method to call if the connection cannot
-                                       be opened
-        :type on_open_error_callback: method
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the default IOLoop in libev
         :param on_signal_callback: Method to call if SIGINT or SIGTERM occur

--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -127,7 +127,7 @@ class LibevConnection(BaseConnection):
             if self._on_signal_callback and not global_sigterm_watcher:
                 global_sigterm_watcher = \
                     self.ioloop.signal(signal.SIGTERM,
-                                                                                  self._handle_sigterm)
+                                       self._handle_sigterm)
 
             if self._on_signal_callback and not global_sigint_watcher:
                 global_sigint_watcher = self.ioloop.signal(signal.SIGINT,
@@ -136,8 +136,8 @@ class LibevConnection(BaseConnection):
             if not self._io_watcher:
                 self._io_watcher = \
                     self.ioloop.io(self.socket.fileno(),
-                                                                        self._PIKA_TO_LIBEV_ARRAY[self.event_state],
-                                                                        self._handle_events)
+                                   self._PIKA_TO_LIBEV_ARRAY[self.event_state],
+                                   self._handle_events)
 
             self.async = pyev.Async(self.ioloop, self._noop_callable)
             self.async.start()
@@ -209,8 +209,9 @@ class LibevConnection(BaseConnection):
                     self._PIKA_TO_LIBEV_ARRAY[self.event_state])
 
                 break
-            except:  # sometimes the stop() doesn't complete in time
-                if retries > 5: raise
+            except Exception:  # sometimes the stop() doesn't complete in time
+                if retries > 5:
+                    raise
                 self._io_watcher.stop()  # so try it again
                 retries += 1
 
@@ -268,7 +269,7 @@ class LibevConnection(BaseConnection):
         :rtype: timer instance handle.
 
         """
-        LOGGER.debug('deadline: {0}'.format(deadline))
+        LOGGER.debug('deadline: %s', deadline)
         timer = self._get_timer(deadline)
         self._active_timers[timer] = (callback_method, callback_timeout,
                                       callback_kwargs)

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -2,6 +2,7 @@
 platform pika is running on.
 
 """
+import abc
 import os
 import logging
 import socket
@@ -64,7 +65,7 @@ class SelectConnection(BaseConnection):
 
     """
 
-    def __init__(self,
+    def __init__(self,  # pylint: disable=R0913
                  parameters=None,
                  on_open_callback=None,
                  on_open_error_callback=None,
@@ -124,10 +125,8 @@ class IOLoop(object):
     def __init__(self):
         self._poller = self._get_poller()
 
-    def __getattr__(self, attr):
-        return getattr(self._poller, attr)
-
-    def _get_poller(self):
+    @staticmethod
+    def _get_poller():
         """Determine the best poller to use for this enviroment."""
 
         poller = None
@@ -154,33 +153,140 @@ class IOLoop(object):
 
         return poller
 
+    def add_timeout(self, deadline, callback_method):
+        """[API] Add the callback_method to the IOLoop timer to fire after
+        deadline seconds. Returns a handle to the timeout. Do not confuse with
+        Tornado's timeout where you pass in the time you want to have your
+        callback called. Only pass in the seconds until it's to be called.
 
-class SelectPoller(object):
-    """Default behavior is to use Select since it's the widest supported and has
-    all of the methods we need for child classes as well. One should only need
-    to override the update_handler and start methods for additional types.
-
-    """
-    # Drop out of the poll loop every POLL_TIMEOUT secs as a worst case, this
-    # is only a backstop value. We will run timeouts when they are scheduled.
-    POLL_TIMEOUT = 5
-    # if the poller uses MS specify 1000
-    POLL_TIMEOUT_MULT = 1
-
-    def __init__(self):
-        """Create an instance of the SelectPoller
+        :param int deadline: The number of seconds to wait to call callback
+        :param method callback_method: The callback method
+        :rtype: str
 
         """
+        return self._poller.add_timeout(deadline, callback_method)
+
+    def remove_timeout(self, timeout_id):
+        """[API] Remove a timeout if it's still in the timeout stack
+
+        :param str timeout_id: The timeout id to remove
+
+        """
+        self._poller.remove_timeout(timeout_id)
+
+    def add_handler(self, fileno, handler, events):
+        """[API] Add a new fileno to the set to be monitored
+
+        :param int fileno: The file descriptor
+        :param method handler: What is called when an event happens
+        :param int events: The event mask using READ, WRITE, ERROR
+
+        """
+        self._poller.add_handler(fileno, handler, events)
+
+    def update_handler(self, fileno, events):
+        """[API] Set the events to the current events
+
+        :param int fileno: The file descriptor
+        :param int events: The event mask using READ, WRITE, ERROR
+
+        """
+        self._poller.update_handler(fileno, events)
+
+    def remove_handler(self, fileno):
+        """[API] Remove a file descriptor from the set
+
+        :param int fileno: The file descriptor
+
+        """
+        self._poller.remove_handler(fileno)
+
+    def start(self):
+        """[API] Start the main poller loop. It will loop until requested to
+        exit. See `IOLoop.stop`.
+
+        """
+        self._poller.start()
+
+    def stop(self):
+        """[API] Request exit from the ioloop. The loop is NOT guaranteed to
+        stop before this method returns. This is the only method that may be
+        called from another thread.
+
+        """
+        self._poller.stop()
+
+    def process_timeouts(self):
+        """[Extension] Process pending timeouts, invoking callbacks for those
+        whose time has come
+
+        """
+        self._poller.process_timeouts()
+
+    def activate_poller(self):
+        """[Extension] Activate the poller
+
+        """
+        self._poller.activate_poller()
+
+    def deactivate_poller(self):
+        """[Extension] Deactivate the poller
+
+        """
+        self._poller.deactivate_poller()
+
+    def poll(self):
+        """[Extension] Wait for events of interest on registered file
+        descriptors until an event of interest occurs or next timer deadline or
+        `_PollerBase._MAX_POLL_TIMEOUT`, whichever is sooner, and dispatch the
+        corresponding event handlers.
+
+        """
+        self._poller.poll()
+
+
+# Define a base class for deriving abstract base classes for compatibility
+# between python 2 and 3 (metaclass syntax changed in Python 3). Ideally, would
+# use `@six.add_metaclass` or `six.with_metaclass`, but pika traditionally has
+# resisted external dependencies in its core code.
+if pika.compat.PY2:
+    class _AbstractBase(object):  # pylint: disable=R0903
+        """PY2 Abstract base for _PollerBase class"""
+        __metaclass__ = abc.ABCMeta
+else:
+    # NOTE: Wrapping in exec, because
+    # `class _AbstractBase(metaclass=abc.ABCMeta)` fails to load on python 2.
+    exec('class _AbstractBase(metaclass=abc.ABCMeta): pass')  # pylint: disable=W0122
+
+
+class _PollerBase(_AbstractBase):  # pylint: disable=R0902
+    """Base class for select-based IOLoop implementations"""
+
+    # Drop out of the poll loop every _MAX_POLL_TIMEOUT secs as a worst case;
+    # this is only a backstop value; we will run timeouts when they are
+    # scheduled.
+    _MAX_POLL_TIMEOUT = 5
+
+    # if the poller uses MS override with 1000
+    POLL_TIMEOUT_MULT = 1
+
+
+    def __init__(self):
         # fd-to-handler function mappings
         self._fd_handlers = dict()
 
         # event-to-fdset mappings
         self._fd_events = {READ: set(), WRITE: set(), ERROR: set()}
 
-        self._stopping = False
+        self._processing_fd_event_map = {}
+
+        # Reentrancy tracker of the `start` method
+        self._start_nesting_levels = 0
+
         self._timeouts = {}
         self._next_timeout = None
-        self._processing_fd_event_map = {}
+
+        self._stopping = False
 
         # Mutex for controlling critical sections where ioloop-interrupt sockets
         # are created, used, and destroyed. Needed in case `stop()` is called
@@ -190,42 +296,6 @@ class SelectPoller(object):
         # ioloop-interrupt socket pair; initialized in start()
         self._r_interrupt = None
         self._w_interrupt = None
-
-    def get_interrupt_pair(self):
-        """ Use a socketpair to be able to interrupt the ioloop if called
-            from another thread. Socketpair() is not supported on some OS (Win)
-            so use a pair of simple UDP sockets instead. The sockets will be
-            closed and garbage collected by python when the ioloop itself is.
-        """
-        try:
-            read_sock, write_sock = socket.socketpair()
-
-        except AttributeError:
-            LOGGER.debug("Using custom socketpair for interrupt")
-            read_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            read_sock.bind(('localhost', 0))
-            write_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            write_sock.connect(read_sock.getsockname())
-
-        read_sock.setblocking(0)
-        write_sock.setblocking(0)
-        return read_sock, write_sock
-
-    def read_interrupt(self, interrupt_sock,
-                       events, write_only):  # pylint: disable=W0613
-        """ Read the interrupt byte(s). We ignore the event mask and write_only
-        flag as we can ony get here if there's data to be read on our fd.
-
-        :param int interrupt_sock: The file descriptor to read from
-        :param int events: (unused) The events generated for this fd
-        :param bool write_only: (unused) True if poll was called to trigger a
-            write
-        """
-        try:
-            os.read(interrupt_sock, 512)
-        except OSError as err:
-            if err.errno != errno.EAGAIN:
-                raise
 
     def add_timeout(self, deadline, callback_method):
         """Add the callback_method to the IOLoop timer to fire after deadline
@@ -246,6 +316,8 @@ class SelectPoller(object):
         if not self._next_timeout or timeout_at < self._next_timeout:
             self._next_timeout = timeout_at
 
+        LOGGER.debug('add_timeout: added timeout %s; deadline=%s at %s',
+                     timeout_id, deadline, timeout_at)
         return timeout_id
 
     def remove_timeout(self, timeout_id):
@@ -256,13 +328,17 @@ class SelectPoller(object):
         """
         try:
             timeout = self._timeouts.pop(timeout_id)
+        except KeyError:
+            LOGGER.warning('remove_timeout: %s not found', timeout_id)
+        else:
             if timeout['deadline'] == self._next_timeout:
                 self._next_timeout = None
-        except KeyError:
-            pass
 
-    def get_next_deadline(self):
+            LOGGER.debug('remove_timeout: removed %s', timeout_id)
+
+    def _get_next_deadline(self):
         """Get the interval to the next timeout event, or a default interval
+
         """
         if self._next_timeout:
             timeout = max((self._next_timeout - time.time(), 0))
@@ -273,15 +349,16 @@ class SelectPoller(object):
             timeout = max((self._next_timeout - time.time(), 0))
 
         else:
-            timeout = SelectPoller.POLL_TIMEOUT
+            timeout = self._MAX_POLL_TIMEOUT
 
-        timeout = min((timeout, SelectPoller.POLL_TIMEOUT))
+        timeout = min((timeout, self._MAX_POLL_TIMEOUT))
         return timeout * self.POLL_TIMEOUT_MULT
 
-
     def process_timeouts(self):
-        """Process the self._timeouts event stack"""
+        """Process pending timeouts, invoking callbacks for those whose time has
+        come
 
+        """
         now = time.time()
         # Run the timeouts in order of deadlines. Although this shouldn't
         # be strictly necessary it preserves old behaviour when timeouts
@@ -302,32 +379,35 @@ class SelectPoller(object):
                 if self._timeouts.pop(k, None) is not None:
                     self._next_timeout = None
 
-
     def add_handler(self, fileno, handler, events):
         """Add a new fileno to the set to be monitored
 
-       :param int fileno: The file descriptor
-       :param method handler: What is called when an event happens
-       :param int events: The event mask
+        :param int fileno: The file descriptor
+        :param method handler: What is called when an event happens
+        :param int events: The event mask using READ, WRITE, ERROR
 
-       """
+        """
         self._fd_handlers[fileno] = handler
-        self.update_handler(fileno, events)
+        self._set_handler_events(fileno, events)
+
+        # Inform the derived class
+        self._register_fd(fileno, events)
 
     def update_handler(self, fileno, events):
         """Set the events to the current events
 
         :param int fileno: The file descriptor
-        :param int events: The event mask
+        :param int events: The event mask using READ, WRITE, ERROR
 
         """
+        # Record the change
+        events_cleared, events_set = self._set_handler_events(fileno, events)
 
-        for ev in (READ, WRITE, ERROR):
-            if events & ev:
-                self._fd_events[ev].add(fileno)
-            else:
-                self._fd_events[ev].discard(fileno)
-
+        # Inform the derived class
+        self._modify_fd_events(fileno,
+                               events=events,
+                               events_to_clear=events_cleared,
+                               events_to_set=events_set)
 
     def remove_handler(self, fileno):
         """Remove a file descriptor from the set
@@ -340,37 +420,96 @@ class SelectPoller(object):
         except KeyError:
             pass
 
-        self.update_handler(fileno, 0)
+        events_cleared, _ = self._set_handler_events(fileno, 0)
         del self._fd_handlers[fileno]
 
-    def start(self):
-        """Start the main poller loop. It will loop here until self._stopping"""
+        # Inform the derived class
+        self._unregister_fd(fileno, events_to_clear=events_cleared)
 
-        LOGGER.debug('Starting IOLoop')
-        self._stopping = False
+    def _set_handler_events(self, fileno, events):
+        """Set the handler's events to the given events; internal to
+        `_PollerBase`.
 
-        with self._mutex:
-            # Watch out for reentry
-            if self._r_interrupt is None:
-                # Create ioloop-interrupt socket pair and register read handler.
-                # NOTE: we defer their creation because some users (e.g.,
-                # BlockingConnection adapter) don't use the event loop and these
-                # sockets would get reported as leaks
-                self._r_interrupt, self._w_interrupt = self.get_interrupt_pair()
-                self.add_handler(self._r_interrupt.fileno(),
-                                 self.read_interrupt,
-                                 READ)
-                interrupt_sockets_created = True
+        :param int fileno: The file descriptor
+        :param int events: The event mask (READ, WRITE, ERROR)
+
+        :returns: a 2-tuple (events_cleared, events_set)
+        """
+        events_cleared = 0
+        events_set = 0
+
+        for evt in (READ, WRITE, ERROR):
+            if events & evt:
+                if fileno not in self._fd_events[evt]:
+                    self._fd_events[evt].add(fileno)
+                    events_set |= evt
             else:
-                interrupt_sockets_created = False
+                if fileno in self._fd_events[evt]:
+                    self._fd_events[evt].discard(fileno)
+                    events_cleared |= evt
+
+        return events_cleared, events_set
+
+    def activate_poller(self):
+        """Activate the poller
+
+        """
+        # Activate the underlying poller and register current events
+        self._init_poller()
+        fd_to_events = defaultdict(int)
+        for event, file_descriptors in self._fd_events.items():
+            for fileno in file_descriptors:
+                fd_to_events[fileno] |= event
+
+        for fileno, events in fd_to_events.items():
+            self._register_fd(fileno, events)
+
+    def deactivate_poller(self):
+        """Deactivate the poller
+
+        """
+        self._uninit_poller()
+
+    def start(self):
+        """Start the main poller loop. It will loop until requested to exit
+
+        """
+        self._start_nesting_levels += 1
+
+        if self._start_nesting_levels == 1:
+            LOGGER.debug('Entering IOLoop')
+            self._stopping = False
+
+            # Activate the underlying poller and register current events
+            self.activate_poller()
+
+            # Create ioloop-interrupt socket pair and register read handler.
+            # NOTE: we defer their creation because some users (e.g.,
+            # BlockingConnection adapter) don't use the event loop and these
+            # sockets would get reported as leaks
+            with self._mutex:
+                assert self._r_interrupt is None
+                self._r_interrupt, self._w_interrupt = self._get_interrupt_pair()
+                self.add_handler(self._r_interrupt.fileno(),
+                                 self._read_interrupt,
+                                 READ)
+
+        else:
+            LOGGER.debug('Reentering IOLoop at nesting level=%s',
+                         self._start_nesting_levels)
+
         try:
             # Run event loop
             while not self._stopping:
                 self.poll()
                 self.process_timeouts()
+
         finally:
-            # Unregister and close ioloop-interrupt socket pair
-            if interrupt_sockets_created:
+            self._start_nesting_levels -= 1
+
+            if self._start_nesting_levels == 0:
+                LOGGER.debug('Cleaning up IOLoop')
+                # Unregister and close ioloop-interrupt socket pair
                 with self._mutex:
                     self.remove_handler(self._r_interrupt.fileno())
                     self._r_interrupt.close()
@@ -378,9 +517,18 @@ class SelectPoller(object):
                     self._w_interrupt.close()
                     self._w_interrupt = None
 
-    def stop(self):
-        """Request exit from the ioloop."""
+                # Deactivate the underlying poller
+                self.deactivate_poller()
+            else:
+                LOGGER.debug('Leaving IOLoop with %s nesting levels remaining',
+                             self._start_nesting_levels)
 
+    def stop(self):
+        """Request exit from the ioloop. The loop is NOT guaranteed to stop
+        before this method returns. This is the only method that may be called
+        from another thread.
+
+        """
         LOGGER.debug('Stopping IOLoop')
         self._stopping = True
 
@@ -401,45 +549,73 @@ class SelectPoller(object):
                 LOGGER.warning("Failed to send ioloop interrupt: %s", err)
                 raise
 
-    def poll(self, write_only=False):
+    @abc.abstractmethod
+    def poll(self):
         """Wait for events on interested filedescriptors.
-
-        :param bool write_only: Passed through to the hadnlers to indicate
-            that they should only process write events.
         """
-        while True:
-            try:
-                read, write, error = select.select(self._fd_events[READ],
-                                                   self._fd_events[WRITE],
-                                                   self._fd_events[ERROR],
-                                                   self.get_next_deadline())
-                break
-            except _SELECT_ERRORS as error:
-                if _is_resumable(error):
-                    continue
-                else:
-                    raise
+        raise NotImplementedError
 
-        # Build an event bit mask for each fileno we've recieved an event for
+    @abc.abstractmethod
+    def _init_poller(self):
+        """Notify the implementation to allocate the poller resource"""
+        raise NotImplementedError
 
-        fd_event_map = defaultdict(int)
-        for fd_set, ev in zip((read, write, error), (READ, WRITE, ERROR)):
-            for fileno in fd_set:
-                fd_event_map[fileno] |= ev
+    @abc.abstractmethod
+    def _uninit_poller(self):
+        """Notify the implementation to release the poller resource"""
+        raise NotImplementedError
 
-        self._process_fd_events(fd_event_map, write_only)
+    @abc.abstractmethod
+    def _register_fd(self, fileno, events):
+        """The base class invokes this method to notify the implementation to
+        register the file descriptor with the polling object. The request must
+        be ignored if the poller is not activated.
 
-    def _process_fd_events(self, fd_event_map, write_only):
-        """ Processes the callbacks for each fileno we've recieved events.
-            Before doing so we re-calculate the event mask based on what is
-            currently set in case it has been changed under our feet by a
-            previous callback. We also take a store a refernce to the
-            fd_event_map in the class so that we can detect removal of an
-            fileno during processing of another callback and not generate
-            spurious callbacks on it.
-
-            :param dict fd_event_map: Map of fds to events recieved on them.
+        :param int fileno: The file descriptor
+        :param int events: The event mask (READ, WRITE, ERROR)
         """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _modify_fd_events(self, fileno, events, events_to_clear, events_to_set):
+        """The base class invoikes this method to notify the implementation to
+        modify an already registered file descriptor. The request must be
+        ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: absolute events (READ, WRITE, ERROR)
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def _unregister_fd(self, fileno, events_to_clear):
+        """The base class invokes this method to notify the implementation to
+        unregister the file descriptor being tracked by the polling object. The
+        request must be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        """
+        raise NotImplementedError
+
+    def _dispatch_fd_events(self, fd_event_map):
+        """ Helper to dispatch callbacks for file descriptors that received
+        events.
+
+        Before doing so we re-calculate the event mask based on what is
+        currently set in case it has been changed under our feet by a
+        previous callback. We also take a store a refernce to the
+        fd_event_map so that we can detect removal of an
+        fileno during processing of another callback and not generate
+        spurious callbacks on it.
+
+        :param dict fd_event_map: Map of fds to events received on them.
+        """
+        # Reset the prior map; if the call is nested, this will suppress the
+        # remaining dispatch in the earlier call.
+        self._processing_fd_event_map.clear()
 
         self._processing_fd_event_map = fd_event_map
 
@@ -449,15 +625,141 @@ class SelectPoller(object):
                 continue
 
             events = fd_event_map[fileno]
-            for ev in [READ, WRITE, ERROR]:
-                if fileno not in self._fd_events[ev]:
-                    events &= ~ev
+            for evt in [READ, WRITE, ERROR]:
+                if fileno not in self._fd_events[evt]:
+                    events &= ~evt
 
             if events:
                 handler = self._fd_handlers[fileno]
-                handler(fileno, events, write_only=write_only)
+                handler(fileno, events)
 
-class KQueuePoller(SelectPoller):
+    @staticmethod
+    def _get_interrupt_pair():
+        """ Use a socketpair to be able to interrupt the ioloop if called
+        from another thread. Socketpair() is not supported on some OS (Win)
+        so use a pair of simple UDP sockets instead. The sockets will be
+        closed and garbage collected by python when the ioloop itself is.
+        """
+        try:
+            read_sock, write_sock = socket.socketpair()
+
+        except AttributeError:
+            LOGGER.debug("Using custom socketpair for interrupt")
+            read_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            read_sock.bind(('localhost', 0))
+            write_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+            write_sock.connect(read_sock.getsockname())
+
+        read_sock.setblocking(0)
+        write_sock.setblocking(0)
+        return read_sock, write_sock
+
+    @staticmethod
+    def _read_interrupt(interrupt_fd, events):  # pylint: disable=W0613
+        """ Read the interrupt byte(s). We ignore the event mask as we can ony
+        get here if there's data to be read on our fd.
+
+        :param int interrupt_fd: The file descriptor to read from
+        :param int events: (unused) The events generated for this fd
+        """
+        try:
+            os.read(interrupt_fd, 512)
+        except OSError as err:
+            if err.errno != errno.EAGAIN:
+                raise
+
+
+class SelectPoller(_PollerBase):
+    """Default behavior is to use Select since it's the widest supported and has
+    all of the methods we need for child classes as well. One should only need
+    to override the update_handler and start methods for additional types.
+
+    """
+    # if the poller uses MS specify 1000
+    POLL_TIMEOUT_MULT = 1
+
+    def __init__(self):
+        """Create an instance of the SelectPoller
+
+        """
+        super(SelectPoller, self).__init__()
+
+
+    def poll(self):
+        """Wait for events of interest on registered file descriptors until an
+        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
+        whichever is sooner, and dispatch the corresponding event handlers.
+
+        """
+        while True:
+            try:
+                read, write, error = select.select(self._fd_events[READ],
+                                                   self._fd_events[WRITE],
+                                                   self._fd_events[ERROR],
+                                                   self._get_next_deadline())
+                break
+            except _SELECT_ERRORS as error:
+                if _is_resumable(error):
+                    continue
+                else:
+                    raise
+
+        # Build an event bit mask for each fileno we've received an event for
+
+        fd_event_map = defaultdict(int)
+        for fd_set, evt in zip((read, write, error), (READ, WRITE, ERROR)):
+            for fileno in fd_set:
+                fd_event_map[fileno] |= evt
+
+        self._dispatch_fd_events(fd_event_map)
+
+    def _init_poller(self):
+        """Notify the implementation to allocate the poller resource"""
+        # It's a no op in SelectPoller
+        pass
+
+    def _uninit_poller(self):
+        """Notify the implementation to release the poller resource"""
+        # It's a no op in SelectPoller
+        pass
+
+    def _register_fd(self, fileno, events):
+        """The base class invokes this method to notify the implementation to
+        register the file descriptor with the polling object. The request must
+        be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: The event mask using READ, WRITE, ERROR
+        """
+        # It's a no op in SelectPoller
+        pass
+
+    def _modify_fd_events(self, fileno, events, events_to_clear, events_to_set):
+        """The base class invoikes this method to notify the implementation to
+        modify an already registered file descriptor. The request must be
+        ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: absolute events (READ, WRITE, ERROR)
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        """
+        # It's a no op in SelectPoller
+        pass
+
+    def _unregister_fd(self, fileno, events_to_clear):
+        """The base class invokes this method to notify the implementation to
+        unregister the file descriptor being tracked by the polling object. The
+        request must be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        """
+        # It's a no op in SelectPoller
+        pass
+
+
+class KQueuePoller(_PollerBase):
     """KQueuePoller works on BSD based systems and is faster than select"""
 
     def __init__(self):
@@ -468,43 +770,12 @@ class KQueuePoller(SelectPoller):
         :param int events: The events to look for
 
         """
-        self._kqueue = select.kqueue()
         super(KQueuePoller, self).__init__()
 
-    def update_handler(self, fileno, events):
-        """Set the events to the current events
+        self._kqueue = None
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask
-
-        """
-
-        kevents = list()
-        if not events & READ:
-            if fileno in self._fd_events[READ]:
-                kevents.append(select.kevent(fileno,
-                                             filter=select.KQ_FILTER_READ,
-                                             flags=select.KQ_EV_DELETE))
-        else:
-            if fileno not in self._fd_events[READ]:
-                kevents.append(select.kevent(fileno,
-                                             filter=select.KQ_FILTER_READ,
-                                             flags=select.KQ_EV_ADD))
-        if not events & WRITE:
-            if fileno in self._fd_events[WRITE]:
-                kevents.append(select.kevent(fileno,
-                                             filter=select.KQ_FILTER_WRITE,
-                                             flags=select.KQ_EV_DELETE))
-        else:
-            if fileno not in self._fd_events[WRITE]:
-                kevents.append(select.kevent(fileno,
-                                             filter=select.KQ_FILTER_WRITE,
-                                             flags=select.KQ_EV_ADD))
-        for event in kevents:
-            self._kqueue.control([event], 0)
-        super(KQueuePoller, self).update_handler(fileno, events)
-
-    def _map_event(self, kevent):
+    @staticmethod
+    def _map_event(kevent):
         """return the event type associated with a kevent object
 
         :param kevent kevent: a kevent object as returned by kqueue.control()
@@ -517,17 +788,16 @@ class KQueuePoller(SelectPoller):
         elif kevent.flags & select.KQ_EV_ERROR:
             return ERROR
 
-    def poll(self, write_only=False):
-        """Check to see if the events that are cared about have fired.
-
-        :param bool write_only: Don't look at self.events, just look to see if
-            the adapter can write.
+    def poll(self):
+        """Wait for events of interest on registered file descriptors until an
+        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
+        whichever is sooner, and dispatch the corresponding event handlers.
 
         """
         while True:
             try:
                 kevents = self._kqueue.control(None, 1000,
-                                               self.get_next_deadline())
+                                               self._get_next_deadline())
                 break
             except _SELECT_ERRORS as error:
                 if _is_resumable(error):
@@ -537,13 +807,83 @@ class KQueuePoller(SelectPoller):
 
         fd_event_map = defaultdict(int)
         for event in kevents:
-            fileno = event.ident
-            fd_event_map[fileno] |= self._map_event(event)
+            fd_event_map[event.ident] |= self._map_event(event)
 
-        self._process_fd_events(fd_event_map, write_only)
+        self._dispatch_fd_events(fd_event_map)
+
+    def _init_poller(self):
+        """Notify the implementation to allocate the poller resource"""
+        assert self._kqueue is None
+
+        self._kqueue = select.kqueue()
+
+    def _uninit_poller(self):
+        """Notify the implementation to release the poller resource"""
+        self._kqueue.close()
+        self._kqueue = None
+
+    def _register_fd(self, fileno, events):
+        """The base class invokes this method to notify the implementation to
+        register the file descriptor with the polling object. The request must
+        be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: The event mask using READ, WRITE, ERROR
+        """
+        self._modify_fd_events(fileno,
+                               events=events,
+                               events_to_clear=0,
+                               events_to_set=events)
+
+    def _modify_fd_events(self, fileno, events, events_to_clear, events_to_set):
+        """The base class invoikes this method to notify the implementation to
+        modify an already registered file descriptor. The request must be
+        ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: absolute events (READ, WRITE, ERROR)
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        """
+        if self._kqueue is None:
+            return
+
+        kevents = list()
+
+        if events_to_clear & READ:
+            kevents.append(select.kevent(fileno,
+                                         filter=select.KQ_FILTER_READ,
+                                         flags=select.KQ_EV_DELETE))
+        if events_to_set & READ:
+            kevents.append(select.kevent(fileno,
+                                         filter=select.KQ_FILTER_READ,
+                                         flags=select.KQ_EV_ADD))
+        if events_to_clear & WRITE:
+            kevents.append(select.kevent(fileno,
+                                         filter=select.KQ_FILTER_WRITE,
+                                         flags=select.KQ_EV_DELETE))
+        if events_to_set & WRITE:
+            kevents.append(select.kevent(fileno,
+                                         filter=select.KQ_FILTER_WRITE,
+                                         flags=select.KQ_EV_ADD))
+
+        self._kqueue.control(kevents, 0)
+
+    def _unregister_fd(self, fileno, events_to_clear):
+        """The base class invokes this method to notify the implementation to
+        unregister the file descriptor being tracked by the polling object. The
+        request must be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        """
+        self._modify_fd_events(fileno,
+                               events=0,
+                               events_to_clear=events_to_clear,
+                               events_to_set=0)
 
 
-class PollPoller(SelectPoller):
+class PollPoller(_PollerBase):
     """Poll works on Linux and can have better performance than EPoll in
     certain scenarios.  Both are faster than select.
 
@@ -558,51 +898,25 @@ class PollPoller(SelectPoller):
         :param int events: The events to look for
 
         """
-        self._poll = self.create_poller()
+        self._poll = None
         super(PollPoller, self).__init__()
 
-    def create_poller(self):
+    @staticmethod
+    def _create_poller():
+        """
+        :rtype: `select.poll`
+        """
         return select.poll()  # pylint: disable=E1101
 
-    def add_handler(self, fileno, handler, events):
-        """Add a file descriptor to the poll set
-
-        :param int fileno: The file descriptor to check events for
-        :param method handler: What is called when an event happens
-        :param int events: The events to look for
-
-        """
-        self._poll.register(fileno, events)
-        super(PollPoller, self).add_handler(fileno, handler, events)
-
-    def update_handler(self, fileno, events):
-        """Set the events to the current events
-
-        :param int fileno: The file descriptor
-        :param int events: The event mask
-
-        """
-        super(PollPoller, self).update_handler(fileno, events)
-        self._poll.modify(fileno, events)
-
-    def remove_handler(self, fileno):
-        """Remove a fileno to the set
-
-        :param int fileno: The file descriptor
-
-        """
-        super(PollPoller, self).remove_handler(fileno)
-        self._poll.unregister(fileno)
-
-    def poll(self, write_only=False):
-        """Poll until the next timeout waiting for an event
-
-        :param bool write_only: Only process write events
+    def poll(self):
+        """Wait for events of interest on registered file descriptors until an
+        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
+        whichever is sooner, and dispatch the corresponding event handlers.
 
         """
         while True:
             try:
-                events = self._poll.poll(self.get_next_deadline())
+                events = self._poll.poll(self._get_next_deadline())
                 break
             except _SELECT_ERRORS as error:
                 if _is_resumable(error):
@@ -614,7 +928,55 @@ class PollPoller(SelectPoller):
         for fileno, event in events:
             fd_event_map[fileno] |= event
 
-        self._process_fd_events(fd_event_map, write_only)
+        self._dispatch_fd_events(fd_event_map)
+
+    def _init_poller(self):
+        """Notify the implementation to allocate the poller resource"""
+        assert self._poll is None
+
+        self._poll = self._create_poller()
+
+    def _uninit_poller(self):
+        """Notify the implementation to release the poller resource"""
+        if hasattr(self._poll, "close"):
+            self._poll.close()
+
+        self._poll = None
+
+    def _register_fd(self, fileno, events):
+        """The base class invokes this method to notify the implementation to
+        register the file descriptor with the polling object. The request must
+        be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: The event mask using READ, WRITE, ERROR
+        """
+        if self._poll is not None:
+            self._poll.register(fileno, events)
+
+    def _modify_fd_events(self, fileno, events, events_to_clear, events_to_set):
+        """The base class invoikes this method to notify the implementation to
+        modify an already registered file descriptor. The request must be
+        ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events: absolute events (READ, WRITE, ERROR)
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        """
+        if self._poll is not None:
+            self._poll.modify(fileno, events)
+
+    def _unregister_fd(self, fileno, events_to_clear):
+        """The base class invokes this method to notify the implementation to
+        unregister the file descriptor being tracked by the polling object. The
+        request must be ignored if the poller is not activated.
+
+        :param int fileno: The file descriptor
+        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        """
+        if self._poll is not None:
+            self._poll.unregister(fileno)
 
 
 class EPollPoller(PollPoller):
@@ -624,5 +986,9 @@ class EPollPoller(PollPoller):
     """
     POLL_TIMEOUT_MULT = 1
 
-    def create_poller(self):
+    @staticmethod
+    def _create_poller():
+        """
+        :rtype: `select.poll`
+        """
         return select.epoll()  # pylint: disable=E1101

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -75,10 +75,10 @@ class SelectConnection(BaseConnection):
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param method on_open_callback: Method to call on connection open
-        :param on_open_error_callback: Method to call if the connection cant
-                                       be opened
-        :type on_open_error_callback: method
-        :param method on_close_callback: Method to call on connection close
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the global IOLoop in Tornado
         :raises: RuntimeError

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -39,9 +39,10 @@ class TornadoConnection(base_connection.BaseConnection):
         :param pika.connection.Parameters parameters: Connection parameters
         :param on_open_callback: The method to call when the connection is open
         :type on_open_callback: method
-        :param on_open_error_callback: Method to call if the connection cant
-                                       be opened
-        :type on_open_error_callback: method
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the global IOLoop in Tornado
 
@@ -55,7 +56,7 @@ class TornadoConnection(base_connection.BaseConnection):
 
     def _adapter_connect(self):
         """Connect to the remote socket, adding the socket to the IOLoop if
-        connected. 
+        connected.
 
         :rtype: bool
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -105,6 +105,9 @@ class TwistedChannel(object):
 
         try:
             consumer_tag = self.__channel.basic_consume(*args, **kwargs)
+        # TODO this except without types would suppress system-exiting
+        # exceptions, such as SystemExit and KeyboardInterrupt. It should be at
+        # least `except Exception` and preferably more specific.
         except:
             return defer.fail()
 
@@ -163,6 +166,9 @@ class TwistedChannel(object):
 
             try:
                 method(*args, **kwargs)
+            # TODO this except without types would suppress system-exiting
+            # exceptions, such as SystemExit and KeyboardInterrupt. It should be
+            # at least `except Exception` and preferably more specific.
             except:
                 return defer.fail()
             return d
@@ -300,13 +306,6 @@ class TwistedConnection(base_connection.BaseConnection):
         self.ioloop.remove_handler(None)
         self._cleanup_socket()
 
-    def _handle_disconnect(self):
-        """Do not stop the reactor, this would cause the entire process to exit,
-        just fire the disconnect callbacks
-
-        """
-        self._on_connection_closed(None, True)
-
     def _on_connected(self):
         """Call superclass and then update the event state to flush the outgoing
         frame out. Commit 50d842526d9f12d32ad9f3c4910ef60b8c301f59 removed a
@@ -339,7 +338,7 @@ class TwistedConnection(base_connection.BaseConnection):
         if not reason.check(error.ConnectionDone):
             log.err(reason)
 
-        self._handle_disconnect()
+        self._on_terminate(-1, str(reason))
 
     def doRead(self):
         self._handle_read()

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -146,7 +146,7 @@ class Channel(object):
         confirm mode. The acknowledgement can be for a single message or a
         set of messages up to and including a specific message.
 
-        :param int delivery_tag: The server-assigned delivery tag
+        :param integer delivery_tag: int/long The server-assigned delivery tag
         :param bool multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
@@ -286,7 +286,7 @@ class Channel(object):
         It can be used to interrupt and cancel large incoming messages, or
         return untreatable messages to their original queue.
 
-        :param int delivery-tag: The server-assigned delivery tag
+        :param integer delivery-tag: int/long The server-assigned delivery tag
         :param bool multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
@@ -381,7 +381,7 @@ class Channel(object):
         message. It can be used to interrupt and cancel large incoming messages,
         or return untreatable messages to their original queue.
 
-        :param int delivery-tag: The server-assigned delivery tag
+        :param integer delivery-tag: int/long The server-assigned delivery tag
         :param bool requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -11,7 +11,7 @@ import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
 from pika.utils import is_callable
-from pika.compat import unicode_type, dictkeys, as_bytes
+from pika.compat import unicode_type, dictkeys, as_bytes, is_integer
 
 
 LOGGER = logging.getLogger(__name__)
@@ -391,7 +391,7 @@ class Channel(object):
         """
         if not self.is_open:
             raise exceptions.ChannelClosed()
-        if not isinstance(delivery_tag, int):
+        if not is_integer(delivery_tag):
             raise TypeError('delivery_tag must be an integer')
         return self._send_method(spec.Basic.Reject(delivery_tag, requeue))
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -26,6 +26,7 @@ class Channel(object):
     method.
 
     """
+
     CLOSED = 0
     OPENING = 1
     OPEN = 2
@@ -1106,8 +1107,7 @@ class Channel(object):
         blocking state and register for `_on_synchronous_complete` before
         sending the request.
 
-        NOTE: A populated callback must be accompanied by populated
-        acceptable_replies.
+        NOTE: A callback must be accompanied by non-empty acceptable_replies.
 
         :param pika.amqp_object.Method method_frame: The method frame to call
         :param method callback: The callback for the RPC response
@@ -1124,11 +1124,11 @@ class Channel(object):
 
         # Validate the callback is callable
         if callback is not None and not is_callable(callback):
-            raise TypeError('callback should be None, a function or method.')
+            raise TypeError('callback should be None, a function, or method.')
 
         if callback is not None and not acceptable_replies:
-            raise ValueError('A populated callback must be accompanied by '
-                             'populated acceptable_replies')
+            raise ValueError(
+                'Unexpected callback for asynchronous (nowait) operation.')
 
         # Make sure the channel is open
         if self.is_closed:

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -29,7 +29,7 @@ class Channel(object):
     CLOSED = 0
     OPENING = 1
     OPEN = 2
-    CLOSING = 3
+    CLOSING = 3  # client-initiated close in progress
 
     _ON_CHANNEL_CLEANUP_CB_KEY = '_on_channel_cleanup'
 
@@ -615,7 +615,8 @@ class Channel(object):
 
     @property
     def is_closing(self):
-        """Returns True if the channel is closing.
+        """Returns True if client-initiated closing of the channel is in
+        progress.
 
         :rtype: bool
 

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -73,6 +73,8 @@ if not PY2:
 
         return str(value)
 
+    def is_integer(value):
+        return isinstance(value, int)
 else:
     from urllib import unquote as url_unquote, urlencode
 
@@ -97,6 +99,8 @@ else:
         except UnicodeEncodeError:
             return str(value.encode('utf-8'))
 
+    def is_integer(value):
+        return isinstance(value, (int, long))
 
 def as_bytes(value):
     if not isinstance(value, bytes):

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -4,6 +4,7 @@ import sys
 import collections
 import logging
 import math
+import numbers
 import platform
 import threading
 import warnings
@@ -586,7 +587,7 @@ class Connection(object):
     CONNECTION_START = 3
     CONNECTION_TUNE = 4
     CONNECTION_OPEN = 5
-    CONNECTION_CLOSING = 6
+    CONNECTION_CLOSING = 6  # client-initiated close in progress
 
     def __init__(self,
                  parameters=None,
@@ -602,9 +603,10 @@ class Connection(object):
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param method on_open_callback: Called when the connection is opened
-        :param method on_open_error_callback: Called if the connection cant
-                                       be opened
-        :param method on_close_callback: Called when the connection is closed
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
 
         """
         self._write_lock = threading.Lock()
@@ -770,8 +772,9 @@ class Connection(object):
         self.remaining_connection_attempts -= 1
         LOGGER.warning('Could not connect, %i attempts left',
                        self.remaining_connection_attempts)
-        if self.remaining_connection_attempts:
+        if self.remaining_connection_attempts > 0:
             LOGGER.info('Retrying in %i seconds', self.params.retry_delay)
+            # TODO: remove timeout if connection is closed before timer fires
             self.add_timeout(self.params.retry_delay, self.connect)
         else:
             self.callbacks.process(0, self.ON_CONNECTION_ERROR, self, self,
@@ -813,7 +816,8 @@ class Connection(object):
     @property
     def is_closing(self):
         """
-        Returns a boolean reporting the current connection state.
+        Returns True if connection is in the process of closing due to
+        client-initiated `close` request, but closing is not yet complete.
         """
         return self.connection_state == self.CONNECTION_CLOSING
 
@@ -1160,6 +1164,13 @@ class Connection(object):
         # Our starting point once connected, first frame received
         self._add_connection_start_callback()
 
+        # Add a callback handler for the Broker telling us to disconnect.
+        # NOTE: As of RabbitMQ 3.6.0, RabbitMQ broker may send Connection.Close
+        # to signal error during connection setup (and wait a longish time
+        # before closing the TCP/IP stream). Earlier RabbitMQ versions
+        # simply closed the TCP/IP stream.
+        self.callbacks.add(0, spec.Connection.Close, self._on_connection_close)
+
     def _is_basic_deliver_frame(self, frame_value):
         """Returns true if the frame is a Basic.Deliver
 
@@ -1168,17 +1179,6 @@ class Connection(object):
 
         """
         return isinstance(frame_value, spec.Basic.Deliver)
-
-    def _is_connection_close_frame(self, value):
-        """Returns true if the frame is a Connection.Close frame.
-
-        :param pika.frame.Method value: The frame to check
-        :rtype: bool
-
-        """
-        if not value:
-            return False
-        return isinstance(value.method, spec.Connection.Close)
 
     def _is_method_frame(self, value):
         """Returns true if the frame is a method frame.
@@ -1250,32 +1250,29 @@ class Connection(object):
         # Start the communication with the RabbitMQ Broker
         self._send_frame(frame.ProtocolHeader())
 
-    def _on_connection_closed(self, method_frame, from_adapter=False):
-        """Called when the connection is closed remotely. The from_adapter value
-        will be true if the connection adapter has been disconnected from
-        the broker and the method was invoked directly instead of by receiving
-        a Connection.Close frame.
+    def _on_connection_close(self, method_frame):
+        """Called when the connection is closed remotely via Connection.Close
+        frame from broker.
 
-        :param pika.frame.Method: The Connection.Close frame
-        :param bool from_adapter: Called by the connection adapter
+        :param pika.frame.Method method_frame: The Connection.Close frame
 
         """
-        if method_frame and self._is_connection_close_frame(method_frame):
-            self.closing = (method_frame.method.reply_code,
-                            method_frame.method.reply_text)
+        LOGGER.debug('_on_connection_close: frame=%s', method_frame)
 
-        # Save the codes because self.closing gets reset by _adapter_disconnect
-        reply_code, reply_text = self.closing
+        self.closing = (method_frame.method.reply_code,
+                        method_frame.method.reply_text)
 
-        # Stop the heartbeat checker if it exists
-        self._remove_heartbeat()
+        self._on_terminate(self.closing[0], self.closing[1])
 
-        # If this did not come from the connection adapter, close the socket
-        if not from_adapter:
-            self._adapter_disconnect()
+    def _on_connection_close_ok(self, method_frame):
+        """Called when Connection.CloseOk is received from remote.
 
-        # Invoke a method frame neutral close
-        self._on_disconnect(reply_code, reply_text)
+        :param pika.frame.Method method_frame: The Connection.CloseOk frame
+
+        """
+        LOGGER.debug('_on_connection_close_ok: frame=%s', method_frame)
+
+        self._on_terminate(self.closing[0], self.closing[1])
 
     def _on_connection_error(self, connection_unused, error_message=None):
         """Default behavior when the connecting connection can not connect.
@@ -1293,9 +1290,6 @@ class Connection(object):
         Connection.Ok.
         """
         self.known_hosts = method_frame.method.known_hosts
-
-        # Add a callback handler for the Broker telling us to disconnect
-        self.callbacks.add(0, spec.Connection.Close, self._on_connection_closed)
 
         # We're now connected at the AMQP level
         self._set_connection_state(self.CONNECTION_OPEN)
@@ -1368,27 +1362,89 @@ class Connection(object):
             self._trim_frame_buffer(consumed_count)
             self._process_frame(frame_value)
 
-    def _on_disconnect(self, reply_code, reply_text):
-        """Invoke passing in the reply_code and reply_text from internal
-        methods to the adapter. Called from on_connection_closed and Heartbeat
-        timeouts.
+    def _on_terminate(self, reason_code, reason_text):
+        """Terminate the connection and notify registered ON_CONNECTION_ERROR
+        and/or ON_CONNECTION_CLOSED callbacks
 
-        :param str reply_code: The numeric close code
-        :param str reply_text: The text close reason
-
+        :param integer reason_code: HTTP error code for AMQP-reported closures
+          or -1 for other errors (such as socket errors)
+        :param str reason_text: human-readable text message describing the error
         """
-        LOGGER.warning('Disconnected from RabbitMQ at %s:%i (%s): %s',
-                       self.params.host, self.params.port, reply_code,
-                       reply_text)
+        LOGGER.warning(
+            'Disconnected from RabbitMQ at %s:%i (%s): %s',
+            self.params.host, self.params.port, reason_code,
+            reason_text)
+
+        if not isinstance(reason_code, numbers.Integral):
+            raise TypeError('reason_code must be an integer, but got %r'
+                            % (reason_code,))
+
+        # Stop the heartbeat checker if it exists
+        self._remove_heartbeat()
+
+        # Remove connection management callbacks
+        # TODO: This call was moved here verbatim from legacy code and the
+        # following doesn't seem to be right: `Connection.Open` here is
+        # unexpected, we don't appear to ever register it, and the broker
+        # shouldn't be sending `Connection.Open` to us, anyway.
+        self._remove_callbacks(0, [spec.Connection.Close, spec.Connection.Start,
+                                   spec.Connection.Open])
+
+        # Close the socket
+        self._adapter_disconnect()
+
+        # Determine whether this was an error during connection setup
+        connection_error = None
+
+        if self.connection_state == self.CONNECTION_PROTOCOL:
+            LOGGER.error('Incompatible Protocol Versions')
+            connection_error = exceptions.IncompatibleProtocolError(
+                reason_code,
+                reason_text)
+        elif self.connection_state == self.CONNECTION_START:
+            LOGGER.error('Connection closed while authenticating indicating a '
+                         'probable authentication error')
+            connection_error = exceptions.ProbableAuthenticationError(
+                reason_code,
+                reason_text)
+        elif self.connection_state == self.CONNECTION_TUNE:
+            LOGGER.error('Connection closed while tuning the connection '
+                         'indicating a probable permission error when '
+                         'accessing a virtual host')
+            connection_error = exceptions.ProbableAccessDeniedError(
+                reason_code,
+                reason_text)
+        elif self.connection_state not in [self.CONNECTION_OPEN,
+                                           self.CONNECTION_CLOSED,
+                                           self.CONNECTION_CLOSING]:
+            LOGGER.warning('Unexpected connection state on disconnect: %i',
+                           self.connection_state)
+
+        # Transition to closed state
         self._set_connection_state(self.CONNECTION_CLOSED)
+
+        # Inform our channel proxies
         for channel in dictkeys(self._channels):
             if channel not in self._channels:
                 continue
-            method_frame = frame.Method(channel, spec.Channel.Close(reply_code,
-                                                                    reply_text))
+            method_frame = frame.Method(channel, spec.Channel.Close(
+                reason_code,
+                reason_text))
             self._channels[channel]._on_close(method_frame)
-        self._process_connection_closed_callbacks(reply_code, reply_text)
-        self._remove_connection_callbacks()
+
+        # Inform interested parties
+        if connection_error is not None:
+            LOGGER.error('Connection setup failed due to %r', connection_error)
+            self.callbacks.process(0,
+                                   self.ON_CONNECTION_ERROR,
+                                   self, self,
+                                   connection_error)
+
+        self.callbacks.process(0, self.ON_CONNECTION_CLOSED, self, self,
+                               reason_code, reason_text)
+
+        # Reset connection properties
+        self._init_connection_state()
 
     def _process_callbacks(self, frame_value):
         """Process the callbacks for the frame if the frame is a method frame
@@ -1406,17 +1462,6 @@ class Connection(object):
                                    frame_value)  # Args
             return True
         return False
-
-    def _process_connection_closed_callbacks(self, reason_code, reason_text):
-        """Process any callbacks that should be called when the connection is
-        closed.
-
-        :param str reason_code: The numeric code from RabbitMQ for the close
-        :param str reason_text: The text reason fro closing
-
-        """
-        self.callbacks.process(0, self.ON_CONNECTION_CLOSED, self, self,
-                               reason_code, reason_text)
 
     def _process_frame(self, frame_value):
         """Process an inbound frame from the socket.
@@ -1489,11 +1534,6 @@ class Connection(object):
         for method_frame in method_frames:
             self._remove_callback(channel_number, method_frame)
 
-    def _remove_connection_callbacks(self):
-        """Remove all callbacks for the connection"""
-        self._remove_callbacks(0, [spec.Connection.Close, spec.Connection.Start,
-                                   spec.Connection.Open])
-
     def _rpc(self, channel_number, method_frame,
              callback_method=None,
              acceptable_replies=None):
@@ -1530,7 +1570,7 @@ class Connection(object):
 
         """
         self._rpc(0, spec.Connection.Close(reply_code, reply_text, 0, 0),
-                  self._on_connection_closed, [spec.Connection.CloseOk])
+                  self._on_connection_close_ok, [spec.Connection.CloseOk])
 
     def _send_connection_open(self):
         """Send a Connection.Open frame"""

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -24,7 +24,7 @@ from pika import utils
 
 from pika import spec
 
-from pika.compat import basestring, url_unquote, dictkeys
+from pika.compat import xrange, basestring, url_unquote, dictkeys
 
 
 BACKPRESSURE_WARNING = ("Pika: Write buffer exceeded warning threshold at "
@@ -1204,13 +1204,13 @@ class Connection(object):
 
         """
         limit = self.params.channel_max or channel.MAX_CHANNELS
-        if len(self._channels) == limit:
+        if len(self._channels) >= limit:
             raise exceptions.NoFreeChannels()
 
-        ckeys = set(self._channels.keys())
-        if not ckeys:
-            return 1
-        return [x + 1 for x in sorted(ckeys) if x + 1 not in ckeys][0]
+        for n in xrange(1, len(self._channels) + 1):
+            if n not in self._channels:
+                return n
+        return len(self._channels) + 1
 
     def _on_channel_cleanup(self, channel):
         """Remove the channel from the dict of channels when Channel.CloseOk is

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -26,7 +26,8 @@ class AMQPConnectionError(AMQPError):
 class IncompatibleProtocolError(AMQPConnectionError):
 
     def __repr__(self):
-        return 'The protocol returned by the server is not supported'
+        return ('The protocol returned by the server is not supported: %s' %
+                (self.args,))
 
 
 class AuthenticationError(AMQPConnectionError):
@@ -40,14 +41,15 @@ class ProbableAuthenticationError(AMQPConnectionError):
 
     def __repr__(self):
         return ('Client was disconnected at a connection stage indicating a '
-                'probable authentication error')
+                'probable authentication error: %s' % (self.args,))
 
 
 class ProbableAccessDeniedError(AMQPConnectionError):
 
     def __repr__(self):
         return ('Client was disconnected at a connection stage indicating a '
-                'probable denial of access to the specified virtual host')
+                'probable denial of access to the specified virtual host: %s' %
+                (self.args,))
 
 
 class NoFreeChannels(AMQPConnectionError):

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -115,10 +115,14 @@ class HeartbeatChecker(object):
                     self._idle_byte_intervals)
         duration = self._max_idle_count * self._interval
         text = HeartbeatChecker._STALE_CONNECTION % duration
+
+        # NOTE: this won't achieve the perceived effect of sending
+        # Connection.Close to broker, because the frame will only get buffered
+        # in memory before the next statement terminates the connection.
         self._connection.close(HeartbeatChecker._CONNECTION_FORCED, text)
-        self._connection._adapter_disconnect()
-        self._connection._on_disconnect(HeartbeatChecker._CONNECTION_FORCED,
-                                        text)
+
+        self._connection._on_terminate(HeartbeatChecker._CONNECTION_FORCED,
+                                       text)
 
     @property
     def _has_received_data(self):

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -1,13 +1,25 @@
+# Suppress pylint messages concerning missing class and method docstrings
+# pylint: disable=C0111
+
+# Suppress pylint warning about attribute defined outside __init__
+# pylint: disable=W0201
+
+# Suppress pylint warning about access to protected member
+# pylint: disable=W0212
+
+# Suppress pylint warning about unused argument
+# pylint: disable=W0613
+
 import time
 import uuid
 
-from pika import spec, URLParameters
+from pika import spec
 from pika.compat import as_bytes
 
 from async_test_base import (AsyncTestCase, BoundQueueTestCase, AsyncAdapters)
 
 
-class TestA_Connect(AsyncTestCase, AsyncAdapters):
+class TestA_Connect(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Connect, open channel and disconnect"
 
     def begin(self, channel):
@@ -26,11 +38,49 @@ class TestConfirmSelect(AsyncTestCase, AsyncAdapters):
         self.stop()
 
 
+class TestBlockingNonBlockingBlockingRPCWontStall(AsyncTestCase, AsyncAdapters):
+    DESCRIPTION = ("Verify that a sequence of blocking, non-blocking, blocking "
+                   "RPC requests won't stall")
+
+    def begin(self, channel):
+        # Queue declaration params table: queue name, nowait value
+        self._expected_queue_params = (
+            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, False),
+            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, True),
+            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, False)
+        )
+
+        self._declared_queue_names = []
+
+        for queue, nowait in self._expected_queue_params:
+            channel.queue_declare(callback=self._queue_declare_ok_cb
+                                  if not nowait else None,
+                                  queue=queue,
+                                  auto_delete=True,
+                                  nowait=nowait,
+                                  arguments={'x-expires': self.TIMEOUT * 1000})
+
+    def _queue_declare_ok_cb(self, declare_ok_frame):
+        self._declared_queue_names.append(declare_ok_frame.method.queue)
+
+        if len(self._declared_queue_names) == 2:
+            # Initiate check for creation of queue declared with nowait=True
+            self.channel.queue_declare(callback=self._queue_declare_ok_cb,
+                                       queue=self._expected_queue_params[1][0],
+                                       passive=True,
+                                       nowait=False)
+        elif len(self._declared_queue_names) == 3:
+            self.assertSequenceEqual(
+                sorted(self._declared_queue_names),
+                sorted(item[0] for item in self._expected_queue_params))
+            self.stop()
+
+
 class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Consume and cancel"
 
     def begin(self, channel):
-        self.queue_name = str(uuid.uuid4())
+        self.queue_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         channel.queue_declare(self.on_queue_declared, queue=self.queue_name)
 
     def on_queue_declared(self, frame):
@@ -58,7 +108,7 @@ class TestExchangeDeclareAndDelete(AsyncTestCase, AsyncAdapters):
     X_TYPE = 'direct'
 
     def begin(self, channel):
-        self.name = self.__class__.__name__ + ':' + str(id(self))
+        self.name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         channel.exchange_declare(self.on_exchange_declared, self.name,
                                  exchange_type=self.X_TYPE,
                                  passive=False,
@@ -81,7 +131,7 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
     X_TYPE2 = 'topic'
 
     def begin(self, channel):
-        self.name = self.__class__.__name__ + ':' + str(id(self))
+        self.name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.channel.add_on_close_callback(self.on_channel_closed)
         channel.exchange_declare(self.on_exchange_declared, self.name,
                                  exchange_type=self.X_TYPE1,
@@ -97,7 +147,7 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
         self.connection.channel(self.on_cleanup_channel)
 
     def on_exchange_declared(self, frame):
-        self.channel.exchange_declare(self.on_exchange_declared, self.name,
+        self.channel.exchange_declare(self.on_bad_result, self.name,
                                       exchange_type=self.X_TYPE2,
                                       passive=False,
                                       durable=False,
@@ -134,7 +184,8 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Create and delete a named queue"
 
     def begin(self, channel):
-        channel.queue_declare(self.on_queue_declared, str(id(self)),
+        self._q_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
+        channel.queue_declare(self.on_queue_declared, self._q_name,
                               passive=False,
                               durable=False,
                               exclusive=True,
@@ -143,10 +194,9 @@ class TestQueueNameDeclareAndDelete(AsyncTestCase, AsyncAdapters):
                               arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_queue_declared(self, frame):
-        queue = str(id(self))
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
         # Frame's method's queue is encoded (impl detail)
-        self.assertEqual(frame.method.queue, queue)
+        self.assertEqual(frame.method.queue, self._q_name)
         self.channel.queue_delete(self.on_queue_delete, frame.method.queue)
 
     def on_queue_delete(self, frame):
@@ -159,8 +209,9 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Should close chan: re-declared queue w/ diff params"
 
     def begin(self, channel):
+        self._q_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.channel.add_on_close_callback(self.on_channel_closed)
-        channel.queue_declare(self.on_queue_declared, str(id(self)),
+        channel.queue_declare(self.on_queue_declared, self._q_name,
                               passive=False,
                               durable=False,
                               exclusive=True,
@@ -172,7 +223,7 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
         self.stop()
 
     def on_queue_declared(self, frame):
-        self.channel.queue_declare(self.on_bad_result, str(id(self)),
+        self.channel.queue_declare(self.on_bad_result, self._q_name,
                                    passive=False,
                                    durable=True,
                                    exclusive=False,
@@ -181,13 +232,13 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
                                    arguments={'x-expires': self.TIMEOUT * 1000})
 
     def on_bad_result(self, frame):
-        self.channel.queue_delete(None, str(id(self)), nowait=True)
+        self.channel.queue_delete(None, self._q_name, nowait=True)
         raise AssertionError("Should not have received a Queue.DeclareOk")
 
 
 
-class TestTX1_Select(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION="Receive confirmation of Tx.Select"
+class TestTX1_Select(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
+    DESCRIPTION = "Receive confirmation of Tx.Select"
 
     def begin(self, channel):
         channel.tx_select(self.on_complete)
@@ -198,8 +249,8 @@ class TestTX1_Select(AsyncTestCase, AsyncAdapters):
 
 
 
-class TestTX2_Commit(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION="Start a transaction, and commit it"
+class TestTX2_Commit(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
+    DESCRIPTION = "Start a transaction, and commit it"
 
     def begin(self, channel):
         channel.tx_select(self.on_selectok)
@@ -213,7 +264,7 @@ class TestTX2_Commit(AsyncTestCase, AsyncAdapters):
         self.stop()
 
 
-class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):
+class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Close the channel: commit without a TX"
 
     def begin(self, channel):
@@ -226,11 +277,12 @@ class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):
     def on_selectok(self, frame):
         self.assertIsInstance(frame.method, spec.Tx.SelectOk)
 
-    def on_commitok(self, frame):
+    @staticmethod
+    def on_commitok(frame):
         raise AssertionError("Should not have received a Tx.CommitOk")
 
 
-class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):
+class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Start a transaction, then rollback"
 
     def begin(self, channel):
@@ -246,7 +298,7 @@ class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):
 
 
 
-class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):
+class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Close the channel: rollback without a TX"
 
     def begin(self, channel):
@@ -256,12 +308,12 @@ class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):
     def on_channel_closed(self, channel, reply_code, reply_text):
         self.stop()
 
-    def on_commitok(self, frame):
+    @staticmethod
+    def on_commitok(frame):
         raise AssertionError("Should not have received a Tx.RollbackOk")
 
 
-
-class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):
+class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Publish a message and consume it"
 
     def on_ready(self, frame):
@@ -282,10 +334,11 @@ class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):
 
 
 
-class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
+class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Publish a big message and consume it"
 
-    def _get_msg_body(self):
+    @staticmethod
+    def _get_msg_body():
         return '\n'.join(["%s" % i for i in range(0, 2097152)])
 
     def on_ready(self, frame):
@@ -305,7 +358,7 @@ class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
         self.channel.basic_cancel(self.on_cancelled, self.ctag)
 
 
-class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):
+class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Publish a message and get it"
 
     def on_ready(self, frame):
@@ -321,13 +374,14 @@ class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):
         self.stop()
 
 
-class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):
+class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Verify that access denied invokes on open error callback"
 
     def start(self, *args, **kwargs):
         self.parameters.virtual_host = str(uuid.uuid4())
         self.error_captured = False
         super(TestZ_AccessDenied, self).start(*args, **kwargs)
+        self.assertTrue(self.error_captured)
 
     def on_open_error(self, connection, error):
         self.error_captured = True
@@ -336,7 +390,3 @@ class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):
     def on_open(self, connection):
         super(TestZ_AccessDenied, self).on_open(connection)
         self.stop()
-
-    def tearDown(self):
-        self.assertTrue(self.error_captured)
-        super(TestZ_AccessDenied, self).tearDown()

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -1,3 +1,10 @@
+# Suppress pylint warnings concerning attribute defined outside __init__
+# pylint: disable=W0201
+
+# Suppress pylint messages concerning missing docstrings
+# pylint: disable=C0111
+
+from datetime import datetime
 import select
 import logging
 try:
@@ -6,7 +13,9 @@ except ImportError:
     import unittest
 
 import platform
-target = platform.python_implementation()
+_TARGET = platform.python_implementation()
+
+import uuid
 
 import pika
 from pika import adapters
@@ -24,6 +33,9 @@ class AsyncTestCase(unittest.TestCase):
             'amqp://guest:guest@localhost:5672/%2F')
         super(AsyncTestCase, self).setUp()
 
+    def tearDown(self):
+        self._stop()
+
     def shortDescription(self):
         method_desc = super(AsyncTestCase, self).shortDescription()
         if self.DESCRIPTION:
@@ -31,11 +43,12 @@ class AsyncTestCase(unittest.TestCase):
         else:
             return method_desc
 
-    def begin(self, channel):
+    def begin(self, channel):  # pylint: disable=R0201,W0613
         """Extend to start the actual tests on the channel"""
-        raise AssertionError("AsyncTestCase.begin_test not extended")
+        self.fail("AsyncTestCase.begin_test not extended")
 
     def start(self, adapter=None):
+        self.logger.info('start at %s', datetime.utcnow())
         self.adapter = adapter or self.ADAPTER
 
         self.connection = self.adapter(self.parameters, self.on_open,
@@ -53,19 +66,18 @@ class AsyncTestCase(unittest.TestCase):
 
     def _stop(self):
         if hasattr(self, 'timeout') and self.timeout:
+            self.logger.info("Removing timeout")
             self.connection.remove_timeout(self.timeout)
             self.timeout = None
         if hasattr(self, 'connection') and self.connection:
+            self.logger.info("Stopping ioloop")
             self.connection.ioloop.stop()
             self.connection = None
 
-    def tearDown(self):
-        self._stop()
-
     def on_closed(self, connection, reply_code, reply_text):
         """called when the connection has finished closing"""
-        self.logger.debug('on_closed: %r %r %r', connection,
-                          reply_code, reply_text)
+        self.logger.info('on_closed: %r %r %r', connection,
+                         reply_code, reply_text)
         self._stop()
 
     def on_open(self, connection):
@@ -73,29 +85,25 @@ class AsyncTestCase(unittest.TestCase):
         self.channel = connection.channel(self.begin)
 
     def on_open_error(self, connection, error):
-        self.logger.debug('on_open_error: %r %r', connection, error)
+        self.logger.error('on_open_error: %r %r', connection, error)
         connection.ioloop.stop()
         raise AssertionError('Error connecting to RabbitMQ')
 
     def on_timeout(self):
         """called when stuck waiting for connection to close"""
+        self.logger.info('on_timeout at %s', datetime.utcnow())
         # force the ioloop to stop
-        self.logger.debug('on_timeout')
+        self.logger.debug('on_timeout called')
         self.connection.ioloop.stop()
         raise AssertionError('Test timed out')
 
 
 class BoundQueueTestCase(AsyncTestCase):
 
-    def tearDown(self):
-        """Cleanup auto-declared queue and exchange"""
-        self._cconn = self.adapter(self.parameters, self._on_cconn_open,
-                                   self._on_cconn_error, self._on_cconn_closed)
-
     def start(self, adapter=None):
         # PY3 compat encoding
-        self.exchange = 'e' + str(id(self))
-        self.queue = 'q' + str(id(self))
+        self.exchange = 'e-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
+        self.queue = 'q-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.routing_key = self.__class__.__name__
         super(BoundQueueTestCase, self).start(adapter)
 
@@ -106,82 +114,70 @@ class BoundQueueTestCase(AsyncTestCase):
                                       durable=False,
                                       auto_delete=True)
 
-    def on_exchange_declared(self, frame):
+    def on_exchange_declared(self, frame):  # pylint: disable=W0613
         self.channel.queue_declare(self.on_queue_declared, self.queue,
                                    passive=False,
                                    durable=False,
                                    exclusive=True,
                                    auto_delete=True,
                                    nowait=False,
-                                   arguments={'x-expires': self.TIMEOUT * 1000}
-                                   )
+                                   arguments={'x-expires': self.TIMEOUT * 1000})
 
-    def on_queue_declared(self, frame):
+    def on_queue_declared(self, frame):  # pylint: disable=W0613
         self.channel.queue_bind(self.on_ready, self.queue, self.exchange,
                                 self.routing_key)
 
     def on_ready(self, frame):
         raise NotImplementedError
 
-    def _on_cconn_closed(self, cconn, *args, **kwargs):
-        cconn.ioloop.stop()
-        self._cconn = None
-
-    def _on_cconn_error(self, connection):
-        connection.ioloop.stop()
-        raise AssertionError('Error connecting to RabbitMQ')
-
-    def _on_cconn_open(self, connection):
-        connection.channel(self._on_cconn_channel)
-
-    def _on_cconn_channel(self, channel):
-        channel.exchange_delete(None, self.exchange, nowait=True)
-        channel.queue_delete(None, self.queue, nowait=True)
-        self._cconn.close()
 
 #
 # In order to write test cases that will tested using all the Async Adapters
-# write a class that inherits both from one of TestCase classes above and 
+# write a class that inherits both from one of TestCase classes above and
 # from the AsyncAdapters class below. This allows you to avoid duplicating the
 # test methods for each adapter in each test class.
 #
 
 class AsyncAdapters(object):
 
+    def start(self, adapter_class):
+        raise NotImplementedError
+
     def select_default_test(self):
         "SelectConnection:DefaultPoller"
-        select_connection.POLLER_TYPE=None
+        select_connection.POLLER_TYPE = None
         self.start(adapters.SelectConnection)
 
     def select_select_test(self):
         "SelectConnection:select"
-        select_connection.POLLER_TYPE='select'
+        select_connection.POLLER_TYPE = 'select'
         self.start(adapters.SelectConnection)
 
-    @unittest.skipIf(not hasattr(select, 'poll') 
-        or not hasattr(select.poll(), 'modify'), "poll not supported")
+    @unittest.skipIf(
+        not hasattr(select, 'poll') or
+        not hasattr(select.poll(), 'modify'), "poll not supported")  # pylint: disable=E1101
     def select_poll_test(self):
         "SelectConnection:poll"
-        select_connection.POLLER_TYPE='poll'
+        select_connection.POLLER_TYPE = 'poll'
         self.start(adapters.SelectConnection)
 
     @unittest.skipIf(not hasattr(select, 'epoll'), "epoll not supported")
     def select_epoll_test(self):
         "SelectConnection:epoll"
-        select_connection.POLLER_TYPE='epoll'
+        select_connection.POLLER_TYPE = 'epoll'
         self.start(adapters.SelectConnection)
 
     @unittest.skipIf(not hasattr(select, 'kqueue'), "kqueue not supported")
     def select_kqueue_test(self):
         "SelectConnection:kqueue"
-        select_connection.POLLER_TYPE='kqueue'
+        select_connection.POLLER_TYPE = 'kqueue'
         self.start(adapters.SelectConnection)
 
     def tornado_test(self):
         "TornadoConnection"
         self.start(adapters.TornadoConnection)
 
-    @unittest.skipIf(target == 'PyPy', 'PyPy is not supported')
+    @unittest.skipIf(_TARGET == 'PyPy', 'PyPy is not supported')
     @unittest.skipIf(adapters.LibevConnection is None, 'pyev is not installed')
     def libev_test(self):
         "LibevConnection"

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -37,6 +37,7 @@ class AsyncTestCase(unittest.TestCase):
         self.logger = logging.getLogger(self.__class__.__name__)
         self.parameters = pika.URLParameters(
             'amqp://guest:guest@localhost:5672/%2F')
+        self._timed_out = False
         super(AsyncTestCase, self).setUp()
 
     def tearDown(self):
@@ -62,6 +63,7 @@ class AsyncTestCase(unittest.TestCase):
         self.timeout = self.connection.add_timeout(self.TIMEOUT,
                                                    self.on_timeout)
         self.connection.ioloop.start()
+        self.assertFalse(self._timed_out)
 
     def stop(self):
         """close the connection and stop the ioloop"""
@@ -98,10 +100,11 @@ class AsyncTestCase(unittest.TestCase):
 
     def on_timeout(self):
         """called when stuck waiting for connection to close"""
-        self.logger.error('%s timed out; on_timeout called at %s', 
+        self.logger.error('%s timed out; on_timeout called at %s',
             self, datetime.utcnow())
-        # Initiate cleanup
         self.timeout = None  # the dispatcher should have removed it
+        self._timed_out = True
+        # initiate cleanup
         self.stop()
 
 

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -41,6 +41,11 @@ DEFAULT_PARAMS = pika.URLParameters(DEFAULT_URL)
 DEFAULT_TIMEOUT = 15
 
 
+
+def setUpModule():
+    logging.basicConfig(level=logging.DEBUG)
+
+
 class BlockingTestCaseBase(unittest.TestCase):
 
     TIMEOUT = DEFAULT_TIMEOUT
@@ -178,7 +183,10 @@ class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
     def test(self):
         """BlockingConnection resets properly on TCP/IP drop during channel()
         """
-        with ForwardServer((DEFAULT_PARAMS.host, DEFAULT_PARAMS.port)) as fwd:
+        with ForwardServer(
+            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+            local_linger_args=(1, 0)) as fwd:
+
             self.connection = self._connect(
                 PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]})
 
@@ -198,7 +206,10 @@ class TestNoAccessToFileDescriptorAfterConnectionClosed(BlockingTestCaseBase):
     def test(self):
         """BlockingConnection no access file descriptor after ConnectionClosed
         """
-        with ForwardServer((DEFAULT_PARAMS.host, DEFAULT_PARAMS.port)) as fwd:
+        with ForwardServer(
+            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+            local_linger_args=(1, 0)) as fwd:
+
             self.connection = self._connect(
                 PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]})
 
@@ -244,7 +255,10 @@ class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_START
         """
-        fwd = ForwardServer((DEFAULT_PARAMS.host, DEFAULT_PARAMS.port))
+        fwd = ForwardServer(
+            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+            local_linger_args=(1, 0))
+
         fwd.start()
         self.addCleanup(lambda: fwd.stop() if fwd.running else None)
 
@@ -267,7 +281,9 @@ class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_TUNE
         """
-        fwd = ForwardServer((DEFAULT_PARAMS.host, DEFAULT_PARAMS.port))
+        fwd = ForwardServer(
+            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+            local_linger_args=(1, 0))
         fwd.start()
         self.addCleanup(lambda: fwd.stop() if fwd.running else None)
 
@@ -290,7 +306,10 @@ class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_PROTOCOL
         """
-        fwd = ForwardServer((DEFAULT_PARAMS.host, DEFAULT_PARAMS.port))
+        fwd = ForwardServer(
+            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+            local_linger_args=(1, 0))
+
         fwd.start()
         self.addCleanup(lambda: fwd.stop() if fwd.running else None)
 

--- a/tests/acceptance/test_utils.py
+++ b/tests/acceptance/test_utils.py
@@ -1,0 +1,73 @@
+"""Acceptance test utils"""
+
+import functools
+import logging
+import time
+import traceback
+
+
+def retry_assertion(timeout_sec, retry_interval_sec=0.1):
+    """Creates a decorator that retries the decorated function or
+    method only upon `AssertionError` exception at the given retry interval
+    not to exceed the overall given timeout.
+
+    :param float timeout_sec: overall timeout in seconds
+    :param float retry_interval_sec: amount of time to sleep
+        between retries in seconds.
+
+    :returns: decorator that implements the following behavior
+
+    1. This decorator guarantees to call the decorated function or method at
+    least once.
+    2. It passes through all exceptions besides `AssertionError`, preserving the
+    original exception and its traceback.
+    3. If no exception, it returns the return value from the decorated function/method.
+    4. It sleeps `time.sleep(retry_interval_sec)` between retries.
+    5. It checks for expiry of the overall timeout before sleeping.
+    6. If the overall timeout is exceeded, it re-raises the latest `AssertionError`,
+    preserving its original traceback
+    """
+
+    def retry_assertion_decorator(func):
+        """Decorator"""
+
+        @functools.wraps(func)
+        def retry_assertion_wrap(*args, **kwargs):
+            """The wrapper"""
+
+            num_attempts = 0
+            start_time = time.time()
+
+            while True:
+                num_attempts += 1
+
+                try:
+                    result = func(*args, **kwargs)
+                except AssertionError:
+
+                    now = time.time()
+                    # Compensate for time adjustment
+                    if now < start_time:
+                        start_time = now
+
+                    if (now - start_time) > timeout_sec:
+                        logging.exception(
+                            'Exceeded retry timeout of %s sec in %s attempts '
+                            'with func %r. Caller\'s stack:\n%s',
+                            timeout_sec, num_attempts, func,
+                            ''.join(traceback.format_stack()))
+                        raise
+
+                    logging.debug('Attempt %s failed; retrying %r in %s sec.',
+                                  num_attempts, func, retry_interval_sec)
+
+                    time.sleep(retry_interval_sec)
+                else:
+                    logging.debug('%r succeeded at attempt %s',
+                                  func, num_attempts)
+                    return result
+
+        return retry_assertion_wrap
+
+    return retry_assertion_decorator
+

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -12,7 +12,7 @@ import socket
 from pika.exceptions import AMQPConnectionError
 
 try:
-    from unittest import mock
+    from unittest import mock  # pylint: disable=E0611
     patch = mock.patch
 except ImportError:
     import mock
@@ -182,8 +182,8 @@ class BlockingConnectionTests(unittest.TestCase):
                   spec_set=SelectConnectionTemplate)
     @patch.object(blocking_connection, 'BlockingChannel',
                   spec_set=blocking_connection.BlockingChannel)
-    def test_channel(self, blocking_channel_class_mock,
-                     select_connection_class_mock):
+    def test_channel(self, blocking_channel_class_mock,  # pylint: disable=W0613
+                     select_connection_class_mock):  # pylint: disable=W0613
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
             connection = blocking_connection.BlockingConnection('params')
@@ -196,7 +196,7 @@ class BlockingConnectionTests(unittest.TestCase):
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)
-    def test_sleep(self, select_connection_class_mock):
+    def test_sleep(self, select_connection_class_mock):  # pylint: disable=W0613
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
             connection = blocking_connection.BlockingConnection('params')
@@ -211,15 +211,28 @@ class BlockingConnectionTests(unittest.TestCase):
         # for whatever conn_attempt we try:
         for conn_attempt in (1, 2, 5):
             # retry_delay of 0 to not wait uselessly during the retry process.
-            params = pika.ConnectionParameters(connection_attempts=conn_attempt, retry_delay=0)
+            params = pika.ConnectionParameters(connection_attempts=conn_attempt,
+                                               retry_delay=0)
             with self.assertRaises(AMQPConnectionError) as ctx:
                 with mock.patch('socket.socket.connect',
                                 side_effect=socket.timeout) as connect_mock:
-                    pika.BlockingConnection(parameters=params)
+                    with mock.patch('socket.getaddrinfo',
+                                    return_value=[(socket.AF_INET,
+                                                   socket.SOCK_STREAM,
+                                                   mock.Mock(name="proto"),
+                                                   mock.Mock(name="canonname"),
+                                                   ('127.0.0.1', 5672))]):
+                        pika.BlockingConnection(parameters=params)
+
             # as any attempt will timeout (directly),
-            # at the end there must be exactly that count of socket.connect() method calls:
+            # at the end there must be exactly that count of socket.connect()
+            # method calls:
             self.assertEqual(conn_attempt, connect_mock.call_count)
+
             # and each must be with the following arguments (always the same):
-            connect_mock.assert_has_calls(conn_attempt * [mock.call(('127.0.0.1', 5672))])
+            connect_mock.assert_has_calls(conn_attempt *
+                                          [mock.call(('127.0.0.1', 5672))])
+
             # and the raised error must then looks like:
-            self.assertEqual('Connection to 127.0.0.1:5672 failed: timeout', str(ctx.exception))
+            self.assertEqual('Connection to 127.0.0.1:5672 failed: timeout',
+                             str(ctx.exception))

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -3,6 +3,10 @@
 Tests for pika.adapters.blocking_connection.BlockingConnection
 
 """
+
+# Suppress pylint warnings concering access to protected member
+# pylint: disable=W0212
+
 import socket
 
 from pika.exceptions import AMQPConnectionError
@@ -26,11 +30,11 @@ class BlockingConnectionMockTemplate(blocking_connection.BlockingConnection):
     pass
 
 class SelectConnectionTemplate(blocking_connection.SelectConnection):
-    is_closed = False
-    is_closing = False
-    is_open = True
-    outbound_buffer = []
-    _channels = dict()
+    is_closed = None
+    is_closing = None
+    is_open = None
+    outbound_buffer = None
+    _channels = None
 
 
 class BlockingConnectionTests(unittest.TestCase):
@@ -41,7 +45,7 @@ class BlockingConnectionTests(unittest.TestCase):
     def test_constructor(self, select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
-            connection = blocking_connection.BlockingConnection('params')
+            blocking_connection.BlockingConnection('params')
 
         select_connection_class_mock.assert_called_once_with(
             parameters='params',
@@ -153,9 +157,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with self.assertRaises(pika.exceptions.ConnectionClosed) as cm:
             connection._flush_output(lambda: False, lambda: True)
 
-        self.assertSequenceEqual(
-            cm.exception.args,
-            ())
+        self.assertSequenceEqual(cm.exception.args, (200, 'ok'))
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)
@@ -190,7 +192,7 @@ class BlockingConnectionTests(unittest.TestCase):
                 blocking_connection.BlockingConnection,
                 '_flush_output',
                 spec_set=blocking_connection.BlockingConnection._flush_output):
-            channel = connection.channel()
+            connection.channel()
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -4,8 +4,17 @@ Tests for pika.adapters.blocking_connection.BlockingConnection
 
 """
 
-# Suppress pylint warnings concering access to protected member
+# Disable pylint warnings concerning access to protected member
 # pylint: disable=W0212
+
+# Disable pylint messages concerning missing docstring
+# pylint: disable=C0111
+
+# Disable pylint messages concerning invalid method names
+# pylint: disable=C0103
+
+# Disable pylint messages concerning "method could be a function"
+# pylint: disable=R0201
 
 import socket
 
@@ -13,7 +22,7 @@ from pika.exceptions import AMQPConnectionError
 
 try:
     from unittest import mock  # pylint: disable=E0611
-    patch = mock.patch
+    from unittest.mock import patch  # pylint: disable=E0611
 except ImportError:
     import mock
     from mock import patch
@@ -29,12 +38,14 @@ from pika.adapters import blocking_connection
 class BlockingConnectionMockTemplate(blocking_connection.BlockingConnection):
     pass
 
+
 class SelectConnectionTemplate(blocking_connection.SelectConnection):
     is_closed = None
     is_closing = None
     is_open = None
     outbound_buffer = None
     _channels = None
+    ioloop = None
 
 
 class BlockingConnectionTests(unittest.TestCase):
@@ -45,7 +56,7 @@ class BlockingConnectionTests(unittest.TestCase):
     def test_constructor(self, select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
-            blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection('params')
 
         select_connection_class_mock.assert_called_once_with(
             parameters='params',
@@ -53,6 +64,8 @@ class BlockingConnectionTests(unittest.TestCase):
             on_open_error_callback=mock.ANY,
             on_close_callback=mock.ANY,
             stop_ioloop_on_close=mock.ANY)
+
+        self.assertEqual(connection._impl.ioloop.activate_poller.call_count, 1)
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)
@@ -120,6 +133,11 @@ class BlockingConnectionTests(unittest.TestCase):
 
         connection._flush_output(lambda: False, lambda: True)
 
+        self.assertEqual(connection._impl.ioloop.activate_poller.call_count,
+                         1)
+        self.assertEqual(connection._impl.ioloop.deactivate_poller.call_count,
+                         1)
+
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate,
                   is_closed=False, outbound_buffer=[])
@@ -140,11 +158,18 @@ class BlockingConnectionTests(unittest.TestCase):
 
         self.assertSequenceEqual(cm.exception.args, (404, 'not found'))
 
+        self.assertEqual(connection._impl.ioloop.activate_poller.call_count,
+                         1)
+        self.assertEqual(connection._impl.ioloop.deactivate_poller.call_count,
+                         1)
+
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate,
                   is_closed=False, outbound_buffer=[])
-    def test_flush_output_server_initiated_no_error_close(self,
-                                                       select_connection_class_mock):
+    def test_flush_output_server_initiated_no_error_close(
+            self,
+            select_connection_class_mock):
+
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
             connection = blocking_connection.BlockingConnection('params')
@@ -159,9 +184,16 @@ class BlockingConnectionTests(unittest.TestCase):
 
         self.assertSequenceEqual(cm.exception.args, (200, 'ok'))
 
+        self.assertEqual(connection._impl.ioloop.activate_poller.call_count,
+                         1)
+        self.assertEqual(connection._impl.ioloop.deactivate_poller.call_count,
+                         1)
+
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)
     def test_close(self, select_connection_class_mock):
+        select_connection_class_mock.return_value.is_closed = False
+
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
             connection = blocking_connection.BlockingConnection('params')

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     from unittest import mock
 
+import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
@@ -405,10 +407,41 @@ class ChannelTests(unittest.TestCase):
 
     @mock.patch('pika.spec.Basic.Reject')
     @mock.patch('pika.channel.Channel._send_method')
-    def test_basic_reject_send_method_request(self, send_method, unused):
+    def test_basic_reject_send_method_request_with_int_tag(self,
+                                                           send_method,
+                                                           unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.basic_reject(1, True)
         send_method.assert_called_once_with(spec.Basic.Reject(1, True))
+
+    def test_basic_reject_spec_with_int_tag(self):
+        decoded = spec.Basic.Reject()
+        decoded.decode(''.join(spec.Basic.Reject(1, True).encode()))
+
+        self.assertEqual(decoded.delivery_tag, 1)
+        self.assertIs(decoded.requeue, True)
+
+    @mock.patch('pika.spec.Basic.Reject')
+    @mock.patch('pika.channel.Channel._send_method')
+    def test_basic_reject_send_method_request_with_long_tag(self,
+                                                           send_method,
+                                                           unused):
+        self.obj._set_state(self.obj.OPEN)
+
+        # NOTE: we use `sys.maxsize` for compatibility with python 3, which
+        # doesn't have `sys.maxint`
+        self.obj.basic_reject(sys.maxsize, True)
+        send_method.assert_called_once_with(spec.Basic.Reject(sys.maxsize,
+                                                              True))
+
+    def test_basic_reject_spec_with_long_tag(self):
+        # NOTE: we use `sys.maxsize` for compatibility with python 3, which
+        # doesn't have `sys.maxint`
+        decoded = spec.Basic.Reject()
+        decoded.decode(''.join(spec.Basic.Reject(sys.maxsize, True).encode()))
+
+        self.assertEqual(decoded.delivery_tag, sys.maxsize)
+        self.assertIs(decoded.requeue, True)
 
     def test_basic_recover_raises_channel_closed(self):
         self.assertRaises(exceptions.ChannelClosed, self.obj.basic_qos, 0,

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -2,6 +2,16 @@
 Tests for pika.heartbeat
 
 """
+
+# Suppress pylint warnings concering access to protected member
+# pylint: disable=W0212
+
+# Suppress pylint messages concering missing docstring
+# pylint: disable=C0111
+
+# Suppress pylint messages concering invalid method name
+# pylint: disable=C0103
+
 try:
     import mock
 except ImportError:
@@ -58,7 +68,7 @@ class HeartbeatTests(unittest.TestCase):
 
     @mock.patch('pika.heartbeat.HeartbeatChecker._setup_timer')
     def test_constructor_called_setup_timer(self, timer):
-        obj = heartbeat.HeartbeatChecker(self.mock_conn, self.INTERVAL)
+        heartbeat.HeartbeatChecker(self.mock_conn, self.INTERVAL)
         timer.assert_called_once_with()
 
     def test_active_true(self):
@@ -135,9 +145,8 @@ class HeartbeatTests(unittest.TestCase):
                                                self.obj._interval)
         self.mock_conn.close.assert_called_once_with(
             self.obj._CONNECTION_FORCED, reason)
-        self.mock_conn._on_disconnect.assert_called_once_with(
+        self.mock_conn._on_terminate.assert_called_once_with(
             self.obj._CONNECTION_FORCED, reason)
-        self.mock_conn._adapter_disconnect.assert_called_once_with()
 
     def test_has_received_data_false(self):
         self.obj._bytes_received = 100


### PR DESCRIPTION
When calling `basic_cancel`, `pika` will attempt to use call `basic_reject` on all pending messages. However, sometimes, `delivery_tag` is a `long`, and it fails the `if not isinstance(delivery_tag, int)` test, resulting in an exception.

On the other hand, `basic_nack` has no such problems.

```pytb
Traceback (most recent call last):
  File ".../site-packages/pika/adapters/blocking_connection.py", line 1598, in basic_cancel
    requeue=True)
  File ".../site-packages/pika/channel.py", line 394, in basic_reject
    raise TypeError('delivery_tag must be an integer')
TypeError: delivery_tag must be an integer
```