### PR TITLE
Handle Connection.Close from broker at any time, including during connection setup, per RabbitMQ 3.6.0

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -10,6 +10,8 @@ Next Release
  - In BaseConnection.close, call _handle_ioloop_stop only if the connection is
    already closed to allow the asynchronous close operation to complete
    gracefully.
+ - Pass error information from failed socket connection to user callbacks
+   on_open_error_callback and on_close_callback with result_code=-1.
 
 0.10.0 2015-09-02
 -----------------

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -10,7 +10,6 @@ import ssl
 
 import pika.compat
 from pika import connection
-from pika import exceptions
 
 try:
     SOL_TCP = socket.SOL_TCP
@@ -52,10 +51,10 @@ class BaseConnection(connection.Connection):
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param method on_open_callback: Method to call on connection open
-        :param on_open_error_callback: Method to call if the connection cant
-                                       be opened
-        :type on_open_error_callback: method
-        :param method on_close_callback: Method to call on connection close
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param object ioloop: IOLoop object to use
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :raises: RuntimeError
@@ -152,38 +151,9 @@ class BaseConnection(connection.Connection):
     def _adapter_disconnect(self):
         """Invoked if the connection is being told to disconnect"""
         try:
-            self._remove_heartbeat()
             self._cleanup_socket()
-            self._check_state_on_disconnect()
         finally:
-            # Ensure proper cleanup since _check_state_on_disconnect may raise
-            # an exception
             self._handle_ioloop_stop()
-            self._init_connection_state()
-
-    def _check_state_on_disconnect(self):
-        """Checks to see if we were in opening a connection with RabbitMQ when
-        we were disconnected and raises exceptions for the anticipated
-        exception types.
-
-        """
-        if self.connection_state == self.CONNECTION_PROTOCOL:
-            LOGGER.error('Incompatible Protocol Versions')
-            raise exceptions.IncompatibleProtocolError
-        elif self.connection_state == self.CONNECTION_START:
-            LOGGER.error("Socket closed while authenticating indicating a "
-                         "probable authentication error")
-            raise exceptions.ProbableAuthenticationError
-        elif self.connection_state == self.CONNECTION_TUNE:
-            LOGGER.error("Socket closed while tuning the connection indicating "
-                         "a probable permission error when accessing a virtual "
-                         "host")
-            raise exceptions.ProbableAccessDeniedError
-        elif self.is_open:
-            LOGGER.warning("Socket closed when connection was open")
-        elif not self.is_closed and not self.is_closing:
-            LOGGER.warning('Unknown state on disconnect: %i',
-                           self.connection_state)
 
     def _cleanup_socket(self):
         """Close the socket cleanly"""
@@ -272,11 +242,14 @@ class BaseConnection(connection.Connection):
         """
         if not error_value:
             return None
+
         if hasattr(error_value, 'errno'):  # Python >= 2.6
             return error_value.errno
-        elif error_value is not None:
+        else:
+            # TODO: this doesn't look right; error_value.args[0] ??? Could
+            # probably remove this code path since pika doesn't test against
+            # Python 2.5
             return error_value[0]  # Python <= 2.5
-        return None
 
     def _flush_outbound(self):
         """Have the state manager schedule the necessary I/O.
@@ -290,21 +263,6 @@ class BaseConnection(connection.Connection):
         # detected in _send_connection_tune_ok, before _send_connection_open is
         # called), etc., etc., etc.
         self._manage_event_state()
-
-    def _handle_disconnect(self):
-        """Called internally when the socket is disconnected already
-        """
-        try:
-            self._adapter_disconnect()
-        except (exceptions.ProbableAccessDeniedError,
-                exceptions.ProbableAuthenticationError) as error:
-            LOGGER.error('disconnected due to %r', error)
-            self.callbacks.process(0,
-                                   self.ON_CONNECTION_ERROR,
-                                   self,
-                                   self, error)
-
-        self._on_connection_closed(None, True)
 
     def _handle_ioloop_stop(self):
         """Invoked when the connection is closed to determine if the IOLoop
@@ -323,9 +281,10 @@ class BaseConnection(connection.Connection):
         :param int|object error_value: The inbound error
 
         """
-        if 'timed out' in str(error_value):
-            raise socket.timeout
+        # TODO: doesn't seem right: docstring defines error_value as int|object,
+        # but _get_error_code expects a falsie or an exception-like object
         error_code = self._get_error_code(error_value)
+
         if not error_code:
             LOGGER.critical("Tried to handle an error where no error existed")
             return
@@ -342,6 +301,8 @@ class BaseConnection(connection.Connection):
         elif self.params.ssl and isinstance(error_value, ssl.SSLError):
 
             if error_value.args[0] == ssl.SSL_ERROR_WANT_READ:
+                # TODO: doesn't seem right: this logic updates event state, but
+                # the logic at the bottom unconditionaly disconnects anyway.
                 self.event_state = self.READ
             elif error_value.args[0] == ssl.SSL_ERROR_WANT_WRITE:
                 self.event_state = self.WRITE
@@ -353,20 +314,21 @@ class BaseConnection(connection.Connection):
             LOGGER.error("Socket Error: %s", error_code)
 
         # Disconnect from our IOLoop and let Connection know what's up
-        self._handle_disconnect()
+        self._on_terminate(-1, repr(error_value))
 
     def _handle_timeout(self):
         """Handle a socket timeout in read or write.
         We don't do anything in the non-blocking handlers because we
         only have the socket in a blocking state during connect."""
-        pass
+        LOGGER.warning("Unexpected socket timeout")
 
     def _handle_events(self, fd, events, error=None, write_only=False):
         """Handle IO/Event loop events, processing them.
 
         :param int fd: The file descriptor for the events
         :param int events: Events from the IO/Event loop
-        :param int error: Was an error specified
+        :param int error: Was an error specified; TODO none of the current
+          adapters appear to be able to pass the `error` arg - is it needed?
         :param bool write_only: Only handle write events
 
         """
@@ -382,10 +344,11 @@ class BaseConnection(connection.Connection):
             self._handle_read()
 
         if (self.socket and write_only and (events & self.READ) and
-            (events & self.ERROR)):
-            LOGGER.error('BAD libc:  Write-Only but Read+Error. '
+                (events & self.ERROR)):
+            error_msg = ('BAD libc:  Write-Only but Read+Error. '
                          'Assume socket disconnected.')
-            self._handle_disconnect()
+            LOGGER.error(error_msg)
+            self._on_terminate(-1, error_msg)
 
         if self.socket and (events & self.ERROR):
             LOGGER.error('Error event %r, %r', events, error)
@@ -427,7 +390,7 @@ class BaseConnection(connection.Connection):
         # Empty data, should disconnect
         if not data or data == 0:
             LOGGER.error('Read empty data, calling disconnect')
-            return self._handle_disconnect()
+            return self._on_terminate(-1, "EOF")
 
         # Pass the data into our top level frame dispatching method
         self._on_data_available(data)

--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -84,9 +84,10 @@ class LibevConnection(BaseConnection):
         :param pika.connection.Parameters parameters: Connection parameters
         :param on_open_callback: The method to call when the connection is open
         :type on_open_callback: method
-        :param on_open_error_callback: Method to call if the connection cannot
-                                       be opened
-        :type on_open_error_callback: method
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the default IOLoop in libev
         :param on_signal_callback: Method to call if SIGINT or SIGTERM occur

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -75,10 +75,10 @@ class SelectConnection(BaseConnection):
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param method on_open_callback: Method to call on connection open
-        :param on_open_error_callback: Method to call if the connection cant
-                                       be opened
-        :type on_open_error_callback: method
-        :param method on_close_callback: Method to call on connection close
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the global IOLoop in Tornado
         :raises: RuntimeError

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -39,9 +39,10 @@ class TornadoConnection(base_connection.BaseConnection):
         :param pika.connection.Parameters parameters: Connection parameters
         :param on_open_callback: The method to call when the connection is open
         :type on_open_callback: method
-        :param on_open_error_callback: Method to call if the connection cant
-                                       be opened
-        :type on_open_error_callback: method
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the global IOLoop in Tornado
 
@@ -55,7 +56,7 @@ class TornadoConnection(base_connection.BaseConnection):
 
     def _adapter_connect(self):
         """Connect to the remote socket, adding the socket to the IOLoop if
-        connected. 
+        connected.
 
         :rtype: bool
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -105,6 +105,9 @@ class TwistedChannel(object):
 
         try:
             consumer_tag = self.__channel.basic_consume(*args, **kwargs)
+        # TODO this except without types would suppress system-exiting
+        # exceptions, such as SystemExit and KeyboardInterrupt. It should be at
+        # least `except Exception` and preferably more specific.
         except:
             return defer.fail()
 
@@ -163,6 +166,9 @@ class TwistedChannel(object):
 
             try:
                 method(*args, **kwargs)
+            # TODO this except without types would suppress system-exiting
+            # exceptions, such as SystemExit and KeyboardInterrupt. It should be
+            # at least `except Exception` and preferably more specific.
             except:
                 return defer.fail()
             return d
@@ -300,13 +306,6 @@ class TwistedConnection(base_connection.BaseConnection):
         self.ioloop.remove_handler(None)
         self._cleanup_socket()
 
-    def _handle_disconnect(self):
-        """Do not stop the reactor, this would cause the entire process to exit,
-        just fire the disconnect callbacks
-
-        """
-        self._on_connection_closed(None, True)
-
     def _on_connected(self):
         """Call superclass and then update the event state to flush the outgoing
         frame out. Commit 50d842526d9f12d32ad9f3c4910ef60b8c301f59 removed a
@@ -339,7 +338,7 @@ class TwistedConnection(base_connection.BaseConnection):
         if not reason.check(error.ConnectionDone):
             log.err(reason)
 
-        self._handle_disconnect()
+        self._on_terminate(-1, str(reason))
 
     def doRead(self):
         self._handle_read()

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -29,7 +29,7 @@ class Channel(object):
     CLOSED = 0
     OPENING = 1
     OPEN = 2
-    CLOSING = 3
+    CLOSING = 3  # client-initiated close in progress
 
     _ON_CHANNEL_CLEANUP_CB_KEY = '_on_channel_cleanup'
 
@@ -615,7 +615,8 @@ class Channel(object):
 
     @property
     def is_closing(self):
-        """Returns True if the channel is closing.
+        """Returns True if client-initiated closing of the channel is in
+        progress.
 
         :rtype: bool
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -4,6 +4,7 @@ import sys
 import collections
 import logging
 import math
+import numbers
 import platform
 import threading
 import warnings
@@ -586,7 +587,7 @@ class Connection(object):
     CONNECTION_START = 3
     CONNECTION_TUNE = 4
     CONNECTION_OPEN = 5
-    CONNECTION_CLOSING = 6
+    CONNECTION_CLOSING = 6  # client-initiated close in progress
 
     def __init__(self,
                  parameters=None,
@@ -602,9 +603,10 @@ class Connection(object):
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param method on_open_callback: Called when the connection is opened
-        :param method on_open_error_callback: Called if the connection cant
-                                       be opened
-        :param method on_close_callback: Called when the connection is closed
+        :param method on_open_error_callback: Called if the connection can't
+            be established: on_open_error_callback(connection, str|exception)
+        :param method on_close_callback: Called when the connection is closed:
+            on_close_callback(connection, reason_code, reason_text)
 
         """
         self._write_lock = threading.Lock()
@@ -770,8 +772,9 @@ class Connection(object):
         self.remaining_connection_attempts -= 1
         LOGGER.warning('Could not connect, %i attempts left',
                        self.remaining_connection_attempts)
-        if self.remaining_connection_attempts:
+        if self.remaining_connection_attempts > 0:
             LOGGER.info('Retrying in %i seconds', self.params.retry_delay)
+            # TODO: remove timeout if connection is closed before timer fires
             self.add_timeout(self.params.retry_delay, self.connect)
         else:
             self.callbacks.process(0, self.ON_CONNECTION_ERROR, self, self,
@@ -813,7 +816,8 @@ class Connection(object):
     @property
     def is_closing(self):
         """
-        Returns a boolean reporting the current connection state.
+        Returns True if connection is in the process of closing due to
+        client-initiated `close` request, but closing is not yet complete.
         """
         return self.connection_state == self.CONNECTION_CLOSING
 
@@ -1160,6 +1164,13 @@ class Connection(object):
         # Our starting point once connected, first frame received
         self._add_connection_start_callback()
 
+        # Add a callback handler for the Broker telling us to disconnect.
+        # NOTE: As of RabbitMQ 3.6.0, RabbitMQ broker may send Connection.Close
+        # to signal error during connection setup (and wait a longish time
+        # before closing the TCP/IP stream). Earlier RabbitMQ versions
+        # simply closed the TCP/IP stream.
+        self.callbacks.add(0, spec.Connection.Close, self._on_connection_close)
+
     def _is_basic_deliver_frame(self, frame_value):
         """Returns true if the frame is a Basic.Deliver
 
@@ -1168,17 +1179,6 @@ class Connection(object):
 
         """
         return isinstance(frame_value, spec.Basic.Deliver)
-
-    def _is_connection_close_frame(self, value):
-        """Returns true if the frame is a Connection.Close frame.
-
-        :param pika.frame.Method value: The frame to check
-        :rtype: bool
-
-        """
-        if not value:
-            return False
-        return isinstance(value.method, spec.Connection.Close)
 
     def _is_method_frame(self, value):
         """Returns true if the frame is a method frame.
@@ -1250,32 +1250,29 @@ class Connection(object):
         # Start the communication with the RabbitMQ Broker
         self._send_frame(frame.ProtocolHeader())
 
-    def _on_connection_closed(self, method_frame, from_adapter=False):
-        """Called when the connection is closed remotely. The from_adapter value
-        will be true if the connection adapter has been disconnected from
-        the broker and the method was invoked directly instead of by receiving
-        a Connection.Close frame.
+    def _on_connection_close(self, method_frame):
+        """Called when the connection is closed remotely via Connection.Close
+        frame from broker.
 
-        :param pika.frame.Method: The Connection.Close frame
-        :param bool from_adapter: Called by the connection adapter
+        :param pika.frame.Method method_frame: The Connection.Close frame
 
         """
-        if method_frame and self._is_connection_close_frame(method_frame):
-            self.closing = (method_frame.method.reply_code,
-                            method_frame.method.reply_text)
+        LOGGER.debug('_on_connection_close: frame=%s', method_frame)
 
-        # Save the codes because self.closing gets reset by _adapter_disconnect
-        reply_code, reply_text = self.closing
+        self.closing = (method_frame.method.reply_code,
+                        method_frame.method.reply_text)
 
-        # Stop the heartbeat checker if it exists
-        self._remove_heartbeat()
+        self._on_terminate(self.closing[0], self.closing[1])
 
-        # If this did not come from the connection adapter, close the socket
-        if not from_adapter:
-            self._adapter_disconnect()
+    def _on_connection_close_ok(self, method_frame):
+        """Called when Connection.CloseOk is received from remote.
 
-        # Invoke a method frame neutral close
-        self._on_disconnect(reply_code, reply_text)
+        :param pika.frame.Method method_frame: The Connection.CloseOk frame
+
+        """
+        LOGGER.debug('_on_connection_close_ok: frame=%s', method_frame)
+
+        self._on_terminate(self.closing[0], self.closing[1])
 
     def _on_connection_error(self, connection_unused, error_message=None):
         """Default behavior when the connecting connection can not connect.
@@ -1293,9 +1290,6 @@ class Connection(object):
         Connection.Ok.
         """
         self.known_hosts = method_frame.method.known_hosts
-
-        # Add a callback handler for the Broker telling us to disconnect
-        self.callbacks.add(0, spec.Connection.Close, self._on_connection_closed)
 
         # We're now connected at the AMQP level
         self._set_connection_state(self.CONNECTION_OPEN)
@@ -1368,27 +1362,89 @@ class Connection(object):
             self._trim_frame_buffer(consumed_count)
             self._process_frame(frame_value)
 
-    def _on_disconnect(self, reply_code, reply_text):
-        """Invoke passing in the reply_code and reply_text from internal
-        methods to the adapter. Called from on_connection_closed and Heartbeat
-        timeouts.
+    def _on_terminate(self, reason_code, reason_text):
+        """Terminate the connection and notify registered ON_CONNECTION_ERROR
+        and/or ON_CONNECTION_CLOSED callbacks
 
-        :param str reply_code: The numeric close code
-        :param str reply_text: The text close reason
-
+        :param integer reason_code: HTTP error code for AMQP-reported closures
+          or -1 for other errors (such as socket errors)
+        :param str reason_text: human-readable text message describing the error
         """
-        LOGGER.warning('Disconnected from RabbitMQ at %s:%i (%s): %s',
-                       self.params.host, self.params.port, reply_code,
-                       reply_text)
+        LOGGER.warning(
+            'Disconnected from RabbitMQ at %s:%i (%s): %s',
+            self.params.host, self.params.port, reason_code,
+            reason_text)
+
+        if not isinstance(reason_code, numbers.Integral):
+            raise TypeError('reason_code must be an integer, but got %r'
+                            % (reason_code,))
+
+        # Stop the heartbeat checker if it exists
+        self._remove_heartbeat()
+
+        # Remove connection management callbacks
+        # TODO: This call was moved here verbatim from legacy code and the
+        # following doesn't seem to be right: `Connection.Open` here is
+        # unexpected, we don't appear to ever register it, and the broker
+        # shouldn't be sending `Connection.Open` to us, anyway.
+        self._remove_callbacks(0, [spec.Connection.Close, spec.Connection.Start,
+                                   spec.Connection.Open])
+
+        # Close the socket
+        self._adapter_disconnect()
+
+        # Determine whether this was an error during connection setup
+        connection_error = None
+
+        if self.connection_state == self.CONNECTION_PROTOCOL:
+            LOGGER.error('Incompatible Protocol Versions')
+            connection_error = exceptions.IncompatibleProtocolError(
+                reason_code,
+                reason_text)
+        elif self.connection_state == self.CONNECTION_START:
+            LOGGER.error('Connection closed while authenticating indicating a '
+                         'probable authentication error')
+            connection_error = exceptions.ProbableAuthenticationError(
+                reason_code,
+                reason_text)
+        elif self.connection_state == self.CONNECTION_TUNE:
+            LOGGER.error('Connection closed while tuning the connection '
+                         'indicating a probable permission error when '
+                         'accessing a virtual host')
+            connection_error = exceptions.ProbableAccessDeniedError(
+                reason_code,
+                reason_text)
+        elif self.connection_state not in [self.CONNECTION_OPEN,
+                                           self.CONNECTION_CLOSED,
+                                           self.CONNECTION_CLOSING]:
+            LOGGER.warning('Unexpected connection state on disconnect: %i',
+                           self.connection_state)
+
+        # Transition to closed state
         self._set_connection_state(self.CONNECTION_CLOSED)
+
+        # Inform our channel proxies
         for channel in dictkeys(self._channels):
             if channel not in self._channels:
                 continue
-            method_frame = frame.Method(channel, spec.Channel.Close(reply_code,
-                                                                    reply_text))
+            method_frame = frame.Method(channel, spec.Channel.Close(
+                reason_code,
+                reason_text))
             self._channels[channel]._on_close(method_frame)
-        self._process_connection_closed_callbacks(reply_code, reply_text)
-        self._remove_connection_callbacks()
+
+        # Inform interested parties
+        if connection_error is not None:
+            LOGGER.error('Connection setup failed due to %r', connection_error)
+            self.callbacks.process(0,
+                                   self.ON_CONNECTION_ERROR,
+                                   self, self,
+                                   connection_error)
+
+        self.callbacks.process(0, self.ON_CONNECTION_CLOSED, self, self,
+                               reason_code, reason_text)
+
+        # Reset connection properties
+        self._init_connection_state()
 
     def _process_callbacks(self, frame_value):
         """Process the callbacks for the frame if the frame is a method frame
@@ -1406,17 +1462,6 @@ class Connection(object):
                                    frame_value)  # Args
             return True
         return False
-
-    def _process_connection_closed_callbacks(self, reason_code, reason_text):
-        """Process any callbacks that should be called when the connection is
-        closed.
-
-        :param str reason_code: The numeric code from RabbitMQ for the close
-        :param str reason_text: The text reason fro closing
-
-        """
-        self.callbacks.process(0, self.ON_CONNECTION_CLOSED, self, self,
-                               reason_code, reason_text)
 
     def _process_frame(self, frame_value):
         """Process an inbound frame from the socket.
@@ -1489,11 +1534,6 @@ class Connection(object):
         for method_frame in method_frames:
             self._remove_callback(channel_number, method_frame)
 
-    def _remove_connection_callbacks(self):
-        """Remove all callbacks for the connection"""
-        self._remove_callbacks(0, [spec.Connection.Close, spec.Connection.Start,
-                                   spec.Connection.Open])
-
     def _rpc(self, channel_number, method_frame,
              callback_method=None,
              acceptable_replies=None):
@@ -1530,7 +1570,7 @@ class Connection(object):
 
         """
         self._rpc(0, spec.Connection.Close(reply_code, reply_text, 0, 0),
-                  self._on_connection_closed, [spec.Connection.CloseOk])
+                  self._on_connection_close_ok, [spec.Connection.CloseOk])
 
     def _send_connection_open(self):
         """Send a Connection.Open frame"""

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -26,7 +26,8 @@ class AMQPConnectionError(AMQPError):
 class IncompatibleProtocolError(AMQPConnectionError):
 
     def __repr__(self):
-        return 'The protocol returned by the server is not supported'
+        return ('The protocol returned by the server is not supported: %s' %
+                (self.args,))
 
 
 class AuthenticationError(AMQPConnectionError):
@@ -40,14 +41,15 @@ class ProbableAuthenticationError(AMQPConnectionError):
 
     def __repr__(self):
         return ('Client was disconnected at a connection stage indicating a '
-                'probable authentication error')
+                'probable authentication error: %s' % (self.args,))
 
 
 class ProbableAccessDeniedError(AMQPConnectionError):
 
     def __repr__(self):
         return ('Client was disconnected at a connection stage indicating a '
-                'probable denial of access to the specified virtual host')
+                'probable denial of access to the specified virtual host: %s' %
+                (self.args,))
 
 
 class NoFreeChannels(AMQPConnectionError):

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -115,10 +115,14 @@ class HeartbeatChecker(object):
                     self._idle_byte_intervals)
         duration = self._max_idle_count * self._interval
         text = HeartbeatChecker._STALE_CONNECTION % duration
+
+        # NOTE: this won't achieve the perceived effect of sending
+        # Connection.Close to broker, because the frame will only get buffered
+        # in memory before the next statement terminates the connection.
         self._connection.close(HeartbeatChecker._CONNECTION_FORCED, text)
-        self._connection._adapter_disconnect()
-        self._connection._on_disconnect(HeartbeatChecker._CONNECTION_FORCED,
-                                        text)
+
+        self._connection._on_terminate(HeartbeatChecker._CONNECTION_FORCED,
+                                       text)
 
     @property
     def _has_received_data(self):

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -3,6 +3,10 @@
 Tests for pika.adapters.blocking_connection.BlockingConnection
 
 """
+
+# Suppress pylint warnings concering access to protected member
+# pylint: disable=W0212
+
 import socket
 
 from pika.exceptions import AMQPConnectionError
@@ -26,11 +30,11 @@ class BlockingConnectionMockTemplate(blocking_connection.BlockingConnection):
     pass
 
 class SelectConnectionTemplate(blocking_connection.SelectConnection):
-    is_closed = False
-    is_closing = False
-    is_open = True
-    outbound_buffer = []
-    _channels = dict()
+    is_closed = None
+    is_closing = None
+    is_open = None
+    outbound_buffer = None
+    _channels = None
 
 
 class BlockingConnectionTests(unittest.TestCase):
@@ -41,7 +45,7 @@ class BlockingConnectionTests(unittest.TestCase):
     def test_constructor(self, select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_process_io_for_connection_setup'):
-            connection = blocking_connection.BlockingConnection('params')
+            blocking_connection.BlockingConnection('params')
 
         select_connection_class_mock.assert_called_once_with(
             parameters='params',
@@ -153,9 +157,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with self.assertRaises(pika.exceptions.ConnectionClosed) as cm:
             connection._flush_output(lambda: False, lambda: True)
 
-        self.assertSequenceEqual(
-            cm.exception.args,
-            ())
+        self.assertSequenceEqual(cm.exception.args, (200, 'ok'))
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)
@@ -190,7 +192,7 @@ class BlockingConnectionTests(unittest.TestCase):
                 blocking_connection.BlockingConnection,
                 '_flush_output',
                 spec_set=blocking_connection.BlockingConnection._flush_output):
-            channel = connection.channel()
+            connection.channel()
 
     @patch.object(blocking_connection, 'SelectConnection',
                   spec_set=SelectConnectionTemplate)

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -2,6 +2,16 @@
 Tests for pika.heartbeat
 
 """
+
+# Suppress pylint warnings concering access to protected member
+# pylint: disable=W0212
+
+# Suppress pylint messages concering missing docstring
+# pylint: disable=C0111
+
+# Suppress pylint messages concering invalid method name
+# pylint: disable=C0103
+
 try:
     import mock
 except ImportError:
@@ -58,7 +68,7 @@ class HeartbeatTests(unittest.TestCase):
 
     @mock.patch('pika.heartbeat.HeartbeatChecker._setup_timer')
     def test_constructor_called_setup_timer(self, timer):
-        obj = heartbeat.HeartbeatChecker(self.mock_conn, self.INTERVAL)
+        heartbeat.HeartbeatChecker(self.mock_conn, self.INTERVAL)
         timer.assert_called_once_with()
 
     def test_active_true(self):
@@ -135,9 +145,8 @@ class HeartbeatTests(unittest.TestCase):
                                                self.obj._interval)
         self.mock_conn.close.assert_called_once_with(
             self.obj._CONNECTION_FORCED, reason)
-        self.mock_conn._on_disconnect.assert_called_once_with(
+        self.mock_conn._on_terminate.assert_called_once_with(
             self.obj._CONNECTION_FORCED, reason)
-        self.mock_conn._adapter_disconnect.assert_called_once_with()
 
     def test_has_received_data_false(self):
         self.obj._bytes_received = 100


### PR DESCRIPTION
One of the changes in RabbitMQ 3.6.0 was for the broker to send Connection.Close to client upon connection setup error, instead of just dropping the connection. Thus, the broker is now able to communicate a specific error code and error message to the client.

One visible side-effect of this RabbitMQ change is that the broker waits for about 30 seconds to close the socket connection after sending Connection.Close to the client. I observed this on both Fedora Linux and Mac OS X. Prior to this PR, pika would drop Connection.Close that was received before completion of the AMQP connection handshake, and thus would not discover the connection error for about 30 seconds. Among other obvious issues with not handling Connection.Close, it was also resulting in failure of the acceptance test that deals with connection-establishment error (the one that uses an invalid vhost).

Fixes #682
Fixes #648 
Fixes #631
Fixes #534
Fixes #634

1. Handle Connection.Close from broker at any time, including during connection setup, per RabbitMQ 3.6.0
2. Refactored and cleaned up handling of connection termination;
3. Facilitated passing of error information from failed socket to user callbacks. (fixes #648, #631, #534)
4. Ensure that socket connection is dropped when heartbeat module detects heartbeat timeout (fixes #634)