### PR TITLE
Add pip freeze at the end of travis install target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
   - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install pyev; fi
   - pip install -r test-requirements.txt
+  - pip freeze
 services:
   - rabbitmq
 script: nosetests


### PR DESCRIPTION
so that we'll know the exact python package versions in use by travis.