### PR TITLE
Updated ValueError message and version history with new treatment of completion callbacks passed with asynchronous requests

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -12,6 +12,10 @@ Next Release
    gracefully.
  - Pass error information from failed socket connection to user callbacks
    on_open_error_callback and on_close_callback with result_code=-1.
+ - ValueError is raised when a completion callback is passed to an asynchronous
+   (nowait) Channel operation. It's an application error to pass a non-None
+   completion callback with an asynchronous request, because this callback can
+   never be serviced in the asynchronous scenario.
 
 0.10.0 2015-09-02
 -----------------

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -26,6 +26,7 @@ class Channel(object):
     method.
 
     """
+
     CLOSED = 0
     OPENING = 1
     OPEN = 2
@@ -1106,8 +1107,7 @@ class Channel(object):
         blocking state and register for `_on_synchronous_complete` before
         sending the request.
 
-        NOTE: A populated callback must be accompanied by populated
-        acceptable_replies.
+        NOTE: A callback must be accompanied by non-empty acceptable_replies.
 
         :param pika.amqp_object.Method method_frame: The method frame to call
         :param method callback: The callback for the RPC response
@@ -1124,11 +1124,11 @@ class Channel(object):
 
         # Validate the callback is callable
         if callback is not None and not is_callable(callback):
-            raise TypeError('callback should be None, a function or method.')
+            raise TypeError('callback should be None, a function, or method.')
 
         if callback is not None and not acceptable_replies:
-            raise ValueError('A populated callback must be accompanied by '
-                             'populated acceptable_replies')
+            raise ValueError(
+                'Unexpected callback for asynchronous (nowait) operation.')
 
         # Make sure the channel is open
         if self.is_closed:


### PR DESCRIPTION
@gmr, when I added `CHANGELOG`, which you later renamed `CHANGELOG.rst`, I think I was not aware of `pika/docs/version_history.rst`. Do we need `CHANGELOG.rst` in addition to the previously-existing `pika/docs/version_history.rst`?