### PR TITLE
Allow the asynchronous close operation to complete and release resources

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -7,6 +7,9 @@ Next Release
  - Connection failures that occur after the socket is opened and before the
    AMQP connection is ready to go are now reported by calling the connection
    error callback.  Previously these were not consistently reported.
+ - In BaseConnection.close, call _handle_ioloop_stop only if the connection is
+   already closed to allow the asynchronous close operation to complete
+   gracefully.
 
 0.10.0 2015-09-02
 -----------------

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -100,8 +100,11 @@ class BaseConnection(connection.Connection):
         :param str reply_text: The text reason for the close
 
         """
-        super(BaseConnection, self).close(reply_code, reply_text)
-        self._handle_ioloop_stop()
+        try:
+            super(BaseConnection, self).close(reply_code, reply_text)
+        finally:
+            if self.is_closed:
+                self._handle_ioloop_stop()
 
     def remove_timeout(self, timeout_id):
         """Remove the timeout from the IOLoop by the ID returned from


### PR DESCRIPTION
Fixes #667

This eliminates most, if not all, `ResourceWarning: unclosed <socket.socket ...` warnings in the python 3.x pika test runs on Travis