### PR TITLE
Client properties override

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -47,7 +47,8 @@ class BaseConnection(connection.Connection):
                  on_open_error_callback=None,
                  on_close_callback=None,
                  ioloop=None,
-                 stop_ioloop_on_close=True):
+                 stop_ioloop_on_close=True,
+                 client_properties=None):
         """Create a new instance of the Connection object.
 
         :param pika.connection.Parameters parameters: Connection parameters
@@ -58,6 +59,8 @@ class BaseConnection(connection.Connection):
         :param method on_close_callback: Method to call on connection close
         :param object ioloop: IOLoop object to use
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
+        :param dict client_properties: Used to overwrite fields in the default
+            client properties reported to RabbitMQ.
         :raises: RuntimeError
         :raises: ValueError
 
@@ -75,9 +78,11 @@ class BaseConnection(connection.Connection):
         self.socket = None
         self.stop_ioloop_on_close = stop_ioloop_on_close
         self.write_buffer = None
-        super(BaseConnection, self).__init__(parameters, on_open_callback,
+        super(BaseConnection, self).__init__(parameters,
+                                             on_open_callback,
                                              on_open_error_callback,
-                                             on_close_callback)
+                                             on_close_callback,
+                                             client_properties)
 
     def add_timeout(self, deadline, callback_method):
         """Add the callback_method to the IOLoop timer to fire after deadline

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -291,13 +291,15 @@ class BlockingConnection(object):  # pylint: disable=R0902
         'BlockingConnection__OnChannelOpenedArgs',
         'channel')
 
-    def __init__(self, parameters=None, _impl_class=None):
+    def __init__(self, parameters=None, client_properties=None,
+                 _impl_class=None):
         """Create a new instance of the Connection object.
 
         :param pika.connection.Parameters parameters: Connection parameters
         :param _impl_class: for tests/debugging only; implementation class;
             None=default
-
+        :param dict client_properties: Used to overwrite fields in the default
+            client properties reported to RabbitMQ.
         :raises RuntimeError:
 
         """
@@ -334,7 +336,8 @@ class BlockingConnection(object):  # pylint: disable=R0902
             on_open_callback=self._opened_result.set_value_once,
             on_open_error_callback=self._open_error_result.set_value_once,
             on_close_callback=self._closed_result.set_value_once,
-            stop_ioloop_on_close=False)
+            stop_ioloop_on_close=False,
+            client_properties=client_properties)
 
         self._process_io_for_connection_setup()
 

--- a/pika/adapters/libev_connection.py
+++ b/pika/adapters/libev_connection.py
@@ -77,7 +77,8 @@ class LibevConnection(BaseConnection):
                  on_close_callback=None,
                  stop_ioloop_on_close=False,
                  custom_ioloop=None,
-                 on_signal_callback=None):
+                 on_signal_callback=None,
+                 client_properties=None):
         """Create a new instance of the LibevConnection class, connecting
         to RabbitMQ automatically
 
@@ -91,6 +92,8 @@ class LibevConnection(BaseConnection):
         :param custom_ioloop: Override using the default IOLoop in libev
         :param on_signal_callback: Method to call if SIGINT or SIGTERM occur
         :type on_signal_callback: method
+        :param dict client_properties: Used to overwrite fields in the default
+            client properties reported to RabbitMQ.
 
         """
         if custom_ioloop:
@@ -107,10 +110,12 @@ class LibevConnection(BaseConnection):
         self._active_timers = {}
         self._stopped_timers = deque()
 
-        super(LibevConnection, self).__init__(parameters, on_open_callback,
+        super(LibevConnection, self).__init__(parameters,
+                                              on_open_callback,
                                               on_open_error_callback,
                                               on_close_callback, self.ioloop,
-                                              stop_ioloop_on_close)
+                                              stop_ioloop_on_close,
+                                              client_properties)
 
     def _adapter_connect(self):
         """Connect to the remote socket, adding the socket to the IOLoop if

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -70,7 +70,8 @@ class SelectConnection(BaseConnection):
                  on_open_error_callback=None,
                  on_close_callback=None,
                  stop_ioloop_on_close=True,
-                 custom_ioloop=None):
+                 custom_ioloop=None,
+                 client_properties=None):
         """Create a new instance of the Connection object.
 
         :param pika.connection.Parameters parameters: Connection parameters
@@ -81,6 +82,8 @@ class SelectConnection(BaseConnection):
         :param method on_close_callback: Method to call on connection close
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the global IOLoop in Tornado
+        :param dict client_properties: Used to overwrite fields in the default
+            client properties reported to RabbitMQ.
         :raises: RuntimeError
 
         """
@@ -88,7 +91,8 @@ class SelectConnection(BaseConnection):
         super(SelectConnection, self).__init__(parameters, on_open_callback,
                                                on_open_error_callback,
                                                on_close_callback, ioloop,
-                                               stop_ioloop_on_close)
+                                               stop_ioloop_on_close,
+                                               client_properties)
 
     def _adapter_connect(self):
         """Connect to the RabbitMQ broker, returning True on success, False

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -32,7 +32,8 @@ class TornadoConnection(base_connection.BaseConnection):
                  on_open_error_callback=None,
                  on_close_callback=None,
                  stop_ioloop_on_close=False,
-                 custom_ioloop=None):
+                 custom_ioloop=None,
+                 client_properties=None):
         """Create a new instance of the TornadoConnection class, connecting
         to RabbitMQ automatically
 
@@ -44,6 +45,8 @@ class TornadoConnection(base_connection.BaseConnection):
         :type on_open_error_callback: method
         :param bool stop_ioloop_on_close: Call ioloop.stop() if disconnected
         :param custom_ioloop: Override using the global IOLoop in Tornado
+        :param dict client_properties: Used to overwrite fields in the default
+            client properties reported to RabbitMQ.
 
         """
         self.sleep_counter = 0
@@ -51,11 +54,12 @@ class TornadoConnection(base_connection.BaseConnection):
         super(TornadoConnection, self).__init__(parameters, on_open_callback,
                                                 on_open_error_callback,
                                                 on_close_callback, self.ioloop,
-                                                stop_ioloop_on_close)
+                                                stop_ioloop_on_close,
+                                                client_properties)
 
     def _adapter_connect(self):
         """Connect to the remote socket, adding the socket to the IOLoop if
-        connected. 
+        connected.
 
         :rtype: bool
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -366,7 +366,7 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
 
     """
 
-    def __init__(self, parameters):
+    def __init__(self, parameters=None, client_properties=None):
         self.ready = defer.Deferred()
         super(TwistedProtocolConnection, self).__init__(
             parameters=parameters,
@@ -374,7 +374,8 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
             on_open_error_callback=self.connectionFailed,
             on_close_callback=None,
             ioloop=IOLoopReactorAdapter(self, reactor),
-            stop_ioloop_on_close=False)
+            stop_ioloop_on_close=False,
+            client_properties=client_properties)
 
     def connect(self):
         # The connection is open asynchronously by Twisted, so skip the whole

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -4,6 +4,7 @@ Tests for pika.adapters.blocking_connection.BlockingConnection
 
 """
 import platform
+import socket
 
 from pika.exceptions import AMQPConnectionError
 

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -2,6 +2,8 @@
 Tests for pika.adapters.tornado_connection
 
 """
+import platform
+
 try:
     from tornado import ioloop
 except ImportError:
@@ -22,6 +24,9 @@ try:
 except ImportError:
     tornado_connection = None
 
+from pika import __version__
+from pika import connection
+
 
 class TornadoConnectionTests(unittest.TestCase):
 
@@ -30,3 +35,41 @@ class TornadoConnectionTests(unittest.TestCase):
     def test_tornado_connection_call_parent(self, mock_init):
         obj = tornado_connection.TornadoConnection()
         mock_init.called_once_with(None, None, False)
+
+    def test_client_properties_default(self):
+        expectation = {
+            'product': connection.PRODUCT,
+            'platform': 'Python %s' % platform.python_version(),
+            'capabilities': {
+                'authentication_failure_close': True,
+                'basic.nack': True,
+                'connection.blocked': True,
+                'consumer_cancel_notify': True,
+                'publisher_confirms': True
+            },
+            'information': 'See http://pika.rtfd.org',
+            'version': __version__
+        }
+        with mock.patch('pika.connection.Connection.connect'):
+            conn = tornado_connection.TornadoConnection()
+            self.assertDictEqual(conn._client_properties, expectation)
+
+    def test_client_properties_override(self):
+        expectation = {
+            'capabilities': {
+                'authentication_failure_close': True,
+                'basic.nack': True,
+                'connection.blocked': True,
+                'consumer_cancel_notify': True,
+                'publisher_confirms': True
+            }
+        }
+        override = {'product': 'My Product',
+                    'platform': 'Your platform',
+                    'version': '0.1',
+                    'information': 'this is my app'}
+        expectation.update(override)
+        with mock.patch('pika.connection.Connection.connect'):
+            conn = tornado_connection.TornadoConnection(
+                    client_properties=override)
+            self.assertDictEqual(conn._client_properties, expectation)


### PR DESCRIPTION
Address #571 by creating an alternate way to override client properties. I don't think this belongs as a connection parameter, but rather at the Connection object level.
