### PR TITLE
Update base_connection.py

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -456,11 +456,13 @@ class BaseConnection(connection.Connection):
         if self.outbound_buffer:
             if not self.event_state & self.WRITE:
                 self.event_state |= self.WRITE
-                self.ioloop.update_handler(self.socket.fileno(),
-                                           self.event_state)
+                if self.socket!=None :
+                    self.ioloop.update_handler(self.socket.fileno(),
+                                                  self.event_state)
         elif self.event_state & self.WRITE:
             self.event_state = self.base_events
-            self.ioloop.update_handler(self.socket.fileno(), self.event_state)
+            if self.socket!=None :
+                self.ioloop.update_handler(self.socket.fileno(), self.event_state)
 
     def _wrap_socket(self, sock):
         """Wrap the socket for connecting over SSL.


### PR DESCRIPTION
Fix None does not have fileno() attribute exception.

once hack fix this at version 0.9.14, in some network that is not stable, this will cause reconnection failed. just after upgrade to 0.10.0, manually hack fix again, hope can merge it to next release.