### PR TITLE
Implement support for Parameters.blocked_connection_timeout, tests, and examples.

### DIFF
--- a/docs/examples/blocking_consume.rst
+++ b/docs/examples/blocking_consume.rst
@@ -9,21 +9,21 @@ When pika calls your method, it will pass in the channel, a :py:class:`pika.spec
 
 Example of consuming messages and acknowledging them::
 
-        import pika
+    import pika
 
 
-        def on_message(channel, method_frame, header_frame, body):
-            print(method_frame.delivery_tag)
-	    print(body)
-	    print()
-	    channel.basic_ack(delivery_tag=method_frame.delivery_tag)
+    def on_message(channel, method_frame, header_frame, body):
+        print(method_frame.delivery_tag)
+        print(body)
+        print()
+        channel.basic_ack(delivery_tag=method_frame.delivery_tag)
 
 
-        connection = pika.BlockingConnection()
-        channel = connection.channel()
-        channel.basic_consume(on_message, 'test')
-        try:
-            channel.start_consuming()
-        except KeyboardInterrupt:
-            channel.stop_consuming()
-        connection.close()
+    connection = pika.BlockingConnection()
+    channel = connection.channel()
+    channel.basic_consume(on_message, 'test')
+    try:
+        channel.start_consuming()
+    except KeyboardInterrupt:
+        channel.stop_consuming()
+    connection.close()

--- a/docs/examples/heartbeat_and_blocked_timeouts.rst
+++ b/docs/examples/heartbeat_and_blocked_timeouts.rst
@@ -1,0 +1,37 @@
+Ensuring well-behaved connection with heartbeat and blocked-connection timeouts
+===============================================================================
+
+
+This example demonstrates explicit setting of heartbeat and blocked connection timeouts.
+
+Starting with RabbitMQ 3.5.5, the broker's default hearbeat timeout decreased from 580 seconds to 60 seconds. As a result, applications that perform lengthy processing in the same thread that also runs their Pika connection may experience unexpected dropped connections due to heartbeat timeout. Here, we specify an explicit lower bound for heartbeat timeout.
+
+When RabbitMQ broker is running out of certain resources, such as memory and disk space, it may block connections that are performing resource-consuming operations, such as publishing messages. Once a connection is blocked, RabbiMQ stops reading from that connection's socket, so no commands from the client will get through to te broker on that connection until the broker unblocks it. A blocked connection may last for an indefinite period of time, stalling the connection and possibly resulting in a hang (e.g., in BlockingConnection) until the connection is unblocked. Blocked Connectin Timeout is intended to interrupt (i.e., drop) a connection that has been blocked longer than the given timeout value.
+
+Example of configuring hertbeat and blocked-connection timeouts::
+
+    import pika
+
+
+    def main():
+
+        # NOTE: These paramerers work with all Pika connection types
+        params = pika.ConnectionParameters(heartbeat_interval=600,
+                                           blocked_connection_timeout=300)
+
+        conn = pika.BlockingConnection(params)
+
+        chan = conn.channel()
+
+        chan.basic_publish('', 'my-alphabet-queue', "abc")
+
+        # If publish causes the connection to become blocked, then this conn.close()
+        # would hang until the connection is unblocked, if ever. However, the
+        # blocked_connection_timeout connection parameter would interrupt the wait,
+        # resulting in ConnectionClosed exception from BlockingConnection (or the
+        # on_connection_closed callback call in an asynchronous adapter)
+        conn.close()
+
+
+    if __name__ == '__main__':
+        main()

--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -18,6 +18,10 @@ Next Release
    never be serviced in the asynchronous scenario.
  - `Channel.basic_reject` fixed to allow `delivery_tag` to be of type `long`
    as well as `int`. (by quantum5)
+ - Implemented support for blocked connection timeouts in
+   `pika.connection.Connection`. This feature is available to all pika adapters.
+   See `pika.connection.ConnectionParameters` docstring to learn more about
+   `blocked_connection_timeout` configuration.
 
 0.10.0 2015-09-02
 -----------------

--- a/examples/heatbeat_and_blocked_timeouts.py
+++ b/examples/heatbeat_and_blocked_timeouts.py
@@ -1,0 +1,48 @@
+"""
+This example demonstrates explicit setting of heartbeat and blocked connection
+timeouts.
+
+Starting with RabbitMQ 3.5.5, the broker's default hearbeat timeout decreased
+from 580 seconds to 60 seconds. As a result, applications that perform lengthy
+processing in the same thread that also runs their Pika connection may
+experience unexpected dropped connections due to heartbeat timeout. Here, we
+specify an explicit lower bound for heartbeat timeout.
+
+When RabbitMQ broker is running out of certain resources, such as memory and
+disk space, it may block connections that are performing resource-consuming
+operations, such as publishing messages. Once a connection is blocked, RabbiMQ
+stops reading from that connection's socket, so no commands from the client will
+get through to te broker on that connection until the broker unblocks it. A
+blocked connection may last for an indefinite period of time, stalling the
+connection and possibly resulting in a hang (e.g., in BlockingConnection) until
+the connection is unblocked. Blocked Connectin Timeout is intended to interrupt
+(i.e., drop) a connection that has been blocked longer than the given timeout
+value.
+"""
+
+
+import pika
+
+
+def main():
+
+    # NOTE: These paramerers work with all Pika connection types
+    params = pika.ConnectionParameters(heartbeat_interval=600,
+                                       blocked_connection_timeout=300)
+
+    conn = pika.BlockingConnection(params)
+
+    chan = conn.channel()
+
+    chan.basic_publish('', 'my-alphabet-queue', "abc")
+
+    # If publish causes the connection to become blocked, then this conn.close()
+    # would hang until the connection is unblocked, if ever. However, the
+    # blocked_connection_timeout connection parameter would interrupt the wait,
+    # resulting in ConnectionClosed exception from BlockingConnection (or the
+    # on_connection_closed callback call in an asynchronous adapter)
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -167,7 +167,7 @@ class IOLoop(object):
         return self._poller.add_timeout(deadline, callback_method)
 
     def remove_timeout(self, timeout_id):
-        """[API] Remove a timeout if it's still in the timeout stack
+        """[API] Remove a timeout
 
         :param str timeout_id: The timeout id to remove
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -16,6 +16,7 @@ import functools
 from twisted.internet import defer, error, reactor
 from twisted.python import log
 
+from pika import connection
 from pika import exceptions
 from pika.adapters import base_connection
 
@@ -338,7 +339,8 @@ class TwistedConnection(base_connection.BaseConnection):
         if not reason.check(error.ConnectionDone):
             log.err(reason)
 
-        self._on_terminate(-1, str(reason))
+        self._on_terminate(connection.InternalCloseReasons.SOCKET_ERROR,
+                           str(reason))
 
     def doRead(self):
         self._handle_read()

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -75,6 +75,11 @@ class Channel(object):
         """
         return self.channel_number
 
+    def __repr__(self):
+        return '<%s number=%s conn=%r>' % (self.__class__.__name__,
+                                           self.channel_number,
+                                           self.connection)
+
     def add_callback(self, callback, replies, one_shot=True):
         """Pass in a callback handler and a list replies from the
         RabbitMQ broker which you'd like the callback notified of. Callbacks
@@ -943,9 +948,10 @@ class Channel(object):
 
         """
         LOGGER.info('%s', method_frame)
-        LOGGER.warning('Received remote Channel.Close (%s): %s',
+        LOGGER.warning('Received remote Channel.Close (%s): %r on channel %s',
                        method_frame.method.reply_code,
-                       method_frame.method.reply_text)
+                       method_frame.method.reply_text,
+                       self)
         if self.connection.is_open:
             self._send_method(spec.Channel.CloseOk())
         self._set_state(self.CLOSED)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1287,6 +1287,8 @@ class ChannelTests(unittest.TestCase):
         method_frame = frame.Method(self.obj.channel_number,
                                     spec.Channel.Close(999, 'Test_Value'))
         self.obj._on_close(method_frame)
-        warning.assert_called_with('Received remote Channel.Close (%s): %s',
-                                   method_frame.method.reply_code,
-                                   method_frame.method.reply_text)
+        warning.assert_called_with(
+            'Received remote Channel.Close (%s): %r on channel %s',
+            method_frame.method.reply_code,
+            method_frame.method.reply_text,
+            self.obj)


### PR DESCRIPTION
Fixes #653

(it's more of a practical complement to the request in issue #653)

This PR adds a new feature to counter deadlock brought on by indefinite Connection.Blocked state (RabbitMQ's AMQP extension). Users may configure `blocked_connection_timeout` via `ConnectionParameters` or `URLParameters` with the desired number of seconds to wait for connection to become unblocked (Connection.Unblock). If the timeout expires before connection becomes unblocked, the connection will be torn down, triggering the adapter-specific mechanism for informing client app about the closed connection (e.g., on_close_callback or ConnectionClosed exception) with `reason_code` of `pika.connection.InternalCloseReasons.BLOCKED_CONNECTION_TIMEOUT`.

See also http://www.rabbitmq.com/connection-blocked.html