### PR TITLE
Permit both int and long as delivery_tag in Channel.basic_reject

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -16,6 +16,8 @@ Next Release
    (nowait) Channel operation. It's an application error to pass a non-None
    completion callback with an asynchronous request, because this callback can
    never be serviced in the asynchronous scenario.
+ - `Channel.basic_reject` fixed to allow `delivery_tag` to be of type `long`
+   as well as `int`. (by quantum5)
 
 0.10.0 2015-09-02
 -----------------

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -146,7 +146,7 @@ class Channel(object):
         confirm mode. The acknowledgement can be for a single message or a
         set of messages up to and including a specific message.
 
-        :param int delivery_tag: The server-assigned delivery tag
+        :param integer delivery_tag: int/long The server-assigned delivery tag
         :param bool multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
@@ -286,7 +286,7 @@ class Channel(object):
         It can be used to interrupt and cancel large incoming messages, or
         return untreatable messages to their original queue.
 
-        :param int delivery-tag: The server-assigned delivery tag
+        :param integer delivery-tag: int/long The server-assigned delivery tag
         :param bool multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
@@ -381,7 +381,7 @@ class Channel(object):
         message. It can be used to interrupt and cancel large incoming messages,
         or return untreatable messages to their original queue.
 
-        :param int delivery-tag: The server-assigned delivery tag
+        :param integer delivery-tag: int/long The server-assigned delivery tag
         :param bool requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -11,7 +11,7 @@ import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
 from pika.utils import is_callable
-from pika.compat import unicode_type, dictkeys, as_bytes
+from pika.compat import unicode_type, dictkeys, as_bytes, is_integer
 
 
 LOGGER = logging.getLogger(__name__)
@@ -391,7 +391,7 @@ class Channel(object):
         """
         if not self.is_open:
             raise exceptions.ChannelClosed()
-        if not isinstance(delivery_tag, int):
+        if not is_integer(delivery_tag):
             raise TypeError('delivery_tag must be an integer')
         return self._send_method(spec.Basic.Reject(delivery_tag, requeue))
 

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -73,6 +73,8 @@ if not PY2:
 
         return str(value)
 
+    def is_integer(value):
+        return isinstance(value, int)
 else:
     from urllib import unquote as url_unquote, urlencode
 
@@ -97,6 +99,8 @@ else:
         except UnicodeEncodeError:
             return str(value.encode('utf-8'))
 
+    def is_integer(value):
+        return isinstance(value, (int, long))
 
 def as_bytes(value):
     if not isinstance(value, bytes):

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -416,7 +416,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_basic_reject_spec_with_int_tag(self):
         decoded = spec.Basic.Reject()
-        decoded.decode(''.join(spec.Basic.Reject(1, True).encode()))
+        decoded.decode(b''.join(spec.Basic.Reject(1, True).encode()))
 
         self.assertEqual(decoded.delivery_tag, 1)
         self.assertIs(decoded.requeue, True)
@@ -438,7 +438,7 @@ class ChannelTests(unittest.TestCase):
         # NOTE: we use `sys.maxsize` for compatibility with python 3, which
         # doesn't have `sys.maxint`
         decoded = spec.Basic.Reject()
-        decoded.decode(''.join(spec.Basic.Reject(sys.maxsize, True).encode()))
+        decoded.decode(b''.join(spec.Basic.Reject(sys.maxsize, True).encode()))
 
         self.assertEqual(decoded.delivery_tag, sys.maxsize)
         self.assertIs(decoded.requeue, True)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -14,6 +14,8 @@ try:
 except ImportError:
     from unittest import mock
 
+import sys
+
 try:
     import unittest2 as unittest
 except ImportError:
@@ -405,10 +407,41 @@ class ChannelTests(unittest.TestCase):
 
     @mock.patch('pika.spec.Basic.Reject')
     @mock.patch('pika.channel.Channel._send_method')
-    def test_basic_reject_send_method_request(self, send_method, unused):
+    def test_basic_reject_send_method_request_with_int_tag(self,
+                                                           send_method,
+                                                           unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.basic_reject(1, True)
         send_method.assert_called_once_with(spec.Basic.Reject(1, True))
+
+    def test_basic_reject_spec_with_int_tag(self):
+        decoded = spec.Basic.Reject()
+        decoded.decode(''.join(spec.Basic.Reject(1, True).encode()))
+
+        self.assertEqual(decoded.delivery_tag, 1)
+        self.assertIs(decoded.requeue, True)
+
+    @mock.patch('pika.spec.Basic.Reject')
+    @mock.patch('pika.channel.Channel._send_method')
+    def test_basic_reject_send_method_request_with_long_tag(self,
+                                                           send_method,
+                                                           unused):
+        self.obj._set_state(self.obj.OPEN)
+
+        # NOTE: we use `sys.maxsize` for compatibility with python 3, which
+        # doesn't have `sys.maxint`
+        self.obj.basic_reject(sys.maxsize, True)
+        send_method.assert_called_once_with(spec.Basic.Reject(sys.maxsize,
+                                                              True))
+
+    def test_basic_reject_spec_with_long_tag(self):
+        # NOTE: we use `sys.maxsize` for compatibility with python 3, which
+        # doesn't have `sys.maxint`
+        decoded = spec.Basic.Reject()
+        decoded.decode(''.join(spec.Basic.Reject(sys.maxsize, True).encode()))
+
+        self.assertEqual(decoded.delivery_tag, sys.maxsize)
+        self.assertIs(decoded.requeue, True)
 
     def test_basic_recover_raises_channel_closed(self):
         self.assertRaises(exceptions.ChannelClosed, self.obj.basic_qos, 0,


### PR DESCRIPTION
This picks up @quantum5's commits from PR #676 + @vitaly-krugl's tests