### PR TITLE
Fixed Channel-related bugs in Channel and Connection classes

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -34,7 +34,22 @@ Next Release
  - `InvalidMinimumFrameSize` and `InvalidMaximumFrameSize` exceptions are
    deprecated. pika.connection.Parameters.frame_max property setter now raises
    the standard `ValueError` exception when the value is out of bounds.
-
+ - Removed deprecated parameter `type` in `Channel.exchange_declare` and
+   `BlockingChannel.exchnage_declare` in favor of the `exchange_type` arg that
+   doesn't overshadow the builtin `type` keyword.
+ - Channel.close() on OPENING channel transitions it to CLOSING instead of
+   raising ChannelClosed.
+ - Channel.close() on CLOSING channel raises `ChannelAlreadyClosing`; used to
+   raise `ChannelClosed`.
+ - Connection.channel() raises `ConnectionClosed` if connection is not in OPEN
+   state.
+ - When performing graceful close on a channel and `Channel.Close` from broker
+   arrives while waiting for CloseOk, don't release the channel number until
+   CloseOk arrives to avoid race condition that may lead to a new channel
+   receiving the CloseOk that was destined for the closing channel.
+ - The `backpressure_detection` option of `ConnectionParameters` and
+   `URLParameters` property is DEPRECATED in favor of `Connection.Blocked` and
+   `Connection.Unblocked`. See `Connection.add_on_connection_blocked_callback`.
 
 0.10.0 2015-09-02
 -----------------

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -86,7 +86,7 @@ class _CallbackResult(object):
         """True if the object is in a signaled state"""
         return self._ready
 
-    def signal_once(self, *_args, **_kwargs): # pylint: disable=W0613
+    def signal_once(self, *_args, **_kwargs):
         """ Set as ready
 
         :raises AssertionError: if result was already signalled
@@ -162,7 +162,7 @@ class _CallbackResult(object):
         return self._values
 
 
-class _IoloopTimerContext(object):  # pylint: disable=R0903
+class _IoloopTimerContext(object):
     """Context manager for registering and safely unregistering a
     SelectConnection ioloop-based timer
     """
@@ -197,7 +197,7 @@ class _IoloopTimerContext(object):  # pylint: disable=R0903
         return self._callback_result.is_ready()
 
 
-class _TimerEvt(object):  # pylint: disable=R0903
+class _TimerEvt(object):
     """Represents a timer created via `BlockingConnection.add_timeout`"""
     __slots__ = ('timer_id', '_callback')
 
@@ -220,7 +220,7 @@ class _TimerEvt(object):  # pylint: disable=R0903
         self._callback()
 
 
-class _ConnectionBlockedUnblockedEvtBase(object):  # pylint: disable=R0903
+class _ConnectionBlockedUnblockedEvtBase(object):
     """Base class for `_ConnectionBlockedEvt` and `_ConnectionUnblockedEvt`"""
     __slots__ = ('_callback', '_method_frame')
 
@@ -245,19 +245,17 @@ class _ConnectionBlockedUnblockedEvtBase(object):  # pylint: disable=R0903
         self._callback(self._method_frame)
 
 
-class _ConnectionBlockedEvt(  # pylint: disable=R0903
-        _ConnectionBlockedUnblockedEvtBase):
+class _ConnectionBlockedEvt(_ConnectionBlockedUnblockedEvtBase):
     """Represents a Connection.Blocked notification from RabbitMQ broker`"""
     pass
 
 
-class _ConnectionUnblockedEvt(  # pylint: disable=R0903
-        _ConnectionBlockedUnblockedEvtBase):
+class _ConnectionUnblockedEvt(_ConnectionBlockedUnblockedEvtBase):
     """Represents a Connection.Unblocked notification from RabbitMQ broker`"""
     pass
 
 
-class BlockingConnection(object):  # pylint: disable=R0902
+class BlockingConnection(object):
     """The BlockingConnection creates a layer on top of Pika's asynchronous core
     providing methods that will block until their expected response has
     returned. Due to the asynchronous nature of the `Basic.Deliver` and
@@ -404,7 +402,7 @@ class BlockingConnection(object):  # pylint: disable=R0902
             # __exit__ part
             self._event_dispatch_suspend_depth -= 1
 
-    def _process_io_for_connection_setup(self):  # pylint: disable=C0103
+    def _process_io_for_connection_setup(self):
         """ Perform follow-up processing for connection setup request: flush
         connection output and process input while waiting for connection-open
         or connection-error.
@@ -570,8 +568,7 @@ class BlockingConnection(object):  # pylint: disable=R0902
 
                 evt.dispatch()
 
-    def add_on_connection_blocked_callback(self,  # pylint: disable=C0103
-                                           callback_method):
+    def add_on_connection_blocked_callback(self, callback_method):
         """Add a callback to be notified when RabbitMQ has sent a
         `Connection.Blocked` frame indicating that RabbitMQ is low on
         resources. Publishers can use this to voluntarily suspend publishing,
@@ -589,8 +586,7 @@ class BlockingConnection(object):  # pylint: disable=R0902
         self._impl.add_on_connection_blocked_callback(
             functools.partial(self._on_connection_blocked, callback_method))
 
-    def add_on_connection_unblocked_callback(self,  # pylint: disable=C0103
-                                             callback_method):
+    def add_on_connection_unblocked_callback(self, callback_method):
         """Add a callback to be notified when RabbitMQ has sent a
         `Connection.Unblocked` frame letting publishers know it's ok
         to start publishing again. The callback will be passed the
@@ -767,7 +763,7 @@ class BlockingConnection(object):  # pylint: disable=R0902
         # Prepare `with` context
         return self
 
-    def __exit__(self, tp, value, traceback):
+    def __exit__(self, exc_type, value, traceback):
         # Close connection after `with` context
         self.close()
 
@@ -811,7 +807,7 @@ class BlockingConnection(object):  # pylint: disable=R0902
         return self._impl.basic_nack
 
     @property
-    def consumer_cancel_notify_supported(self):  # pylint: disable=C0103
+    def consumer_cancel_notify_supported(self):
         """Specifies if the server supports consumer cancel notification on the
         active connection.
 
@@ -821,7 +817,7 @@ class BlockingConnection(object):  # pylint: disable=R0902
         return self._impl.consumer_cancel_notify
 
     @property
-    def exchange_exchange_bindings_supported(self):  # pylint: disable=C0103
+    def exchange_exchange_bindings_supported(self):
         """Specifies if the active connection supports exchange to exchange
         bindings.
 
@@ -846,12 +842,12 @@ class BlockingConnection(object):  # pylint: disable=R0902
     publisher_confirms = publisher_confirms_supported
 
 
-class _ChannelPendingEvt(object):  # pylint: disable=R0903
+class _ChannelPendingEvt(object):
     """Base class for BlockingChannel pending events"""
     pass
 
 
-class _ConsumerDeliveryEvt(_ChannelPendingEvt):  # pylint: disable=R0903
+class _ConsumerDeliveryEvt(_ChannelPendingEvt):
     """This event represents consumer message delivery `Basic.Deliver`; it
     contains method, properties, and body of the delivered message.
     """
@@ -871,7 +867,7 @@ class _ConsumerDeliveryEvt(_ChannelPendingEvt):  # pylint: disable=R0903
         self.body = body
 
 
-class _ConsumerCancellationEvt(_ChannelPendingEvt):  # pylint: disable=R0903
+class _ConsumerCancellationEvt(_ChannelPendingEvt):
     """This event represents server-initiated consumer cancellation delivered to
     client via Basic.Cancel. After receiving Basic.Cancel, there will be no
     further deliveries for the consumer identified by `consumer_tag` in
@@ -897,12 +893,12 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):  # pylint: disable=R0903
         return self.method_frame.method
 
 
-class _ReturnedMessageEvt(_ChannelPendingEvt):  # pylint: disable=R0903
+class _ReturnedMessageEvt(_ChannelPendingEvt):
     """This event represents a message returned by broker via `Basic.Return`"""
 
     __slots__ = ('callback', 'channel', 'method', 'properties', 'body')
 
-    def __init__(self, callback, channel, method, properties, body):  # pylint: disable=R0913
+    def __init__(self, callback, channel, method, properties, body):
         """
         :param callable callback: user's callback, having the signature
             callback(channel, method, properties, body), where
@@ -933,7 +929,7 @@ class _ReturnedMessageEvt(_ChannelPendingEvt):  # pylint: disable=R0903
         self.callback(self.channel, self.method, self.properties, self.body)
 
 
-class ReturnedMessage(object):  # pylint: disable=R0903
+class ReturnedMessage(object):
     """Represents a message returned via Basic.Return in publish-acknowledgments
     mode
     """
@@ -1014,7 +1010,7 @@ class _ConsumerInfo(object):
         return self.state == self.CANCELLED_BY_BROKER
 
 
-class _QueueConsumerGeneratorInfo(object):  # pylint: disable=R0903
+class _QueueConsumerGeneratorInfo(object):
     """Container for information about the active queue consumer generator """
     __slots__ = ('params', 'consumer_tag', 'pending_events')
 
@@ -1037,7 +1033,7 @@ class _QueueConsumerGeneratorInfo(object):  # pylint: disable=R0903
             self.__class__.__name__, self.params, self.consumer_tag)
 
 
-class BlockingChannel(object):  # pylint: disable=R0904,R0902
+class BlockingChannel(object):
     """The BlockingChannel implements blocking semantics for most things that
     one would use callback-passing-style for with the
     :py:class:`~pika.channel.Channel` class. In addition,
@@ -1076,7 +1072,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
 
     # Broker's basic-ack/basic-nack args when delivery confirmation is enabled;
     # may concern a single or multiple messages
-    _OnMessageConfirmationReportArgs = namedtuple(  # pylint: disable=C0103
+    _OnMessageConfirmationReportArgs = namedtuple(
         'BlockingChannel__OnMessageConfirmationReportArgs',
         'method_frame')
 
@@ -1135,7 +1131,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         self._basic_consume_ok_result = _CallbackResult()
 
         # Receives the broker-inititated Channel.Close parameters
-        self._channel_closed_by_broker_result = _CallbackResult(  # pylint: disable=C0103
+        self._channel_closed_by_broker_result = _CallbackResult(
             self._OnChannelClosedByBrokerArgs)
 
         # Receives args from Basic.GetEmpty response
@@ -1291,8 +1287,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         self.connection._request_channel_dispatch(self.channel_number)
 
 
-    def _on_consumer_cancelled_by_broker(self,  # pylint: disable=C0103
-                                         method_frame):
+    def _on_consumer_cancelled_by_broker(self, method_frame):
         """Called by impl when broker cancels consumer via Basic.Cancel.
 
         This is a RabbitMQ-specific feature. The circumstances include deletion
@@ -1316,8 +1311,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         else:
             self._add_pending_event(evt)
 
-    def _on_consumer_message_delivery(self, channel,  # pylint: disable=W0613
-                                      method, properties, body):
+    def _on_consumer_message_delivery(self, _channel, method, properties, body):
         """Called by impl when a message is delivered for a consumer
 
         :param Channel channel: The implementation channel object
@@ -1474,7 +1468,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
                     _ReturnedMessageEvt(
                         callback, self, method, properties, body))))
 
-    def basic_consume(self,  # pylint: disable=R0913
+    def basic_consume(self,
                       consumer_callback,
                       queue,
                       no_ack=False,
@@ -1529,7 +1523,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
             arguments=arguments,
             consumer_callback=consumer_callback)
 
-    def _basic_consume_impl(self,  # pylint: disable=R0913
+    def _basic_consume_impl(self,
                             queue,
                             no_ack,
                             exclusive,
@@ -1645,7 +1639,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
                 consumer_info.state)
 
             # Assertion failure here signals disconnect between consumer state
-            # in BlockingConnection and Connection
+            # in BlockingChannel and Channel
             assert (consumer_info.cancelled_by_broker or
                     consumer_tag in self._impl._consumers), consumer_tag
 
@@ -1764,7 +1758,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         else:
             self._cancel_all_consumers()
 
-    def consume(self, queue, no_ack=False,  # pylint: disable=R0913
+    def consume(self, queue, no_ack=False,
                 exclusive=False, arguments=None,
                 inactivity_timeout=None):
         """Blocking consumption of a queue instead of via a callback. This
@@ -2012,7 +2006,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
                         "wait completed without GetOk and GetEmpty")
                     return None, None, None
 
-    def basic_publish(self, exchange, routing_key, body,   # pylint: disable=R0913
+    def basic_publish(self, exchange, routing_key, body,
                       properties=None, mandatory=False, immediate=False):
         """Publish to the channel with the given exchange, routing key and body.
         Returns a boolean value indicating the success of the operation.
@@ -2052,7 +2046,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         else:
             return True
 
-    def publish(self, exchange, routing_key, body,  # pylint: disable=R0913
+    def publish(self, exchange, routing_key, body,
                 properties=None, mandatory=False, immediate=False):
         """Publish to the channel with the given exchange, routing key, and
         body. Unlike the legacy `BlockingChannel.basic_publish`, this method
@@ -2229,10 +2223,10 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         # of publisher acknowledgments
         self._impl.add_on_return_callback(self._on_puback_message_returned)
 
-    def exchange_declare(self, exchange=None,  # pylint: disable=R0913
+    def exchange_declare(self, exchange=None,
                          exchange_type='direct', passive=False, durable=False,
                          auto_delete=False, internal=False,
-                         arguments=None, **kwargs):
+                         arguments=None):
         """This method creates an exchange if it does not already exist, and if
         the exchange exists, verifies that it is of the correct and expected
         class.
@@ -2252,15 +2246,12 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
         :param bool auto_delete: Remove when no more queues are bound to it
         :param bool internal: Can only be published to by other exchanges
         :param dict arguments: Custom key/value pair arguments for the exchange
-        :param str type: via kwargs: the deprecated exchange type parameter
 
         :returns: Method frame from the Exchange.Declare-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
           `spec.Exchange.DeclareOk`
 
         """
-        assert len(kwargs) <= 1, kwargs
-
         with _CallbackResult(
             self._MethodFrameCallbackResultArgs) as declare_ok_result:
             self._impl.exchange_declare(
@@ -2272,8 +2263,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
                 auto_delete=auto_delete,
                 internal=internal,
                 nowait=False,
-                arguments=arguments,
-                type=kwargs["type"] if kwargs else None)
+                arguments=arguments)
 
             self._flush_output(declare_ok_result.is_ready)
             return declare_ok_result.value.method_frame
@@ -2318,8 +2308,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Exchange.BindOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as bind_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                bind_ok_result:
             self._impl.exchange_bind(
                 callback=bind_ok_result.set_value_once,
                 destination=destination,
@@ -2361,7 +2351,7 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
             self._flush_output(unbind_ok_result.is_ready)
             return unbind_ok_result.value.method_frame
 
-    def queue_declare(self, queue='', passive=False, durable=False,  # pylint: disable=R0913
+    def queue_declare(self, queue='', passive=False, durable=False,
                       exclusive=False, auto_delete=False,
                       arguments=None):
         """Declare queue, create if needed. This method creates or checks a
@@ -2385,8 +2375,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Queue.DeclareOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as declare_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                declare_ok_result:
             self._impl.queue_declare(
                 callback=declare_ok_result.set_value_once,
                 queue=queue,
@@ -2413,8 +2403,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Queue.DeleteOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as delete_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                delete_ok_result:
             self._impl.queue_delete(callback=delete_ok_result.set_value_once,
                                     queue=queue,
                                     if_unused=if_unused,
@@ -2435,8 +2425,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Queue.PurgeOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as purge_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                purge_ok_result:
             self._impl.queue_purge(callback=purge_ok_result.set_value_once,
                                    queue=queue,
                                    nowait=False)
@@ -2490,8 +2480,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Queue.UnbindOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as unbind_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                unbind_ok_result:
             self._impl.queue_unbind(callback=unbind_ok_result.set_value_once,
                                     queue=queue,
                                     exchange=exchange,
@@ -2510,8 +2500,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Tx.SelectOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as select_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                select_ok_result:
             self._impl.tx_select(select_ok_result.set_value_once)
 
             self._flush_output(select_ok_result.is_ready)
@@ -2525,8 +2515,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Tx.CommitOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as commit_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                commit_ok_result:
             self._impl.tx_commit(commit_ok_result.set_value_once)
 
             self._flush_output(commit_ok_result.is_ready)
@@ -2540,8 +2530,8 @@ class BlockingChannel(object):  # pylint: disable=R0904,R0902
           `spec.Tx.CommitOk`
 
         """
-        with _CallbackResult(
-                self._MethodFrameCallbackResultArgs) as rollback_ok_result:
+        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
+                rollback_ok_result:
             self._impl.tx_rollback(rollback_ok_result.set_value_once)
 
             self._flush_output(rollback_ok_result.is_ready)

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -58,6 +58,13 @@ if not PY2:
         """
         return dct.items()
 
+    def dict_itervalues(dct):
+        """
+        :param dict dct:
+        :returns: an iterator of the values of a dictionary
+        """
+        return dct.values()
+
     def byte(*args):
         """
         This is the same as Python 2 `chr(n)` for bytes in Python 3
@@ -97,6 +104,7 @@ else:
     dictkeys = dict.keys
     dictvalues = dict.values
     dict_iteritems = dict.iteritems
+    dict_itervalues = dict.itervalues
     byte = chr
     long = long
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -97,7 +97,7 @@ class Parameters(object):
 
     DEFAULT_BACKPRESSURE_DETECTION = False
     DEFAULT_BLOCKED_CONNECTION_TIMEOUT = None
-    DEFAULT_CHANNEL_MAX = channel.MAX_CHANNELS
+    DEFAULT_CHANNEL_MAX = pika.channel.MAX_CHANNELS
     DEFAULT_CREDENTIALS = pika_credentials.PlainCredentials(DEFAULT_USERNAME,
                                                             DEFAULT_PASSWORD)
     DEFAULT_CONNECTION_ATTEMPTS = 1
@@ -243,9 +243,9 @@ class Parameters(object):
         """
         if not isinstance(value, numbers.Integral):
             raise TypeError('channel_max must be an int, but got %r' % (value,))
-        if value < 1 or value > channel.MAX_CHANNELS:
+        if value < 1 or value > pika.channel.MAX_CHANNELS:
             raise ValueError('channel_max must be <= %i and > 0, but got %r' %
-                             (channel.MAX_CHANNELS, value))
+                             (pika.channel.MAX_CHANNELS, value))
         self._channel_max = value
 
     @property

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -84,6 +84,11 @@ class ChannelClosed(AMQPChannelError):
             return 'The channel was closed: %s' % (self.args,)
 
 
+class ChannelAlreadyClosing(AMQPChannelError):
+    """Raised when `Channel.close` is called while channel is already closing"""
+    pass
+
+
 class DuplicateConsumerTag(AMQPChannelError):
 
     def __repr__(self):

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,391 @@
+[MASTER]
+
+# Specify a configuration file.
+#rcfile=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Profiled execution.
+profile=no
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Pickle collected data for later comparisons.
+persistent=no
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Deprecated. It was used to include message's id in output. Use --msg-template
+# instead.
+#include-ids=no
+
+# Deprecated. It was used to include symbolic ids of messages in output. Use
+# --msg-template instead.
+#symbols=no
+
+# Use multiple processes to speed up Pylint.
+#jobs=1
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+#unsafe-load-any-extension=no
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+#extension-pkg-whitelist=
+
+# Allow optimization of some AST trees. This will activate a peephole AST
+# optimizer, which will apply various small optimizations. For instance, it can
+# be used to obtain the result of joining multiple strings with the addition
+# operator. Joining a lot of strings can lead to a maximum recursion error in
+# Pylint and this flag can prevent that. It has one side effect, the resulting
+# AST will be different than the one from reality.
+#optimize-ast=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=
+
+
+[REPORTS]
+
+# Set the output format. Available formats are text, parseable, colorized, msvs
+# (visual studio) and html. You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Put messages in a separate file for each module / package specified on the
+# command line instead of printing them on stdout. Reports (if any) will be
+# written in a file name "pylint_global.[txt|html]".
+files-output=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Add a comment according to your evaluation note. This is used by the global
+# evaluation report (RP0004).
+comment=no
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+msg-template={msg_id}, {line:3d}:{column:2d} - {msg} ({symbol})
+#msg-template=
+
+
+[BASIC]
+
+# Required attributes for module, separated by a comma
+required-attributes=
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=map,filter,input
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,j,k,ex,fd,Run,_
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,bar,baz,toto,tutu,tata
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Regular expression matching correct function names
+function-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for function names
+function-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct variable names
+variable-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for variable names
+variable-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct constant names
+const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Naming hint for constant names
+const-name-hint=(([A-Z_][A-Z0-9_]*)|(__.*__))$
+
+# Regular expression matching correct attribute names
+attr-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for attribute names
+attr-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression matching correct argument names
+argument-rgx=[a-z_][a-z0-9_]{2,30}$
+
+# Naming hint for argument names
+argument-name-hint=[a-z_][a-z0-9_]{2,30}$
+
+# Regular expression matching correct class attribute names
+class-attribute-rgx=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
+
+# Naming hint for class attribute names
+class-attribute-name-hint=([A-Za-z_][A-Za-z0-9_]{2,40}|(__.*__))$
+
+# Regular expression matching correct inline iteration names
+inlinevar-rgx=[A-Za-z_][A-Za-z0-9_]*$
+
+# Naming hint for inline iteration names
+inlinevar-name-hint=[A-Za-z_][A-Za-z0-9_]*$
+
+# Regular expression matching correct class names
+class-rgx=[A-Z_][a-zA-Z0-9]+$
+
+# Naming hint for class names
+class-name-hint=[A-Z_][a-zA-Z0-9]+$
+
+# Regular expression matching correct module names
+module-rgx=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Naming hint for module names
+module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9]+))$
+
+# Regular expression matching correct method names
+method-rgx=[a-z_][a-z0-9_]{2,40}$
+
+# Naming hint for method names
+method-name-hint=[a-z_][a-z0-9_]{2,40}$
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=__.*__
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=100
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+# List of optional constructs for which whitespace checking is disabled
+no-space-check=trailing-comma,dict-separator
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,XXX,TODO
+
+
+[SIMILARITIES]
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+
+[SPELLING]
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[TYPECHECK]
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis
+ignored-modules=
+
+# List of classes names for which member attributes should not be checked
+# (useful for classes with attributes dynamically set).
+ignored-classes=SQLObject
+
+# When zope mode is activated, add a predefined set of Zope acquired attributes
+# to generated-members.
+zope=no
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E0201 when accessed. Python regular
+# expressions are accepted.
+generated-members=REQUEST,acl_users,aq_parent
+
+
+[VARIABLES]
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_|_$|dummy
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,_cb
+
+
+[CLASSES]
+
+# List of interface methods to ignore, separated by a comma. This is used for
+# instance to not check methods defines in Zope's Interface base class.
+ignore-iface-methods=isImplementedBy,deferred,extends,names,namesAndDescriptions,queryDescriptionFor,getBases,getDescriptionFor,getDoc,getName,getTaggedValue,getTaggedValueTags,isEqualOrExtendedBy,setTaggedValue,isImplementedByInstancesOf,adaptWith,is_implemented_by
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,__new__,setUp
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,_fields,_replace,_source,_make
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=10
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of branch for function / method body
+max-branches=20
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=20
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=40
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -18,6 +18,16 @@ from pika.adapters import base_connection
 
 class BaseConnectionTests(unittest.TestCase):
 
+    def setUp(self):
+        with mock.patch('pika.connection.Connection.connect'):
+            self.connection = base_connection.BaseConnection()
+            self.connection._set_connection_state(
+                base_connection.BaseConnection.CONNECTION_OPEN)
+
+    def test_repr(self):
+        text = repr(self.connection)
+        self.assertTrue(text.startswith('<BaseConnection'), text)
+
     def test_should_raise_value_exception_with_no_params_func_instead(self):
 
         def foo():

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -1,6 +1,6 @@
 # -*- encoding: utf-8 -*-
 """
-Tests for pika.channel.ContentFrameDispatcher
+Tests for pika.channel.ContentFrameAssembler
 
 """
 import marshal
@@ -16,10 +16,10 @@ from pika import frame
 from pika import spec
 
 
-class ContentFrameDispatcherTests(unittest.TestCase):
+class ContentFrameAssemblerTests(unittest.TestCase):
 
     def setUp(self):
-        self.obj = channel.ContentFrameDispatcher()
+        self.obj = channel.ContentFrameAssembler()
 
     def test_init_method_frame(self):
         self.assertEqual(self.obj._method_frame, None)
@@ -135,7 +135,7 @@ class ContentFrameDispatcherTests(unittest.TestCase):
 
     def test_ascii_body_value(self):
         expectation = b'foo-bar-baz'
-        self.obj = channel.ContentFrameDispatcher()
+        self.obj = channel.ContentFrameAssembler()
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
         header_frame = frame.Header(1, 11, spec.BasicProperties)
@@ -147,7 +147,7 @@ class ContentFrameDispatcherTests(unittest.TestCase):
 
     def test_binary_non_unicode_value(self):
         expectation = ('a', 0.8)
-        self.obj = channel.ContentFrameDispatcher()
+        self.obj = channel.ContentFrameAssembler()
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
         marshalled_body = marshal.dumps(expectation)

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -172,9 +172,9 @@ class HeartbeatTests(unittest.TestCase):
         self.assertEqual(self.obj._heartbeat_frames_sent, 1)
 
     def test_setup_timer_called(self):
-        self.obj._setup_timer()
-        self.mock_conn.add_timeout.called_once_with(self.INTERVAL,
-                                                    self.obj.send_and_check)
+        self.mock_conn.add_timeout.assert_called_once_with(
+            self.INTERVAL,
+            self.obj.send_and_check)
 
     @mock.patch('pika.heartbeat.HeartbeatChecker._setup_timer')
     def test_start_timer_not_active(self, setup_timer):

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -29,4 +29,7 @@ class TornadoConnectionTests(unittest.TestCase):
     @mock.patch('pika.adapters.base_connection.BaseConnection.__init__')
     def test_tornado_connection_call_parent(self, mock_init):
         obj = tornado_connection.TornadoConnection()
-        mock_init.called_once_with(None, None, False)
+        mock_init.assert_called_once_with(
+            None, None, None, None,
+            tornado_connection.ioloop.IOLoop.instance(),
+            False)


### PR DESCRIPTION
@gmr Please review and consider merging.

Fixed a number of bugs discovered through code review in Channel-related logic in `Channel`and `Connection` classes. See commit message for details.

Sorry about combining these changes with pylint cleanup; it was difficult to use pylint productively with so many pylint messages.

I created `pylintrc `at root level with defaults that seem to work well for pika. This should be much easier going forward.

To make it easy to find changes that merit review, I labeled corresponding sections of changed code with **REVIEWME** in comments. Search for this label in channel.py and conneciton.py in the "Files changed" view. Here is a high-level summary of changed files:

Changes that merit review:
* pika/channel.py: merits review
* pika/connection.py: merits review
* tests/unit/channel_tests.py: added test logic
* tests/unit/connection_tests.py: added test logic
* pika/compat.py: minor change
* pika/exceptions.py: minor change

Minor changes and primarily pylint-related fixups:
* pika/adapters/blocking_connection.py: remove the deprecated type arg; everything else is pylint fixup
* pika/adapters/base_connection.py: minor change, primarily in `__repr__`.
* tests/unit/base_connection_tests.py: minor; added test for `__repr__`.
* tests/unit/{content_frame_dispatcher_tests.py → content_frame_assembler_tests.py}
* tests/unit/heartbeat_tests.py: minor fix
*  tests/unit/tornado_tests.py: minor fix
* docs/version_history.rst: minor change
* pylintrc: new file; pylint defaults