### PR TITLE
Log disconnect as an info - not a warning

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1532,7 +1532,7 @@ class Connection(object):
             internal causes, such as socket errors
         :param str reason_text: human-readable text message describing the error
         """
-        LOGGER.warning(
+        LOGGER.info(
             'Disconnected from RabbitMQ at %s:%i (%s): %s',
             self.params.host, self.params.port, reason_code,
             reason_text)


### PR DESCRIPTION
This fixes issue #719. 

I wasn't sure whether to continue to log certain termination reasons as a warning (based on `reason_code`) but it looks to me like this is already taken care of by the callers of `_on_terminate`.