### PR TITLE
Don't allow use of subsequent basic_get calls

### DIFF
--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -248,3 +248,10 @@ class ShortStringTooLong(AMQPError):
     def __repr__(self):
         return ('AMQP Short String can contain up to 255 bytes: '
                 '%.300s' % self.args[0])
+
+
+class DuplicateGetOkCallback(ChannelError):
+
+    def __repr__(self):
+        return ('basic_get can only be called again after the callback for the'
+                'previous basic_get is executed')

--- a/tests/acceptance/enforce_one_basicget_test.py
+++ b/tests/acceptance/enforce_one_basicget_test.py
@@ -1,0 +1,32 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from mock import MagicMock
+from pika.frame import Method, Header
+from pika.exceptions import DuplicateGetOkCallback
+from pika.channel import Channel
+from pika.connection import Connection
+
+
+class OnlyOneBasicGetTestCase(unittest.TestCase):
+    def setUp(self):
+        self.channel = Channel(MagicMock(Connection)(), 0, None)
+        self.channel._state = Channel.OPEN
+        self.callback = MagicMock()
+
+    def test_two_basic_get_with_callback(self):
+        self.channel.basic_get(self.callback)
+        self.channel._on_getok(MagicMock(Method)(), MagicMock(Header)(), '')
+        self.channel.basic_get(self.callback)
+        self.channel._on_getok(MagicMock(Method)(), MagicMock(Header)(), '')
+        self.assertEqual(self.callback.call_count, 2)
+
+    def test_two_basic_get_without_callback(self):
+        self.channel.basic_get(self.callback)
+        with self.assertRaises(DuplicateGetOkCallback):
+            self.channel.basic_get(self.callback)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This ensures users of future versions of Pika won't get bitten by  #709

Todo:
- [x] Fix `BlockingConnection.basic_get` test.
- [x] Add acceptance test