### PR TITLE
Update TwistedProtocolConnection to work with Twisted endpoints

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -367,7 +367,7 @@ class TwistedProtocolConnection(base_connection.BaseConnection):
 
     """
 
-    def __init__(self, parameters):
+    def __init__(self, parameters=None):
         self.ready = defer.Deferred()
         super(TwistedProtocolConnection, self).__init__(
             parameters=parameters,


### PR DESCRIPTION
No other connection adapter has ``parameters`` as a required argument,
and Twisted's ``protocol.Factory.forProtocol`` expects a callable that
requires no arguments to work. This sets the default value for
``parameters`` to be ``None`` to match other adapters

Signed-off-by: Jeremy Cline <jeremy@jcline.org>