### PR TITLE
Fixing ioloop command call to stopping consumer

### DIFF
--- a/docs/examples/asynchronous_consumer_example.rst
+++ b/docs/examples/asynchronous_consumer_example.rst
@@ -334,7 +334,7 @@ consumer.py::
             LOGGER.info('Stopping')
             self._closing = True
             self.stop_consuming()
-            self._connection.ioloop.start()
+            self._connection.ioloop.stop()
             LOGGER.info('Stopped')
 
         def close_connection(self):


### PR DESCRIPTION
Command that should be called to stop a consumer on ioloop should be `stop`. Fixing the sample consumer in the documentation.