### PR TITLE
.Stop() method does not close the IOLoop

### DIFF
--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -331,7 +331,7 @@ consumer.py::
             LOGGER.info('Stopping')
             self._closing = True
             self.stop_consuming()
-            self._connection.ioloop.start()
+            self._connection.ioloop.stop()
             LOGGER.info('Stopped')
 
 


### PR DESCRIPTION
In Line 334, we call 

    self._connection.ioloop.start()

Given that this call resides in the stop method, the intention is most likely to stop consuming, close the client, and thus also closing the ioloop. 

According to the documentation at https://github.com/pika/pika/blob/master/pika/adapters/tornado_connection.py#L23

this likely should read 

    self._connection.ioloop.stop()

Likely a minor slip of the pen (or the CTRL+C, V, for that matter). :)