### PR TITLE
blocking_adapter: only consider processable events

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -699,8 +699,10 @@ class BlockingConnection(object):
             until I/O produces actionalable events. Defaults to 0 for backward
             compatibility. This parameter is NEW in pika 0.10.0.
         """
-        common_terminator = lambda: bool(
-            self._channels_pending_dispatch or self._ready_events)
+        with self._acquire_event_dispatch() as dispatch_acquired:
+            # Check if we can actually process pending events
+            common_terminator = lambda: bool(dispatch_acquired and
+                (self._channels_pending_dispatch or self._ready_events))
 
         if time_limit is None:
             self._flush_output(common_terminator)


### PR DESCRIPTION
In `process_data_events()` the`common_terminator` that is passed to
`_flush_output()` was also set to true for events that could not be
processed because of the call context.

Considering those events anyway will lead to `_flush_output()` returning
immediately.

This can lead to a dropped connection e.g. when there is a timeout
event ready but `process_data_events()` is called from a callback
(e.g. `on_message`). The timeout event is considered as a terminator in
this case but can not be processed.

Fixes: #753