### PR TITLE
blocking_adapter: only consider processable events

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -703,12 +703,11 @@ class BlockingConnection(object):
             # Check if we can actually process pending events
             common_terminator = lambda: bool(dispatch_acquired and
                 (self._channels_pending_dispatch or self._ready_events))
-
-        if time_limit is None:
-            self._flush_output(common_terminator)
-        else:
-            with _IoloopTimerContext(time_limit, self._impl) as timer:
-                self._flush_output(timer.is_ready, common_terminator)
+            if time_limit is None:
+                self._flush_output(common_terminator)
+            else:
+                with _IoloopTimerContext(time_limit, self._impl) as timer:
+                    self._flush_output(timer.is_ready, common_terminator)
 
         if self._ready_events:
             self._dispatch_connection_events()

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -699,8 +699,10 @@ class BlockingConnection(object):
             until I/O produces actionalable events. Defaults to 0 for backward
             compatibility. This parameter is NEW in pika 0.10.0.
         """
-        common_terminator = lambda: bool(
-            self._channels_pending_dispatch or self._ready_events)
+        with self._acquire_event_dispatch() as dispatch_acquired:
+            # Check if we can actually process pending events
+            common_terminator = lambda: bool(dispatch_acquired and
+                (self._channels_pending_dispatch or self._ready_events))
 
         if time_limit is None:
             self._flush_output(common_terminator)


### PR DESCRIPTION
Includes and supercedes #803 

Does not resolve #753 (initially thought it might)