### PR TITLE
Remove "Downloads" from README header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Pika
 ====
 Pika is a RabbitMQ (AMQP-0-9-1) client library for Python.
 
-|Version| |Downloads| |Status| |Coverage| |License| |Docs|
+|Version| |Status| |Coverage| |License| |Docs|
 
 Introduction
 -------------

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,6 @@ with ``google`` style prior to issuing your pull request.
 .. |License| image:: https://img.shields.io/pypi/l/pika.svg?
    :target: https://pika.readthedocs.io
 
-.. |Docs| image:: https://readthedocs.io/projects/pika/badge/?version=stable
+.. |Docs| image:: https://readthedocs.org/projects/pika/badge/?version=stable
    :target: https://pika.readthedocs.io
    :alt: Documentation Status


### PR DESCRIPTION
I jinxed myself saying that #854 was the last PR for `0.11.0`...

View the document via this link:

https://github.com/pika/pika/blob/downloads-readme-fix/README.rst