### PR TITLE
Allow setting TCP options, such as keepalive and user-timeout

### DIFF
--- a/pika/compat.py
+++ b/pika/compat.py
@@ -130,11 +130,8 @@ def as_bytes(value):
     return value
 
 
-def get_linux_version():
-    if platform.system() != 'Linux':
-        return None
-
-    ver_str = platform.release().split('-')[0]
+def get_linux_version(release_str):
+    ver_str = release_str.split('-')[0]
     return tuple(map(int, ver_str.split('.')[:3]))
 
 
@@ -142,4 +139,6 @@ HAVE_SIGNAL = os.name == 'posix'
 
 EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3,4)
 
-LINUX_VERSION = get_linux_version()
+LINUX_VERSION = None
+if platform.system() == 'Linux':
+    LINUX_VERSION = get_linux_version(platform.release())

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -1,5 +1,6 @@
 import os
 import sys as _sys
+import platform
 
 PY2 = _sys.version_info < (3,)
 PY3 = not PY2
@@ -129,6 +130,16 @@ def as_bytes(value):
     return value
 
 
+def get_linux_version():
+    if platform.system() != 'Linux':
+        return None
+
+    ver_str = platform.release().split('-')[0]
+    return tuple(map(int, ver_str.split('.')[:3]))
+
+
 HAVE_SIGNAL = os.name == 'posix'
 
 EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3,4)
+
+LINUX_VERSION = get_linux_version()

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -546,13 +546,17 @@ class Parameters(object):  # pylint: disable=R0902
 
     @property
     def tcp_options(self):
+        """
+        :returns: None or a dict of options to pass to the underlying socket
+        """
         return self._tcp_options
 
     @tcp_options.setter
     def tcp_options(self, value):
         """
-        :param bool value: None or a dict of options to pass to
-            socket as tcp options
+        :param bool value: None or a dict of options to pass to the underlying
+            socket. Currently supported are TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
+            and TCP_USER_TIMEOUT. Availability of these may depend on your platform.
         """
         if not isinstance(value, (dict, type(None))):
             raise TypeError('tcp_options must be a dict or None, but got %r' %
@@ -749,7 +753,7 @@ class URLParameters(Parameters):
             expires before connection becomes unblocked, the connection will be
             torn down, triggering the connection's on_close_callback
         - tcp_options:
-            Set the tcp options for the socket.
+            Set the tcp options for the underlying socket.
 
     :param str url: The AMQP URL to connect to
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -68,7 +68,7 @@ class Parameters(object):  # pylint: disable=R0902
     :param bool ssl: `DEFAULT_SSL`
     :param dict ssl_options: `DEFAULT_SSL_OPTIONS`
     :param str virtual_host: `DEFAULT_VIRTUAL_HOST`
-
+    :param int tcp_options: `DEFAULT_TCP_OPTIONS`
     """
 
     # Declare slots to protect against accidental assignment of an invalid
@@ -89,7 +89,8 @@ class Parameters(object):  # pylint: disable=R0902
         '_socket_timeout',
         '_ssl',
         '_ssl_options',
-        '_virtual_host'
+        '_virtual_host',
+        '_tcp_options'
     )
 
     DEFAULT_USERNAME = 'guest'
@@ -113,6 +114,7 @@ class Parameters(object):  # pylint: disable=R0902
     DEFAULT_SSL_OPTIONS = None
     DEFAULT_SSL_PORT = 5671
     DEFAULT_VIRTUAL_HOST = '/'
+    DEFAULT_TCP_OPTIONS = None
 
     DEFAULT_HEARTBEAT_INTERVAL = DEFAULT_HEARTBEAT_TIMEOUT # DEPRECATED
 
@@ -169,6 +171,9 @@ class Parameters(object):  # pylint: disable=R0902
 
         self._virtual_host = None
         self.virtual_host = self.DEFAULT_VIRTUAL_HOST
+
+        self._tcp_options = None
+        self.tcp_options = self.DEFAULT_TCP_OPTIONS
 
     def __repr__(self):
         """Represent the info about the instance.
@@ -539,6 +544,21 @@ class Parameters(object):  # pylint: disable=R0902
             raise TypeError('virtual_host must be a str, but got %r' % (value,))
         self._virtual_host = value
 
+    @property
+    def tcp_options(self):
+        return self._tcp_options
+
+    @tcp_options.setter
+    def tcp_options(self, value):
+        """
+        :param bool value: None or a dict of options to pass to
+            socket as tcp options
+        """
+        if not isinstance(value, (dict, type(None))):
+            raise TypeError('tcp_options must be a dict or None, but got %r' %
+                            (value,))
+        self._tcp_options = value
+
 
 class ConnectionParameters(Parameters):
     """Connection parameters object that is passed into the connection adapter
@@ -570,6 +590,7 @@ class ConnectionParameters(Parameters):
                  backpressure_detection=_DEFAULT,
                  blocked_connection_timeout=_DEFAULT,
                  client_properties=_DEFAULT,
+                 tcp_options=_DEFAULT,
                  **kwargs):
         """Create a new ConnectionParameters instance. See `Parameters` for
         default values.
@@ -607,7 +628,7 @@ class ConnectionParameters(Parameters):
             RabbitMQ via `Connection.StartOk` method.
         :param heartbeat_interval: DEPRECATED; use `heartbeat` instead, and
             don't pass both
-
+        :param tcp_options: None or a dict of TCP options to set for socket
         """
         super(ConnectionParameters, self).__init__()
 
@@ -675,6 +696,9 @@ class ConnectionParameters(Parameters):
         if virtual_host is not self._DEFAULT:
             self.virtual_host = virtual_host
 
+        if tcp_options is not self._DEFAULT:
+            self.tcp_options = tcp_options
+
         if kwargs:
             raise TypeError('Unexpected kwargs: %r' % (kwargs,))
 
@@ -724,6 +748,8 @@ class URLParameters(Parameters):
             (triggered by Connection.Blocked from broker); if the timeout
             expires before connection becomes unblocked, the connection will be
             torn down, triggering the connection's on_close_callback
+        - tcp_options:
+            Set the tcp options for the socket.
 
     :param str url: The AMQP URL to connect to
 
@@ -903,6 +929,10 @@ class URLParameters(Parameters):
     def _set_url_ssl_options(self, value):
         """Deserialize and apply the corresponding query string arg"""
         self.ssl_options = ast.literal_eval(value)
+
+    def _set_url_tcp_options(self, value):
+        """Deserialize and apply the corresponding query string arg"""
+        self.tcp_options = ast.literal_eval(value)
 
 
 class Connection(object):

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -12,6 +12,7 @@ try:
 except ImportError:
     import unittest
 
+import socket
 import pika
 from pika.adapters import base_connection
 
@@ -37,7 +38,7 @@ class BaseConnectionTests(unittest.TestCase):
 
     def test_tcp_options_with_dict_tcp_options(self):
 
-        tcp_options = dict(TCP_USER_TIMEOUT=1000)
+        tcp_options = dict(TCP_KEEPIDLE=60)
         params = pika.ConnectionParameters(tcp_options=tcp_options)
         self.assertEqual(params.tcp_options, tcp_options)
 
@@ -47,8 +48,8 @@ class BaseConnectionTests(unittest.TestCase):
             conn._set_tcp_opts(sock_mock)
 
             expected = [
-                mock.call.setsockopt(65535, 8, 1),  # TCP_SOCKET, SO_KEEPALIVE, 1
-                mock.call.setsockopt(6, 18, 1000)   # SOL_TCP, TCP_USER_TIMEOUT, 1000
+                mock.call.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
+                mock.call.setsockopt(socket.SOL_TCP, socket.TCP_KEEPIDLE, 60)
             ]
             self.assertEquals(sock_mock.method_calls, expected)
 
@@ -64,7 +65,7 @@ class BaseConnectionTests(unittest.TestCase):
             conn._set_tcp_opts(sock_mock)
 
             expected = [
-                mock.call.setsockopt(65535, 8, 1),  # TCP_SOCKET, SO_KEEPALIVE, 1
+                mock.call.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
             ]
             self.assertEquals(sock_mock.method_calls, expected)
 
@@ -79,7 +80,7 @@ class BaseConnectionTests(unittest.TestCase):
             conn._set_tcp_opts(sock_mock)
 
             expected = [
-                mock.call.setsockopt(65535, 8, 1)  # TCP_SOCKET, SO_KEEPALIVE, 1
+                mock.call.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
             ]
             self.assertEquals(sock_mock.method_calls, expected)
 

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -1,0 +1,15 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from pika import compat
+
+
+class UtilsTests(unittest.TestCase):
+
+    def test_get_linux_version_normal(self):
+        self.assertEqual(compat.get_linux_version("4.11.0-2-amd64"), (4, 11, 0))
+
+    def test_get_linux_version_short(self):
+        self.assertEqual(compat.get_linux_version("4.11.0"), (4, 11, 0))

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -62,7 +62,8 @@ class _ParametersTestsBase(unittest.TestCase):
             'socket_timeout': kls.DEFAULT_SOCKET_TIMEOUT,
             'ssl': kls.DEFAULT_SSL,
             'ssl_options': kls.DEFAULT_SSL_OPTIONS,
-            'virtual_host': kls.DEFAULT_VIRTUAL_HOST
+            'virtual_host': kls.DEFAULT_VIRTUAL_HOST,
+            'tcp_options': kls.DEFAULT_TCP_OPTIONS
         }
 
         # Make sure we didn't miss anything
@@ -361,6 +362,19 @@ class ParametersTests(_ParametersTestsBase):
         with self.assertRaises(TypeError):
             params.virtual_host = 99
 
+    def test_tcp_options(self):
+        params = connection.Parameters()
+
+        opt = dict(TCP_KEEPIDLE=60, TCP_KEEPINTVL=2, TCP_KEEPCNT=1, TCP_USER_TIMEOUT=1000)
+        params.tcp_options = copy.deepcopy(opt)
+        self.assertEqual(params.tcp_options, opt)
+
+        params.tcp_options = None
+        self.assertIsNone(params.tcp_options)
+
+        with self.assertRaises(TypeError):
+            params.tcp_options = str(opt)
+
 
 class ConnectionParametersTests(_ParametersTestsBase):
     def test_default_property_values(self):
@@ -409,6 +423,7 @@ class ConnectionParametersTests(_ParametersTestsBase):
             'ssl': True,
             'ssl_options': {'ssl': 'options'},
             'virtual_host': u'vvhost',
+            'tcp_options': {'TCP_USER_TIMEOUT': 1000}
         }
         params = connection.ConnectionParameters(**kwargs)
 
@@ -537,7 +552,8 @@ class URLParametersTests(_ParametersTestsBase):
             'locale': 'en_UK',
             'retry_delay': 3,
             'socket_timeout': 100.5,
-            'ssl_options': {'ssl': 'options'}
+            'ssl_options': {'ssl': 'options'},
+            'tcp_options': {'TCP_USER_TIMEOUT': 1000, 'TCP_KEEPIDLE': 60}
         }
 
         for backpressure in ('t', 'f'):


### PR DESCRIPTION
This is a proposal for adding tcp keepalive and tcp-user-timeout support to pika. The idea was to make the tcp option setting generic so that it can support possibly more options in the future.

As far as possible problems go, I'm not entirely sure  how acceptable it is to set SO_KEEPALIVE for every connection since it does change behaviour. Also, compatibility on different platforms still needs work.

Even so, here's a PR. I'd like to hear thoughts on it, and whether something like this would be accepted and what needs to be done to that end ? :)