### PR TITLE
Cast port to int

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -428,9 +428,10 @@ class Parameters(object):  # pylint: disable=R0902
         :param int value: port number of broker's listening socket
 
         """
-        if not isinstance(value, numbers.Integral):
+        try:
+            self._port = int(value)
+        except (TypeError, ValueError):
             raise TypeError('port must be an int, but got %r' % (value,))
-        self._port = value
 
     @property
     def retry_delay(self):

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -276,11 +276,17 @@ class ParametersTests(_ParametersTestsBase):
         params.port = 5672
         self.assertEqual(params.port, 5672)
 
-        with self.assertRaises(TypeError):
-            params.port = 1.5
+        params.port = '5672'
+        self.assertEqual(params.port, 5672)
+
+        params.port = 1.5
+        self.assertEqual(params.port, 1)
 
         with self.assertRaises(TypeError):
-            params.port = '5672'
+            params.port = '50a'
+
+        with self.assertRaises(TypeError):
+            params.port = []
 
     def test_retry_delay(self):
         params = connection.Parameters()
@@ -453,7 +459,7 @@ class ConnectionParametersTests(_ParametersTestsBase):
         }
         # Test Type Errors
         for bad_field, bad_value in (
-                ('host', 15672), ('port', '5672'), ('virtual_host', True),
+                ('host', 15672), ('port', '5672a'), ('virtual_host', True),
                 ('channel_max', '4'), ('frame_max', '5'),
                 ('credentials', 'bad'), ('locale', 1),
                 ('heartbeat', '6'), ('socket_timeout', '42'),


### PR DESCRIPTION
Check if the ``port`` is an integer by casting it to one.

My motivation/desire for this change is to negate the need to cast the port value from an environment variable. The is the behavior I've grown to expect when configuring connections in Python.