### PR TITLE
update heartbeat determin policy when tune

### DIFF
--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -589,7 +589,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         #Test
         self.connection._on_connection_tune(method_frame)
         #verfy
-        self.assertEqual(60, self.connection.params.heartbeat)
+        self.assertEqual(20, self.connection.params.heartbeat)
 
         # Repeat with user deferring to server's heartbeat timeout
         method_frame.method.heartbeat = 500


### PR DESCRIPTION
if client_value > 0 then this value should be used as heartbeat.
because sometimes, the max value of client_value and the server_value
may too big for firmwall, the firmwall may have broken off the
connection.