### PR TITLE
Change heartbeat negotiation strategy

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1824,19 +1824,6 @@ class Connection(object):
         > - The client responds and **MAY reduce those limits** for its
             connection
 
-        When negotiating heartbeat timeout, the reasoning needs to be reversed.
-        The way I think it makes sense to interpret this rule for heartbeats is
-        that the consumable resource is the frequency of heartbeats, which is
-        the inverse of the timeout. The more frequent heartbeats consume more
-        resources than less frequent heartbeats. So, when both heartbeat
-        timeouts are non-zero, we should pick the max heartbeat timeout rather
-        than the min. The heartbeat timeout value 0 (zero) has a special
-        meaning - it's supposed to disable the timeout. This makes zero a
-        setting for the least frequent heartbeats (i.e., never); therefore, if
-        any (or both) of the two is zero, then the above rules would suggest
-        that negotiation should yield 0 value for heartbeat, effectively turning
-        it off.
-
         :param client_value: None to accept server_value; otherwise, an integral
             number in seconds; 0 (zero) to disable heartbeat.
         :param server_value: integral value of the heartbeat timeout proposed by
@@ -1852,9 +1839,7 @@ class Connection(object):
             # least frequent heartbeat value there is
             timeout = 0
         else:
-            # Pick the one with the bigger heartbeat timeout (i.e., the less
-            # frequent one)
-            timeout = max(client_value, server_value)
+            timeout = client_value
 
         return timeout
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -589,7 +589,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         #Test
         self.connection._on_connection_tune(method_frame)
         #verfy
-        self.assertEqual(60, self.connection.params.heartbeat)
+        self.assertEqual(20, self.connection.params.heartbeat)
 
         # Repeat with user deferring to server's heartbeat timeout
         method_frame.method.heartbeat = 500


### PR DESCRIPTION
if client_value > 0 then this value should be used as heartbeat.
because sometimes, the max value of client_value and the
server_value may too big for firmwall, the firmwall may have broken
off the connection.