### PR TITLE
Allow setting common TCP socket options

### DIFF
--- a/pika/compat.py
+++ b/pika/compat.py
@@ -1,9 +1,9 @@
 import os
 import sys as _sys
+import platform
 
 PY2 = _sys.version_info < (3,)
 PY3 = not PY2
-
 
 if not PY2:
     # these were moved around for Python 3
@@ -22,7 +22,6 @@ if not PY2:
 
     # the unicode type is str
     unicode_type = str
-
 
     def dictkeys(dct):
         """
@@ -123,12 +122,22 @@ else:
     def is_integer(value):
         return isinstance(value, (int, long))
 
+
 def as_bytes(value):
     if not isinstance(value, bytes):
         return value.encode('UTF-8')
     return value
 
 
+def get_linux_version(release_str):
+    ver_str = release_str.split('-')[0]
+    return tuple(map(int, ver_str.split('.')[:3]))
+
+
 HAVE_SIGNAL = os.name == 'posix'
 
-EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3,4)
+EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3, 4)
+
+LINUX_VERSION = None
+if platform.system() == 'Linux':
+    LINUX_VERSION = get_linux_version(platform.release())

--- a/pika/tcp_socket_opts.py
+++ b/pika/tcp_socket_opts.py
@@ -15,7 +15,7 @@ try:
     _SUPPORTED_TCP_OPTIONS['TCP_USER_TIMEOUT'] = socket.TCP_USER_TIMEOUT
 except AttributeError:
     if pika.compat.LINUX_VERSION and pika.compat.LINUX_VERSION >= (2, 6, 37):
-        _SUPPORTED_TCP_OPTIONS['TCP_USER_TIMEOUT'] = 18
+        _SUPPORTED_TCP_OPTIONS['TCP_USER_TIMEOUT'] = 60
 
 try:
     _SUPPORTED_TCP_OPTIONS['TCP_KEEPIDLE'] = socket.TCP_KEEPIDLE

--- a/pika/tcp_socket_opts.py
+++ b/pika/tcp_socket_opts.py
@@ -1,0 +1,44 @@
+import logging
+import socket
+import pika.compat
+
+try:
+    SOL_TCP = socket.SOL_TCP
+except AttributeError:
+    SOL_TCP = socket.IPPROTO_TCP
+
+LOGGER = logging.getLogger(__name__)
+
+_SUPPORTED_TCP_OPTIONS = {}
+
+try:
+    _SUPPORTED_TCP_OPTIONS['TCP_USER_TIMEOUT'] = socket.TCP_USER_TIMEOUT
+except AttributeError:
+    if pika.compat.LINUX_VERSION and pika.compat.LINUX_VERSION >= (2, 6, 37):
+        _SUPPORTED_TCP_OPTIONS['TCP_USER_TIMEOUT'] = 18
+
+try:
+    _SUPPORTED_TCP_OPTIONS['TCP_KEEPIDLE'] = socket.TCP_KEEPIDLE
+    _SUPPORTED_TCP_OPTIONS['TCP_KEEPCNT'] = socket.TCP_KEEPCNT
+    _SUPPORTED_TCP_OPTIONS['TCP_KEEPINTVL'] = socket.TCP_KEEPINTVL
+except AttributeError:
+    pass
+
+
+def socket_requires_keepalive(tcp_options):
+    return 'TCP_KEEPIDLE' in tcp_options or 'TCP_KEEPCNT' in tcp_options or 'TCP_KEEPINTVL' in tcp_options
+
+
+def set_sock_opts(tcp_options, sock):
+    if not tcp_options:
+        return
+
+    if socket_requires_keepalive(tcp_options):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+
+    for key, value in tcp_options.items():
+        option = _SUPPORTED_TCP_OPTIONS.get(key)
+        if option:
+            sock.setsockopt(SOL_TCP, option, value)
+        else:
+            LOGGER.warning('Unsupported TCP option %s:%s', key, value)

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -1,0 +1,15 @@
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from pika import compat
+
+
+class UtilsTests(unittest.TestCase):
+
+    def test_get_linux_version_normal(self):
+        self.assertEqual(compat.get_linux_version("4.11.0-2-amd64"), (4, 11, 0))
+
+    def test_get_linux_version_short(self):
+        self.assertEqual(compat.get_linux_version("4.11.0"), (4, 11, 0))

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -62,7 +62,8 @@ class _ParametersTestsBase(unittest.TestCase):
             'socket_timeout': kls.DEFAULT_SOCKET_TIMEOUT,
             'ssl': kls.DEFAULT_SSL,
             'ssl_options': kls.DEFAULT_SSL_OPTIONS,
-            'virtual_host': kls.DEFAULT_VIRTUAL_HOST
+            'virtual_host': kls.DEFAULT_VIRTUAL_HOST,
+            'tcp_options': kls.DEFAULT_TCP_OPTIONS
         }
 
         # Make sure we didn't miss anything
@@ -367,6 +368,19 @@ class ParametersTests(_ParametersTestsBase):
         with self.assertRaises(TypeError):
             params.virtual_host = 99
 
+    def test_tcp_options(self):
+        params = connection.Parameters()
+
+        opt = dict(TCP_KEEPIDLE=60, TCP_KEEPINTVL=2, TCP_KEEPCNT=1, TCP_USER_TIMEOUT=1000)
+        params.tcp_options = copy.deepcopy(opt)
+        self.assertEqual(params.tcp_options, opt)
+
+        params.tcp_options = None
+        self.assertIsNone(params.tcp_options)
+
+        with self.assertRaises(TypeError):
+            params.tcp_options = str(opt)
+
 
 class ConnectionParametersTests(_ParametersTestsBase):
     def test_default_property_values(self):
@@ -415,6 +429,7 @@ class ConnectionParametersTests(_ParametersTestsBase):
             'ssl': True,
             'ssl_options': {'ssl': 'options'},
             'virtual_host': u'vvhost',
+            'tcp_options': {'TCP_USER_TIMEOUT': 1000}
         }
         params = connection.ConnectionParameters(**kwargs)
 
@@ -543,7 +558,8 @@ class URLParametersTests(_ParametersTestsBase):
             'locale': 'en_UK',
             'retry_delay': 3,
             'socket_timeout': 100.5,
-            'ssl_options': {'ssl': 'options'}
+            'ssl_options': {'ssl': 'options'},
+            'tcp_options': {'TCP_USER_TIMEOUT': 1000, 'TCP_KEEPIDLE': 60}
         }
 
         for backpressure in ('t', 'f'):


### PR DESCRIPTION
Includes and supercedes #864 

It appears that the RabbitMQ Java client does not set TCP keepalives [by default](https://github.com/rabbitmq/rabbitmq-java-client/blob/master/src/main/java/com/rabbitmq/client/DefaultSocketConfigurator.java#L21-L38), but does disable Nagle's algorithm, so we should probably follow the lead there.

Also see #67 about using `IPPROTO_TCP` instead of `6`