### PR TITLE
Ensure that Channel.Close stops event processing and raises exception

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -129,7 +129,7 @@ class Channel(object):
     def add_on_close_callback(self, callback):
         """Pass a callback function that will be called when the channel is
         closed. The callback function will receive the channel, the
-        reply_code (int) and the reply_text (int) describing why the channel was
+        reply_code (int) and the reply_text (string) describing why the channel was
         closed.
 
         If the channel is closed by broker via Channel.Close, the callback will


### PR DESCRIPTION
Fixes #841 

These changes basically emulate what is done [in this code](https://github.com/pika/pika/blob/master/pika/adapters/blocking_connection.py#L1253-L1258) but also uses `_request_channel_dispatch` to ensure `start_consuming()` or other blocking channel methods resume.