### PR TITLE
Ensure large numbers are encoded correctly

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -119,8 +119,12 @@ def encode_value(pieces, value):
         pieces.append(struct.pack('>cq', b'l', value))
         return 9
     elif isinstance(value, int):
-        pieces.append(struct.pack('>ci', b'I', value))
-        return 5
+        try:
+            pieces.append(struct.pack('>ci', b'I', value))
+            return 5
+        except struct.error:
+            pieces.append(struct.pack('>cq', b'l', long(value)))
+            return 9
     elif isinstance(value, decimal.Decimal):
         value = value.normalize()
         if value.as_tuple().exponent < 0:

--- a/pika/data.py
+++ b/pika/data.py
@@ -2,6 +2,8 @@
 import struct
 import decimal
 import calendar
+import warnings
+
 from datetime import datetime
 
 from pika import exceptions
@@ -119,12 +121,16 @@ def encode_value(pieces, value):
         pieces.append(struct.pack('>cq', b'l', value))
         return 9
     elif isinstance(value, int):
-        try:
-            pieces.append(struct.pack('>ci', b'I', value))
-            return 5
-        except struct.error:
-            pieces.append(struct.pack('>cq', b'l', long(value)))
-            return 9
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error')
+            try:
+                p = struct.pack('>ci', b'I', value)
+                pieces.append(p)
+                return 5
+            except (struct.error, DeprecationWarning):
+                p = struct.pack('>cq', b'l', long(value))
+                pieces.append(p)
+                return 9
     elif isinstance(value, decimal.Decimal):
         value = value.normalize()
         if value.as_tuple().exponent < 0:

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -24,14 +24,15 @@ from pika.compat import long
 class DataTests(unittest.TestCase):
 
     FIELD_TBL_ENCODED = (
-        b'\x00\x00\x00\xbb'
+        b'\x00\x00\x00\xcb'
         b'\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I\x00\x00\x00\x02I\x00\x00\x00\x03'
         b'\x07boolvalt\x01'
         b'\x07decimalD\x02\x00\x00\x01:'
         b'\x0bdecimal_tooD\x00\x00\x00\x00d'
         b'\x07dictvalF\x00\x00\x00\x0c\x03fooS\x00\x00\x00\x03bar'
         b'\x06intvalI\x00\x00\x00\x01'
-        b'\x07longvall\x00\x00\x00\x006e&U'
+        b'\x06bigint\x6c\x00\x00\x00\x00\x9a\x7e\xc8\x00'
+        b'\x07longval\x6c\x00\x00\x00\x00\x36\x65\x26\x55'
         b'\x04nullV'
         b'\x06strvalS\x00\x00\x00\x04Test'
         b'\x0ctimestampvalT\x00\x00\x00\x00Ec)\x92'
@@ -44,7 +45,8 @@ class DataTests(unittest.TestCase):
         ('decimal', decimal.Decimal('3.14')),
         ('decimal_too', decimal.Decimal('100')),
         ('dictval', {'foo': 'bar'}),
-        ('intval', 1)	,
+        ('intval', 1),
+        ('bigint', 2592000000),
         ('longval', long(912598613)),
         ('null', None),
         ('strval', 'Test'),
@@ -60,7 +62,7 @@ class DataTests(unittest.TestCase):
     def test_encode_table_bytes(self):
         result = []
         byte_count = data.encode_table(result, self.FIELD_TBL_VALUE)
-        self.assertEqual(byte_count, 191)
+        self.assertEqual(byte_count, 207)
 
     def test_decode_table(self):
         value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
@@ -68,7 +70,7 @@ class DataTests(unittest.TestCase):
 
     def test_decode_table_bytes(self):
         value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
-        self.assertEqual(byte_count, 191)
+        self.assertEqual(byte_count, 207)
 
     def test_encode_raises(self):
         self.assertRaises(exceptions.UnsupportedAMQPFieldException,


### PR DESCRIPTION
Fixes #861

The struct module throws `struct.error` when attempting to encode a greater-than-4-byte number using the "i" (4 byte) format. This will catch the error and promote the encoding to "q" (8 byte) format.