### PR TITLE
Remove `+` character from platform releases string

### DIFF
--- a/pika/compat.py
+++ b/pika/compat.py
@@ -1,9 +1,12 @@
 import os
 import sys as _sys
 import platform
+import re
 
 PY2 = _sys.version_info < (3,)
 PY3 = not PY2
+RE_NUM = re.compile(r'(\d+).+')
+
 
 if not PY2:
     # these were moved around for Python 3
@@ -129,10 +132,16 @@ def as_bytes(value):
     return value
 
 
+def to_digit(value):
+    if value.isdigit():
+        return int(value)
+    match = RE_NUM.match(value)
+    return int(match.groups()[0]) if match else 0
+
+
 def get_linux_version(release_str):
     ver_str = release_str.split('-')[0]
-    ver_str = ver_str[:-1] if ver_str[-1] == '+' else ver_str
-    return tuple(map(int, ver_str.split('.')[:3]))
+    return tuple(map(to_digit, ver_str.split('.')[:3]))
 
 
 HAVE_SIGNAL = os.name == 'posix'

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -131,6 +131,7 @@ def as_bytes(value):
 
 def get_linux_version(release_str):
     ver_str = release_str.split('-')[0]
+    ver_str = ver_str[:-1] if ver_str[-1] == '+' else ver_str
     return tuple(map(int, ver_str.split('.')[:3]))
 
 

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -16,3 +16,12 @@ class UtilsTests(unittest.TestCase):
 
     def test_get_linux_version_gcp(self):
         self.assertEqual(compat.get_linux_version("4.4.64+"), (4, 4, 64))
+
+    def test_to_digit(self):
+        self.assertEqual(compat.to_digit("64"), 64)
+
+    def test_to_digit_with_plus_sign(self):
+        self.assertEqual(compat.to_digit("64+"), 64)
+
+    def test_to_digit_with_dot(self):
+        self.assertEqual(compat.to_digit("64."), 64)

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -13,3 +13,6 @@ class UtilsTests(unittest.TestCase):
 
     def test_get_linux_version_short(self):
         self.assertEqual(compat.get_linux_version("4.11.0"), (4, 11, 0))
+
+    def test_get_linux_version_gcp(self):
+        self.assertEqual(compat.get_linux_version("4.4.64+"), (4, 4, 64))


### PR DESCRIPTION
There is an issue when pika is used within GCP(Google Cloud Platform) and following patch tries to fix that. 

### Details:

pika has a method `get_linux_version` which returns Linux platform information tuple. However, on GCP, it fails. Since that method fails, its not possible to use pika and hence its makes impossible to use pika on GCP.

This is what one of the GCP vm instance returns when asked for platform information: 

```
$ python
Python 2.7.10 (default, Aug 30 2017, 20:23:35)
[GCC 4.9.x 20150123 (prerelease)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> platform.release()
'4.4.64+'
>>>
```

Due `+` character, `get_linux_version` fails and thus, we cannot import pika:

```
$ python
Python 2.7.13 (default, Sep 14 2017, 23:47:22)
[GCC 4.9.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import pika
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/lib/python2.7/site-packages/pika/__init__.py", line 17, in <module>
    from pika.connection import ConnectionParameters
  File "/usr/local/lib/python2.7/site-packages/pika/connection.py", line 18, in <module>
    from pika import callback
  File "/usr/local/lib/python2.7/site-packages/pika/callback.py", line 8, in <module>
    from pika import frame
  File "/usr/local/lib/python2.7/site-packages/pika/frame.py", line 7, in <module>
    from pika import spec
  File "/usr/local/lib/python2.7/site-packages/pika/spec.py", line 16, in <module>
    from pika import data
  File "/usr/local/lib/python2.7/site-packages/pika/data.py", line 10, in <module>
    from pika.compat import PY2, PY3
  File "/usr/local/lib/python2.7/site-packages/pika/compat.py", line 143, in <module>
    LINUX_VERSION = get_linux_version(platform.release())
  File "/usr/local/lib/python2.7/site-packages/pika/compat.py", line 134, in get_linux_version
    return tuple(map(int, ver_str.split('.')[:3]))
ValueError: invalid literal for int() with base 10: '70+'
```

### Steps to reproduce:

I couldn't figure out a way to reproduce this bug outside GCP, on my local machine etc. So, to reproduce this bug I think one needs an access to GCP. Create a VM instance and try above. I created a Kubernetes installation (which does the VMs installations too) and tried this. This platform information is also passed to Docker, hence my Docker containers are also failing. 

Let me know if any information is needed. Or a better way to fix this. 

Thank you 😃 