### PR TITLE
Replace home-grown socketpair

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -632,22 +632,10 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
     def _get_interrupt_pair():
         """ Use a socketpair to be able to interrupt the ioloop if called
         from another thread. Socketpair() is not supported on some OS (Win)
-        so use a pair of simple UDP sockets instead. The sockets will be
+        so use a pair of simple TCP sockets instead. The sockets will be
         closed and garbage collected by python when the ioloop itself is.
         """
-        try:
-            read_sock, write_sock = socket.socketpair()
-
-        except AttributeError:
-            LOGGER.debug("Using custom socketpair for interrupt")
-            read_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            read_sock.bind(('localhost', 0))
-            write_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            write_sock.connect(read_sock.getsockname())
-
-        read_sock.setblocking(0)
-        write_sock.setblocking(0)
-        return read_sock, write_sock
+        return socket.socketpair()
 
     def _read_interrupt(self, interrupt_fd, events):  # pylint: disable=W0613
         """ Read the interrupt byte(s). We ignore the event mask as we can ony
@@ -658,9 +646,6 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
         """
         try:
             # NOTE Use recv instead of os.read for windows compatibility
-            # TODO _r_interrupt is a DGRAM sock, so attempted reading of 512
-            # bytes will not have the desired effect in case stop was called
-            # multiple times
             self._r_interrupt.recv(512)
         except SOCKET_ERROR as err:
             if err.errno != errno.EAGAIN:

--- a/pika/compat/__init__.py
+++ b/pika/compat/__init__.py
@@ -1,8 +1,9 @@
+import errno
 import os
-import sys as _sys
 import platform
 import re
 import socket
+import sys as _sys
 
 PY2 = _sys.version_info < (3,)
 PY3 = not PY2
@@ -162,3 +163,55 @@ EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3, 4)
 LINUX_VERSION = None
 if platform.system() == 'Linux':
     LINUX_VERSION = get_linux_version(platform.release())
+
+_LOCALHOST = '127.0.0.1'
+_LOCALHOST_V6 = '::1'
+
+if not hasattr(socket, 'socketpair'):
+    # Origin: https://gist.github.com/4325783, by Geert Jansen.  Public domain.
+    def socketpair(family=socket.AF_INET, type=socket.SOCK_STREAM, proto=0):
+        if family == socket.AF_INET:
+            host = _LOCALHOST
+        elif family == socket.AF_INET6:
+            host = _LOCALHOST_V6
+        else:
+            raise ValueError(
+                'Only AF_INET and AF_INET6 socket address families '
+                'are supported')
+        if type != socket.SOCK_STREAM:
+            raise ValueError('Only SOCK_STREAM socket type is supported')
+        if proto != 0:
+            raise ValueError('Only protocol zero is supported')
+
+        # We create a connected TCP socket. Note the trick with
+        # setblocking(False) that prevents us from having to create a thread.
+        lsock = socket.socket(family, type, proto)
+        try:
+            lsock.bind((host, 0))
+            lsock.listen(min(socket.SOMAXCONN, 128))
+            # On IPv6, ignore flow_info and scope_id
+            addr, port = lsock.getsockname()[:2]
+            csock = socket.socket(family, type, proto)
+            try:
+                csock.setblocking(False)
+                if _sys.version_info >= (3, 0):
+                    try:
+                        csock.connect((addr, port))
+                    except (BlockingIOError, InterruptedError):
+                        pass
+                else:
+                    try:
+                        csock.connect((addr, port))
+                    except socket.error as e:
+                        if e.errno != errno.EWOULDBLOCK:
+                            raise
+                csock.setblocking(True)
+                ssock, _ = lsock.accept()
+            except Exception:
+                csock.close()
+                raise
+        finally:
+            lsock.close()
+        return (ssock, csock)
+
+    socket.socketpair = socketpair

--- a/pika/compat/__init__.py
+++ b/pika/compat/__init__.py
@@ -202,7 +202,7 @@ if not hasattr(socket, 'socketpair'):
                 else:
                     try:
                         csock.connect((addr, port))
-                    except socket.error as e:
+                    except SOCKET_ERROR as e:
                         if e.errno != errno.EWOULDBLOCK:
                             raise
                 csock.setblocking(True)

--- a/tests/acceptance/forward_server.py
+++ b/tests/acceptance/forward_server.py
@@ -376,7 +376,7 @@ class _TCPHandler(SocketServer.StreamRequestHandler, object):
                    remote_dest_sock.getpeername())
         else:
             # Echo set-up
-            remote_dest_sock, remote_src_sock = socket_pair()
+            remote_dest_sock, remote_src_sock = socket.socketpair()
 
         try:
             local_forwarder = threading.Thread(
@@ -524,56 +524,3 @@ def _safe_shutdown_socket(sock, how=socket.SHUT_RDWR):
     except SOCKET_ERROR as exc:
         if exc.errno != errno.ENOTCONN:
             raise
-
-
-def socket_pair(family=None,
-                sock_type=socket.SOCK_STREAM,
-                proto=socket.IPPROTO_IP):
-    """ socket.socketpair abstraction with support for Windows
-
-    :param family: address family; e.g., socket.AF_UNIX, socket.AF_INET, etc.;
-      defaults to socket.AF_UNIX if available, with fallback to socket.AF_INET.
-    :param sock_type: socket type; defaults to socket.SOCK_STREAM
-    :param proto: protocol; defaults to socket.IPPROTO_IP
-    """
-    if family is None:
-        if hasattr(socket, "AF_UNIX"):
-            family = socket.AF_UNIX
-        else:
-            family = socket.AF_INET
-
-    if hasattr(socket, "socketpair"):
-        socket1, socket2 = socket.socketpair(family, sock_type, proto)
-    else:
-        # Probably running on Windows where socket.socketpair isn't supported
-
-        # Work around lack of socket.socketpair()
-
-        socket1 = socket2 = None
-
-        listener = socket.socket(family, sock_type, proto)
-        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-
-        listener.bind(("localhost", 0))
-        listener.listen(1)
-        listener_port = listener.getsockname()[1]
-
-        socket1 = socket.socket(family, sock_type, proto)
-
-        # Use thread to connect in background, while foreground issues the
-        # blocking accept()
-        conn_thread = threading.Thread(
-            target=socket1.connect, args=(('localhost', listener_port),))
-        conn_thread.setDaemon(1)
-        conn_thread.start()
-
-        try:
-            socket2 = listener.accept()[0]
-        finally:
-            listener.close()
-
-            # Join/reap background thread
-            conn_thread.join(timeout=10)
-            assert not conn_thread.isAlive()
-
-    return (socket1, socket2)


### PR DESCRIPTION
Use the version of socketpair that comes in Python 3.5, which is also in this project:

https://github.com/mhils/backports.socketpair