### PR TITLE
Refactor Connection._send_message in terms of _send_frame to avoid  code duplication

### DIFF
--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -880,7 +880,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         props = spec.BasicProperties()
         body = b'b' * 1000000
 
-        self.connection._send_message(
+        self.connection._send_method(
             channel_number=1, method=method, content=(props, body))
 
         frames_sent = len(self.connection.outbound_buffer)


### PR DESCRIPTION
Refactor Connection._send_message in terms of Connection._send_frame to avoid  code duplication.

Also, remove default content arg default value of None since implementation assumes content is a sequence.

Renamed `method` arg name to `method_frame` to reflect the expected object type and for consistency with other methods in same module.

Fixed method comment not to refer to lock, since locking was unnecessary and was removed some time ago.

Covered by existing tests

cc @lukebakken 