### PR TITLE
SSL advanced parameters

### DIFF
--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -8,6 +8,7 @@ logging.getLogger(__name__).addHandler(NullHandler())
 
 from pika.connection import ConnectionParameters
 from pika.connection import URLParameters
+from pika.connection import SSLOptions
 from pika.credentials import PlainCredentials
 from pika.spec import BasicProperties
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -974,7 +974,7 @@ class SSLOptions(object):
                  certfile=None,
                  server_side=False,
                  verify_mode=ssl.CERT_NONE,
-                 ssl_version=ssl.PROTOCOL_SSLv3,
+                 ssl_version=ssl.PROTOCOL_SSLv23,
                  cafile=None,
                  capath=None,
                  cadata=None,

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -8,6 +8,7 @@ import math
 import numbers
 import platform
 import warnings
+import ssl
 
 if sys.version_info > (3,):
     import urllib.parse as urlparse  # pylint: disable=E0611,F0401
@@ -517,14 +518,17 @@ class Parameters(object):  # pylint: disable=R0902
     @ssl_options.setter
     def ssl_options(self, value):
         """
-        :param value: None or a dict of options to pass to `ssl.wrap_socket`.
+        :param value: None, a dict of options to pass to `ssl.wrap_socket` or
+            a SSLOptions object for advanced setup.
 
         """
-        if not isinstance(value, (dict, type(None))):
-            raise TypeError('ssl_options must be a dict or None, but got %r' %
-                            (value,))
+        if not isinstance(value, (dict, SSLOptions, type(None))):
+            raise TypeError(
+                'ssl_options must be a dict, None or an SSLOptions but got %r'
+                % (value, ))
         # Copy the mutable object to avoid accidental side-effects
         self._ssl_options = copy.deepcopy(value)
+
 
     @property
     def virtual_host(self):
@@ -939,6 +943,58 @@ class URLParameters(Parameters):
         """Deserialize and apply the corresponding query string arg"""
         self.tcp_options = ast.literal_eval(value)
 
+class SSLOptions(object):
+    """Class used to provide parameters for optional fine grained control of SSL
+    socket wrapping.
+
+    :param string keyfile: The key file to pass to SSLContext.load_cert_chain
+    :param string key_password: The key password to passed to
+                                                    SSLContext.load_cert_chain
+    :param string certfile: The certificate file to passed to
+                                                    SSLContext.load_cert_chain
+    :param bool server_side: Passed to SSLContext.wrap_socket
+    :param verify_mode: Passed to SSLContext.wrap_socket
+    :param ssl_version: Passed to SSLContext init, defines the ssl
+                                                                version to use
+    :param string cafile: The CA file passed to
+                                            SSLContext.load_verify_locations
+    :param string capath: The CA path passed to
+                                            SSLContext.load_verify_locations
+    :param string cadata: The CA data passed to
+                                            SSLContext.load_verify_locations
+    :param do_handshake_on_connect: Passed to SSLContext.wrap_socket
+    :param suppress_ragged_eofs: Passed to SSLContext.wrap_socket
+    :param ciphers: Passed to SSLContext.set_ciphers
+    :param server_hostname: SSLContext.wrap_socket, used to enable SNI
+    """
+
+    def __init__(self,
+                 keyfile=None,
+                 key_password=None,
+                 certfile=None,
+                 server_side=False,
+                 verify_mode=ssl.CERT_NONE,
+                 ssl_version=ssl.PROTOCOL_SSLv3,
+                 cafile=None,
+                 capath=None,
+                 cadata=None,
+                 do_handshake_on_connect=True,
+                 suppress_ragged_eofs=True,
+                 ciphers=None,
+                 server_hostname=None):
+        self.keyfile = keyfile
+        self.key_password = key_password
+        self.certfile = certfile
+        self.server_side = server_side
+        self.verify_mode = verify_mode
+        self.ssl_version = ssl_version
+        self.cafile = cafile
+        self.capath = capath
+        self.cadata = cadata
+        self.do_handshake_on_connect = do_handshake_on_connect
+        self.suppress_ragged_eofs = suppress_ragged_eofs
+        self.ciphers = ciphers
+        self.server_hostname = server_hostname
 
 class Connection(object):
     """This is the core class that implements communication with RabbitMQ. This

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -9,8 +9,12 @@ import unittest
 import mock
 
 import pika
+import sys
+import ssl
+
 import pika.tcp_socket_opts
 from pika.adapters import base_connection
+
 
 # If this is missing, set it manually. We need it to test tcp opt setting.
 try:
@@ -115,3 +119,84 @@ class BaseConnectionTests(unittest.TestCase):
                     do_handshake_on_connect=conn.DO_HANDSHAKE,
                     ssl='options',
                     handshake=False)
+
+    @mock.patch('ssl.SSLContext.load_cert_chain')
+    @mock.patch('ssl.SSLContext.load_verify_locations')
+    @mock.patch('ssl.SSLContext.set_ciphers')
+    @mock.patch('ssl.SSLContext.wrap_socket')
+    @unittest.skipIf(sys.version_info < (2,7,0), 'Unavailable ssl features')
+    def test_ssl_wrap_socket_with_default_ssl_options_obj(self,
+                                                          wrap_socket_mock,
+                                                          set_ciphers_mock,
+                                                          load_verify_mock,
+                                                          load_certs_mock):
+        ssl_options = pika.SSLOptions()
+        params = pika.ConnectionParameters(ssl_options=ssl_options)
+        #self.assertEqual(params.ssl_options, ssl_options)
+
+
+        with mock.patch('pika.connection.Connection.connect'):
+            conn = base_connection.BaseConnection(parameters=params)
+
+            sock_mock = mock.Mock()
+            conn._wrap_socket(sock_mock)
+
+            load_certs_mock.assert_not_called()
+            load_verify_mock.assert_not_called()
+            # the __init__ of SSLContext calls set_ciphers,
+            # hence the 'called once'
+            set_ciphers_mock.assert_called_once()
+            wrap_socket_mock.assert_called_once_with(
+                sock_mock,
+                server_side=False,
+                do_handshake_on_connect=conn.DO_HANDSHAKE,
+                suppress_ragged_eofs=True,
+                server_hostname=None
+                )
+
+    @mock.patch('ssl.SSLContext.load_cert_chain')
+    @mock.patch('ssl.SSLContext.load_verify_locations')
+    @mock.patch('ssl.SSLContext.set_ciphers')
+    @mock.patch('ssl.SSLContext.wrap_socket')
+    @unittest.skipIf(sys.version_info < (2,7,0), 'Unavailable ssl features')
+    def test_ssl_wrap_socket_with_ssl_options_obj(self,
+                                                        wrap_socket_mock,
+                                                        set_ciphers_mock,
+                                                        load_verify_mock,
+                                                        load_certs_mock):
+        ssl_options = pika.SSLOptions(certfile='/some/cert/file.crt',
+                                      keyfile='/some/key/file.crt',
+                                      key_password='pa55w0rd',
+                                      cafile='/some/ca/file.crt',
+                                      capath='/some/ca/path',
+                                      cadata='/some/data/or/something',
+                                      ciphers='ciphers',
+                                      server_hostname='some.virtual.host',
+                                      do_handshake_on_connect=False,
+                                      suppress_ragged_eofs=False,
+                                      server_side=True)
+        params = pika.ConnectionParameters(ssl_options=ssl_options)
+        #self.assertEqual(params.ssl_options, ssl_options)
+
+
+        with mock.patch('pika.connection.Connection.connect'):
+            conn = base_connection.BaseConnection(parameters=params)
+
+            sock_mock = mock.Mock()
+            conn._wrap_socket(sock_mock)
+
+            load_certs_mock.assert_called_once_with(certfile='/some/cert/file.crt',
+                                                    keyfile='/some/key/file.crt',
+                                                    password='pa55w0rd')
+            load_verify_mock.assert_called_once_with(cafile='/some/ca/file.crt',
+                                                     capath='/some/ca/path',
+                                                     cadata='/some/data/or/something')
+            # the constructor of SSLContext calls set_ciphers as well
+            set_ciphers_mock.assert_called_with('ciphers')
+            wrap_socket_mock.assert_called_once_with(
+                sock_mock,
+                server_side=True,
+                do_handshake_on_connect=False,
+                suppress_ragged_eofs=False,
+                server_hostname='some.virtual.host'
+                )


### PR DESCRIPTION
PR for #929 
Added class for defining advanced SSL options which can be optionally used instead of the normal SSL options dict. This allows advanced config using the ssl.SSLContext.wrap_socket() instead of the more basic but simpler ssl.wrap_socket(). 