### PR TITLE
Drop support for EOL Python 2.6 and 3.3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Introduction
 Pika is a pure-Python implementation of the AMQP 0-9-1 protocol including RabbitMQ's
 extensions.
 
-- Python 2.6+ and 3.3+ are supported.
+- Python 2.7 and 3.3+ are supported.
 
 - Since threads aren't appropriate to every situation, it doesn't
   require threads. It takes care not to forbid them, either. The same

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ Pika
 ====
 Pika is a RabbitMQ (AMQP-0-9-1) client library for Python.
 
-|Version| |Status| |Coverage| |License| |Docs|
+|Version| |Python versions| |Status| |Coverage| |License| |Docs|
 
 Introduction
 -------------
@@ -83,6 +83,9 @@ with ``google`` style prior to issuing your pull request.
 
 .. |Version| image:: https://img.shields.io/pypi/v/pika.svg?
    :target: http://badge.fury.io/py/pika
+
+.. |Python versions| image:: https://img.shields.io/pypi/pyversions/pika.svg
+    :target: https://pypi.python.org/pypi/pika
 
 .. |Status| image:: https://img.shields.io/travis/pika/pika.svg?
    :target: https://travis-ci.org/pika/pika

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Introduction
 Pika is a pure-Python implementation of the AMQP 0-9-1 protocol including RabbitMQ's
 extensions.
 
-- Python 2.7 and 3.3+ are supported.
+- Python 2.7 and 3.4+ are supported.
 
 - Since threads aren't appropriate to every situation, it doesn't
   require threads. It takes care not to forbid them, either. The same

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -1,15 +1,7 @@
 __version__ = '0.12.0b1'
 
 import logging
-try:
-    # not available in python 2.6
-    from logging import NullHandler
-except ImportError:
-
-    class NullHandler(logging.Handler):
-
-        def emit(self, record):
-            pass
+from logging import NullHandler
 
 # Add NullHandler to prevent logging warnings
 logging.getLogger(__name__).addHandler(NullHandler())

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -285,13 +285,7 @@ class BaseConnection(connection.Connection):
         if not error_value:
             return None
 
-        if hasattr(error_value, 'errno'):  # Python >= 2.6
-            return error_value.errno
-        else:
-            # TODO this doesn't look right; error_value.args[0] ??? Could
-            # probably remove this code path since pika doesn't test against
-            # Python 2.5
-            return error_value[0]  # Python <= 2.5
+        return error_value.errno
 
     def _flush_outbound(self):
         """Have the state manager schedule the necessary I/O.

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English', 'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setuptools.setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -8,11 +8,7 @@ from datetime import datetime
 import select
 import sys
 import logging
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import platform
 _TARGET = platform.python_implementation()

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -3,11 +3,7 @@ from datetime import datetime
 import logging
 import socket
 import time
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
+import unittest
 import uuid
 
 from forward_server import ForwardServer

--- a/tests/acceptance/enforce_one_basicget_test.py
+++ b/tests/acceptance/enforce_one_basicget_test.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from mock import MagicMock
 from pika.frame import Method, Header

--- a/tests/unit/amqp_object_tests.py
+++ b/tests/unit/amqp_object_tests.py
@@ -8,10 +8,7 @@ try:
 except:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import amqp_object
 

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -4,15 +4,11 @@ Tests for pika.base_connection.BaseConnection
 """
 try:
     import mock
-except:
+except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 import socket
+import unittest
 import pika
 import pika.tcp_socket_opts
 from pika.adapters import base_connection

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -4,24 +4,15 @@ Tests for pika.adapters.blocking_connection.BlockingChannel
 
 """
 from collections import deque
-import logging
+import unittest
 
 try:
     import mock
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
 from pika.adapters import blocking_connection
-from pika import callback
 from pika import channel
-from pika import exceptions
-from pika import frame
-from pika import spec
 
 BLOCKING_CHANNEL = 'pika.adapters.blocking_connection.BlockingChannel'
 BLOCKING_CONNECTION = 'pika.adapters.blocking_connection.BlockingConnection'

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -25,10 +25,8 @@ try:
 except ImportError:
     import mock
     from mock import patch
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+
+import unittest
 
 import pika
 from pika.adapters import blocking_connection

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -4,17 +4,12 @@ Tests for pika.callback
 
 """
 import logging
+import unittest
 try:
     import mock
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-from pika import amqp_object
 from pika import callback
 from pika import frame
 from pika import spec

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -12,6 +12,7 @@ Tests for pika.channel.Channel
 import collections
 import logging
 import sys
+import unittest
 import warnings
 
 try:
@@ -19,11 +20,6 @@ try:
 except ImportError:
     from unittest import mock  # pylint: disable=E0611
 
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 from pika import channel
 from pika import connection

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import compat
 

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -7,19 +7,14 @@ Test `pika.connection.Parameters`, `pika.connection.ConnectionParameters`, and
 # pylint: disable=C0111,C0103
 
 import copy
+import unittest
 import warnings
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
 
 import pika
 from pika.compat import urlencode, url_quote, dict_iteritems
 from pika import channel
 from pika import connection
 from pika import credentials
-from pika import exceptions
 from pika import spec
 
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -21,10 +21,7 @@ except ImportError:
 
 import random
 import platform
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import pika
 from pika import connection

--- a/tests/unit/connection_timeout_tests.py
+++ b/tests/unit/connection_timeout_tests.py
@@ -18,10 +18,7 @@ try:
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 import pika
 from pika.adapters import base_connection

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -4,11 +4,7 @@ Tests for pika.channel.ContentFrameAssembler
 
 """
 import marshal
-
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import channel
 from pika import exceptions

--- a/tests/unit/credentials_tests.py
+++ b/tests/unit/credentials_tests.py
@@ -7,10 +7,7 @@ try:
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import credentials
 from pika import spec

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -5,16 +5,8 @@ pika.data tests
 """
 import datetime
 import decimal
-import platform
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
-
-try:
-    from collections import OrderedDict
-except ImportError:
-    from ordereddict import OrderedDict
+import unittest
+from collections import OrderedDict
 
 from pika import data
 from pika import exceptions

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -2,10 +2,7 @@
 Tests for pika.exceptions
 
 """
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import exceptions
 

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -2,10 +2,7 @@
 Tests for pika.frame
 
 """
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import exceptions
 from pika import frame

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -17,10 +17,7 @@ try:
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import connection
 from pika import frame

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -15,13 +15,6 @@ Tests for SelectConnection IOLoops
 import select
 
 try:
-    #pylint: disable=F0401
-    import unittest2 as unittest
-except ImportError:
-    #pylint: disable=W0404
-    import unittest
-
-try:
     #pylint: disable=F0401,E0611
     from unittest import mock
 except ImportError:
@@ -34,6 +27,7 @@ import signal
 import socket
 import time
 import threading
+import unittest
 
 import pika
 from pika.adapters import select_connection

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -12,10 +12,7 @@ try:
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 try:
     from pika.adapters import tornado_connection

--- a/tests/unit/twisted_tests.py
+++ b/tests/unit/twisted_tests.py
@@ -11,10 +11,7 @@ try:
 except ImportError:
     from unittest import mock
 
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 try:
     from pika.adapters import twisted_connection

--- a/tests/unit/utils_tests.py
+++ b/tests/unit/utils_tests.py
@@ -1,7 +1,4 @@
-try:
-    import unittest2 as unittest
-except ImportError:
-    import unittest
+import unittest
 
 from pika import utils
 


### PR DESCRIPTION
https://github.com/pika/pika/pull/932#issuecomment-361425622 says:

> don't worry so much about 2.6. We need to drop support for that ancient version anyway. If anything, detect 2.6 and disable the changes you're making.

Here's the pip installs for pika from PyPI for last month:

| python_version | percent | download_count |
| -------------- | ------: | -------------: |
| 2.7            |   75.0% |        202,328 |
| 3.6            |   11.1% |         30,057 |
| 3.5            |    8.6% |         23,204 |
| 3.4            |    4.8% |         13,008 |
| 2.6            |    0.2% |            663 |
| 3.3            |    0.1% |            159 |
| 3.7            |    0.0% |            133 |
| 3.2            |    0.0% |             50 |
| None           |    0.0% |              5 |

Source: `pypinfo --start-date -60 --end-date -30 --percent --pip --markdown pika pyversion`

Python 3.3 is also EOL and even less used, so let's drop that too.

It also does some minor code cleanup.
