### PR TITLE
Moved to staged build with combined coverage, drop pyenv

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,24 +31,26 @@ stages:
    if: tag IS present
 
 services: []
-install: []
-before_script: []
-script: []
-after_success: []
+before_install: true
+install: true
+before_script: true
+script: true
+after_success: true
 
 jobs:
   include:
    - stage: test
      services:
        - rabbitmq
-     install:
-       - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
-       - pip install -r test-requirements.txt
-     before_script:
+     before_install:
        - which -a python
        - python --version
        - which pip
        - pip --version
+     install:
+       - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
+       - pip install -r test-requirements.txt
+     before_script:
        - pip freeze
        - sudo rabbitmqctl status
      script: nosetests

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
+  - pypy
+  - pypy3
 
 before_install:
   - sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse"
@@ -14,35 +16,69 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install libev-dev/trusty
 
+env:
+  global:
+   - PATH=$HOME/.local/bin:$PATH
+   - AWS_DEFAULT_REGION=us-east-1
+   - secure: "Eghft2UgJmWuCgnqz6O+KV5F9AERzUbKIeXkcw7vsFAVdkB9z01XgqVLhQ6N+n6i8mkiRDkc0Jes6htVtO4Hi6lTTFeDhu661YCXXTFdRdsx+D9v5bgw8Q2bP41xFy0iao7otYqkzFKIo32Q2cUYzMUqXlS661Yai5DXldr3mjM="
+   - secure: "LjieH/Yh0ng5gwT6+Pl3rL7RMxxb/wOlogoLG7cS99XKdX6N4WRVFvWbHWwCxoVr0be2AcyQynu4VOn+0jC8iGfQjkJZ7UrJjZCDGWbNjAWrNcY0F9VdretFDy8Vn2sHfBXq8fINqszJkgTnmbQk8dZWUtj0m/RNVnOBeBcsIOU="
+
+install:
+ - pip install awscli
+ - pip install -r requires/testing.txt
+ - python setup.py develop
+
+stages:
+ - test
+ - name: upload_coverage
+   if: branch = master
+ - name: deploy
+   if: tag IS present
+
 install:
   - which -a python
   - python --version
   - which pip
   - pip --version
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install pyev; fi
   - pip install -r test-requirements.txt
   - pip freeze
 
-services:
-  - rabbitmq
-
-before_script:
-  - sudo rabbitmqctl status
-
-script:
-  - nosetests
+script: nosetests
 
 after_success:
-  - codecov
+ - aws s3 cp .coverage "s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/.coverage.${TRAVIS_PYTHON_VERSION}"
 
-deploy:
-  distributions: sdist bdist_wheel
-  provider: pypi
-  user: crad
-  on:
-    python: 2.7
-    tags: true
-    all_branches: true
-  password:
-    secure: "V/JTU/X9C6uUUVGEAWmWWbmKW7NzVVlC/JWYpo05Ha9c0YV0vX4jOfov2EUAphM0WwkD/MRhz4dq3kCU5+cjHxR3aTSb+sbiElsCpaciaPkyrns+0wT5MCMO29Lpnq2qBLc1ePR1ey5aTWC/VibgFJOL7H/3wyvukL6ZaCnktYk="
+jobs:
+  include:
+   - stage: test
+     services:
+     - rabbitmq
+     before_script:
+     - sudo rabbitmqctl status
+     script: nosetests
+   - stage: upload coverage
+     python: 3.6
+     install:
+     - pip install awscli coverage codecov
+     script:
+     - mkdir coverage
+     - aws s3 cp --recursive s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/
+       coverage
+     - cd coverage
+     - coverage combine
+     - cd ..
+     - mv coverage/.coverage .
+     - coverage report
+     after_success: codecov
+   - stage: deploy
+     python: 3.6
+     deploy:
+       distributions: sdist bdist_wheel
+       provider: pypi
+       user: crad
+       on:
+         tags: true
+         all_branches: true
+       password:
+         secure: "V/JTU/X9C6uUUVGEAWmWWbmKW7NzVVlC/JWYpo05Ha9c0YV0vX4jOfov2EUAphM0WwkD/MRhz4dq3kCU5+cjHxR3aTSb+sbiElsCpaciaPkyrns+0wT5MCMO29Lpnq2qBLc1ePR1ey5aTWC/VibgFJOL7H/3wyvukL6ZaCnktYk="

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,29 +24,31 @@ env:
      - secure: "LjieH/Yh0ng5gwT6+Pl3rL7RMxxb/wOlogoLG7cS99XKdX6N4WRVFvWbHWwCxoVr0be2AcyQynu4VOn+0jC8iGfQjkJZ7UrJjZCDGWbNjAWrNcY0F9VdretFDy8Vn2sHfBXq8fINqszJkgTnmbQk8dZWUtj0m/RNVnOBeBcsIOU="
 
 stages:
- - test
- - name: upload_coverage
-   if: branch = master
- - name: deploy
-   if: tag IS present
+  - test
+  - name: upload_coverage
+    if: branch = master
+  - name: deploy
+    if: tag IS present
 
-services: []
-before_install: true
-install: true
-before_script: true
-script: true
-after_success: true
+services:
+  - rabbitmq
+
+before_install:
+ - which -a python
+ - python --version
+ - which pip
+ - pip --version
+
+install: /bin/true
+before_script: /bin/true
+script: /bin/true
+after_success:
+  - aws s3 cp .coverage "s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/.coverage.${TRAVIS_PYTHON_VERSION}"
 
 jobs:
   include:
    - stage: test
-     services:
-       - rabbitmq
-     before_install:
-       - which -a python
-       - python --version
-       - which pip
-       - pip --version
+
      install:
        - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
        - pip install -r test-requirements.txt
@@ -54,8 +56,6 @@ jobs:
        - pip freeze
        - sudo rabbitmqctl status
      script: nosetests
-     after_success:
-       - aws s3 cp .coverage "s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/.coverage.${TRAVIS_PYTHON_VERSION}"
    - stage: upload coverage
      python: 3.6
      install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,10 @@ before_install:
 
 env:
   global:
-   - PATH=$HOME/.local/bin:$PATH
-   - AWS_DEFAULT_REGION=us-east-1
-   - secure: "Eghft2UgJmWuCgnqz6O+KV5F9AERzUbKIeXkcw7vsFAVdkB9z01XgqVLhQ6N+n6i8mkiRDkc0Jes6htVtO4Hi6lTTFeDhu661YCXXTFdRdsx+D9v5bgw8Q2bP41xFy0iao7otYqkzFKIo32Q2cUYzMUqXlS661Yai5DXldr3mjM="
-   - secure: "LjieH/Yh0ng5gwT6+Pl3rL7RMxxb/wOlogoLG7cS99XKdX6N4WRVFvWbHWwCxoVr0be2AcyQynu4VOn+0jC8iGfQjkJZ7UrJjZCDGWbNjAWrNcY0F9VdretFDy8Vn2sHfBXq8fINqszJkgTnmbQk8dZWUtj0m/RNVnOBeBcsIOU="
-
-install:
- - pip install awscli
- - pip install -r requires/testing.txt
- - python setup.py develop
+     - PATH=$HOME/.local/bin:$PATH
+     - AWS_DEFAULT_REGION=us-east-1
+     - secure: "Eghft2UgJmWuCgnqz6O+KV5F9AERzUbKIeXkcw7vsFAVdkB9z01XgqVLhQ6N+n6i8mkiRDkc0Jes6htVtO4Hi6lTTFeDhu661YCXXTFdRdsx+D9v5bgw8Q2bP41xFy0iao7otYqkzFKIo32Q2cUYzMUqXlS661Yai5DXldr3mjM="
+     - secure: "LjieH/Yh0ng5gwT6+Pl3rL7RMxxb/wOlogoLG7cS99XKdX6N4WRVFvWbHWwCxoVr0be2AcyQynu4VOn+0jC8iGfQjkJZ7UrJjZCDGWbNjAWrNcY0F9VdretFDy8Vn2sHfBXq8fINqszJkgTnmbQk8dZWUtj0m/RNVnOBeBcsIOU="
 
 stages:
  - test
@@ -35,41 +30,42 @@ stages:
  - name: deploy
    if: tag IS present
 
-install:
-  - which -a python
-  - python --version
-  - which pip
-  - pip --version
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
-  - pip install -r test-requirements.txt
-  - pip freeze
-
-script: nosetests
-
-after_success:
- - aws s3 cp .coverage "s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/.coverage.${TRAVIS_PYTHON_VERSION}"
+services: []
+install: []
+before_script: []
+script: []
+after_success: []
 
 jobs:
   include:
    - stage: test
      services:
-     - rabbitmq
+       - rabbitmq
+     install:
+       - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
+       - pip install -r test-requirements.txt
      before_script:
-     - sudo rabbitmqctl status
+       - which -a python
+       - python --version
+       - which pip
+       - pip --version
+       - pip freeze
+       - sudo rabbitmqctl status
      script: nosetests
+     after_success:
+       - aws s3 cp .coverage "s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/.coverage.${TRAVIS_PYTHON_VERSION}"
    - stage: upload coverage
      python: 3.6
      install:
-     - pip install awscli coverage codecov
+       - pip install awscli coverage codecov
      script:
-     - mkdir coverage
-     - aws s3 cp --recursive s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/
-       coverage
-     - cd coverage
-     - coverage combine
-     - cd ..
-     - mv coverage/.coverage .
-     - coverage report
+       - mkdir coverage
+       - aws s3 cp --recursive s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/ coverage
+       - cd coverage
+       - coverage combine
+       - cd ..
+       - mv coverage/.coverage .
+       - coverage report
      after_success: codecov
    - stage: deploy
      python: 3.6

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 coverage
-codecov
 mock
 nose
 tornado


### PR DESCRIPTION
Does a few things WRT travis build pipeline:
1. Adds pypy and pypy3 to testing
2. Uses a S3 bucket to stage python version specific coverage reports to combine them together before reporting to codecov
3. Uses the new travis stages structure

Please don't review or merge until I get the job running clean.