### PR TITLE
Update the travis-ci build pipeline

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,2 @@
 [run]
-branch = True
-
-[report]
 omit = pika/spec.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,10 +21,6 @@ before_install:
 - sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe multiverse"
 - sudo apt-get update -qq
 - sudo apt-get install libev-dev/trusty
-- which -a python
-- python --version
-- which pip
-- pip --version
 
 install:
 - pip install -r test-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,48 +1,82 @@
 language: python
 
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
-  - 3.6
+env:
+  global:
+   - PATH=$HOME/.local/bin:$PATH
+   - AWS_DEFAULT_REGION=us-east-1
+   - secure: "Eghft2UgJmWuCgnqz6O+KV5F9AERzUbKIeXkcw7vsFAVdkB9z01XgqVLhQ6N+n6i8mkiRDkc0Jes6htVtO4Hi6lTTFeDhu661YCXXTFdRdsx+D9v5bgw8Q2bP41xFy0iao7otYqkzFKIo32Q2cUYzMUqXlS661Yai5DXldr3mjM="
+   - secure: "LjieH/Yh0ng5gwT6+Pl3rL7RMxxb/wOlogoLG7cS99XKdX6N4WRVFvWbHWwCxoVr0be2AcyQynu4VOn+0jC8iGfQjkJZ7UrJjZCDGWbNjAWrNcY0F9VdretFDy8Vn2sHfBXq8fINqszJkgTnmbQk8dZWUtj0m/RNVnOBeBcsIOU="
 
-before_install:
-  - sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse"
-  - sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe multiverse"
-  - sudo apt-get update -qq
-  - sudo apt-get install libev-dev/trusty
-
-install:
-  - which -a python
-  - python --version
-  - which pip
-  - pip --version
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi
-  - if [[ $TRAVIS_PYTHON_VERSION != '2.6' ]]; then pip install pyev; fi
-  - pip install -r test-requirements.txt
-  - pip freeze
+stages:
+- test
+- coverage
+- name: deploy
+  if: tag IS present
 
 services:
-  - rabbitmq
+- rabbitmq
+
+before_install:
+- sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty main restricted universe multiverse"
+- sudo add-apt-repository "deb http://us.archive.ubuntu.com/ubuntu/ trusty-updates main restricted universe multiverse"
+- sudo apt-get update -qq
+- sudo apt-get install libev-dev/trusty
+- which -a python
+- python --version
+- which pip
+- pip --version
+
+install:
+- pip install -r test-requirements.txt
+- pip install aws
 
 before_script:
-  - sudo rabbitmqctl status
+- pip freeze
+- sudo rabbitmqctl status
 
-script:
-  - nosetests
+script: nosetests
 
 after_success:
-  - codecov
+- aws s3 cp .coverage "s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/.coverage.${TRAVIS_PYTHON_VERSION}"
 
-deploy:
-  distributions: sdist bdist_wheel
-  provider: pypi
-  user: crad
-  on:
-    python: 2.7
-    tags: true
-    all_branches: true
-  password:
-    secure: "V/JTU/X9C6uUUVGEAWmWWbmKW7NzVVlC/JWYpo05Ha9c0YV0vX4jOfov2EUAphM0WwkD/MRhz4dq3kCU5+cjHxR3aTSb+sbiElsCpaciaPkyrns+0wT5MCMO29Lpnq2qBLc1ePR1ey5aTWC/VibgFJOL7H/3wyvukL6ZaCnktYk="
+jobs:
+  include:
+   - python: 2.7
+   - python: 3.4
+   - python: 3.5
+   - python: 3.6
+   - python: pypy
+   - python: pypy3
+   - stage: coverage
+     python: 3.6
+     services: []
+     before_install: true
+     install:
+     - pip install awscli coverage codecov
+     brefore_script: true
+     script:
+     - mkdir coverage
+     - aws s3 cp --recursive s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/ coverage
+     - cd coverage
+     - coverage combine
+     - cd ..
+     - mv coverage/.coverage .
+     - coverage report
+     after_success: codecov
+   - stage: deploy
+     python: 3.6
+     services: []
+     before_install: true
+     install: true
+     before_script: true
+     script: true
+     after_success: true
+     deploy:
+       distributions: sdist bdist_wheel
+       provider: pypi
+       user: crad
+       on:
+         tags: true
+         all_branches: true
+       password:
+         secure: "V/JTU/X9C6uUUVGEAWmWWbmKW7NzVVlC/JWYpo05Ha9c0YV0vX4jOfov2EUAphM0WwkD/MRhz4dq3kCU5+cjHxR3aTSb+sbiElsCpaciaPkyrns+0wT5MCMO29Lpnq2qBLc1ePR1ey5aTWC/VibgFJOL7H/3wyvukL6ZaCnktYk="

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
 
 install:
 - pip install -r test-requirements.txt
-- pip install aws
+- pip install awscli
 
 before_script:
 - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,10 +46,10 @@ jobs:
    - stage: coverage
      python: 3.6
      services: []
-     before_install: true
+     before_install: []
      install:
      - pip install awscli coverage codecov
-     brefore_script: true
+     before_script: []
      script:
      - mkdir coverage
      - aws s3 cp --recursive s3://com-gavinroy-travis/pika/$TRAVIS_BUILD_NUMBER/ coverage
@@ -62,11 +62,11 @@ jobs:
    - stage: deploy
      python: 3.6
      services: []
-     before_install: true
+     before_install: []
      install: true
-     before_script: true
+     before_script: []
      script: true
-     after_success: true
+     after_success: []
      deploy:
        distributions: sdist bdist_wheel
        provider: pypi

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2017, Tony Garnock-Jones, Gavin M. Roy, Pivotal and others.
+Copyright (c) 2009-2018, Tony Garnock-Jones, Gavin M. Roy, Pivotal and others.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,9 +2,15 @@
 universal = 1
 
 [nosetests]
-with-coverage=1
-cover-package=pika
-cover-branches=1
-cover-erase=1
+cover-branches = 1
+cover-erase = 1
+cover-html = 1
+cover-html-dir = build/coverage
+cover-package = pika
+cover-tests = 1
+logging-level = DEBUG
+stop = 1
 tests=tests/unit,tests/acceptance
-verbosity=3
+verbosity = 3
+with-coverage = 1
+detailed-errors = 1

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,4 @@
 coverage
-codecov
 mock
 nose
 tornado


### PR DESCRIPTION
- Drops testing support for Python 2.6
- Drops use of pyenv
- Moves to the build stages setup for travis
- Builds combined coverage across all Python versions and uploads it to codecov
- Adds testing of pypy and pypy3