### PR TITLE
Rename no_ack => auto_ack to match Java and .NET clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@ build
 dist
 docs/_build
 *.conf.in
-venvs/
+venv*/
 env/

--- a/docs/examples/direct_reply_to.rst
+++ b/docs/examples/direct_reply_to.rst
@@ -46,12 +46,12 @@ direct_reply_to.py::
             # Also, client must create the consumer *before* starting to publish the
             # RPC requests.
             #
-            # Client must create its consumer with no_ack=True, because the reply-to
+            # Client must create its consumer with auto_ack=True, because the reply-to
             # queue isn't real.
 
             channel.basic_consume('amq.rabbitmq.reply-to',
                                   on_client_rx_reply_from_server,
-                                  no_ack=True)
+                                  auto_ack=True)
             channel.basic_publish(
                 exchange='',
                 routing_key=SERVER_QUEUE,

--- a/docs/examples/twisted_example.rst
+++ b/docs/examples/twisted_example.rst
@@ -23,7 +23,7 @@ Example of writing a consumer using the :py:class:`Twisted connection adapter <p
 
         yield channel.basic_qos(prefetch_count=1)
 
-        queue_object, consumer_tag = yield channel.basic_consume('hello', no_ack=False)
+        queue_object, consumer_tag = yield channel.basic_consume('hello', auto_ack=False)
 
         l = task.LoopingCall(read, queue_object)
 

--- a/examples/consumer_queued.py
+++ b/examples/consumer_queued.py
@@ -53,7 +53,7 @@ def callback(ch, method, properties, body):
     process_buffer()
 
 
-consumer_channel.basic_consume(queue, callback, no_ack=True)
+consumer_channel.basic_consume(queue, callback, auto_ack=True)
 
 try:
     consumer_channel.start_consuming()

--- a/examples/consumer_simple.py
+++ b/examples/consumer_simple.py
@@ -44,7 +44,7 @@ def callback(ch, method, properties, body):
 import logging
 logging.basicConfig(level=logging.INFO)
 
-consumer_channel.basic_consume(queue, callback, no_ack=True)
+consumer_channel.basic_consume(queue, callback, auto_ack=True)
 
 try:
     consumer_channel.start_consuming()

--- a/examples/direct_reply_to.py
+++ b/examples/direct_reply_to.py
@@ -41,12 +41,12 @@ def main():
         # Also, client must create the consumer *before* starting to publish the
         # RPC requests.
         #
-        # Client must create its consumer with no_ack=True, because the reply-to
+        # Client must create its consumer with auto_ack=True, because the reply-to
         # queue isn't real.
 
         channel.basic_consume('amq.rabbitmq.reply-to',
                               on_client_rx_reply_from_server,
-                              no_ack=True)
+                              auto_ack=True)
         channel.basic_publish(
             exchange='',
             routing_key=SERVER_QUEUE,

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -94,7 +94,7 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
 
         self.channel.queue_declare(queue=routing_key, durable=True)
 
-        (queue, consumer_tag,) = yield self.channel.basic_consume(queue=routing_key, no_ack=False)
+        (queue, consumer_tag,) = yield self.channel.basic_consume(queue=routing_key, auto_ack=False)
         d = queue.get()
         d.addCallback(self._read_item, queue, callback)
         d.addErrback(self._read_item_err)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1528,8 +1528,10 @@ class BlockingChannel(object):
                 method: spec.Basic.Deliver
                 properties: spec.BasicProperties
                 body: str or unicode
-        :param bool auto_ack: Tell the broker to not expect a response (i.e.,
-          no ack/nack)
+        :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
+                              (see http://www.rabbitmq.com/confirms.html). This corresponds
+                              with the 'no_ack' parameter in the basic.consume AMQP 0.9.1
+                              method
         :param bool exclusive: Don't allow other consumers on the queue
         :param consumer_tag: You may specify your own consumer tag; if left
           empty, a consumer tag will be generated automatically

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1505,8 +1505,7 @@ class BlockingChannel(object):
                       auto_ack=False,
                       exclusive=False,
                       consumer_tag=None,
-                      arguments=None,
-                      **kwargs):
+                      arguments=None):
         """Sends the AMQP command Basic.Consume to the broker and binds messages
         for the consumer_tag to the consumer callback. If you do not pass in
         a consumer_tag, one will be automatically generated for you. Returns
@@ -1543,9 +1542,6 @@ class BlockingChannel(object):
             consumer_tag is already present.
 
         """
-        if 'no_ack' in kwargs:
-            auto_ack = bool(kwargs.get('no_ack'))
-
         if not callable(on_message_callback):
             raise ValueError('callback on_message_callback must be callable; got %r'
                              % on_message_callback)
@@ -1801,8 +1797,7 @@ class BlockingChannel(object):
 
     def consume(self, queue, auto_ack=False,
                 exclusive=False, arguments=None,
-                inactivity_timeout=None,
-                **kwargs):
+                inactivity_timeout=None):
         """Blocking consumption of a queue instead of via a callback. This
         method is a generator that yields each message as a tuple of method,
         properties, and body. The active generator iterator terminates when the
@@ -1842,9 +1837,6 @@ class BlockingChannel(object):
             of the existing queue consumer generator, if any.
             NEW in pika 0.10.0
         """
-        if 'no_ack' in kwargs:
-            auto_ack = bool(kwargs.get('no_ack'))
-
         params = (queue, auto_ack, exclusive)
 
         if self._queue_consumer_generator is not None:
@@ -2021,7 +2013,7 @@ class BlockingChannel(object):
                               requeue=requeue)
         self._flush_output()
 
-    def basic_get(self, queue, auto_ack=False, **kwargs):
+    def basic_get(self, queue, auto_ack=False):
         """Get a single message from the AMQP broker. Returns a sequence with
         the method frame, message properties, and body.
 
@@ -2034,9 +2026,6 @@ class BlockingChannel(object):
                                     spec.BasicProperties,
                                     str or unicode or None)
         """
-        if 'no_ack' in kwargs:
-            auto_ack = bool(kwargs.get('no_ack'))
-
         assert not self._basic_getempty_result
 
         # NOTE: nested with for python 2.6 compatibility

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1543,19 +1543,17 @@ class BlockingChannel(object):
             consumer_tag is already present.
 
         """
+        if 'no_ack' in kwargs:
+            auto_ack = bool(kwargs.get('no_ack'))
+
         if not callable(on_message_callback):
             raise ValueError('callback on_message_callback must be callable; got %r'
                              % on_message_callback)
 
-        no_ack = kwargs.get("no_ack")
-        use_auto_ack = auto_ack
-        if not(no_ack is None):
-            use_auto_ack = kwargs.get("no_ack")
-
         return self._basic_consume_impl(
             queue=queue,
             on_message_callback=on_message_callback,
-            auto_ack=use_auto_ack,
+            auto_ack=auto_ack,
             exclusive=exclusive,
             consumer_tag=consumer_tag,
             arguments=arguments)
@@ -1844,12 +1842,10 @@ class BlockingChannel(object):
             of the existing queue consumer generator, if any.
             NEW in pika 0.10.0
         """
-        no_ack = kwargs.get("no_ack")
-        use_auto_ack = auto_ack
-        if not(no_ack is None):
-            use_auto_ack = kwargs.get("no_ack")
+        if 'no_ack' in kwargs:
+            auto_ack = bool(kwargs.get('no_ack'))
 
-        params = (queue, use_auto_ack, exclusive)
+        params = (queue, auto_ack, exclusive)
 
         if self._queue_consumer_generator is not None:
             if params != self._queue_consumer_generator.params:
@@ -1858,7 +1854,7 @@ class BlockingChannel(object):
                     'queue consumer generator; previous params: %r; '
                     'new params: %r'
                     % (self._queue_consumer_generator.params,
-                       (queue, use_auto_ack, exclusive)))
+                       (queue, auto_ack, exclusive)))
         else:
             LOGGER.debug('Creating new queue consumer generator; params: %r',
                          params)
@@ -1874,7 +1870,7 @@ class BlockingChannel(object):
             try:
                 self._basic_consume_impl(
                     queue=queue,
-                    auto_ack=use_auto_ack,
+                    auto_ack=auto_ack,
                     exclusive=exclusive,
                     consumer_tag=consumer_tag,
                     arguments=arguments,
@@ -2038,16 +2034,16 @@ class BlockingChannel(object):
                                     spec.BasicProperties,
                                     str or unicode or None)
         """
+        if 'no_ack' in kwargs:
+            auto_ack = bool(kwargs.get('no_ack'))
+
         assert not self._basic_getempty_result
-        no_ack = kwargs.get("no_ack")
-        use_auto_ack = auto_ack
-        if not(no_ack is None):
-            use_auto_ack = kwargs.get("no_ack")
+
         # NOTE: nested with for python 2.6 compatibility
         with _CallbackResult(self._RxMessageArgs) as get_ok_result:
             with self._basic_getempty_result:
                 self._impl.basic_get(queue=queue,
-                                     auto_ack=use_auto_ack,
+                                     auto_ack=auto_ack,
                                      callback=get_ok_result.set_value_once)
                 self._flush_output(get_ok_result.is_ready,
                                    self._basic_getempty_result.is_ready)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -955,7 +955,7 @@ class ReturnedMessage(object):
 class _ConsumerInfo(object):
     """Information about an active consumer"""
 
-    __slots__ = ('consumer_tag', 'no_ack', 'on_message_callback',
+    __slots__ = ('consumer_tag', 'auto_ack', 'on_message_callback',
                  'alternate_event_sink', 'state')
 
     # Consumer states
@@ -964,13 +964,13 @@ class _ConsumerInfo(object):
     TEARING_DOWN = 3
     CANCELLED_BY_BROKER = 4
 
-    def __init__(self, consumer_tag, no_ack, on_message_callback=None,
+    def __init__(self, consumer_tag, auto_ack, on_message_callback=None,
                  alternate_event_sink=None):
         """
         NOTE: exactly one of callback/alternate_event_sink musts be non-None.
 
         :param str consumer_tag:
-        :param bool no_ack: the no-ack value for the consumer
+        :param bool auto_ack: the no-ack value for the consumer
         :param callable on_message_callback: The function for dispatching messages to
             user, having the signature:
             on_message_callback(channel, method, properties, body)
@@ -988,7 +988,7 @@ class _ConsumerInfo(object):
             'exactly one of on_message_callback/alternate_event_sink must be non-None',
             on_message_callback, alternate_event_sink)
         self.consumer_tag = consumer_tag
-        self.no_ack = no_ack
+        self.auto_ack = auto_ack
         self.on_message_callback = on_message_callback
         self.alternate_event_sink = alternate_event_sink
         self.state = self.SETTING_UP
@@ -1020,7 +1020,7 @@ class _QueueConsumerGeneratorInfo(object):
 
     def __init__(self, params, consumer_tag):
         """
-        :params tuple params: a three-tuple (queue, no_ack, exclusive) that were
+        :params tuple params: a three-tuple (queue, auto_ack, exclusive) that were
            used to create the queue consumer
         :param str consumer_tag: consumer tag
         """
@@ -1502,10 +1502,11 @@ class BlockingChannel(object):
     def basic_consume(self,
                       queue,
                       on_message_callback,
-                      no_ack=False,
+                      auto_ack=False,
                       exclusive=False,
                       consumer_tag=None,
-                      arguments=None):
+                      arguments=None,
+                      **kwargs):
         """Sends the AMQP command Basic.Consume to the broker and binds messages
         for the consumer_tag to the consumer callback. If you do not pass in
         a consumer_tag, one will be automatically generated for you. Returns
@@ -1528,7 +1529,7 @@ class BlockingChannel(object):
                 method: spec.Basic.Deliver
                 properties: spec.BasicProperties
                 body: str or unicode
-        :param bool no_ack: Tell the broker to not expect a response (i.e.,
+        :param bool auto_ack: Tell the broker to not expect a response (i.e.,
           no ack/nack)
         :param bool exclusive: Don't allow other consumers on the queue
         :param consumer_tag: You may specify your own consumer tag; if left
@@ -1546,17 +1547,22 @@ class BlockingChannel(object):
             raise ValueError('callback on_message_callback must be callable; got %r'
                              % on_message_callback)
 
+        no_ack = kwargs.get("no_ack")
+        use_auto_ack = auto_ack
+        if not(no_ack is None):
+            use_auto_ack = kwargs.get("no_ack")
+
         return self._basic_consume_impl(
             queue=queue,
             on_message_callback=on_message_callback,
-            no_ack=no_ack,
+            auto_ack=use_auto_ack,
             exclusive=exclusive,
             consumer_tag=consumer_tag,
             arguments=arguments)
 
     def _basic_consume_impl(self,
                             queue,
-                            no_ack,
+                            auto_ack,
                             exclusive,
                             consumer_tag,
                             arguments=None,
@@ -1599,7 +1605,7 @@ class BlockingChannel(object):
         # Create new consumer
         self._consumer_infos[consumer_tag] = _ConsumerInfo(
             consumer_tag,
-            no_ack=no_ack,
+            auto_ack=auto_ack,
             on_message_callback=on_message_callback,
             alternate_event_sink=alternate_event_sink)
 
@@ -1608,7 +1614,7 @@ class BlockingChannel(object):
                 tag = self._impl.basic_consume(
                     on_message_callback=self._on_consumer_message_delivery,
                     queue=queue,
-                    no_ack=no_ack,
+                    auto_ack=auto_ack,
                     exclusive=exclusive,
                     consumer_tag=consumer_tag,
                     arguments=arguments)
@@ -1639,18 +1645,18 @@ class BlockingChannel(object):
         of messages in between sending the cancel method and receiving the
         cancel-ok reply.
 
-        NOTE: When cancelling a no_ack=False consumer, this implementation
+        NOTE: When cancelling an auto_ack=False consumer, this implementation
         automatically Nacks and suppresses any incoming messages that have not
         yet been dispatched to the consumer's callback. However, when cancelling
-        a no_ack=True consumer, this method will return any pending messages
+        a auto_ack=True consumer, this method will return any pending messages
         that arrived before broker confirmed the cancellation.
 
         :param str consumer_tag: Identifier for the consumer; the result of
             passing a consumer_tag that was created on another channel is
             undefined (bad things will happen)
 
-        :returns: (NEW IN pika 0.10.0) empty sequence for a no_ack=False
-            consumer; for a no_ack=True consumer, returns a (possibly empty)
+        :returns: (NEW IN pika 0.10.0) empty sequence for a auto_ack=False
+            consumer; for a auto_ack=True consumer, returns a (possibly empty)
             sequence of pending messages that arrived before broker confirmed
             the cancellation (this is done instead of via consumer's callback in
             order to prevent reentrancy/recursion. Each message is four-tuple:
@@ -1678,13 +1684,13 @@ class BlockingChannel(object):
             assert (consumer_info.cancelled_by_broker or
                     consumer_tag in self._impl._consumers), consumer_tag
 
-            no_ack = consumer_info.no_ack
+            auto_ack = consumer_info.auto_ack
 
             consumer_info.state = _ConsumerInfo.TEARING_DOWN
 
             with _CallbackResult() as cancel_ok_result:
-                # Nack pending messages for no_ack=False consumer
-                if not no_ack:
+                # Nack pending messages for auto_ack=False consumer
+                if not auto_ack:
                     pending_messages = self._remove_pending_deliveries(
                         consumer_tag)
                     if pending_messages:
@@ -1698,7 +1704,7 @@ class BlockingChannel(object):
                                                     requeue=True)
 
                 # Cancel the consumer; impl takes care of rejecting any
-                # additional deliveries that arrive for a no_ack=False
+                # additional deliveries that arrive for a auto_ack=False
                 # consumer
                 self._impl.basic_cancel(
                     consumer_tag=consumer_tag,
@@ -1710,8 +1716,8 @@ class BlockingChannel(object):
                     cancel_ok_result.is_ready,
                     lambda: consumer_tag not in self._impl._consumers)
 
-            if no_ack:
-                # Return pending messages for no_ack=True consumer
+            if auto_ack:
+                # Return pending messages for auto_ack=True consumer
                 return [
                     (evt.method, evt.properties, evt.body)
                     for evt in self._remove_pending_deliveries(consumer_tag)]
@@ -1795,9 +1801,10 @@ class BlockingChannel(object):
         else:
             self._cancel_all_consumers()
 
-    def consume(self, queue, no_ack=False,
+    def consume(self, queue, auto_ack=False,
                 exclusive=False, arguments=None,
-                inactivity_timeout=None):
+                inactivity_timeout=None,
+                **kwargs):
         """Blocking consumption of a queue instead of via a callback. This
         method is a generator that yields each message as a tuple of method,
         properties, and body. The active generator iterator terminates when the
@@ -1813,13 +1820,13 @@ class BlockingChannel(object):
         generator loop.
 
         If you don't cancel this consumer, then next call on the same channel
-        to `consume()` with the exact same (queue, no_ack, exclusive) parameters
+        to `consume()` with the exact same (queue, auto_ack, exclusive) parameters
         will resume the existing consumer generator; however, calling with
         different parameters will result in an exception.
 
         :param queue: The queue name to consume
         :type queue: str or unicode
-        :param bool no_ack: Tell the broker to not expect a ack/nack response
+        :param bool auto_ack: Tell the broker to not expect a ack/nack response
         :param bool exclusive: Don't allow other consumers on the queue
         :param dict arguments: Custom key/value pair arguments for the consumer
         :param float inactivity_timeout: if a number is given (in
@@ -1837,7 +1844,12 @@ class BlockingChannel(object):
             of the existing queue consumer generator, if any.
             NEW in pika 0.10.0
         """
-        params = (queue, no_ack, exclusive)
+        no_ack = kwargs.get("no_ack")
+        use_auto_ack = auto_ack
+        if not(no_ack is None):
+            use_auto_ack = kwargs.get("no_ack")
+
+        params = (queue, use_auto_ack, exclusive)
 
         if self._queue_consumer_generator is not None:
             if params != self._queue_consumer_generator.params:
@@ -1846,7 +1858,7 @@ class BlockingChannel(object):
                     'queue consumer generator; previous params: %r; '
                     'new params: %r'
                     % (self._queue_consumer_generator.params,
-                       (queue, no_ack, exclusive)))
+                       (queue, use_auto_ack, exclusive)))
         else:
             LOGGER.debug('Creating new queue consumer generator; params: %r',
                          params)
@@ -1862,7 +1874,7 @@ class BlockingChannel(object):
             try:
                 self._basic_consume_impl(
                     queue=queue,
-                    no_ack=no_ack,
+                    auto_ack=use_auto_ack,
                     exclusive=exclusive,
                     consumer_tag=consumer_tag,
                     arguments=arguments,
@@ -1948,8 +1960,8 @@ class BlockingChannel(object):
             return 0
 
         try:
-            _, no_ack, _ = self._queue_consumer_generator.params
-            if not no_ack:
+            _, auto_ack, _ = self._queue_consumer_generator.params
+            if not auto_ack:
                 # Reject messages held by queue consumer generator; NOTE: we
                 # can't use basic_nack with the multiple option to avoid nacking
                 # messages already held by our client.
@@ -1965,7 +1977,7 @@ class BlockingChannel(object):
 
         # Return 0 for compatibility with legacy implementation; the number of
         # nacked messages is not meaningful since only messages consumed with
-        # no_ack=False may be nacked, and those arriving after calling
+        # auto_ack=False may be nacked, and those arriving after calling
         # basic_cancel will be rejected automatically by impl channel, so we'll
         # never know how many of those were nacked.
         return 0
@@ -2013,13 +2025,13 @@ class BlockingChannel(object):
                               requeue=requeue)
         self._flush_output()
 
-    def basic_get(self, queue, no_ack=False):
+    def basic_get(self, queue, auto_ack=False, **kwargs):
         """Get a single message from the AMQP broker. Returns a sequence with
         the method frame, message properties, and body.
 
         :param queue: Name of queue from which to get a message
         :type queue: str or unicode
-        :param bool no_ack: Tell the broker to not expect a reply
+        :param bool auto_ack: Tell the broker to not expect a reply
         :returns: a three-tuple; (None, None, None) if the queue was empty;
             otherwise (method, properties, body); NOTE: body may be None
         :rtype: (None, None, None)|(spec.Basic.GetOk,
@@ -2027,11 +2039,15 @@ class BlockingChannel(object):
                                     str or unicode or None)
         """
         assert not self._basic_getempty_result
+        no_ack = kwargs.get("no_ack")
+        use_auto_ack = auto_ack
+        if not(no_ack is None):
+            use_auto_ack = kwargs.get("no_ack")
         # NOTE: nested with for python 2.6 compatibility
         with _CallbackResult(self._RxMessageArgs) as get_ok_result:
             with self._basic_getempty_result:
                 self._impl.basic_get(queue=queue,
-                                     no_ack=no_ack,
+                                     auto_ack=use_auto_ack,
                                      callback=get_ok_result.set_value_once)
                 self._flush_output(get_ok_result.is_ready,
                                    self._basic_getempty_result.is_ready)

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -288,7 +288,9 @@ class Channel(object):
                                 properties: pika.spec.BasicProperties
                                 body: str, unicode, or bytes (python 3.x)
         :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
-                            (see http://www.rabbitmq.com/confirms.html)
+                              (see http://www.rabbitmq.com/confirms.html). This corresponds
+                              with the 'no_ack' parameter in the basic.consume AMQP 0.9.1
+                              method
         :param bool exclusive: Don't allow other consumers on the queue
         :param consumer_tag: Specify your own consumer tag
         :type consumer_tag: str or unicode

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -263,11 +263,12 @@ class Channel(object):
     def basic_consume(self,
                       queue,
                       on_message_callback,
-                      no_ack=False,
+                      auto_ack=False,
                       exclusive=False,
                       consumer_tag=None,
                       arguments=None,
-                      callback=None):
+                      callback=None,
+                      **kwargs):
         """Sends the AMQP 0-9-1 command Basic.Consume to the broker and binds messages
         for the consumer_tag to the consumer callback. If you do not pass in
         a consumer_tag, one will be automatically generated for you. Returns
@@ -287,7 +288,7 @@ class Channel(object):
                                 method: pika.spec.Basic.Deliver
                                 properties: pika.spec.BasicProperties
                                 body: str, unicode, or bytes (python 3.x)
-        :param bool no_ack: if set to True, automatic acknowledgement mode will be used
+        :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
                             (see http://www.rabbitmq.com/confirms.html)
         :param bool exclusive: Don't allow other consumers on the queue
         :param consumer_tag: Specify your own consumer tag
@@ -310,7 +311,12 @@ class Channel(object):
         if consumer_tag in self._consumers or consumer_tag in self._cancelled:
             raise exceptions.DuplicateConsumerTag(consumer_tag)
 
-        if no_ack:
+        no_ack = kwargs.get("no_ack")
+        use_auto_ack = auto_ack
+        if not(no_ack is None):
+            use_auto_ack = kwargs.get("no_ack")
+
+        if use_auto_ack:
             self._consumers_with_noack.add(consumer_tag)
 
         self._consumers[consumer_tag] = on_message_callback
@@ -319,7 +325,7 @@ class Channel(object):
 
         self._rpc(spec.Basic.Consume(queue=queue,
                                      consumer_tag=consumer_tag,
-                                     no_ack=no_ack,
+                                     no_ack=use_auto_ack,
                                      exclusive=exclusive,
                                      arguments=arguments or dict()),
                   rpc_callback, [(spec.Basic.ConsumeOk,
@@ -339,7 +345,7 @@ class Channel(object):
         return 'ctag%i.%s' % (self.channel_number,
                               uuid.uuid4().hex)
 
-    def basic_get(self, queue, callback, no_ack=False):
+    def basic_get(self, queue, callback, auto_ack=False, **kwargs):
         """Get a single message from the AMQP broker. If you want to
         be notified of Basic.GetEmpty, use the Channel.add_callback method
         adding your Basic.GetEmpty callback which should expect only one
@@ -359,7 +365,7 @@ class Channel(object):
             method: pika.spec.Basic.GetOk
             properties: pika.spec.BasicProperties
             body: str, unicode, or bytes (python 3.x)
-        :param bool no_ack: Tell the broker to not expect a reply
+        :param bool auto_ack: Tell the broker to not expect a reply
         :raises ValueError:
 
         """
@@ -367,11 +373,15 @@ class Channel(object):
         if self._on_getok_callback is not None:
             raise exceptions.DuplicateGetOkCallback()
         self._on_getok_callback = callback
+        no_ack = kwargs.get("no_ack")
+        use_auto_ack = auto_ack
+        if not(no_ack is None):
+            use_auto_ack = kwargs.get("no_ack")
         # pylint: disable=W0511
         # TODO Strangely, not using _rpc for the synchronous Basic.Get. Would
         # need to extend _rpc to handle Basic.GetOk method, header, and body
         # frames (or similar)
-        self._send_method(spec.Basic.Get(queue=queue, no_ack=no_ack))
+        self._send_method(spec.Basic.Get(queue=queue, no_ack=use_auto_ack))
 
     def basic_nack(self, delivery_tag=None, multiple=False, requeue=True):
         """This method allows a client to reject one or more incoming messages.

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -267,8 +267,7 @@ class Channel(object):
                       exclusive=False,
                       consumer_tag=None,
                       arguments=None,
-                      callback=None,
-                      **kwargs):
+                      callback=None):
         """Sends the AMQP 0-9-1 command Basic.Consume to the broker and binds messages
         for the consumer_tag to the consumer callback. If you do not pass in
         a consumer_tag, one will be automatically generated for you. Returns
@@ -300,9 +299,6 @@ class Channel(object):
         :raises ValueError:
 
         """
-        if 'no_ack' in kwargs:
-            auto_ack = bool(kwargs.get('no_ack'))
-
         self._require_callback(on_message_callback)
         self._validate_channel()
         self._validate_rpc_completion_callback(callback)
@@ -343,7 +339,7 @@ class Channel(object):
         return 'ctag%i.%s' % (self.channel_number,
                               uuid.uuid4().hex)
 
-    def basic_get(self, queue, callback, auto_ack=False, **kwargs):
+    def basic_get(self, queue, callback, auto_ack=False):
         """Get a single message from the AMQP broker. If you want to
         be notified of Basic.GetEmpty, use the Channel.add_callback method
         adding your Basic.GetEmpty callback which should expect only one
@@ -367,9 +363,6 @@ class Channel(object):
         :raises ValueError:
 
         """
-        if 'no_ack' in kwargs:
-            auto_ack = bool(kwargs.get('no_ack'))
-
         self._require_callback(callback)
         if self._on_getok_callback is not None:
             raise exceptions.DuplicateGetOkCallback()

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -327,7 +327,7 @@ class Channel(object):
                                      exclusive=exclusive,
                                      arguments=arguments or dict()),
                   rpc_callback, [(spec.Basic.ConsumeOk,
-                                 {'consumer_tag': consumer_tag})])
+                                  {'consumer_tag': consumer_tag})])
 
         return consumer_tag
 
@@ -1429,6 +1429,12 @@ class Channel(object):
                 'Completion callback must be callable if not None')
 
     def _validate_zero_or_greater(self, name, value):
+        """Verify that value is zero or greater. If not, 'name'
+        will be used in error message
+
+        :raises: ValueError
+
+        """
         if int(value) < 0:
             errmsg = '{} must be >= 0, but got {}'.format(name, value)
             raise ValueError(errmsg)

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -94,7 +94,7 @@ class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
             self.channel.basic_publish('', self.queue_name, msg_body)
         self.ctag = self.channel.basic_consume(self.queue_name,
                                                self.on_message,
-                                               no_ack=True)
+                                               auto_ack=True)
 
     def on_message(self, _channel, _frame, _header, body):
         self.channel.basic_cancel(self.ctag, callback=self.on_cancel)

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -208,7 +208,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
         # Publish the message to the queue by way of default exchange
         ch.publish(exchange='', routing_key=q_name, body=body1)
 
-        # Create a non-ackable consumer
+        # Create a consumer that uses automatic ack mode
         ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
                          exclusive=False, arguments=None)
 
@@ -243,7 +243,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgeme
         # Publish the message to the queue by way of default exchange
         ch.publish(exchange='', routing_key=q_name, body=body1)
 
-        # Create a non-ackable consumer
+        # Create a consumer that uses automatic ack mode
         ch.basic_consume(q_name, lambda *x: None, no_ack=True,
                          exclusive=False, arguments=None)
 
@@ -2304,7 +2304,7 @@ class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
                                                       queue=q_name,
                                                       expected_count=2)
 
-        # Create a non-ackable consumer
+        # Create a consumer that uses automatic ack mode
         consumer_tag = ch.basic_consume(q_name, lambda *x: None, no_ack=True,
                                         exclusive=False, arguments=None)
 

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -209,6 +209,41 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
         ch.publish(exchange='', routing_key=q_name, body=body1)
 
         # Create a non-ackable consumer
+        ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
+                         exclusive=False, arguments=None)
+
+        connection.close()
+        self.assertTrue(connection.is_closed)
+        self.assertFalse(connection.is_open)
+        self.assertFalse(connection.is_closing)
+
+        self.assertFalse(connection._impl._channels)
+
+        self.assertFalse(ch._consumer_infos)
+        self.assertFalse(ch._impl._consumers)
+
+class TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgementModeKeyword(BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingConnection: Create and close connection with channel and consumer using no_ack for acknowledgement mode"""  # pylint: disable=C0301
+        connection = self._connect()
+
+        ch = connection.channel()
+
+        q_name = (
+            'TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgementModeKeyword_q' +
+            uuid.uuid1().hex)
+
+        body1 = 'a' * 1024
+
+        # Declare a new queue
+        ch.queue_declare(q_name, auto_delete=True)
+        self.addCleanup(self._connect().channel().queue_delete, q_name)
+
+        # Publish the message to the queue by way of default exchange
+        ch.publish(exchange='', routing_key=q_name, body=body1)
+
+        # Create a non-ackable consumer
         ch.basic_consume(q_name, lambda *x: None, no_ack=True,
                          exclusive=False, arguments=None)
 

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -222,41 +222,6 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
         self.assertFalse(ch._consumer_infos)
         self.assertFalse(ch._impl._consumers)
 
-class TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgementModeKeyword(BlockingTestCaseBase):
-
-    def test(self):
-        """BlockingConnection: Create and close connection with channel and consumer using auto_ack for acknowledgement mode"""  # pylint: disable=C0301
-        connection = self._connect()
-
-        ch = connection.channel()
-
-        q_name = (
-            'TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgementModeKeyword_q' +
-            uuid.uuid1().hex)
-
-        body1 = 'a' * 1024
-
-        # Declare a new queue
-        ch.queue_declare(q_name, auto_delete=True)
-        self.addCleanup(self._connect().channel().queue_delete, q_name)
-
-        # Publish the message to the queue by way of default exchange
-        ch.publish(exchange='', routing_key=q_name, body=body1)
-
-        # Create a consumer that uses automatic ack mode
-        ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
-                         exclusive=False, arguments=None)
-
-        connection.close()
-        self.assertTrue(connection.is_closed)
-        self.assertFalse(connection.is_open)
-        self.assertFalse(connection.is_closing)
-
-        self.assertFalse(connection._impl._channels)
-
-        self.assertFalse(ch._consumer_infos)
-        self.assertFalse(ch._impl._consumers)
-
 
 class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
 

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -225,7 +225,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
 class TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgementModeKeyword(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: Create and close connection with channel and consumer using no_ack for acknowledgement mode"""  # pylint: disable=C0301
+        """BlockingConnection: Create and close connection with channel and consumer using auto_ack for acknowledgement mode"""  # pylint: disable=C0301
         connection = self._connect()
 
         ch = connection.channel()
@@ -244,7 +244,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumerUsingLegacyAcknowledgeme
         ch.publish(exchange='', routing_key=q_name, body=body1)
 
         # Create a consumer that uses automatic ack mode
-        ch.basic_consume(q_name, lambda *x: None, no_ack=True,
+        ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
                          exclusive=False, arguments=None)
 
         connection.close()
@@ -839,7 +839,7 @@ class TestBasicGet(BlockingTestCaseBase):
         LOGGER.info('%s DECLARED QUEUE (%s)', datetime.utcnow(), self)
 
         # Verify result of getting a message from an empty queue
-        msg = ch.basic_get(q_name, no_ack=False)
+        msg = ch.basic_get(q_name, auto_ack=False)
         self.assertTupleEqual(msg, (None, None, None))
         LOGGER.info('%s GOT FROM EMPTY QUEUE (%s)', datetime.utcnow(), self)
 
@@ -851,7 +851,7 @@ class TestBasicGet(BlockingTestCaseBase):
         LOGGER.info('%s PUBLISHED (%s)', datetime.utcnow(), self)
 
         # Get the message
-        (method, properties, body) = ch.basic_get(q_name, no_ack=False)
+        (method, properties, body) = ch.basic_get(q_name, auto_ack=False)
         LOGGER.info('%s GOT FROM NON-EMPTY QUEUE (%s)', datetime.utcnow(), self)
         self.assertIsInstance(method, pika.spec.Basic.GetOk)
         self.assertEqual(method.delivery_tag, 1)
@@ -902,10 +902,10 @@ class TestBasicReject(BlockingTestCaseBase):
                    mandatory=True)
 
         # Get the messages
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestBasicReject1'))
 
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestBasicReject2'))
 
         # Nack the second message
@@ -916,7 +916,7 @@ class TestBasicReject(BlockingTestCaseBase):
         self._assert_exact_message_count_with_retries(channel=ch,
                                                       queue=q_name,
                                                       expected_count=1)
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestBasicReject2'))
 
 
@@ -948,11 +948,11 @@ class TestBasicRejectNoRequeue(BlockingTestCaseBase):
                    mandatory=True)
 
         # Get the messages
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicRejectNoRequeue1'))
 
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicRejectNoRequeue2'))
 
@@ -993,10 +993,10 @@ class TestBasicNack(BlockingTestCaseBase):
                    mandatory=True)
 
         # Get the messages
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestBasicNack1'))
 
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestBasicNack2'))
 
         # Nack the second message
@@ -1007,7 +1007,7 @@ class TestBasicNack(BlockingTestCaseBase):
         self._assert_exact_message_count_with_retries(channel=ch,
                                                       queue=q_name,
                                                       expected_count=1)
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestBasicNack2'))
 
 
@@ -1039,11 +1039,11 @@ class TestBasicNackNoRequeue(BlockingTestCaseBase):
                    mandatory=True)
 
         # Get the messages
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicNackNoRequeue1'))
 
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicNackNoRequeue2'))
 
@@ -1084,11 +1084,11 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
                    mandatory=True)
 
         # Get the messages
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicNackMultiple1'))
 
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicNackMultiple2'))
 
@@ -1099,10 +1099,10 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
         self._assert_exact_message_count_with_retries(channel=ch,
                                                       queue=q_name,
                                                       expected_count=2)
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicNackMultiple1'))
-        (rx_method, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body,
                          as_bytes('TestBasicNackMultiple2'))
 
@@ -1141,7 +1141,7 @@ class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
 
         rx_messages = []
         num_messages = 0
-        for msg in ch.consume(q_name, no_ack=False):
+        for msg in ch.consume(q_name, auto_ack=False):
             num_messages += 1
 
             if num_messages == 2:
@@ -1199,7 +1199,7 @@ class TestTxCommit(BlockingTestCaseBase):
         frame = ch.queue_declare(q_name, passive=True)
         self.assertEqual(frame.method.message_count, 1)
 
-        (_, _, rx_body) = ch.basic_get(q_name, no_ack=False)
+        (_, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
         self.assertEqual(rx_body, as_bytes('TestTxCommit1'))
 
 
@@ -1602,7 +1602,7 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
         consumer_tag = ch.basic_consume(
             q_name,
             lambda *args: rx_messages.append(args),
-            no_ack=False,
+            auto_ack=False,
             exclusive=False,
             arguments=None)
 
@@ -1730,7 +1730,7 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
         q1_consumer_tag = ch.basic_consume(
             q1_name,
             lambda *args: q1_rx_messages.append(args),
-            no_ack=False,
+            auto_ack=False,
             exclusive=False,
             arguments=None)
 
@@ -1738,7 +1738,7 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
         q2_consumer_tag = ch.basic_consume(
             q2_name,
             lambda *args: q2_rx_messages.append(args),
-            no_ack=False,
+            auto_ack=False,
             exclusive=False,
             arguments=None)
 
@@ -1887,7 +1887,7 @@ class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
         consumer_tag = ch.basic_consume(
             q_name,
             lambda *args: rx_messages.append(args),
-            no_ack=False,
+            auto_ack=False,
             exclusive=False,
             arguments=None)
 
@@ -1994,12 +1994,12 @@ class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch.basic_consume(src_q_name,
                          on_consume,
-                         no_ack=False,
+                         auto_ack=False,
                          exclusive=False,
                          arguments=None)
 
         # Consume from destination queue
-        for _, _, rx_body in ch.consume(dest_q_name, no_ack=True):
+        for _, _, rx_body in ch.consume(dest_q_name, auto_ack=True):
             self.assertEqual(rx_body, as_bytes('via-publish'))
             break
         else:
@@ -2044,7 +2044,7 @@ class TestStopConsumingFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch.basic_consume(q_name,
                          on_consume,
-                         no_ack=False,
+                         auto_ack=False,
                          exclusive=False,
                          arguments=None)
 
@@ -2099,7 +2099,7 @@ class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch.basic_consume(q_name,
                          on_consume,
-                         no_ack=False,
+                         auto_ack=False,
                          exclusive=False,
                          arguments=None)
 
@@ -2153,7 +2153,7 @@ class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch.basic_consume(q_name,
                          on_consume,
-                         no_ack=False,
+                         auto_ack=False,
                          exclusive=False,
                          arguments=None)
 
@@ -2191,7 +2191,7 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
         LOGGER.info('Published message body size=%s', len(body))
 
         # Consume the message
-        for rx_method, rx_props, rx_body in ch.consume(q_name, no_ack=False,
+        for rx_method, rx_props, rx_body in ch.consume(q_name, auto_ack=False,
                                                        exclusive=False,
                                                        arguments=None):
             self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
@@ -2244,7 +2244,7 @@ class TestNonPubackPublishAndConsumeManyMessages(BlockingTestCaseBase):
         # Consume the messages
         num_consumed = 0
         for rx_method, rx_props, rx_body in ch.consume(q_name,
-                                                       no_ack=False,
+                                                       auto_ack=False,
                                                        exclusive=False,
                                                        arguments=None):
             num_consumed += 1
@@ -2305,7 +2305,7 @@ class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
                                                       expected_count=2)
 
         # Create a consumer that uses automatic ack mode
-        consumer_tag = ch.basic_consume(q_name, lambda *x: None, no_ack=True,
+        consumer_tag = ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
                                         exclusive=False, arguments=None)
 
         # Wait for all messages to be sent by broker to client
@@ -2362,7 +2362,7 @@ class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
                                                       expected_count=2)
 
         # Create an ackable consumer
-        consumer_tag = ch.basic_consume(q_name, lambda *x: None, no_ack=False,
+        consumer_tag = ch.basic_consume(q_name, lambda *x: None, auto_ack=False,
                                         exclusive=False, arguments=None)
 
         # Wait for all messages to be sent by broker to client
@@ -2411,7 +2411,7 @@ class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCaseBase):
         # Consume the events, but don't ack
         rx_messages = []
         ch.basic_consume(q_name, lambda *args: rx_messages.append(args),
-                         no_ack=False, exclusive=False, arguments=None)
+                         auto_ack=False, exclusive=False, arguments=None)
         while len(rx_messages) != 2:
             connection.process_data_events(time_limit=None)
 
@@ -2457,7 +2457,7 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
         # Consume, but don't ack
         num_messages = 0
-        for rx_method, _, _ in ch.consume(q_name, no_ack=True, exclusive=False):
+        for rx_method, _, _ in ch.consume(q_name, auto_ack=True, exclusive=False):
             num_messages += 1
 
             self.assertEqual(rx_method.delivery_tag, num_messages)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -330,7 +330,7 @@ class ChannelTests(unittest.TestCase):
         expectation = spec.Basic.Consume(
             queue='test-queue',
             consumer_tag=consumer_tag,
-            no_ack=False,
+            auto_ack=False,
             exclusive=False)
         rpc.assert_called_once_with(expectation, self.obj._on_eventok,
                                     [(spec.Basic.ConsumeOk, {
@@ -350,7 +350,7 @@ class ChannelTests(unittest.TestCase):
         expectation = spec.Basic.Consume(
             queue='test-queue',
             consumer_tag=consumer_tag,
-            no_ack=False,
+            auto_ack=False,
             exclusive=False)
         rpc.assert_called_once_with(expectation, mock_callback,
                                     [(spec.Basic.ConsumeOk, {
@@ -378,7 +378,7 @@ class ChannelTests(unittest.TestCase):
         mock_callback = mock.Mock()
         self.obj.basic_get('test-queue', mock_callback)
         send_method.assert_called_once_with(
-            spec.Basic.Get(queue='test-queue', no_ack=False))
+            spec.Basic.Get(queue='test-queue', auto_ack=False))
 
     @mock.patch('pika.spec.Basic.Get')
     @mock.patch('pika.channel.Channel._send_method')
@@ -387,7 +387,7 @@ class ChannelTests(unittest.TestCase):
         mock_callback = mock.Mock()
         self.obj.basic_get('test-queue', mock_callback, auto_ack=True)
         send_method.assert_called_once_with(
-            spec.Basic.Get(queue='test-queue', no_ack=True))
+            spec.Basic.Get(queue='test-queue', auto_ack=True))
 
     def test_basic_nack_raises_channel_closed(self):
         self.assertRaises(exceptions.ChannelClosed, self.obj.basic_nack, 0,

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -380,6 +380,15 @@ class ChannelTests(unittest.TestCase):
         send_method.assert_called_once_with(
             spec.Basic.Get(queue='test-queue', no_ack=False))
 
+    @mock.patch('pika.spec.Basic.Get')
+    @mock.patch('pika.channel.Channel._send_method')
+    def test_basic_get_send_method_called_auto_ack(self, send_method, _unused):
+        self.obj._set_state(self.obj.OPEN)
+        mock_callback = mock.Mock()
+        self.obj.basic_get('test-queue', mock_callback, auto_ack=True)
+        send_method.assert_called_once_with(
+            spec.Basic.Get(queue='test-queue', no_ack=True))
+
     def test_basic_nack_raises_channel_closed(self):
         self.assertRaises(exceptions.ChannelClosed, self.obj.basic_nack, 0,
                           False, True)


### PR DESCRIPTION
See #951 for background and discussion.

no_ack is still accepted for backwards compatibility.

This is a quick experiment, so there is probably something that I'm missing, missed opportunities
to add more tests and terrible/idiosyncratic Python code. I'm happy to add more tests and address any other feedback.

Closes #951.