### PR TITLE
Implement add_callback_threadsafe in all connection adapters

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -3,7 +3,7 @@ Frequently Asked Questions
 
 - Is Pika thread safe?
 
-    Pika does not have any notion of threading in the code. If you want to use Pika with threading, make sure you have a Pika connection per thread, created in that thread. It is not safe to share one Pika connection across threads.
+    Pika does not have any notion of threading in the code. If you want to use Pika with threading, make sure you have a Pika connection per thread, created in that thread. It is not safe to share one Pika connection across threads, with one exception: you may call the connection method `add_callback_threadsafe` from another thread to schedule a callback within an active pika connection.
 
 - How do I report a bug with Pika?
 

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -21,6 +21,14 @@ class IOLoopAdapter:
         self.writers = set()
 
     def close(self):
+        """Release ioloop's resources.
+
+        This method is intended to be called by the application or test code
+        only after the ioloop's outermost `start()` call returns. After calling
+        `close()`, no other interaction with the closed instance of ioloop
+        should be performed.
+
+        """
         self.loop.close()
 
     def add_timeout(self, deadline, callback):

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -20,6 +20,9 @@ class IOLoopAdapter:
         self.readers = set()
         self.writers = set()
 
+    def close(self):
+        self.loop.close()
+
     def add_timeout(self, deadline, callback):
         """Add the callback to the EventLoop timer to fire after deadline
         seconds. Returns a Handle to the timeout.

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -41,6 +41,28 @@ class IOLoopAdapter:
         """
         return handle.cancel()
 
+    def add_callback_threadsafe(self, callback):
+        """Requests a call to the given function as soon as possible in the
+        context of this IOLoop's thread.
+
+        NOTE: This is the only thread-safe method offered by the IOLoop adapter.
+         All other manipulations of the IOLoop adapter and its parent connection
+         must be performed from the connection's thread.
+
+        For example, a thread may request a call to the
+        `channel.basic_ack` method of a connection that is running in a
+        different thread via
+
+        ```
+        connection.add_callback_threadsafe(
+            functools.partial(channel.basic_ack, delivery_tag=...))
+        ```
+
+        :param method callback: The callback method; must be callable.
+
+        """
+        self.loop.call_soon_threadsafe(callback)
+
     def add_handler(self, fd, cb, event_state):
         """ Registers the given handler to receive the given events for ``fd``.
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -135,6 +135,32 @@ class BaseConnection(connection.Connection):
         """
         self.ioloop.remove_timeout(timeout_id)
 
+    def add_callback_threadsafe(self, callback):
+        """Requests a call to the given function as soon as possible in the
+        context of this connection's IOLoop thread.
+
+        NOTE: This is the only thread-safe method offered by the connection. All
+         other manipulations of the connection must be performed from the
+         connection's thread.
+
+        For example, a thread may request a call to the
+        `channel.basic_ack` method of a connection that is running in a
+        different thread via
+
+        ```
+        connection.add_callback_threadsafe(
+            functools.partial(channel.basic_ack, delivery_tag=...))
+        ```
+
+        :param method callback: The callback method; must be callable.
+
+        """
+        if not callable(callback):
+            raise TypeError(
+                'callback must be a callable, but got %r' % (callback,))
+
+        self.ioloop.add_callback_threadsafe(callback)
+
     def _adapter_connect(self):
         """Connect to the RabbitMQ broker, returning True if connected.
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1844,7 +1844,8 @@ class BlockingChannel(object):
         """Blocking consumption of a queue instead of via a callback. This
         method is a generator that yields each message as a tuple of method,
         properties, and body. The active generator iterator terminates when the
-        consumer is cancelled by client or broker.
+        consumer is cancelled by client via `BlockingChannel.cancel()` or by
+        broker.
 
         Example:
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -303,9 +303,6 @@ class IOLoop(object):
     def close(self):
         """Release IOLoop's resources.
 
-        TODO Need to call this from IOLoop and SelectConnection tests as well as
-        TODO from BlockingConnection to avoid socket resource leak messages
-
         `IOLoop.close` is intended to be called by the application or test code
         only after `IOLoop.start()` returns. After calling `close()`, no other
         interaction with the closed instance of `IOLoop` should be performed.
@@ -405,7 +402,7 @@ class IOLoop(object):
 
     def process_timeouts(self):
         """[Extension] Process pending callbacks and timeouts, invoking those
-         whose time has come. Internal use only.
+        whose time has come. Internal use only.
 
         """
         # Avoid I/O starvation by postponing new callbacks to the next iteration
@@ -465,12 +462,8 @@ class IOLoop(object):
 
     def stop(self):
         """[API] Request exit from the ioloop. The loop is NOT guaranteed to
-        stop before this method returns. This is the only method that may be
-        called from another thread.
+        stop before this method returns.
 
-        TODO This shouldn't have been made thread-safe. Instead, `add_callback`
-        TODO should be used to safely call `stop` from the IOLoop's own thread.
-        TODO Update documentation/implementation
         """
         self._poller.stop()
 
@@ -545,9 +538,6 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
 
     def close(self):
         """Release poller's resources.
-
-        TODO Need to call this from Poller tests to avoid socket resource
-        TODO leak messages
 
         `close()` is intended to be called after the poller's `start()` method
         returns. After calling `close()`, no other interaction with the closed
@@ -738,8 +728,7 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
 
     def stop(self):
         """Request exit from the ioloop. The loop is NOT guaranteed to stop
-        before this method returns. This is the only method that may be called
-        from another thread.
+        before this method returns.
 
         """
         LOGGER.debug('Stopping IOLoop')

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -944,9 +944,8 @@ class KQueuePoller(_PollerBase):
     def __init__(self, get_wait_seconds, process_timeouts):
         """Create an instance of the KQueuePoller
         """
-        super(KQueuePoller, self).__init__(get_wait_seconds, process_timeouts)
-
         self._kqueue = None
+        super(KQueuePoller, self).__init__(get_wait_seconds, process_timeouts)
 
     @staticmethod
     def _map_event(kevent):

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -396,6 +396,8 @@ class IOLoop(object):
             # Wake up the IOLoop running in another thread
             self._poller.wake_threadsafe()
 
+        LOGGER.debug('add_callback_threadsafe: added callback=%r', callback)
+
     def process_timeouts(self):
         """[Extension] Process pending callbacks and timeouts, invoking those
          whose time has come. Internal use only.

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -3,6 +3,7 @@ platform pika is running on.
 
 """
 import abc
+import collections
 import errno
 import functools
 import heapq
@@ -10,8 +11,6 @@ import logging
 import select
 import time
 import threading
-
-from collections import defaultdict
 
 import pika.compat
 
@@ -282,7 +281,14 @@ class IOLoop(object):
     def __init__(self):
         self._timer = _Timer()
 
-        self._poller = self._get_poller(self._timer.get_remaining_interval,
+        # Callbacks requested via `add_callback`
+        self._callbacks = collections.deque()
+
+        # Identity of this IOLoop's thread
+        self._thread_id = None
+
+
+        self._poller = self._get_poller(self._get_remaining_interval,
                                         self.process_timeouts)
 
     @staticmethod
@@ -346,12 +352,54 @@ class IOLoop(object):
         """
         self._timer.remove_timeout(timeout_id)
 
-    def process_timeouts(self):
-        """[Extension] Process pending timeouts, invoking callbacks for those
-        whose time has come. Internal use only.
+    def add_callback_threadsafe(self, callback):
+        """Calls the given function on the next iteration of the IOLoop in the
+        context of the IOLoop's thread.
+
+        NOTE: This is the only thread-safe method in IOLoop. All other
+        manipulations of IOLoop must be performed from the IOLoop's thread.
+
+        For example, a thread may request a call to the `stop` method of an
+        ioloop that is running in a different thread via
+        `ioloop.add_callback_threadsafe(ioloop.stop)`
+
+        :param method callback: The callback method
 
         """
+        if not callable(callback):
+            raise TypeError(
+                'callback must be a callable, but got %r' % (callback,))
+
+        # NOTE: `deque.append` is atomic
+        self._callbacks.append(callback)
+        if threading.current_thread().ident != self._thread_id:
+            # Wake up the IOLoop running in another thread
+            self._poller.wake_threadsafe()
+
+    def process_timeouts(self):
+        """[Extension] Process pending callbacks and timeouts, invoking those
+         whose time has come. Internal use only.
+
+        """
+        # Avoid I/O starvation by postponing new callbacks to the next iteration
+        for _ in pika.compat.xrange(len(self._callbacks)):
+            self._callbacks.popleft()()
+
         self._timer.process_timeouts()
+
+    def _get_remaining_interval(self):
+        """Get the remaining interval to the next callback or timeout
+        expiration.
+
+        :returns: non-negative number of seconds until next callback or timer
+                  expiration; None if there are no callbacks and timers
+        :rtype: float
+
+        """
+        if self._callbacks:
+            return 0
+
+        return self._timer.get_remaining_interval()
 
     def add_handler(self, fileno, handler, events):
         """[API] Add a new fileno to the set to be monitored
@@ -385,6 +433,7 @@ class IOLoop(object):
         exit. See `IOLoop.stop`.
 
         """
+        self._thread_id = threading.current_thread().ident
         self._poller.start()
 
     def stop(self):
@@ -392,6 +441,9 @@ class IOLoop(object):
         stop before this method returns. This is the only method that may be
         called from another thread.
 
+        TODO This shouldn't have been made thread-safe. Instead, `add_callback`
+        TODO should be used to safely call `stop` from the IOLoop's own thread.
+        TODO Update documentation/implementation
         """
         self._poller.stop()
 
@@ -399,6 +451,7 @@ class IOLoop(object):
         """[Extension] Activate the poller
 
         """
+        self._thread_id = threading.current_thread().ident
         self._poller.activate_poller()
 
     def deactivate_poller(self):
@@ -442,6 +495,10 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
         self._get_wait_seconds = get_wait_seconds
         self._process_timeouts = process_timeouts
 
+        # We guard access to the waking file descriptors to avoid races from
+        # closing them while another thread is calling our `wake()` method.
+        self._waking_mutex = threading.Lock()
+
         # fd-to-handler function mappings
         self._fd_handlers = dict()
 
@@ -455,14 +512,42 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
 
         self._stopping = False
 
-        # Mutex for controlling critical sections where ioloop-interrupt sockets
-        # are created, used, and destroyed. Needed in case `stop()` is called
-        # from a thread.
-        self._mutex = threading.Lock()
+        # Create ioloop-interrupt socket pair and register read handler.
+        self._r_interrupt, self._w_interrupt = self._get_interrupt_pair()
+        self.add_handler(self._r_interrupt.fileno(), self._read_interrupt, READ)
 
-        # ioloop-interrupt socket pair; initialized in start()
-        self._r_interrupt = None
-        self._w_interrupt = None
+    def close(self):
+        """TODO figure out where to call it
+        """
+        # Unregister and close ioloop-interrupt socket pair
+        with self._waking_mutex:
+            self.remove_handler(self._r_interrupt.fileno()) # pylint: disable=E1101
+            self._r_interrupt.close()
+            self._r_interrupt = None
+            self._w_interrupt.close()
+            self._w_interrupt = None
+
+    def wake_threadsafe(self):
+        """Wake up the poller as soon as possible. As the name indicates, this
+        method is thread-safe.
+        """
+        with self._waking_mutex:
+            if self._w_interrupt is None:
+                return
+
+            try:
+                # Send byte to interrupt the poll loop, use send() instead of
+                # os.write for Windows compatibility
+                self._w_interrupt.send(b'X')
+            except pika.compat.SOCKET_ERROR as err:
+                if err.errno != errno.EWOULDBLOCK:
+                    raise
+            except Exception as err:
+                # There's nothing sensible to do here, we'll exit the interrupt
+                # loop after POLL_TIMEOUT secs in worst case anyway.
+                LOGGER.warning("Failed to send interrupt to poller: %s", err)
+                raise
+
 
     def _get_max_wait(self):
         """Get the interval to the next timeout event, or a default interval
@@ -557,7 +642,7 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
         """
         # Activate the underlying poller and register current events
         self._init_poller()
-        fd_to_events = defaultdict(int)
+        fd_to_events = collections.defaultdict(int)
         for event, file_descriptors in self._fd_events.items():
             for fileno in file_descriptors:
                 fd_to_events[fileno] |= event
@@ -584,17 +669,6 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
             # Activate the underlying poller and register current events
             self.activate_poller()
 
-            # Create ioloop-interrupt socket pair and register read handler.
-            # NOTE: we defer their creation because some users (e.g.,
-            # BlockingConnection adapter) don't use the event loop and these
-            # sockets would get reported as leaks
-            with self._mutex:
-                assert self._r_interrupt is None
-                self._r_interrupt, self._w_interrupt = self._get_interrupt_pair(
-                )
-                self.add_handler(self._r_interrupt.fileno(),
-                                 self._read_interrupt, READ)
-
         else:
             LOGGER.debug('Reentering IOLoop at nesting level=%s',
                          self._start_nesting_levels)
@@ -609,14 +683,7 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
             self._start_nesting_levels -= 1
 
             if self._start_nesting_levels == 0:
-                LOGGER.debug('Cleaning up IOLoop')
-                # Unregister and close ioloop-interrupt socket pair
-                with self._mutex:
-                    self.remove_handler(self._r_interrupt.fileno())
-                    self._r_interrupt.close()
-                    self._r_interrupt = None
-                    self._w_interrupt.close()
-                    self._w_interrupt = None
+                LOGGER.debug('Deactivating poller')
 
                 # Deactivate the underlying poller
                 self.deactivate_poller()
@@ -633,22 +700,7 @@ class _PollerBase(_AbstractBase):  # pylint: disable=R0902
         LOGGER.debug('Stopping IOLoop')
         self._stopping = True
 
-        with self._mutex:
-            if self._w_interrupt is None:
-                return
-
-            try:
-                # Send byte to interrupt the poll loop, use send() instead of
-                # os.write for Windows compatibility
-                self._w_interrupt.send(b'X')
-            except pika.compat.SOCKET_ERROR as err:
-                if err.errno != errno.EWOULDBLOCK:
-                    raise
-            except Exception as err:
-                # There's nothing sensible to do here, we'll exit the interrupt
-                # loop after POLL_TIMEOUT secs in worst case anyway.
-                LOGGER.warning("Failed to send ioloop interrupt: %s", err)
-                raise
+        self.wake_threadsafe()
 
     @abc.abstractmethod
     def poll(self):
@@ -796,7 +848,7 @@ class SelectPoller(_PollerBase):
 
         # Build an event bit mask for each fileno we've received an event for
 
-        fd_event_map = defaultdict(int)
+        fd_event_map = collections.defaultdict(int)
         for fd_set, evt in zip((read, write, error), (READ, WRITE, ERROR)):
             for fileno in fd_set:
                 fd_event_map[fileno] |= evt
@@ -893,7 +945,7 @@ class KQueuePoller(_PollerBase):
                 else:
                     raise
 
-        fd_event_map = defaultdict(int)
+        fd_event_map = collections.defaultdict(int)
         for event in kevents:
             fd_event_map[event.ident] |= self._map_event(event)
 
@@ -1012,7 +1064,7 @@ class PollPoller(_PollerBase):
                 else:
                     raise
 
-        fd_event_map = defaultdict(int)
+        fd_event_map = collections.defaultdict(int)
         for fileno, event in events:
             fd_event_map[fileno] |= event
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -373,8 +373,8 @@ class IOLoop(object):
         self._timer.remove_timeout(timeout_id)
 
     def add_callback_threadsafe(self, callback):
-        """Calls the given function on the next iteration of the IOLoop in the
-        context of the IOLoop's thread.
+        """Requests a call to the given function as soon as possible in the
+        context of this IOLoop's thread.
 
         NOTE: This is the only thread-safe method in IOLoop. All other
         manipulations of IOLoop must be performed from the IOLoop's thread.

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -150,7 +150,7 @@ class _Timeout(object):
 
 
 class _Timer(object):
-    """Manage timers for use in ioloop"""
+    """Manage timeouts for use in ioloop"""
 
     # Cancellation count threshold for triggering garbage collection of
     # cancelled timers

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -464,7 +464,17 @@ class IOLoop(object):
         """[API] Request exit from the ioloop. The loop is NOT guaranteed to
         stop before this method returns.
 
+        To invoke `stop()` safely from a thread other than this IOLoop's thread,
+        call it via `add_callback_threadsafe`; e.g.,
+
+            `ioloop.add_callback_threadsafe(ioloop.stop)`
+
         """
+        if (self._thread_id is not None and
+                threading.current_thread().ident != self._thread_id):
+            LOGGER.warning('Use add_callback_threadsafe to request '
+                           'ioloop.stop() from another thread')
+
         self._poller.stop()
 
     def activate_poller(self):

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -94,3 +94,29 @@ class TornadoConnection(base_connection.BaseConnection):
 
         """
         return self.ioloop.remove_timeout(timeout_id)
+
+    def add_callback_threadsafe(self, callback):
+        """Requests a call to the given function as soon as possible in the
+        context of this connection's IOLoop thread.
+
+        NOTE: This is the only thread-safe method offered by the connection. All
+         other manipulations of the connection must be performed from the
+         connection's thread.
+
+        For example, a thread may request a call to the
+        `channel.basic_ack` method of a connection that is running in a
+        different thread via
+
+        ```
+        connection.add_callback_threadsafe(
+            functools.partial(channel.basic_ack, delivery_tag=...))
+        ```
+
+        :param method callback: The callback method; must be callable.
+
+        """
+        if not callable(callback):
+            raise TypeError(
+                'callback must be a callable, but got %r' % (callback,))
+
+        self.ioloop.add_callback(callback)

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -225,6 +225,28 @@ class IOLoopReactorAdapter(object):
         """
         call.cancel()
 
+    def add_callback_threadsafe(self, callback):
+        """Requests a call to the given function as soon as possible in the
+        context of this IOLoop's thread.
+
+        NOTE: This is the only thread-safe method offered by the IOLoop adapter.
+         All other manipulations of the IOLoop adapter and its parent connection
+         must be performed from the connection's thread.
+
+        For example, a thread may request a call to the
+        `channel.basic_ack` method of a connection that is running in a
+        different thread via
+
+        ```
+        connection.add_callback_threadsafe(
+            functools.partial(channel.basic_ack, delivery_tag=...))
+        ```
+
+        :param method callback: The callback method; must be callable.
+
+        """
+        self.reactor.callFromThread(callback)
+
     def stop(self):
         # Guard against stopping the reactor multiple times
         if not self.started:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1244,8 +1244,11 @@ class Connection(object):
             LOGGER.warning('Suppressing close request on %s', self)
             return
 
+        # NOTE The connection is either in opening or open state
+
         # Initiate graceful closing of channels that are OPEN or OPENING
-        self._close_channels(reply_code, reply_text)
+        if self._channels:
+            self._close_channels(reply_code, reply_text)
 
         # Set our connection state
         self._set_connection_state(self.CONNECTION_CLOSING)

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -535,6 +535,7 @@ class TestAddCallbackThreadsafeFromAnotherThread(AsyncTestCase, AsyncAdapters):
             0,
             lambda: channel.connection.add_callback_threadsafe(
                 self.on_requested_callback))
+        self.addCleanup(timer.cancel)
         timer.start()
 
     def on_requested_callback(self):

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -498,19 +498,18 @@ class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):  # pylint: di
 class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Test add_callback_threadsafe request before ioloop starts."
 
-    def _instantiate_connection(self, *args, **kwargs):  # pylint: disable=W0221
+    def _run_ioloop(self, *args, **kwargs):  # pylint: disable=W0221
         """We intercept this method from AsyncTestCase in order to call
         add_callback_threadsafe before AsyncTestCase starts the ioloop.
-        """
-        connection = super(
-            TestAddCallbackThreadsafeRequestBeforeIOLoopStarts, self)._instantiate_connection(
-                *args, **kwargs)
 
+        """
         self.my_start_time = time.time()
         # Request a callback from our current (ioloop's) thread
-        connection.add_callback_threadsafe(self.on_requested_callback)
+        self.connection.add_callback_threadsafe(self.on_requested_callback)
 
-        return connection
+        return super(
+            TestAddCallbackThreadsafeRequestBeforeIOLoopStarts, self)._run_ioloop(
+                *args, **kwargs)
 
     def start(self, *args, **kwargs):  # pylint: disable=W0221
         self.loop_thread_ident = threading.current_thread().ident
@@ -583,19 +582,16 @@ class TestAddCallbackThreadsafeFromAnotherThread(AsyncTestCase, AsyncAdapters):
 class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Test ioloop.stop() before ioloop starts causes ioloop to exit quickly."
 
-    def _instantiate_connection(self, *args, **kwargs):  # pylint: disable=W0221
+    def _run_ioloop(self, *args, **kwargs):  # pylint: disable=W0221
         """We intercept this method from AsyncTestCase in order to call
         ioloop.stop() before AsyncTestCase starts the ioloop.
         """
-        connection = super(
-            TestIOLoopStopBeforeIOLoopStarts, self)._instantiate_connection(
-                *args, **kwargs)
-
         # Request ioloop to stop before it starts
         self.my_start_time = time.time()
-        connection.ioloop.stop()
+        self.stop_ioloop_only()
 
-        return connection
+        return super(
+            TestIOLoopStopBeforeIOLoopStarts, self)._run_ioloop(*args, **kwargs)
 
     def start(self, *args, **kwargs):  # pylint: disable=W0221
         self.loop_thread_ident = threading.current_thread().ident

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -503,7 +503,7 @@ class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(AsyncTestCase, AsyncAda
         add_callback_threadsafe before AsyncTestCase starts the ioloop.
         """
         connection = super(
-            TestAddCallbackThreadsafeRequestBeforeIOLoopStarts, self).start(
+            TestAddCallbackThreadsafeRequestBeforeIOLoopStarts, self)._instantiate_connection(
                 *args, **kwargs)
 
         self.my_start_time = time.time()
@@ -589,7 +589,7 @@ class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
         ioloop.stop() before AsyncTestCase starts the ioloop.
         """
         connection = super(
-            TestIOLoopStopBeforeIOLoopStarts, self).start(
+            TestIOLoopStopBeforeIOLoopStarts, self)._instantiate_connection(
                 *args, **kwargs)
 
         # Request ioloop to stop before it starts

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -520,14 +520,13 @@ class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(AsyncTestCase, AsyncAda
         self.assertTrue(self.got_callback)
 
     def begin(self, channel):
-        pass
+        self.stop()
 
     def on_requested_callback(self):
         self.assertEqual(threading.current_thread().ident,
                          self.loop_thread_ident)
         self.assertLess(time.time() - self.my_start_time, 0.25)
         self.got_callback = True
-        self.stop()
 
 
 class TestAddCallbackThreadsafeFromIOLoopThread(AsyncTestCase, AsyncAdapters):

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -63,9 +63,6 @@ class AsyncTestCase(unittest.TestCase):
         self.connection.ioloop.start()
         self.assertFalse(self._timed_out)
 
-        # Release ioloop resources
-        self.connection.ioloop.close()
-
     def stop(self):
         """close the connection and stop the ioloop"""
         self.logger.info("Stopping test")
@@ -79,9 +76,10 @@ class AsyncTestCase(unittest.TestCase):
             self.logger.info("Removing timeout")
             self.connection.remove_timeout(self.timeout)
             self.timeout = None
-        if hasattr(self, 'connection') and self.connection:
+        if hasattr(self, 'connection') and self.connection is not None:
             self.logger.info("Stopping ioloop")
             self.connection.ioloop.stop()
+            self.connection.ioloop.close()
             self.connection = None
 
     def on_closed(self, connection, reply_code, reply_text):

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -63,6 +63,9 @@ class AsyncTestCase(unittest.TestCase):
         self.connection.ioloop.start()
         self.assertFalse(self._timed_out)
 
+        # Release ioloop resources
+        self.connection.ioloop.close()
+
     def stop(self):
         """close the connection and stop the ioloop"""
         self.logger.info("Stopping test")

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -156,6 +156,18 @@ class BoundQueueTestCase(AsyncTestCase):
 class AsyncAdapters(object):
 
     def start(self, adapter_class, ioloop_factory):
+        """
+
+        :param adapter_class: pika connection adapter class to test.
+        :param ioloop_factory: to be called without args to instantiate a
+           non-shared ioloop to be passed as the `custom_ioloop` arg to the
+           `adapter_class` constructor. This is needed because some of the
+           adapters default to using a singleton ioloop, which results in
+           tests errors after prior tests close the ioloop to release resources,
+           in order to eliminate ResourceWarning warnings concerning unclosed
+           sockets from our adapters.
+        :return:
+        """
         raise NotImplementedError
 
     def select_default_test(self):

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -58,10 +58,15 @@ class AsyncTestCase(unittest.TestCase):
 
         self.connection = self.adapter(self.parameters, self.on_open,
                                        self.on_open_error, self.on_closed)
-        self.timeout = self.connection.add_timeout(self.TIMEOUT,
-                                                   self.on_timeout)
-        self.connection.ioloop.start()
-        self.assertFalse(self._timed_out)
+        try:
+            self.timeout = self.connection.add_timeout(self.TIMEOUT,
+                                                       self.on_timeout)
+            self.connection.ioloop.start()
+            self.assertFalse(self._timed_out)
+        finally:
+            self.connection.ioloop.close()
+            self.connection = None
+
 
     def stop(self):
         """close the connection and stop the ioloop"""
@@ -79,8 +84,6 @@ class AsyncTestCase(unittest.TestCase):
         if hasattr(self, 'connection') and self.connection is not None:
             self.logger.info("Stopping ioloop")
             self.connection.ioloop.stop()
-            self.connection.ioloop.close()
-            self.connection = None
 
     def on_closed(self, connection, reply_code, reply_text):
         """called when the connection has finished closing"""

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -483,6 +483,7 @@ class TestAddCallbackThreadsafeFromAnotherThread(BlockingTestCaseBase):
             0,
             functools.partial(connection.add_callback_threadsafe,
                               lambda: rx_callback.append(time.time())))
+        self.addCleanup(timer.cancel)
         timer.start()
         while not rx_callback:
             connection.process_data_events(time_limit=None)
@@ -1789,6 +1790,7 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
             timer = threading.Timer(0,
                                     lambda: connection.add_callback_threadsafe(
                                         processOnConnectionThread))
+            self.addCleanup(timer.cancel)
             timer.start()
 
         consumer_tag = ch.basic_consume(
@@ -1888,6 +1890,7 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
             timer = threading.Timer(0,
                                     lambda: connection.add_callback_threadsafe(
                                         processOnConnectionThread))
+            self.addCleanup(timer.cancel)
             timer.start()
 
         for method, properties, body in ch.consume(q_name, auto_ack=False):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1880,7 +1880,7 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
                                  rx_method.consumer_tag)
                     # NOTE Need to use cancel() for the consumer generator
                     # instead of basic_cancel()
-                    rx_ch.cancel(rx_method.consumer_tag)
+                    rx_ch.cancel()
 
             # Spawn a thread to initiate ACKing
             timer = threading.Timer(0,

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1808,8 +1808,8 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
                      consumer_tag)
 
         self.assertEqual(len(rx_messages), 2)
-        self.assertEqual(rx_messages[0], 'msg1')
-        self.assertEqual(rx_messages[1], 'last-msg')
+        self.assertEqual(rx_messages[0], b'msg1')
+        self.assertEqual(rx_messages[1], b'last-msg')
 
 
 class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
@@ -1897,8 +1897,8 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
                                                  rx_body=body)
 
         self.assertEqual(len(rx_messages), 2)
-        self.assertEqual(rx_messages[0], 'msg1')
-        self.assertEqual(rx_messages[1], 'last-msg')
+        self.assertEqual(rx_messages[0], b'msg1')
+        self.assertEqual(rx_messages[1], b'last-msg')
 
 
 class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1878,7 +1878,9 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
                     LOGGER.debug('%s: Canceling consumer consumer-tag=%r',
                                  datetime.now(),
                                  rx_method.consumer_tag)
-                    rx_ch.basic_cancel(rx_method.consumer_tag)
+                    # NOTE Need to use cancel() for the consumer generator
+                    # instead of basic_cancel()
+                    rx_ch.cancel(rx_method.consumer_tag)
 
             # Spawn a thread to initiate ACKing
             timer = threading.Timer(0,

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1784,9 +1784,10 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
                     rx_ch.basic_cancel(rx_method.consumer_tag)
 
             # Spawn a thread to initiate ACKing
-            threading.Timer(0,
-                            lambda: connection.add_callback_threadsafe(
-                                processOnConnectionThread))
+            timer = threading.Timer(0,
+                                    lambda: connection.add_callback_threadsafe(
+                                        processOnConnectionThread))
+            timer.start()
 
         rx_messages = []
         consumer_tag = ch.basic_consume(

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1778,7 +1778,8 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
                              multiple=False)
                 rx_messages.append(rx_body)
 
-                if rx_body == 'last-msg':
+                # NOTE on python3, `b'last-msg' != 'last-msg'`
+                if rx_body == b'last-msg':
                     LOGGER.debug('%s: Canceling consumer consumer-tag=%r',
                                  datetime.now(),
                                  rx_method.consumer_tag)
@@ -1874,7 +1875,8 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
                              multiple=False)
                 rx_messages.append(rx_body)
 
-                if rx_body == 'last-msg':
+                # NOTE on python3, `b'last-msg' != 'last-msg'`
+                if rx_body == b'last-msg':
                     LOGGER.debug('%s: Canceling consumer consumer-tag=%r',
                                  datetime.now(),
                                  rx_method.consumer_tag)

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -126,8 +126,7 @@ class BlockingConnectionTests(unittest.TestCase):
         connection._flush_output(lambda: False, lambda: True)
 
         self.assertEqual(connection._impl.ioloop.activate_poller.call_count, 1)
-        self.assertEqual(connection._impl.ioloop.deactivate_poller.call_count,
-                         1)
+        self.assertEqual(connection._impl.ioloop.close.call_count, 1)
 
     @patch.object(
         blocking_connection,
@@ -152,8 +151,7 @@ class BlockingConnectionTests(unittest.TestCase):
         self.assertSequenceEqual(cm.exception.args, (404, 'not found'))
 
         self.assertEqual(connection._impl.ioloop.activate_poller.call_count, 1)
-        self.assertEqual(connection._impl.ioloop.deactivate_poller.call_count,
-                         1)
+        self.assertEqual(connection._impl.ioloop.close.call_count, 1)
 
     @patch.object(
         blocking_connection,
@@ -178,8 +176,7 @@ class BlockingConnectionTests(unittest.TestCase):
         self.assertSequenceEqual(cm.exception.args, (200, 'ok'))
 
         self.assertEqual(connection._impl.ioloop.activate_poller.call_count, 1)
-        self.assertEqual(connection._impl.ioloop.deactivate_poller.call_count,
-                         1)
+        self.assertEqual(connection._impl.ioloop.close.call_count, 1)
 
     @patch.object(
         blocking_connection,

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -19,6 +19,7 @@ import pika
 from pika import compat
 from pika.adapters import select_connection
 
+
 EPOLL_SUPPORTED = hasattr(select, 'epoll')
 POLL_SUPPORTED = hasattr(select, 'poll') and hasattr(select.poll(), 'modify')
 KQUEUE_SUPPORTED = hasattr(select, 'kqueue')
@@ -97,7 +98,9 @@ class IOLoopThreadStopTestSelect(IOLoopBaseTest):
 
     def start_test(self):
         """Starts a thread that stops ioloop after a while and start polling"""
-        timer = threading.Timer(0.1, self.ioloop.stop)
+        timer = threading.Timer(
+            0.1,
+            lambda: self.ioloop.add_callback_threadsafe(self.ioloop.stop))
         self.addCleanup(timer.cancel)
         timer.start()
         self.start()

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -36,6 +36,7 @@ class IOLoopBaseTest(unittest.TestCase):
 
         self.ioloop = select_connection.IOLoop()
         self.addCleanup(setattr, self, 'ioloop', None)
+        self.addCleanup(self.ioloop.close)
 
         activate_poller_patch = mock.patch.object(
             self.ioloop._poller,

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -19,6 +19,11 @@ import pika
 from pika import compat
 from pika.adapters import select_connection
 
+# protected-access
+# pylint: disable=W0212
+# missing-docstring
+# pylint: disable=C0111
+
 
 EPOLL_SUPPORTED = hasattr(select, 'epoll')
 POLL_SUPPORTED = hasattr(select, 'poll') and hasattr(select.poll(), 'modify')

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -439,6 +439,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         timer = select_connection._Timer()
         self.poller = self.ioloop._get_poller(timer.get_remaining_interval,
                                               timer.process_timeouts)
+        self.addCleanup(self.poller.close)
 
         sockpair = self.poller._get_interrupt_pair()
         self.addCleanup(sockpair[0].close)
@@ -494,6 +495,7 @@ class SelectPollerTestPollWithoutSockets(unittest.TestCase):
         poller = select_connection.SelectPoller(
             get_wait_seconds=timer.get_remaining_interval,
             process_timeouts=timer.process_timeouts)
+        self.addCleanup(poller.close)
 
         timer_call_container = []
         timer.call_later(0.00001, lambda: timer_call_container.append(1))

--- a/tests/unit/select_connection_timer_tests.py
+++ b/tests/unit/select_connection_timer_tests.py
@@ -91,6 +91,20 @@ class TimeoutClassTests(unittest.TestCase):
 class TimerClassTests(unittest.TestCase):
     """Test select_connection._Timer class"""
 
+    def test_close_empty(self):
+        timer = select_connection._Timer()
+        timer.close()
+        self.assertIsNone(timer._timeout_heap)
+
+    def test_close_non_empty(self):
+        timer = select_connection._Timer()
+        t1 = timer.call_later(10, lambda: 10)
+        t2 = timer.call_later(20, lambda: 20)
+        timer.close()
+        self.assertIsNone(timer._timeout_heap)
+        self.assertIsNone(t1.callback)
+        self.assertIsNone(t2.callback)
+
     def test_no_timeouts_remaining_interval_is_none(self):
         timer = select_connection._Timer()
         self.assertIsNone(timer.get_remaining_interval())

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -15,4 +15,4 @@ class TornadoConnectionTests(unittest.TestCase):
         obj = tornado_connection.TornadoConnection()
         mock_init.assert_called_once_with(
             None, None, None, None,
-            tornado_connection.ioloop.IOLoop.instance(), False)
+            tornado_connection.ioloop.IOLoop.instance())

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -15,4 +15,4 @@ class TornadoConnectionTests(unittest.TestCase):
         obj = tornado_connection.TornadoConnection()
         mock_init.assert_called_once_with(
             None, None, None, None,
-            tornado_connection.ioloop.IOLoop.instance())
+            tornado_connection.ioloop.IOLoop.instance(), False)


### PR DESCRIPTION
(*NOTE that the failed coverage test results from pika's encrypted credentials configuration issue*)

This pull request implements a new method `add_callback_threadsafe` on all supported connection adapters in pika. This method enables the application to delegate calls from other threads into the context of the adapter's IOLoop thread (similarly to Tornado's `add_callback`, Twisted's `callFromThread`, and asyncio's `call_soon_threadsafe`).

Lack of this feature has been a pain point for users of `BlockingConnection` and `SelectConnection` for as long as I can remember, and users have had to rely on clumsy and inefficient workarounds.

Here is a sampling of several relevant issues: #963, #927, #892, #930, #752, #418, #753, #636, #564.

For example, this feature facilitates the app to delegate long-lasting processing of incoming messages to a background thread and then use `add_callback_threadsafe` to efficiently delegate ACKing of the message in the context of the connection's thread, thus avoiding lost heartbeat/connection issues from blocking too long and also hacky polling techniques that applications have been using to work around the limitation in the past.

ADDITIONAL INFO FOR CHANGELOG: It is customary among frameworks - such as tornado, twisted, and asyncio - to designate a single threadsafe method that accepts a callback to be executed in the IOLoop's thread, and no others are thread-safe for ease of support/maintenance and for API orthogonality. Following this rationale, I removed the thread-safe designation inside the docstring of the ioloop `stop()` method in `select_connection.IOLoop`.

Fixes #892