### PR TITLE
Ensure blocked Channel.Close methods are processed

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -31,7 +31,6 @@ class BaseConnection(connection.Connection):
     ]
     ERRORS_TO_IGNORE = [errno.EWOULDBLOCK, errno.EAGAIN, errno.EINTR]
     DO_HANDSHAKE = True
-    WARN_ABOUT_IOLOOP = False
 
     def __init__(self,
                  parameters=None,
@@ -307,8 +306,6 @@ class BaseConnection(connection.Connection):
         """
         if self.stop_ioloop_on_close and self.ioloop:
             self.ioloop.stop()
-        elif self.WARN_ABOUT_IOLOOP:
-            LOGGER.warning('Connection is closed but not stopping IOLoop')
 
     def _handle_error(self, error_value):
         """Internal error handling method. Here we expect a socket error

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -24,7 +24,6 @@ class TornadoConnection(base_connection.BaseConnection):
     :param custom_ioloop: Override using the global IOLoop in Tornado
 
     """
-    WARN_ABOUT_IOLOOP = True
 
     def __init__(self,
                  parameters=None,

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1269,6 +1269,9 @@ class Channel(object):
         """
         LOGGER.debug('%i blocked frames', len(self._blocked))
         self._blocking = None
+        # self._blocking must be checked here as a callback could
+        # potentially change the state of that variable during an
+        # iteration of the while loop
         while self._blocked and self._blocking is None:
             self._rpc(*self._blocked.popleft())
 
@@ -1280,9 +1283,12 @@ class Channel(object):
         """
         LOGGER.debug('Draining %i blocked frames due to remote Channel.Close', len(self._blocked))
         self._blocking = None
+        # self._blocking must be checked here as a callback could
+        # potentially change the state of that variable during an
+        # iteration of the while loop
         while self._blocked and self._blocking is None:
             method = self._blocked.popleft()[0]
-            if method.NAME == spec.Channel.Close.NAME:
+            if isinstance(method, spec.Channel.Close):
                 # in this case, the Channel.Close method has not yet been
                 # sent to the broker. At this point, the channel has been
                 # closed by the broker, so we do not want to send this method,

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1279,17 +1279,17 @@ class Channel(object):
         """This is called when the broker sends a Channel.Close while the
         client is in CLOSING state. This method checks the blocked method
         queue for a pending client-initiated Channel.Close method and
-        ensures its callbacks are processed, but does send the method to
-        the broker.
+        ensures its callbacks are processed, but does not send the method
+        to the broker.
 
         The broker may close the channel before responding to outstanding
-        (blocked) synchronous methods, or even before these methods have
-        been sent to the broker. AMQP 0.9.1 obliges the server to drop all
-        methods arriving on a closed channel other than Channel.CloseOk and
-        Channel.Close. Since the response to the blocked synchronous
-        method never arrives, the channel never becomes unblocked, and the
-        Channel.Close, if any, in the blocked queue has no opportunity to
-        be sent, and thus its completion callback would never be called.
+        in-transit synchronous methods, or even before these methods have been
+        sent to the broker. AMQP 0.9.1 obliges the server to drop all methods
+        arriving on a closed channel other than Channel.CloseOk and
+        Channel.Close. Since the response to a synchronous method that blocked
+        the channel never arrives, the channel never becomes unblocked, and the
+        Channel.Close, if any, in the blocked queue has no opportunity to be
+        sent, and thus its completion callback would never be called.
 
         """
         LOGGER.debug('Draining %i blocked frames due to remote Channel.Close',

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -169,6 +169,13 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
 class TestPassiveExchangeDeclareWithConcurrentClose(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "should close channel: declare passive exchange with close"
 
+    # To observe the behavior that this is testing, comment out this line
+    # in pika/channel.py - _on_close:
+    #
+    # self._drain_blocked_methods_on_remote_close()
+    #
+    # With the above line commented out, this test will hang
+
     def begin(self, channel):
         self.name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.channel.add_on_close_callback(self.on_channel_closed)


### PR DESCRIPTION
If Pika receives a server-initiated Channel.Close method, it will not process blocked Channel.Close methods which could hang application code.

See https://gist.github.com/lukebakken/ab49531e504dfd8f4c133fcb9994a7d7#file-testpika-py for code to reproduce.

Fixes #945