### PR TITLE
Clean up connection socket error handling

### DIFF
--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -228,7 +228,7 @@ class AsyncioConnection(base_connection.BaseConnection):
         if not error:
             self.ioloop.add_handler(
                 self.socket.fileno(),
-                self._handle_connection_sock_events,
+                self._handle_connection_socket_events,
                 self.event_state,
             )
 

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -228,7 +228,7 @@ class AsyncioConnection(base_connection.BaseConnection):
         if not error:
             self.ioloop.add_handler(
                 self.socket.fileno(),
-                self._handle_events,
+                self._handle_connection_sock_events,
                 self.event_state,
             )
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -304,7 +304,7 @@ class BaseConnection(connection.Connection):
         # called), etc., etc., etc.
         self._manage_event_state()
 
-    def _handle_connection_sock_error(self, exception):
+    def _handle_connection_socket_error(self, exception):
         """Internal error handling method. Here we expect a socket error
         coming in and will handle different socket errors differently.
 
@@ -350,7 +350,7 @@ class BaseConnection(connection.Connection):
         only have the socket in a blocking state during connect."""
         LOGGER.warning("Unexpected socket timeout")
 
-    def _handle_connection_sock_events(self, fd, events):
+    def _handle_connection_socket_events(self, fd, events):
         """Handle IO/Event loop events, processing them.
 
         :param int fd: The file descriptor for the events
@@ -405,12 +405,12 @@ class BaseConnection(connection.Connection):
                 # ssl wants more data but there is nothing currently
                 # available in the socket, wait for it to become readable.
                 return 0
-            return self._handle_connection_sock_error(error)
+            return self._handle_connection_socket_error(error)
 
         except SOCKET_ERROR as error:
             if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
                 return 0
-            return self._handle_connection_sock_error(error)
+            return self._handle_connection_socket_error(error)
 
         if not data:
             # Remote peer closed or shut down our input stream - disconnect
@@ -459,14 +459,14 @@ class BaseConnection(connection.Connection):
                 LOGGER.debug("Would block, requeuing frame")
                 self.outbound_buffer.appendleft(frame)
             else:
-                return self._handle_connection_sock_error(error)
+                return self._handle_connection_socket_error(error)
 
         except SOCKET_ERROR as error:
             if error.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
                 LOGGER.debug("Would block, requeuing frame")
                 self.outbound_buffer.appendleft(frame)
             else:
-                return self._handle_connection_sock_error(error)
+                return self._handle_connection_socket_error(error)
 
         return total_bytes_sent
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -364,15 +364,13 @@ class BaseConnection(connection.Connection):
         only have the socket in a blocking state during connect."""
         LOGGER.warning("Unexpected socket timeout")
 
-    def _handle_connection_sock_events(self, fd, events, error=None,
-                                       write_only=False):
+    def _handle_connection_sock_events(self, fd, events, error=None):
         """Handle IO/Event loop events, processing them.
 
         :param int fd: The file descriptor for the events
         :param int events: Events from the IO/Event loop
         :param int error: Was an error specified; TODO none of the current
           adapters appear to be able to pass the `error` arg - is it needed?
-        :param bool write_only: Only handle write events
 
         """
         if not self.socket:
@@ -383,16 +381,8 @@ class BaseConnection(connection.Connection):
             self._handle_write()
             self._manage_event_state()
 
-        if self.socket and not write_only and (events & self.READ):
+        if self.socket and (events & self.READ):
             self._handle_read()
-
-        if (self.socket and write_only and (events & self.READ) and
-            (events & self.ERROR)):
-            error_msg = ('BAD libc:  Write-Only but Read+Error. '
-                         'Assume socket disconnected.')
-            LOGGER.error(error_msg)
-            self._on_terminate(connection.InternalCloseReasons.SOCKET_ERROR,
-                               error_msg)
 
         if self.socket and (events & self.ERROR):
             LOGGER.error('Error event %r, %r', events, error)

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -364,13 +364,11 @@ class BaseConnection(connection.Connection):
         only have the socket in a blocking state during connect."""
         LOGGER.warning("Unexpected socket timeout")
 
-    def _handle_connection_sock_events(self, fd, events, error=None):
+    def _handle_connection_sock_events(self, fd, events):
         """Handle IO/Event loop events, processing them.
 
         :param int fd: The file descriptor for the events
         :param int events: Events from the IO/Event loop
-        :param int error: Was an error specified; TODO none of the current
-          adapters appear to be able to pass the `error` arg - is it needed?
 
         """
         if not self.socket:
@@ -385,6 +383,7 @@ class BaseConnection(connection.Connection):
             self._handle_read()
 
         if self.socket and (events & self.ERROR):
+            error = self.socket.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
             LOGGER.error('Error event %r, %r', events, error)
             self._handle_error(error)
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -385,6 +385,7 @@ class BaseConnection(connection.Connection):
             while True:
                 try:
                     if self.params.ssl:
+                        # TODO Why using read instead of recv on ssl socket?
                         data = self.socket.read(self._buffer_size)
                     else:
                         data = self.socket.recv(self._buffer_size)

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -364,7 +364,8 @@ class BaseConnection(connection.Connection):
         only have the socket in a blocking state during connect."""
         LOGGER.warning("Unexpected socket timeout")
 
-    def _handle_events(self, fd, events, error=None, write_only=False):
+    def _handle_connection_sock_events(self, fd, events, error=None,
+                                       write_only=False):
         """Handle IO/Event loop events, processing them.
 
         :param int fd: The file descriptor for the events

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -101,7 +101,7 @@ class SelectConnection(BaseConnection):
         error = super(SelectConnection, self)._adapter_connect()
         if not error:
             self.ioloop.add_handler(self.socket.fileno(),
-                                    self._handle_connection_sock_events,
+                                    self._handle_connection_socket_events,
                                     self.event_state)
         return error
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -100,7 +100,8 @@ class SelectConnection(BaseConnection):
         """
         error = super(SelectConnection, self)._adapter_connect()
         if not error:
-            self.ioloop.add_handler(self.socket.fileno(), self._handle_events,
+            self.ioloop.add_handler(self.socket.fileno(),
+                                    self._handle_connection_sock_events,
                                     self.event_state)
         return error
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -48,7 +48,8 @@ class TornadoConnection(base_connection.BaseConnection):
         """
         error = super(TornadoConnection, self)._adapter_connect()
         if not error:
-            self.ioloop.add_handler(self.socket.fileno(), self._handle_events,
+            self.ioloop.add_handler(self.socket.fileno(),
+                                    self._handle_connection_sock_events,
                                     self.event_state)
         return error
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -49,7 +49,7 @@ class TornadoConnection(base_connection.BaseConnection):
         error = super(TornadoConnection, self)._adapter_connect()
         if not error:
             self.ioloop.add_handler(self.socket.fileno(),
-                                    self._handle_connection_sock_events,
+                                    self._handle_connection_socket_events,
                                     self.event_state)
         return error
 

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -587,20 +587,22 @@ class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
         ioloop.stop() before AsyncTestCase starts the ioloop.
         """
         # Request ioloop to stop before it starts
-        self.my_start_time = time.time()
+        my_start_time = time.time()
         self.stop_ioloop_only()
 
-        return super(
+        super(
             TestIOLoopStopBeforeIOLoopStarts, self)._run_ioloop(*args, **kwargs)
 
-    def start(self, *args, **kwargs):  # pylint: disable=W0221
-        self.loop_thread_ident = threading.current_thread().ident
-        self.my_start_time = None
-        super(TestIOLoopStopBeforeIOLoopStarts, self).start(*args, **kwargs)
-        self.assertLess(time.time() - self.my_start_time, 0.25)
+        self.assertLess(time.time() - my_start_time, 0.25)
+
+        # Resume I/O loop to facilitate normal course of events and closure
+        # of connection in order to prevent reporting of a socket resource leak
+        # from an unclosed connection.
+        super(
+            TestIOLoopStopBeforeIOLoopStarts, self)._run_ioloop(*args, **kwargs)
 
     def begin(self, channel):
-        pass
+        self.stop()
 
 
 class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103


### PR DESCRIPTION
`BasicConnection._handle_events` took redundant args with default values that are actually not passed by anything calling it, yet it passed the `error` arg (defaulting to None and not set explicitly by any of the callers) to `_handle_error` upon ERROR socket event, which was resulting in the confusing log message "Tried to handle an error where no error existed".

In fact, `_handle_events` shouldn't even react to the ERROR event individually, since when there is an error on the TCP/IP stream, an IO event (READ and/or WRITE) will also be indicated and a subsequent attempt by pika to perform the corresponding I/O on the socket will generate the appropriate error condition and be handled appropriately by read/write handler(s). In fact, you could have an ERROR event (e.g., HUP) indicated on the socket, yet a socket read could succeed if incoming data was still available on the socket buffer. So it's better to handle the error once attempted I/O trips up on it.

From https://github.com/pika/pika/issues/779#issuecomment-368005734:
```
[ERROR] Error event 25, None
[CRITICAL] Tried to handle an error where no error existed
[ERROR] Socket Error: 104
[INFO] Disconnected from RabbitMQ at blablabla.com:5672 (-1): ConnectionResetError(104, 'Connection reset by peer')
[ERROR] Connection close detected; result=BlockingConnection__OnClosedArgs(connection=<SelectConnection CLOSED socket=None params=<ConnectionParameters host=blablabla.com port=5672 virtual_host=/ ssl=False>>, reason_code=-1, reason_text="ConnectionResetError(104, 'Connection reset by peer')")
```