### PR TITLE
(Bug fix) Wrong condition check when trying to set self.virtual_host

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -784,7 +784,7 @@ class URLParameters(Parameters):
                                                                  url_unquote(parts.password))
 
         # Get the Virtual Host
-        if len(parts.path) > 1:
+        if len(parts.path.split('/')) > 1:
             self.virtual_host = url_unquote(parts.path.split('/')[1])
 
         # Handle query string values, validating and assigning them


### PR DESCRIPTION
Wrong condition check when trying to set self.virtual_host in URLParameters, this will fix "list index out of range" error.