### PR TITLE
Fixed leaking of ChannelClosed exception back through the callback from SelectConnection that notified BlockingChannel about broker-initiated Channel.Close

### DIFF
--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -35,7 +35,7 @@ class IOLoopAdapter:
         """Add the callback to the EventLoop timer to fire after deadline
         seconds. Returns a Handle to the timeout.
 
-        :param int deadline: The number of seconds to wait to call callback
+        :param float deadline: The number of seconds to wait to call callback
         :param method callback: The callback method
         :rtype: asyncio.Handle
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -98,7 +98,7 @@ class BaseConnection(connection.Connection):
         """Add the callback to the IOLoop timer to fire after deadline
         seconds. Returns a handle to the timeout
 
-        :param int deadline: The number of seconds to wait to call callback
+        :param float deadline: The number of seconds to wait to call callback
         :param method callback: The callback method
         :rtype: str
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -361,7 +361,7 @@ class IOLoop(object):
         Tornado's timeout where you pass in the time you want to have your
         callback called. Only pass in the seconds until it's to be called.
 
-        :param int deadline: The number of seconds to wait to call callback
+        :param float deadline: The number of seconds to wait to call callback
         :param method callback: The callback method
         :rtype: str
 
@@ -409,7 +409,9 @@ class IOLoop(object):
         """
         # Avoid I/O starvation by postponing new callbacks to the next iteration
         for _ in pika.compat.xrange(len(self._callbacks)):
-            self._callbacks.popleft()()
+            callback = self._callbacks.popleft()
+            LOGGER.debug('process_timeouts: invoking callback=%r', callback)
+            callback()
 
         self._timer.process_timeouts()
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -1,7 +1,8 @@
 """Use pika with the Tornado IOLoop"""
-from tornado import ioloop
 import logging
 import time
+
+from tornado import ioloop
 
 from pika.adapters import base_connection
 
@@ -65,7 +66,7 @@ class TornadoConnection(base_connection.BaseConnection):
         Tornado's timeout where you pass in the time you want to have your
         callback called. Only pass in the seconds until it's to be called.
 
-        :param int deadline: The number of seconds to wait to call callback
+        :param float deadline: The number of seconds to wait to call callback
         :param method callback: The callback method
         :rtype: str
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -21,6 +21,10 @@ from pika import exceptions
 from pika.adapters import base_connection
 
 
+# Disable invalid-name because Twisted interfaces force their convention on
+# our implementation
+# pylint: disable=C0103
+
 class ClosableDeferredQueue(defer.DeferredQueue):
     """
     Like the normal Twisted DeferredQueue, but after close() is called with an
@@ -210,7 +214,7 @@ class IOLoopReactorAdapter(object):
         Tornado's timeout where you pass in the time you want to have your
         callback called. Only pass in the seconds until it's to be called.
 
-        :param int deadline: The number of seconds to wait to call callback
+        :param float deadline: The number of seconds to wait to call callback
         :param method callback: The callback method
         :rtype: twisted.internet.interfaces.IDelayedCall
 

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -71,17 +71,50 @@ class ConnectionClosed(AMQPConnectionError):
 class AMQPChannelError(AMQPError):
 
     def __repr__(self):
-        return 'An unspecified AMQP channel error has occurred'
+        return 'An unspecified AMQP channel error has occurred: {!r}'.format(
+            self.args)
 
 
 class ChannelClosed(AMQPChannelError):
+    """The channel is in a state other than OPEN (e.g., OPENING, CLOSING, or
+    CLOSED). You may introspect the channel's state properties (`is_closed`,
+    `is_closing`).
+
+    """
+    def __init__(self, reply_code, reply_text):
+        """
+
+        :param int reply_code: reply-code that was used in user's or broker's
+            `Channel.Close` method. One of the AMQP-defined Channel Errors or
+            negative error values from `Channel.ClientChannelErrors`;
+            NEW in v1.0.0
+        :param str reply_text: reply-text that was used in user's or broker's
+            `Channel.Close` method. Human-readable string corresponding to
+            `reply_code`;
+            NEW in v1.0.0
+        """
+        super(ChannelClosed, self).__init__(int(reply_code), str(reply_text))
 
     def __repr__(self):
-        if len(self.args) == 2:
-            return 'The channel was closed (%s) %s' % (self.args[0],
-                                                       self.args[1])
-        else:
-            return 'The channel was closed: %s' % (self.args,)
+        return '{}: ({}) {!r}'.format(self.__class__.__name__,
+                                      self.reply_code,
+                                      self.reply_text)
+
+    @property
+    def reply_code(self):
+        """ NEW in v1.0.0
+        :rtype: int
+
+        """
+        return self.args[0]
+
+    @property
+    def reply_text(self):
+        """ NEW in v1.0.0
+        :rtype: int
+
+        """
+        return self.args[1]
 
 
 class ChannelAlreadyClosing(AMQPChannelError):

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -231,7 +231,7 @@ class BlockingConnectionTests(unittest.TestCase):
         channel1_mock = mock.Mock(
             is_open=True,
             close=mock.Mock(
-                side_effect=ChannelClosed,
+                side_effect=ChannelClosed(-1, 'Just because'),
                 spec_set=pika.channel.Channel.close),
             spec_set=blocking_connection.BlockingChannel)
 

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -7,6 +7,13 @@ import unittest
 from pika import exceptions
 
 
+# missing-docstring
+# pylint: disable=C0111
+
+# invalid-name - our tests use long, descriptive names
+# pylint: disable=C0103
+
+
 class ExceptionTests(unittest.TestCase):
     def test_amqp_connection_error_one_param_repr(self):
         self.assertEqual(
@@ -38,3 +45,18 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(
             repr(exceptions.InvalidMaximumFrameSize()),
             'AMQP Maximum Frame Size is 131072 Bytes')
+
+    def test_channel_closed_properties_positional_args(self):
+        exc = exceptions.ChannelClosed(9, 'args abcd')
+        self.assertEqual(exc.reply_code, 9)
+        self.assertEqual(exc.reply_text, 'args abcd')
+
+    def test_channel_closed_properties_kwargs(self):
+        exc = exceptions.ChannelClosed(reply_code=9, reply_text='kwargs abcd')
+        self.assertEqual(exc.reply_code, 9)
+        self.assertEqual(exc.reply_text, 'kwargs abcd')
+
+    def test_channel_closed_repr(self):
+        exc = exceptions.ChannelClosed(200, 'all is swell')
+
+        self.assertEqual(repr(exc), "ChannelClosed: (200) 'all is swell'")


### PR DESCRIPTION
This tests changes from pull request #886 that stop event processing and raise ChannelClosed upon channel failure (i.e., when Channel.Close is received from broker).

Also test `BlockingChannel.start_consuming()` and `BlockingChannel.consume()` encounters of Cancel from broker.

Fixed leaking of ChannelClosed exception (introduced in #886) back through the callback from SelectConnection that notified BlockingChannel about broker-initiated `Channel.Close` and on through the I/O loop..

# NOTABLE BEHAVIOR/API CHANGES:

1. ChannelClosed due to broker-initiated Channel.Close  is now raised for a channel only when the user interacts with that channel by invoking that channel's API that leads to I/O loop activity (e.g., sending a request to broker, running the BlockingChannel.consume() generator, running in BlockingChannel.start_consuming(). Simply calling BlockingConnection.sleep() won't raise ChannelClosed.
2. Added explicit `reply_code` and `reply_text` constructor args to the `ChannelClosed` exception class and provided corresponding `reply_code` and `reply_text` properties to retrieve them.
3. Standardized raising of the ChannelClosed exception via `Channel._raise_if_not_open()` that supplies reasonable `reply_code` and `reply_text` args based on current channel state to the `ChannelClosed` exception.
4. Added class `pika.channel. ClientChannelErrors` that defines client-side channel reply codes for use in `ChannelClosed.reply_code`.
5. When dispatching `'_on_channel_close'` callbacks after user-initiated closing of the channel, pass the `reply_code` and `reply_text` that were provided by user to `Channel.close()` and `BlockingChannel.close()` instead of the dummy `(0, '')`, which was counter to the original intention and documentation described [here](https://github.com/pika/pika/blob/b7f27983cfbcbaf34a06b6fc9259a7fd50b8838d/pika/channel.py#L85-L87).
6. Implemented new public property `Channel.is_closed_by_broker` that may be used in conjunction with `Channel.is_closed` to glean the source of the channel's closing.