### PR TITLE
Don't attempt graceful AMQP Connection.Close upon heartbeat timeout

### DIFF
--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -85,7 +85,8 @@ class HeartbeatChecker(object):
                      self._heartbeat_frames_sent)
 
         if self.connection_is_idle:
-            return self._close_connection()
+            self._close_connection()
+            return
 
         # Connection has not received any data, increment the counter
         if not self._has_received_data:
@@ -116,13 +117,9 @@ class HeartbeatChecker(object):
         duration = self._max_idle_count * self._interval
         text = HeartbeatChecker._STALE_CONNECTION % duration
 
-        # NOTE: this won't achieve the perceived effect of sending
-        # Connection.Close to broker, because the frame will only get buffered
-        # in memory before the next statement terminates the connection.
-        self._connection.close(HeartbeatChecker._CONNECTION_FORCED, text)
-
-        self._connection._on_terminate(HeartbeatChecker._CONNECTION_FORCED,
-                                       text)
+        self._connection._on_terminate(  # pylint: disable=W0212
+            HeartbeatChecker._CONNECTION_FORCED,
+            text)
 
     @property
     def _has_received_data(self):
@@ -147,7 +144,8 @@ class HeartbeatChecker(object):
 
         """
         LOGGER.debug('Sending heartbeat frame')
-        self._connection._send_frame(self._new_heartbeat_frame())
+        self._connection._send_frame(  # pylint: disable=W0212
+            self._new_heartbeat_frame())
         self._heartbeat_frames_sent += 1
 
     def _setup_timer(self):

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -125,8 +125,6 @@ class HeartbeatTests(unittest.TestCase):
         self.obj._close_connection()
         reason = self.obj._STALE_CONNECTION % (
             self.obj._max_idle_count * self.obj._interval)
-        self.mock_conn.close.assert_called_once_with(
-            self.obj._CONNECTION_FORCED, reason)
         self.mock_conn._on_terminate.assert_called_once_with(
             self.obj._CONNECTION_FORCED, reason)
 


### PR DESCRIPTION
cc @lukebakken 

Once heartbeat logic concludes that the connection is dead due to missed heartbeats, there is no point attempting a graceful Connection.Close, including Channel.Close requests if there were open channels.