### PR TITLE
Call self._connection.ioloop.run_forever() in asyncio_consumer.rst example

### DIFF
--- a/docs/examples/asyncio_consumer.rst
+++ b/docs/examples/asyncio_consumer.rst
@@ -321,7 +321,7 @@ consumer.py::
 
             """
             self._connection = self.connect()
-            self._connection.ioloop.start()
+            self._connection.ioloop.run_forever()
 
         def stop(self):
             """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
@@ -337,7 +337,7 @@ consumer.py::
             LOGGER.info('Stopping')
             self._closing = True
             self.stop_consuming()
-            self._connection.ioloop.start()
+            self._connection.ioloop.run_forever()
             LOGGER.info('Stopped')
 
 


### PR DESCRIPTION
In `asyncio_consumer.rst` example, call `self._connection.ioloop.run_forever()` instead of `self._connection.ioloop.start()`, since `BaseConnection` now exposes the native loop
properly.