### PR TITLE
Cleaned up "on channel closed" callback and ChannelClosed exception scenarios

### DIFF
--- a/docs/examples/asynchronous_consumer_example.rst
+++ b/docs/examples/asynchronous_consumer_example.rst
@@ -142,7 +142,7 @@ consumer.py::
             LOGGER.info('Adding channel close callback')
             self._channel.add_on_close_callback(self.on_channel_closed)
 
-        def on_channel_closed(self, channel, reply_code, reply_text):
+        def on_channel_closed(self, channel, reason):
             """Invoked by pika when RabbitMQ unexpectedly closes the channel.
             Channels are usually closed if you attempt to do something that
             violates the protocol, such as re-declare an exchange or queue with
@@ -150,12 +150,10 @@ consumer.py::
             to shutdown the object.
 
             :param pika.channel.Channel: The closed channel
-            :param int reply_code: The numeric reason the channel was closed
-            :param str reply_text: The text reason the channel was closed
+            :param Exception reason: why the channel was closed
 
             """
-            LOGGER.warning('Channel %i was closed: (%s) %s',
-                           channel, reply_code, reply_text)
+            LOGGER.warning('Channel %i was closed: %s', channel, reason)
             self._connection.close()
 
         def setup_exchange(self, exchange_name):

--- a/docs/examples/asynchronous_publisher_example.rst
+++ b/docs/examples/asynchronous_publisher_example.rst
@@ -138,7 +138,7 @@ publisher.py::
             LOGGER.info('Adding channel close callback')
             self._channel.add_on_close_callback(self.on_channel_closed)
 
-        def on_channel_closed(self, channel, reply_code, reply_text):
+        def on_channel_closed(self, channel, reason):
             """Invoked by pika when RabbitMQ unexpectedly closes the channel.
             Channels are usually closed if you attempt to do something that
             violates the protocol, such as re-declare an exchange or queue with
@@ -146,11 +146,10 @@ publisher.py::
             to shutdown the object.
 
             :param pika.channel.Channel channel: The closed channel
-            :param int reply_code: The numeric reason the channel was closed
-            :param str reply_text: The text reason the channel was closed
+            :param Exception reason: why the channel was closed
 
             """
-            LOGGER.warning('Channel was closed: (%s) %s', reply_code, reply_text)
+            LOGGER.warning('Channel %i was closed: %s', channel, reason)
             self._channel = None
             if not self._stopping:
                 self._connection.close()

--- a/docs/examples/asyncio_consumer.rst
+++ b/docs/examples/asyncio_consumer.rst
@@ -123,7 +123,7 @@ consumer.py::
             LOGGER.info('Adding channel close callback')
             self._channel.add_on_close_callback(self.on_channel_closed)
 
-        def on_channel_closed(self, channel, reply_code, reply_text):
+        def on_channel_closed(self, channel, reason):
             """Invoked by pika when RabbitMQ unexpectedly closes the channel.
             Channels are usually closed if you attempt to do something that
             violates the protocol, such as re-declare an exchange or queue with
@@ -131,12 +131,10 @@ consumer.py::
             to shutdown the object.
 
             :param pika.channel.Channel: The closed channel
-            :param int reply_code: The numeric reason the channel was closed
-            :param str reply_text: The text reason the channel was closed
+            :param Exception reason: why the channel was closed
 
             """
-            LOGGER.warning('Channel %i was closed: (%s) %s',
-                           channel, reply_code, reply_text)
+            LOGGER.warning('Channel %i was closed: %s', channel, reason)
             self._connection.close()
 
         def on_channel_open(self, channel):

--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -117,7 +117,7 @@ consumer.py::
             LOGGER.info('Adding channel close callback')
             self._channel.add_on_close_callback(self.on_channel_closed)
 
-        def on_channel_closed(self, channel, reply_code, reply_text):
+        def on_channel_closed(self, channel, reason):
             """Invoked by pika when RabbitMQ unexpectedly closes the channel.
             Channels are usually closed if you attempt to do something that
             violates the protocol, such as re-declare an exchange or queue with
@@ -125,12 +125,10 @@ consumer.py::
             to shutdown the object.
 
             :param pika.channel.Channel: The closed channel
-            :param int reply_code: The numeric reason the channel was closed
-            :param str reply_text: The text reason the channel was closed
+            :param Exception reason: why the channel was closed
 
             """
-            LOGGER.warning('Channel %i was closed: (%s) %s',
-                           channel, reply_code, reply_text)
+            LOGGER.warning('Channel %i was closed: %s', channel, reason)
             self._connection.close()
 
         def on_channel_open(self, channel):

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -141,7 +141,7 @@ class ExampleConsumer(object):
         LOGGER.info('Adding channel close callback')
         self._channel.add_on_close_callback(self.on_channel_closed)
 
-    def on_channel_closed(self, channel, reply_code, reply_text):
+    def on_channel_closed(self, channel, reason):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
         violates the protocol, such as re-declare an exchange or queue with
@@ -149,12 +149,10 @@ class ExampleConsumer(object):
         to shutdown the object.
 
         :param pika.channel.Channel: The closed channel
-        :param int reply_code: The numeric reason the channel was closed
-        :param str reply_text: The text reason the channel was closed
+        :param Exception reason: why the channel was closed
 
         """
-        LOGGER.warning('Channel %i was closed: (%s) %s',
-                        channel, reply_code, reply_text)
+        LOGGER.warning('Channel %i was closed: %s', channel, reason)
         self._connection.close()
 
     def setup_exchange(self, exchange_name):

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -133,7 +133,7 @@ class ExamplePublisher(object):
         LOGGER.info('Adding channel close callback')
         self._channel.add_on_close_callback(self.on_channel_closed)
 
-    def on_channel_closed(self, channel, reply_code, reply_text):
+    def on_channel_closed(self, channel, reason):
         """Invoked by pika when RabbitMQ unexpectedly closes the channel.
         Channels are usually closed if you attempt to do something that
         violates the protocol, such as re-declare an exchange or queue with
@@ -141,11 +141,10 @@ class ExamplePublisher(object):
         to shutdown the object.
 
         :param pika.channel.Channel channel: The closed channel
-        :param int reply_code: The numeric reason the channel was closed
-        :param str reply_text: The text reason the channel was closed
+        :param Exception reason: why the channel was closed
 
         """
-        LOGGER.warning('Channel was closed: (%s) %s', reply_code, reply_text)
+        LOGGER.warning('Channel %i was closed: %s', channel, reason)
         self._channel = None
         if not self._stopping:
             self._connection.close()

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1201,6 +1201,9 @@ class BlockingChannel(object):
         # Basic.Return in publisher-acknowledgments mode.
         self._puback_return = None
 
+        # self._on_channel_closed() saves the reason exception here
+        self._closing_reason = None  # type: None | Exception
+
         # Receives Basic.ConsumeOk reply from server
         self._basic_consume_ok_result = _CallbackResult()
 
@@ -1243,10 +1246,8 @@ class BlockingChannel(object):
         return self
 
     def __exit__(self, exc_type, value, traceback):
-        try:
+        if self.is_open:
             self.close()
-        except exceptions.ChannelClosed:
-            pass
 
     def _cleanup(self):
         """Clean up members that might inhibit garbage collection"""
@@ -1318,8 +1319,9 @@ class BlockingChannel(object):
             lambda: self.is_closed,
             *waiters)
 
-        if self.is_closed and self._impl.is_closed_by_broker:
-            self._impl._raise_if_not_open()
+        if self.is_closed and isinstance(self._closing_reason,
+                                         exceptions.ChannelClosedByBroker):
+            raise self._closing_reason  # pylint: disable=E0702
 
     def _on_puback_message_returned(self, channel, method, properties, body):
         """Called as the result of Basic.Return from broker in
@@ -1359,7 +1361,7 @@ class BlockingChannel(object):
         self._pending_events.append(evt)
         self.connection._request_channel_dispatch(self.channel_number)
 
-    def _on_channel_closed(self, _channel, reply_code, reply_text):
+    def _on_channel_closed(self, _channel, reason):
         """Callback from impl notifying us that the channel has been closed.
         This may be as the result of user-, broker-, or internal connection
         clean-up initiated closing or meta-closing of the channel.
@@ -1379,16 +1381,14 @@ class BlockingChannel(object):
         See `pika.Channel.add_on_close_callback()` for additional documentation.
 
         :param pika.Channel _channel: (unused)
-        :param int reply_code:
-        :param str reply_text:
-        """
-        LOGGER.debug('_on_channel_closed: by_broker=%s; (%s) %s; %r',
-                     self._impl.is_closed_by_broker,
-                     reply_code,
-                     reply_text,
-                     self)
+        :param Exception reason:
 
-        if self._impl.is_closed_by_broker:
+        """
+        LOGGER.debug('_on_channel_closed: %r; %r', reason, self)
+
+        self._closing_reason = reason
+
+        if isinstance(reason, exceptions.ChannelClosedByBroker):
             self._cleanup()
 
             # Request urgent termination of `process_data_events()`, in case
@@ -2020,11 +2020,11 @@ class BlockingChannel(object):
 
         """
         self.connection.process_data_events(time_limit=time_limit)
-        if self.is_closed and self._impl.is_closed_by_broker:
-            LOGGER.debug(
-                'Channel close by broker detected, raising ChannelClose...; %r',
-                self)
-            self._impl._raise_if_not_open()
+        if self.is_closed and isinstance(self._closing_reason,
+                                         exceptions.ChannelClosedByBroker):
+            LOGGER.debug('Channel close by broker detected, raising %r; %r',
+                         self._closing_reason, self)
+            raise self._closing_reason  # pylint: disable=E0702
 
     def get_waiting_message_count(self):
         """Returns the number of messages that may be retrieved from the current

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -91,9 +91,9 @@ class TwistedChannel(object):
 
         channel.add_on_close_callback(self.channel_closed)
 
-    def channel_closed(self, _channel, reply_code, reply_text):
+    def channel_closed(self, _channel, reason):
         # enter the closed state
-        self.__closed = exceptions.ChannelClosed(reply_code, reply_text)
+        self.__closed = reason
         # errback all pending calls
         for d in self.__calls:
             d.errback(self.__closed)

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2143,9 +2143,7 @@ class Connection(pika.compat.AbstractBase):
             if channel not in self._channels:
                 continue
             # pylint: disable=W0212
-            self._channels[channel]._on_close_meta(
-                pika.channel.ClientChannelErrors.CONNECTION_CLOSED,
-                repr(self._error))
+            self._channels[channel]._on_close_meta(self._error)
 
         # Inform interested parties
         if not self._opened:

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -250,6 +250,7 @@ class TestConnectionContextManagerExitSurvivesClosedConnection(BlockingTestCaseB
         with self._connect() as connection:
             self.assertTrue(connection.is_open)
             connection.close()
+            self.assertTrue(connection.is_closed)
 
         self.assertTrue(connection.is_closed)
 
@@ -387,7 +388,7 @@ class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
         self.assertIsNone(self.connection._impl._transport)
 
 
-class TestNoAccessToFileDescriptorAfterConnectionClosed(BlockingTestCaseBase):
+class TestNoAccessToConnectionAfterConnectionLost(BlockingTestCaseBase):
 
     def test(self):
         """BlockingConnection no access file descriptor after StreamLostError
@@ -807,7 +808,7 @@ class TestExchangeDeclareAndDelete(BlockingTestCaseBase):
         self.assertIsInstance(frame.method, pika.spec.Exchange.DeleteOk)
 
         # Verify that it's been deleted
-        with self.assertRaises(pika.exceptions.ChannelClosed) as cm:
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
             ch.exchange_declare(name, passive=True)
 
         self.assertEqual(cm.exception.args[0], 404)
@@ -899,7 +900,7 @@ class TestQueueDeclareAndDelete(BlockingTestCaseBase):
         self.assertIsInstance(frame.method, pika.spec.Queue.DeleteOk)
 
         # Verify that it's been deleted
-        with self.assertRaises(pika.exceptions.ChannelClosed) as cm:
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
             ch.queue_declare(q_name, passive=True)
 
         self.assertEqual(cm.exception.args[0], 404)
@@ -915,7 +916,7 @@ class TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed(
         q_name = ("TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed_q_"
                   + uuid.uuid1().hex)
 
-        with self.assertRaises(pika.exceptions.ChannelClosed) as ex_cm:
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
             ch.queue_declare(q_name, passive=True)
 
         self.assertEqual(ex_cm.exception.args[0], 404)
@@ -1421,7 +1422,7 @@ class TestBasicConsumeFromUnknownQueueRaisesChannelClosed(BlockingTestCaseBase):
         q_name = ("TestBasicConsumeFromUnknownQueueRaisesChannelClosed_q_" +
                   uuid.uuid1().hex)
 
-        with self.assertRaises(pika.exceptions.ChannelClosed) as ex_cm:
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
             ch.basic_consume(q_name, lambda *args: None)
 
         self.assertEqual(ex_cm.exception.args[0], 404)
@@ -2570,12 +2571,8 @@ class TestStartConsumingRaisesChannelClosedOnSameChannelFailure(BlockingTestCase
                 routing_key='123',
                 body=b'Nope this is wrong'))
 
-        self.assertFalse(ch._impl.is_closed_by_broker)
-
-        with self.assertRaises(pika.exceptions.ChannelClosed):
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker):
             ch.start_consuming()
-
-        self.assertTrue(ch._impl.is_closed_by_broker)
 
 
 class TestStartConsumingReturnsAfterCancelFromBroker(BlockingTestCaseBase):
@@ -3031,13 +3028,9 @@ class TestConsumeGeneratorPassesChannelClosedOnSameChannelFailure(BlockingTestCa
                 routing_key='123',
                 body=b'Nope this is wrong'))
 
-        self.assertFalse(ch._impl.is_closed_by_broker)
-
-        with self.assertRaises(pika.exceptions.ChannelClosed):
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker):
             for _ in ch.consume(q_name):
                 pass
-
-        self.assertTrue(ch._impl.is_closed_by_broker)
 
 
 class TestChannelFlow(BlockingTestCaseBase):
@@ -3072,6 +3065,66 @@ class TestChannelFlow(BlockingTestCaseBase):
         # Verify still one active consumer on the queue now
         frame = ch.queue_declare(q_name, passive=True)
         self.assertEqual(frame.method.consumer_count, 1)
+
+
+class TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel(BlockingTestCaseBase):
+    def test(self):
+        """BlockingConnection: Declaring queue on closed channel raises ChannelWrongStateError"""
+        q_name = (
+            'TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel_q' +
+            uuid.uuid1().hex)
+
+        channel = self._connect().channel()
+        channel.close()
+        with self.assertRaises(pika.exceptions.ChannelWrongStateError):
+            channel.queue_declare(q_name)
+
+
+class TestChannelRaisesWrongStateWhenClosingClosedChannel(BlockingTestCaseBase):
+    def test(self):
+        """BlockingConnection: Closing closed channel raises ChannelWrongStateError"""
+        channel = self._connect().channel()
+        channel.close()
+        with self.assertRaises(pika.exceptions.ChannelWrongStateError):
+            channel.close()
+
+
+class TestChannelContextManagerClosesChannel(BlockingTestCaseBase):
+    def test(self):
+        """BlockingConnection: chanel context manager exit survives closed channel"""
+        with self._connect().channel() as channel:
+            self.assertTrue(channel.is_open)
+
+        self.assertTrue(channel.is_closed)
+
+
+class TestChannelContextManagerExitSurvivesClosedChannel(BlockingTestCaseBase):
+    def test(self):
+        """BlockingConnection: chanel context manager exit survives closed channel"""
+        with self._connect().channel() as channel:
+            self.assertTrue(channel.is_open)
+            channel.close()
+            self.assertTrue(channel.is_closed)
+
+        self.assertTrue(channel.is_closed)
+
+
+class TestChannelContextManagerDoesNotSuppressChannelClosedByBroker(
+        BlockingTestCaseBase):
+    def test(self):
+        """BlockingConnection: chanel context manager doesn't suppress ChannelClosedByBroker exception"""
+
+        exg_name = (
+            "TestChannelContextManagerDoesNotSuppressChannelClosedByBroker" +
+            uuid.uuid1().hex)
+
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
+            with self._connect().channel() as channel:
+                # Passively declaring non-existent exchange should force broker
+                # to close channel
+                channel.exchange_declare(exg_name, passive=True)
+
+        self.assertTrue(channel.is_closed)
 
 
 if __name__ == '__main__':

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -190,9 +190,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         heartbeat.stop.assert_called_once_with()
 
-        self.channel._on_close_meta.assert_called_once_with(
-            pika.channel.ClientChannelErrors.CONNECTION_CLOSED,
-            repr(original_exc))
+        self.channel._on_close_meta.assert_called_once_with(original_exc)
 
         self.assertTrue(self.connection.is_closed)
 


### PR DESCRIPTION
## Backward-incompatible improvements for v1.0.0:
- Raise `ChannelWrongStateError` instead of `ChannelClosed` and `ChannelAlreadyClosing` when requesting channel operation incompatible with channel state. For consistency with `ConnectionWrongStateError` scenarios. Also foregoes having to invent fake reason codes.
- Got rid of `pika.channel.ClientChannelError` enumeration. The fake channel error codes aren't needed any more.
- `"_on_channel_close"` callback registered via `Channel.add_on_close_callback()` passes
exception as reason instead of reply_code/reply_text. For consistency with "on connection closed" callback.
- Removed `Channel.is_closed_by_broker` property (which was added not long ago for v1.0.0). Users can now simply check whether the reason exception passed to the close callback is an instance of `ChannelClosedByBroker` exception.

## Other improvements for v1.0.0:
- Added ChannelClosed-based exceptions ChannelClosedByClient and ChannelClosedByBroker to help user distinguish between the scenarios.