### PR TITLE
Privatize non-blocking adapters' methods add_timeout(), remove_timeout(), and add_connection_threadsafe() for v1.0.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,15 @@ And an example of writing a blocking consumer:
     print('Requeued %i messages' % requeued_messages)
     connection.close()
 
+Pika provides the following adapters
+------------------------------------
+
+- AsyncioConnection  - adapter for the Python3 AsyncIO event loop
+- BlockingConnection - enables blocking, synchronous operation on top of library for simple usage
+- SelectConnection   - fast asynchronous adapter without 3rd-party dependencies
+- TornadoConnection  - adapter for use with the Tornado IO Loop http://tornadoweb.org
+- TwistedConnection  - adapter for use with the Twisted asynchronous package http://twistedmatrix.com/
+
 Multiple Connection Parameters
 ------------------------------
 You can also pass multiple connection parameter instances for
@@ -80,18 +89,52 @@ fail.
                                   connection_attempts=5, retry_delay=1))
     connection = pika.BlockingConnection(configs)
 
-With non-blocking adapters, you can request a connection using multiple
-connection parameter instances via the connection adapter's
-`create_connection()` class method.
+With non-blocking adapters, such as `SelectConnection` and `AsyncioConnection`,
+you can request a connection using multiple connection parameter instances via
+the connection adapter's `create_connection()` class method.
 
-Pika provides the following adapters
-------------------------------------
+Requesting message ACKs from another thread
+-------------------------------------------
+The single-threaded usage constraint of inidivdual Pika connection adapter
+instances may result in a dropped AMQP connection due to heartbeat timeout in
+consumers that take a long time to process an incoming message. A common
+solution is to delegate processing of the incoming messages to another thread
+while the connection adapter's thread continues to service its ioloop's message
+pump.
 
-- AsyncioConnection  - adapter for the Python3 AsyncIO event loop
-- BlockingConnection - enables blocking, synchronous operation on top of library for simple usage
-- SelectConnection   - fast asynchronous adapter without 3rd-party dependencies
-- TornadoConnection  - adapter for use with the Tornado IO Loop http://tornadoweb.org
-- TwistedConnection  - adapter for use with the Twisted asynchronous package http://twistedmatrix.com/
+Messages processed in another thread may not be acked directly from that thread,
+since all accesses to the connection adapter must be from a single thread - the
+thread that is running the adapter's ioloop. However, this may be accomplished
+by requesting a callback to be executed in the adapter's ioloop thread. For
+example, the callback function's implementation might look like this:
+
+.. code :: python
+
+    def ack_message(channel, delivery_tag):
+        """Note that `channel` must be the same pika channel instance via which
+        the message being ACKed was retrieved (AMQP protocol constraint).
+        """
+        if channel.is_open:
+            channel.basic_ack(delivery_tag)
+        else:
+            # Channel is already closed, so we can't ACK this message;
+            # log and/or do something that makes sense for your app in this case.
+            pass
+
+The code running in the other thread may request the `ack_message()` function
+to be executed in the connection adapter's ioloop thread using an
+adapter-specific mechanism:
+
+- :py:class:`pika.BlockingConnection` abstracts its ioloop from the application
+  and thus exposes :py:meth:`pika.BlockingConnection.add_callback_threadsafe()`.
+  Refer to this method's docstring for additional information. For example:
+  `connection.add_callback_threadsafe(functools.partial(ack_message, channel, delivery_tag))`.
+- When using a non-blocking connection adapter, such as
+  :py:class:`pika.AsyncioConnection` or :py:class:`pika.SelectConnection`, you
+  use the underlying asynchronous framework's native API for requesting an
+  ioloop-bound callback from another thread. For example, `SelectConnection`'s
+  `IOLoop` provides `add_callback_threadsafe()`, `Tornado`'s `IOLoop` has
+  `add_callback()`, while `asyncio`'s event loop exposes `call_soon_threadsafe()`.
 
 Connection recovery
 -------------------

--- a/docs/examples/asynchronous_consumer_example.rst
+++ b/docs/examples/asynchronous_consumer_example.rst
@@ -93,7 +93,7 @@ consumer.py::
             else:
                 LOGGER.warning('Connection closed, reopening in 5 seconds: %s',
                                reason)
-                self._connection.add_timeout(5, self.reconnect)
+                self._connection.ioloop.call_later(5, self.reconnect)
 
         def reconnect(self):
             """Will be invoked by the IOLoop timer if the connection is

--- a/docs/examples/asynchronous_publisher_example.rst
+++ b/docs/examples/asynchronous_publisher_example.rst
@@ -86,7 +86,7 @@ publisher.py::
 
             """
             LOGGER.error('Connection open failed, reopening in 5 seconds: %s', err)
-            self._connection.add_timeout(5, self._connection.ioloop.stop)
+            self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
 
         def on_connection_closed(self, connection, reason):
             """This method is invoked by pika when the connection to RabbitMQ is
@@ -104,7 +104,8 @@ publisher.py::
             else:
                 LOGGER.warning('Connection closed, reopening in 5 seconds: %s',
                                reason)
-                self._connection.add_timeout(5, self._connection.ioloop.stop)
+                self._connection.ioloop.call_later(5,
+                                                   self._connection.ioloop.stop)
 
         def open_channel(self):
             """This method will open a new channel with RabbitMQ by issuing the
@@ -267,8 +268,8 @@ publisher.py::
             """
             LOGGER.info('Scheduling next message for %0.1f seconds',
                         self.PUBLISH_INTERVAL)
-            self._connection.add_timeout(self.PUBLISH_INTERVAL,
-                                         self.publish_message)
+            self._connection.ioloop.call_later(self.PUBLISH_INTERVAL,
+                                               self.publish_message)
 
         def publish_message(self):
             """If the class is not stopping, publish a message to RabbitMQ,

--- a/docs/examples/asyncio_consumer.rst
+++ b/docs/examples/asyncio_consumer.rst
@@ -91,7 +91,7 @@ consumer.py::
             else:
                 LOGGER.warning('Connection closed, reopening in 5 seconds: %s',
                                reason)
-                self._connection.add_timeout(5, self.reconnect)
+                self._connection.ioloop.call_later(5, self.reconnect)
 
         def on_connection_open(self, unused_connection):
             """This method is called by pika once the connection to RabbitMQ has

--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -85,7 +85,7 @@ consumer.py::
             else:
                 LOGGER.warning('Connection closed, reopening in 5 seconds: %s',
                                reason)
-                self._connection.add_timeout(5, self.reconnect)
+                self._connection.ioloop.call_later(5, self.reconnect)
 
         def on_connection_open(self, unused_connection):
             """This method is called by pika once the connection to RabbitMQ has

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -74,7 +74,7 @@ class ExampleConsumer(object):
 
         """
         LOGGER.error('Connection open failed: %s', err)
-        self._connection.add_timeout(5, self.reconnect)
+        self._connection.ioloop.call_later(5, self.reconnect)
 
     def on_connection_closed(self, connection, reason):
         """This method is invoked by pika when the connection to RabbitMQ is
@@ -92,7 +92,7 @@ class ExampleConsumer(object):
         else:
             LOGGER.warning('Connection closed, reopening in 5 seconds: %s',
                             reason)
-            self._connection.add_timeout(5, self.reconnect)
+            self._connection.ioloop.call_later(5, self.reconnect)
 
     def reconnect(self):
         """Will be invoked by the IOLoop timer if the connection is

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -81,7 +81,7 @@ class ExamplePublisher(object):
 
         """
         LOGGER.error('Connection open failed, reopening in 5 seconds: %s', err)
-        self._connection.add_timeout(5, self._connection.ioloop.stop)
+        self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
 
     def on_connection_closed(self, connection, reason):
         """This method is invoked by pika when the connection to RabbitMQ is
@@ -99,7 +99,7 @@ class ExamplePublisher(object):
         else:
             LOGGER.warning('Connection closed, reopening in 5 seconds: %s',
                            reason)
-            self._connection.add_timeout(5, self._connection.ioloop.stop)
+            self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
 
     def open_channel(self):
         """This method will open a new channel with RabbitMQ by issuing the
@@ -269,8 +269,8 @@ class ExamplePublisher(object):
         """
         LOGGER.info('Scheduling next message for %0.1f seconds',
                     self.PUBLISH_INTERVAL)
-        self._connection.add_timeout(self.PUBLISH_INTERVAL,
-                                     self.publish_message)
+        self._connection.ioloop.call_later(self.PUBLISH_INTERVAL,
+                                           self.publish_message)
 
     def publish_message(self):
         """If the class is not stopping, publish a message to RabbitMQ,

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -209,43 +209,23 @@ class BaseConnection(connection.Connection):
         """
         return self._nbio.get_native_ioloop()
 
-    def add_timeout(self, deadline, callback):
-        """Add the callback to the IOLoop timer to fire after deadline
-        seconds.
-
-        :param float deadline: The number of seconds to wait to call callback
-        :param method callback: The callback method
-        :return: Handle that can be passed to `remove_timeout()` to cancel the
-            callback.
+    def _adapter_add_timeout(self, deadline, callback):
+        """Implement
+        :py:meth:`pika.connection.Connection._adapter_add_timeout()`.
 
         """
         return self._nbio.call_later(deadline, callback)
 
-    def remove_timeout(self, timeout_id):
-        """Remove the timeout from the IOLoop by the ID returned from
-        add_timeout.
+    def _adapter_remove_timeout(self, timeout_id):
+        """Implement
+        :py:meth:`pika.connection.Connection._adapter_remove_timeout()`.
 
         """
         timeout_id.cancel()
 
-    def add_callback_threadsafe(self, callback):
-        """Requests a call to the given function as soon as possible in the
-        context of this connection's IOLoop thread.
-
-        NOTE: This is the only thread-safe method offered by the connection. All
-         other manipulations of the connection must be performed from the
-         connection's thread.
-
-        For example, a thread may request a call to the
-        `channel.basic_ack` method of a connection that is running in a
-        different thread via
-
-        ```
-        connection.add_callback_threadsafe(
-            functools.partial(channel.basic_ack, delivery_tag=...))
-        ```
-
-        :param method callback: The callback method; must be callable.
+    def _adapter_add_callback_threadsafe(self, callback):
+        """Implement
+        :py:meth:`pika.connection.Connection._adapter_add_callback_threadsafe()`.
 
         """
         if not callable(callback):

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -181,7 +181,7 @@ class _IoloopTimerContext(object):
         :param float duration: non-negative timer duration in seconds
         :param select_connection.SelectConnection connection:
         """
-        assert hasattr(connection, 'add_timeout'), connection
+        assert hasattr(connection, '_adapter_add_timeout'), connection
         self._duration = duration
         self._connection = connection
         self._callback_result = _CallbackResult()
@@ -189,7 +189,7 @@ class _IoloopTimerContext(object):
 
     def __enter__(self):
         """Register a timer"""
-        self._timer_handle = self._connection.add_timeout(
+        self._timer_handle = self._connection._adapter_add_timeout(
             self._duration,
             self._callback_result.signal_once)
         return self
@@ -197,7 +197,7 @@ class _IoloopTimerContext(object):
     def __exit__(self, *_args, **_kwargs):
         """Unregister timer if it hasn't fired yet"""
         if not self._callback_result:
-            self._connection.remove_timeout(self._timer_handle)
+            self._connection._adapter_remove_timeout(self._timer_handle)
             self._timer_handle = None
 
     def is_ready(self):
@@ -218,7 +218,7 @@ class _TimerEvt(object):
         self._callback = callback
 
         # Will be set to timer id returned from the underlying implementation's
-        # `add_timeout` method
+        # `_adapter_add_timeout` method
         self.timer_id = None
 
     def __repr__(self):
@@ -577,7 +577,8 @@ class BlockingConnection(object):
                     impl_channel._get_cookie()._dispatch_events()
 
     def _on_timer_ready(self, evt):
-        """Handle expiry of a timer that was registered via `add_timeout`
+        """Handle expiry of a timer that was registered via
+        `_adapter_add_timeout()`
 
         :param _TimerEvt evt:
 
@@ -585,10 +586,11 @@ class BlockingConnection(object):
         self._ready_events.append(evt)
 
     def _on_threadsafe_callback(self, user_callback):
-        """Handle callback that was registered via `add_callback_threadsafe`.
+        """Handle callback that was registered via
+        `self._impl._adapter_add_callback_threadsafe`.
 
-        :param user_callback: callback passed to `add_callback_threadsafe` by
-                              the application.
+        :param user_callback: callback passed to our
+            `add_callback_threadsafe` by the application.
 
         """
         # Turn it into a 0-delay timeout to take advantage of our existing logic
@@ -684,8 +686,8 @@ class BlockingConnection(object):
 
         NOTE: the timer callbacks are dispatched only in the scope of
         specially-designated methods: see
-        `BlockingConnection.process_data_events` and
-        `BlockingChannel.start_consuming`.
+        `BlockingConnection.process_data_events()` and
+        `BlockingChannel.start_consuming()`.
 
         :param float deadline: The number of seconds to wait to call callback
         :param callable callback: The callback method with the signature
@@ -699,7 +701,7 @@ class BlockingConnection(object):
                 'callback must be a callable, but got %r' % (callback,))
 
         evt = _TimerEvt(callback=callback)
-        timer_id = self._impl.add_timeout(
+        timer_id = self._impl._adapter_add_timeout(
             deadline,
             functools.partial(self._on_timer_ready, evt))
         evt.timer_id = timer_id
@@ -713,6 +715,11 @@ class BlockingConnection(object):
         NOTE: This is the only thread-safe method in `BlockingConnection`. All
          other manipulations of `BlockingConnection` must be performed from the
          connection's thread.
+
+        NOTE: the callbacks are dispatched only in the scope of
+        specially-designated methods: see
+        `BlockingConnection.process_data_events()` and
+        `BlockingChannel.start_consuming()`.
 
         For example, a thread may request a call to the
         `BlockingChannel.basic_ack` method of a `BlockingConnection` that is
@@ -734,7 +741,7 @@ class BlockingConnection(object):
                     'BlockingConnection.add_callback_threadsafe() called on '
                     'closed or closing connection.')
 
-            self._impl.add_callback_threadsafe(
+            self._impl._adapter_add_callback_threadsafe(
                 functools.partial(self._on_threadsafe_callback, callback))
 
     def remove_timeout(self, timeout_id):
@@ -744,7 +751,7 @@ class BlockingConnection(object):
 
         """
         # Remove from the impl's timeout stack
-        self._impl.remove_timeout(timeout_id)
+        self._impl._adapter_remove_timeout(timeout_id)
 
         # Remove from ready events, if the timer fired already
         for i, evt in enumerate(self._ready_events):

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -345,21 +345,28 @@ class TwistedProtocolConnection(pika.connection.Connection):
         return d.addCallback(TwistedChannel)
 
 
-    def add_timeout(self, deadline, callback):
-        """Implement pure virtual
-        :py:ref:meth:`pika.connection.Connection.add_timeout()` method.
+    def _adapter_add_timeout(self, deadline, callback):
+        """Implement
+        :py:meth:`pika.connection.Connection._adapter_add_timeout()`.
 
         """
         check_callback_arg(callback, 'callback')
         return _TimerHandle(self._reactor.callLater(deadline, callback))
 
-    def remove_timeout(self, timeout_id):
-        """Implement pure virtual
-        :py:ref:meth:`pika.connection.Connection.remove_timeout()` method.
+    def _adapter_remove_timeout(self, timeout_id):
+        """Implement
+        :py:meth:`pika.connection.Connection._adapter_remove_timeout()`.
 
-        :param _TimerHandle timeout_id:
         """
         timeout_id.cancel()
+
+    def _adapter_add_callback_threadsafe(self, callback):
+        """Implement
+        :py:meth:`pika.connection.Connection._adapter_add_callback_threadsafe()`.
+
+        """
+        check_callback_arg(callback, 'callback')
+        self._reactor.callFromThread(callback)
 
     def _adapter_connect_stream(self):
         """Implement pure virtual

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -107,7 +107,7 @@ class HeartbeatChecker(object):
         """Stop the heartbeat checker"""
         if self._timer:
             LOGGER.debug('Removing timeout for next heartbeat interval')
-            self._connection.remove_timeout(self._timer)
+            self._connection._adapter_remove_timeout(self._timer)  # pylint: disable=W0212
             self._timer = None
 
     def _close_connection(self):
@@ -156,8 +156,9 @@ class HeartbeatChecker(object):
         every interval seconds.
 
         """
-        self._timer = self._connection.add_timeout(self._interval,
-                                                   self.send_and_check)
+        self._timer = self._connection._adapter_add_timeout(  # pylint: disable=W0212
+            self._interval,
+            self.send_and_check)
 
     def _start_timer(self):
         """If the connection still has this object set for heartbeats, add a

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -166,8 +166,8 @@ class AsyncTestCase(unittest.TestCase):
                                        self.on_closed,
                                        custom_ioloop=ioloop_factory())
         try:
-            self.timeout = self.connection.add_timeout(self.TIMEOUT,
-                                                       self.on_timeout)
+            self.timeout = self.connection._adapter_add_timeout(self.TIMEOUT,
+                                                                self.on_timeout)
             self._run_ioloop()
 
             self.assertFalse(self._timed_out)
@@ -222,7 +222,7 @@ class AsyncTestCase(unittest.TestCase):
     def _safe_remove_test_timeout(self):
         if hasattr(self, 'timeout') and self.timeout is not None:
             self.logger.info("Removing timeout")
-            self.connection.remove_timeout(self.timeout)
+            self.connection._adapter_remove_timeout(self.timeout)
             self.timeout = None
 
     def _stop(self):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -75,8 +75,8 @@ class BlockingTestCaseBase(unittest.TestCase):
 
         # We use impl's timer directly in order to get a callback regardless
         # of BlockingConnection's event dispatch modality
-        connection._impl.add_timeout(self.TIMEOUT, # pylint: disable=E1101
-                                     self._on_test_timeout)
+        connection._impl._adapter_add_timeout(self.TIMEOUT, # pylint: disable=E1101
+                                              self._on_test_timeout)
 
         # Patch calls into I/O loop to fail test if exceptions are
         # leaked back through SelectConnection or the I/O loop.

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -32,8 +32,10 @@ class ConnectionTemplate(connection.Connection):
     _adapter_emit_data = connection.Connection._adapter_emit_data
     _adapter_get_write_buffer_size = (
         connection.Connection._adapter_get_write_buffer_size)
-    add_timeout = connection.Connection.add_timeout
-    remove_timeout = connection.Connection.remove_timeout
+    _adapter_add_timeout = connection.Connection._adapter_add_timeout
+    _adapter_remove_timeout = connection.Connection._adapter_remove_timeout
+    _adapter_add_callback_threadsafe = (
+        connection.Connection._adapter_add_callback_threadsafe)
 
 
 class ChannelTests(unittest.TestCase):

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -168,7 +168,7 @@ class HeartbeatTests(unittest.TestCase):
         self.assertEqual(self.obj._heartbeat_frames_sent, 1)
 
     def test_setup_timer_called(self):
-        self.mock_conn.add_timeout.assert_called_once_with(
+        self.mock_conn._adapter_add_timeout.assert_called_once_with(
             self.INTERVAL, self.obj.send_and_check)
 
     @mock.patch('pika.heartbeat.HeartbeatChecker._setup_timer')


### PR DESCRIPTION
## Backward-incompatible cleanup for v1.0.0:
- Privatize non-blocking adapters' add_timeout(), remove_timeout(), add_connection_threadsafe().
  - Rationale: pika.connection.Connection defines the abstract I/O methods
for services that it and generic connection tests need which may change without notice. But they are not for clients, who should instead be using the native methods for timers and thread-safe callbacks provided by their ioloops. In other words, a non-blocking connection instance is not an ioloop.

## Other changes:
- Added blurb in README describing how to safely ACK a mesage from another thread.