### PR TITLE
Update the client and server configuration examples for TLS communication

### DIFF
--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -1,7 +1,7 @@
 TLS parameters example
 ======================
 
-This examples demonstrates a TLS session with RabbitMQ using mutual authentication. It was tested against RabbitMQ 3.7.4, using Python 3.6.5 and Pika 1.0.0b1.
+This example demonstrates a TLS session with RabbitMQ using mutual authentication (server and client authentication). It was tested against RabbitMQ 3.7.4, using Python 3.6.5 and Pika 1.0.0b1.
 
 See https://www.rabbitmq.com/ssl.html for certificate generation and RabbitMQ TLS configuration.
 
@@ -16,14 +16,13 @@ tls_example.py::
         cafile="/Users/me/tls-gen/basic/testca/cacert.pem")
     context.load_cert_chain("/Users/me/tls-gen/basic/client/cert.pem",
                             "/Users/me/tls-gen/basic/client/key.pem")
-    server_hostname = "example.com"
     ssl_options = pika.SSLOptions(context=context,
-                                  server_hostname=server_hostname)
+                                  server_hostname="example.com")
     conn_params = pika.ConnectionParameters(ssl_options=ssl_options)
     
     with pika.BlockingConnection(conn_params) as conn:
         ch = conn.channel()
-        print(ch.queue_declare("foobar"))
+        ch.queue_declare("foobar")
         ch.publish("", "foobar", "Hello, world!")
         print(ch.basic_get("foobar"))
 

--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -28,7 +28,7 @@ tls_example.py::
 
 rabbitmq.config::
 
-    # Enable A.M.Q.P.S.
+    # Enable AMQPS
     listeners.ssl.default = 5671
     ssl_options.cacertfile = PIKA_DIR/testdata/certs/ca_certificate.pem
     ssl_options.certfile = PIKA_DIR/testdata/certs/server_certificate.pem
@@ -36,7 +36,7 @@ rabbitmq.config::
     ssl_options.verify = verify_peer
     ssl_options.fail_if_no_peer_cert = true
 
-    # Enable H.T.T.P.S.
+    # Enable HTTPS
     management.listener.port = 15671
     management.listener.ssl = true
     management.listener.ssl_opts.cacertfile = PIKA_DIR/testdata/certs/ca_certificate.pem

--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -17,7 +17,8 @@ tls_example.py::
     context.load_cert_chain("/Users/me/tls-gen/basic/client/cert.pem",
                             "/Users/me/tls-gen/basic/client/key.pem")
     ssl_options = pika.SSLOptions(context, "example.com")
-    conn_params = pika.ConnectionParameters(ssl_options=ssl_options)
+    conn_params = pika.ConnectionParameters(port=5671,
+                                            ssl_options=ssl_options)
     
     with pika.BlockingConnection(conn_params) as conn:
         ch = conn.channel()

--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -1,9 +1,9 @@
 TLS parameters example
 ======================
 
-This examples demonstrates a TLS session with RabbitMQ using mutual authentication. It was tested against RabbitMQ 3.7.4, using Python 3.6.5 and Pika `1.0.0b1`.
+This examples demonstrates a TLS session with RabbitMQ using mutual authentication. It was tested against RabbitMQ 3.7.4, using Python 3.6.5 and Pika 1.0.0b1.
 
-See https://www.rabbitmq.com/ssl.html for certificate generation and RabbitMQ SSL configuration instructions.
+See https://www.rabbitmq.com/ssl.html for certificate generation and RabbitMQ TLS configuration.
 
 tls_example.py::
 

--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -13,10 +13,10 @@ tls_example.py::
 
     logging.basicConfig(level=logging.INFO)
     context = ssl.create_default_context(
-        cafile="/Users/me/tls-gen/basic/testca/cacert.pem")
-    context.load_cert_chain("/Users/me/tls-gen/basic/client/cert.pem",
-                            "/Users/me/tls-gen/basic/client/key.pem")
-    ssl_options = pika.SSLOptions(context, "example.com")
+        cafile="PIKA_DIR/testdata/certs/ca_certificate.pem")
+    context.load_cert_chain("PIKA_DIR/testdata/certs/client_certificate.pem",
+                            "PIKA_DIR/testdata/certs/client_key.pem")
+    ssl_options = pika.SSLOptions(context, "localhost")
     conn_params = pika.ConnectionParameters(port=5671,
                                             ssl_options=ssl_options)
     
@@ -30,15 +30,15 @@ rabbitmq.config::
 
     # Enable A.M.Q.P.S.
     listeners.ssl.default = 5671
-    ssl_options.cacertfile = /Users/me/tls-gen/basic/testca/cacert.pem
-    ssl_options.certfile = /Users/me/tls-gen/basic/server/cert.pem
-    ssl_options.keyfile = /Users/me/tls-gen/basic/server/key.pem
+    ssl_options.cacertfile = PIKA_DIR/testdata/certs/ca_certificate.pem
+    ssl_options.certfile = PIKA_DIR/testdata/certs/server_certificate.pem
+    ssl_options.keyfile = PIKA_DIR/testdata/certs/server_key.pem
     ssl_options.verify = verify_peer
     ssl_options.fail_if_no_peer_cert = true
 
     # Enable H.T.T.P.S.
     management.listener.port = 15671
     management.listener.ssl = true
-    management.listener.ssl_opts.cacertfile = /Users/me/tls-gen/basic/testca/cacert.pem
-    management.listener.ssl_opts.certfile = /Users/me/tls-gen/basic/server/cert.pem
-    management.listener.ssl_opts.keyfile = /Users/me/tls-gen/basic/server/key.pem
+    management.listener.ssl_opts.cacertfile = PIKA_DIR/testdata/certs/ca_certificate.pem
+    management.listener.ssl_opts.certfile = PIKA_DIR/testdata/certs/server_certificate.pem
+    management.listener.ssl_opts.keyfile = PIKA_DIR/testdata/certs/server_key.pem

--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -16,8 +16,7 @@ tls_example.py::
         cafile="/Users/me/tls-gen/basic/testca/cacert.pem")
     context.load_cert_chain("/Users/me/tls-gen/basic/client/cert.pem",
                             "/Users/me/tls-gen/basic/client/key.pem")
-    ssl_options = pika.SSLOptions(context=context,
-                                  server_hostname="example.com")
+    ssl_options = pika.SSLOptions(context, "example.com")
     conn_params = pika.ConnectionParameters(ssl_options=ssl_options)
     
     with pika.BlockingConnection(conn_params) as conn:

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -125,13 +125,11 @@ class AsyncTestCase(unittest.TestCase):
         self.logger.info('testing using TLS/SSL connection to port 5671')
         params = self._new_plaintext_connection_params()
         params.port = 5671
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
-        context.verify_mode = ssl.CERT_REQUIRED
-        context.load_verify_locations('testdata/certs/ca_certificate.pem')
+        context = ssl.create_default_context(
+            cafile='testdata/certs/ca_certificate.pem')
         context.load_cert_chain('testdata/certs/client_certificate.pem',
                                 'testdata/certs/client_key.pem')
-        params.ssl_options = pika.SSLOptions(context)
-
+        params.ssl_options = pika.SSLOptions(context, "localhost")
         return params
 
     @staticmethod

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -129,7 +129,7 @@ class AsyncTestCase(unittest.TestCase):
             cafile='testdata/certs/ca_certificate.pem')
         context.load_cert_chain('testdata/certs/client_certificate.pem',
                                 'testdata/certs/client_key.pem')
-        params.ssl_options = pika.SSLOptions(context, "localhost")
+        params.ssl_options = pika.SSLOptions(context, 'localhost')
         return params
 
     @staticmethod


### PR DESCRIPTION
- ``ssl.PROTOCOL_TLSv1`` is now deprecated (https://docs.python.org/3/library/ssl.html#ssl.PROTOCOL_TLSv1), ``ssl.PROTOCOL_TLS`` should be preferred, which is used by ``ssl.create_default_context`` among other parameters which provide a higher security level (https://docs.python.org/3/library/ssl.html#ssl.create_default_context).
- Checking server hostnames prevents man-in-the-middle attacks (https://github.com/pika/pika/issues/464).
- RabbitMQ 3.7.0 introduced a new systemctl syntax for rabbitmq.conf (https://www.rabbitmq.com/configure.html#config-file).
- TLS server configuration for HTTPS for the ``rabbitmq-management`` plugin might as well be demonstrated.