### PR TITLE
Fix setup package missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     maintainer='Gavin M. Roy',
     maintainer_email='gavinmroy@gmail.com',
     url='https://pika.readthedocs.io',
-    packages=['pika', 'pika.adapters'],
+    packages=setuptools.find_packages('pika', 'pika.*'),
     license='BSD',
     install_requires=requirements,
     package_data={'': ['LICENSE', 'README.rst']},


### PR DESCRIPTION
When I install from git url `git+https://github.com/pika/pika.git@master` the package `pika.adapters.utils` is missing