### PR TITLE
Fix race condition between BlockingConnection.add_callback_threasafe() and BlockingConnection._cleanup()

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -352,7 +352,10 @@ class IOLoop(AbstractSelectorIOLoop):
         if self._callbacks is not None:
             self._poller.close()
             self._timer.close()
-            self._callbacks = None
+            # Set _callbacks to empty list rather than None so that race from
+            # another thread calling add_callback_threadsafe() won't result in
+            # AttributeError
+            self._callbacks = []
 
     @staticmethod
     def _get_poller(get_wait_seconds, process_timeouts):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -635,6 +635,18 @@ class TestAddCallbackThreadsafeFromAnotherThread(BlockingTestCaseBase):
         self.assertLess(elapsed, 0.25)
 
 
+class TestAddCallbackThreadsafeOnClosedConnectionRaisesWrongState(
+        BlockingTestCaseBase):
+
+    def test(self):
+        """BlockingConnection.add_callback_threadsafe on closed connection raises ConnectionWrongStateError"""
+        connection = self._connect()
+        connection.close()
+
+        with self.assertRaises(pika.exceptions.ConnectionWrongStateError):
+            connection.add_callback_threadsafe(lambda: None)
+
+
 class TestAddTimeoutRemoveTimeout(BlockingTestCaseBase):
 
     def test(self):


### PR DESCRIPTION
Fix race condition between `BlockingConnection.add_callback_threasafe()` and `BlockingConnection._cleanup()`.

`BlockingConnection.add_callback_threasafe()` raises `ConnectionWrongStateError` when called during/after blocking connection is closed.