### PR TITLE
Remove inapplicable state descriptors BlockingConnection.is_closing and BlockingChannel.is_closing for Pika v1.0.0

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -729,6 +729,11 @@ class BlockingConnection(object):
             closed
         """
         with self._cleanup_mutex:
+            # NOTE: keep in mind that we may be called from another thread and
+            # this mutex only synchronizes us with our connection cleanup logic,
+            # so a simple check for "is_closed" is pretty much all we're allowed
+            # to do here besides calling the only thread-safe method
+            # _adapter_add_callback_threadsafe().
             if self.is_closed:
                 raise exceptions.ConnectionWrongStateError(
                     'BlockingConnection.add_callback_threadsafe() called on '

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -878,14 +878,6 @@ class BlockingConnection(object):
         return self._impl.is_closed
 
     @property
-    def is_closing(self):
-        """
-        Returns True if connection is in the process of closing due to
-        client-initiated `close` request, but closing is not yet complete.
-        """
-        return self._impl.is_closing
-
-    @property
     def is_open(self):
         """
         Returns a boolean reporting the current connection state.
@@ -1292,16 +1284,6 @@ class BlockingChannel(object):
 
         """
         return self._impl.is_closed
-
-    @property
-    def is_closing(self):
-        """Returns True if client-initiated closing of the channel is in
-        progress.
-
-        :rtype: bool
-
-        """
-        return self._impl.is_closing
 
     @property
     def is_open(self):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -146,12 +146,12 @@ class TestCreateAndCloseConnection(BlockingTestCaseBase):
         self.assertIsInstance(connection, pika.BlockingConnection)
         self.assertTrue(connection.is_open)
         self.assertFalse(connection.is_closed)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
 
         connection.close()
         self.assertTrue(connection.is_closed)
         self.assertFalse(connection.is_open)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
 
 
 class TestCreateConnectionWithNoneSocketAndStackTimeouts(BlockingTestCaseBase):
@@ -223,12 +223,12 @@ class TestMultiCloseConnectionRaisesWrongState(BlockingTestCaseBase):
         self.assertIsInstance(connection, pika.BlockingConnection)
         self.assertTrue(connection.is_open)
         self.assertFalse(connection.is_closed)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
 
         connection.close()
         self.assertTrue(connection.is_closed)
         self.assertFalse(connection.is_open)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
 
         with self.assertRaises(pika.exceptions.ConnectionWrongStateError):
             connection.close()
@@ -347,7 +347,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
         connection.close()
         self.assertTrue(connection.is_closed)
         self.assertFalse(connection.is_open)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
 
         self.assertFalse(connection._impl._channels)
 
@@ -761,7 +761,7 @@ class TestConnectionProperties(BlockingTestCaseBase):
         connection = self._connect()
 
         self.assertTrue(connection.is_open)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
         self.assertFalse(connection.is_closed)
 
         self.assertTrue(connection.basic_nack_supported)
@@ -771,7 +771,7 @@ class TestConnectionProperties(BlockingTestCaseBase):
 
         connection.close()
         self.assertFalse(connection.is_open)
-        self.assertFalse(connection.is_closing)
+        self.assertFalse(connection._impl.is_closing)
         self.assertTrue(connection.is_closed)
 
 
@@ -786,13 +786,13 @@ class TestCreateAndCloseChannel(BlockingTestCaseBase):
         self.assertIsInstance(ch, blocking_connection.BlockingChannel)
         self.assertTrue(ch.is_open)
         self.assertFalse(ch.is_closed)
-        self.assertFalse(ch.is_closing)
+        self.assertFalse(ch._impl.is_closing)
         self.assertIs(ch.connection, connection)
 
         ch.close()
         self.assertTrue(ch.is_closed)
         self.assertFalse(ch.is_open)
-        self.assertFalse(ch.is_closing)
+        self.assertFalse(ch._impl.is_closing)
 
 
 class TestExchangeDeclareAndDelete(BlockingTestCaseBase):


### PR DESCRIPTION
## Backward-incompatible change for pika v1.0.0
- Remove inapplicable state descriptors `BlockingConnection.is_closing` and `BlockingChannel.is_closing`.  Rationale: `BlockingConnection` and `BlockingChannel` publicly only have two states - either open or closed, so they have no in-between state "is_closing" as far as the API users are concerned.