### PR TITLE
Fix setup.py included packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setuptools.setup(
     maintainer='Gavin M. Roy',
     maintainer_email='gavinmroy@gmail.com',
     url='https://pika.readthedocs.io',
-    packages=setuptools.find_packages('pika', 'pika.*'),
+    packages=setuptools.find_packages(include=['pika', 'pika.*']),
     license='BSD',
     install_requires=requirements,
     package_data={'': ['LICENSE', 'README.rst']},


### PR DESCRIPTION
Current setup.py does not install pika module correctly due to a bug in find_pakages syntax. This merge request fixes that.