### PR TITLE
WIP: Validate parameters to API methods that have changed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,19 @@ Version History
 
 - `BlockingConnection.consume` now returns `(None, None, None)` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
 
+API changes from previous versions:
+
+pika/channel.py
+
+def basic_consume(self,
+                  queue,
+                  on_message_callback,
+                  auto_ack=False,
+                  exclusive=False,
+                  consumer_tag=None,
+                  arguments=None,
+                  callback=None)
+
 0.11.2 2017-11-30
 -----------------
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1642,9 +1642,12 @@ class BlockingChannel(object):
             consumer_tag is already present.
 
         """
+        if not isinstance(queue, compat.basestring):
+            raise TypeError('queue must be a str or unicode str, but got %r' %
+                            (queue,))
         if not callable(on_message_callback):
-            raise ValueError('callback on_message_callback must be callable; got %r'
-                             % on_message_callback)
+            raise TypeError('callback on_message_callback must be callable; got %r'
+                            % on_message_callback)
 
         return self._basic_consume_impl(
             queue=queue,

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -12,7 +12,7 @@ import uuid
 import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
-from pika.compat import unicode_type, dictkeys, is_integer
+from pika.compat import basestring, unicode_type, dictkeys, is_integer
 
 
 LOGGER = logging.getLogger(__name__)
@@ -301,6 +301,7 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(queue, 'queue')
         self._require_callback(on_message_callback)
         self._raise_if_not_open()
         self._validate_rpc_completion_callback(callback)
@@ -1442,6 +1443,28 @@ class Channel(object):
 
         """
         LOGGER.error('Unexpected frame: %r', frame_value)
+
+    @staticmethod
+    def _require_string(value, value_name):
+        """Require that value is a string
+
+        :raises: TypeError
+
+        """
+        if not isinstance(value, basestring):
+            raise TypeError('%s must be a str or unicode str, but got %r' %
+                            (value_name, value,))
+
+    @staticmethod
+    def _require_callback(callback):
+        """Require that callback is callable and is not None
+
+        :raises: TypeError
+
+        """
+        if not callable(callback):
+            raise TypeError(
+                'Callback must be callable, but got %r' % (callback,))
 
     @staticmethod
     def _require_callback(callback):

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -5,7 +5,7 @@ import re
 import socket
 import sys as _sys
 
-PY2 = _sys.version_info < (3,)
+PY2 = _sys.version_info.major == 2
 PY3 = not PY2
 RE_NUM = re.compile(r'(\d+).+')
 
@@ -29,7 +29,7 @@ try:
 except AttributeError:
     SOL_TCP = socket.IPPROTO_TCP
 
-if not PY2:
+if PY3:
     # these were moved around for Python 3
     from urllib.parse import (quote as url_quote, unquote as url_unquote,
                               urlencode, parse_qs as url_parse_qs,

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -47,6 +47,17 @@ class BlockingChannelTests(unittest.TestCase):
     def test_init_initial_value_buback_return(self):
         self.assertIsNone(self.obj._puback_return)
 
+    def test_basic_consume_legacy_parameter_queue(self):
+        # This is for the unlikely scenario where only
+        # the first parameter is updated
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume('queue',
+                                   'whoops this should be a callback')
+
+    def test_basic_consume_legacy_parameter_callback(self):
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume(mock.Mock(), 'queue')
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -250,6 +250,21 @@ class ChannelTests(unittest.TestCase):
         self.obj.basic_cancel(consumer_tag, callback=callback_mock)
         self.assertFalse(rpc.called)
 
+    def test_basic_consume_legacy_parameter_queue(self):
+        # This is for the unlikely scenario where only
+        # the first parameter is updated
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume('queue',
+                                   'whoops this should be a callback')
+
+    def test_basic_consume_legacy_parameter_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume(callback_mock, 'queue')
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()


### PR DESCRIPTION
Fixes #977

Raise helpful exceptions if legacy parameter ordering is used after upgrading to Pika 1.0.0