### PR TITLE
Fixup for #1055

### DIFF
--- a/examples/consume.py
+++ b/examples/consume.py
@@ -1,17 +1,15 @@
+import functools
+import logging
 import pika
 
-def on_message(channel, method_frame, header_frame, body):
-    channel.queue_declare(queue=body, auto_delete=True)
+LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
+              '-35s %(lineno) -5d: %(message)s')
+LOGGER = logging.getLogger(__name__)
 
-    if body.startswith("queue:"):
-        queue = body.replace("queue:", "")
-        key = body + "_key"
-        print("Declaring queue %s bound with key %s" %(queue, key))
-        channel.queue_declare(queue=queue, auto_delete=True)
-        channel.queue_bind(queue=queue, exchange="test_exchange", routing_key=key)
-    else:
-        print("Message body", body)
+logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
 
+def on_message(channel, method_frame, header_frame, body, userdata=None):
+    LOGGER.info('Userdata: {} Message body: {}'.format(userdata, body))
     channel.basic_ack(delivery_tag=method_frame.delivery_tag)
 
 credentials = pika.PlainCredentials('guest', 'guest')
@@ -24,7 +22,8 @@ channel.queue_declare(queue="standard", auto_delete=True)
 channel.queue_bind(queue="standard", exchange="test_exchange", routing_key="standard_key")
 channel.basic_qos(prefetch_count=1)
 
-channel.basic_consume(on_message, 'standard')
+on_message_callback = functools.partial(on_message, userdata='on_message_userdata')
+channel.basic_consume(on_message_callback, 'standard')
 
 try:
     channel.start_consuming()

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -23,13 +23,22 @@ class HeartbeatChecker(object):
         :param pika.connection.Connection: Connection object
         :param int interval: Heartbeat check interval. Note: heartbeats will
                              be sent at interval / 2 frequency.
+        :param int idle_count: The number of heartbeat intervals without data
+                               received that will close the current connection.
 
         """
         self._connection = connection
+
         # Note: see the following document:
         # https://www.rabbitmq.com/heartbeats.html#heartbeats-timeout
         self._interval = float(interval / 2)
-        self._max_idle_count = idle_count
+
+        # Note: even though we're sending heartbeats in half the specified
+        # interval, the broker will be sending them to us at the specified
+        # interval. This means we'll be checking for an idle connection
+        # twice as many times as the broker will send heartbeats to us,
+        # so we need to double the max idle count here
+        self._max_idle_count = idle_count * 2
 
         # Initialize counters
         self._bytes_received = 0
@@ -82,9 +91,12 @@ class HeartbeatChecker(object):
         been idle too long.
 
         """
-        LOGGER.debug('Received %i heartbeat frames, sent %i',
+        LOGGER.debug('Received %i heartbeat frames, sent %i, '
+                     'idle intervals %i, max idle count %i',
                      self._heartbeat_frames_received,
-                     self._heartbeat_frames_sent)
+                     self._heartbeat_frames_sent,
+                     self._idle_byte_intervals,
+                     self._max_idle_count)
 
         if self.connection_is_idle:
             return self._close_connection()

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -29,7 +29,7 @@ class HeartbeatTests(unittest.TestCase):
         self.assertEqual(self.obj._interval, self.HALF_INTERVAL)
 
     def test_default_initialization_max_idle_count(self):
-        self.assertEqual(self.obj._max_idle_count, self.obj.MAX_IDLE_COUNT)
+        self.assertEqual(self.obj._max_idle_count, self.obj.MAX_IDLE_COUNT * 2)
 
     def test_constructor_assignment_connection(self):
         self.assertIs(self.obj._connection, self.mock_conn)


### PR DESCRIPTION
Note: even though we send heartbeats in half the specified interval, the broker will be sending them to us at the specified interval. This means we will be checking for an idle connection twice as many times as the broker will send heartbeats to us, so we need to double the max idle count.

The changes in `example/consume.py` back-port the example changes from the `master` branch.

Fixes #1055