### PR TITLE
Fixup for #1055

### DIFF
--- a/examples/consume.py
+++ b/examples/consume.py
@@ -6,7 +6,7 @@ LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
               '-35s %(lineno) -5d: %(message)s')
 LOGGER = logging.getLogger(__name__)
 
-logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
+logging.basicConfig(level=logging.DEBUG, format=LOG_FORMAT)
 
 def on_message(channel, method_frame, header_frame, body, userdata=None):
     LOGGER.info('Userdata: {} Message body: {}'.format(userdata, body))

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -73,7 +73,7 @@ class HeartbeatTests(unittest.TestCase):
         self.assertEqual(self.obj._interval, self.HALF_INTERVAL)
 
     def test_default_initialization_max_idle_count(self):
-        self.assertEqual(self.obj._max_idle_count, self.obj.MAX_IDLE_COUNT)
+        self.assertEqual(self.obj._max_idle_count, self.obj.MAX_IDLE_COUNT * 2)
 
     def test_constructor_assignment_connection(self):
         self.assertIs(self.obj._connection, self.mock_conn)


### PR DESCRIPTION
Note: even though we send heartbeats in half the specified interval, the broker will be sending them to us at the specified interval. This means we will be checking for an idle connection twice as many times as the broker will send heartbeats to us, so we need to double the max idle count.

Fixes #1055

(cherry picked from commit c921b25b8114fe2fc231aa322e65cf29ddc0dcb0)