### PR TITLE
Validate parameters to API methods that have changed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -75,8 +75,6 @@ exchange_bind
 exchange_delete
 exchange_unbind
 flow
-
-TODO:
 queue_delete
 queue_purge
 queue_unbind

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,34 @@
 Version History
 ===============
 
-1.0.0b1 2018-12-31
+1.0.0b2 2019-01-22
+------------------
 
 `GitHub milestone <https://github.com/pika/pika/milestone/8>`_
 
-- `AsyncioConnection`, `TornadoConnection` and `TwistedProtocolConnection` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
-- `BlockingConnection.consume` now returns `(None, None, None)` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
-- Python `3.7` support (`Issue <https://github.com/pika/pika/issues/1107>`_)
+- ``AsyncioConnection``, ``TornadoConnection`` and ``TwistedProtocolConnection`` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
+- ``BlockingConnection.consume`` now returns ``(None, None, None)`` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
+- Python 3.7 support (`Issue <https://github.com/pika/pika/issues/1107>`_)
+
+
+**IMPORTANT**: The signature of the following methods has changed from Pika 0.13.0. In general, the callback parameter that indicates completion of the method has been moved to the end of the parameter list to be consistent with other parts of Pika's API and with other libraries in general.
+
+- ``basic_cancel``
+- ``basic_consume``
+- ``basic_get``
+- ``basic_qos``
+- ``basic_recover``
+- ``confirm_delivery``
+- ``exchange_bind``
+- ``exchange_declare``
+- ``exchange_delete``
+- ``exchange_unbind``
+- ``flow``
+- ``queue_bind``
+- ``queue_declare``
+- ``queue_delete``
+- ``queue_purge``
+- ``queue_unbind``
 
 0.12.0 2018-06-19
 -----------------
@@ -57,28 +78,6 @@ New features:
 Please see `examples/basic_consumer_threaded.py` for an example. As always, `SelectConnection` and a fully async consumer/publisher is the preferred method of using Pika.
 
 Heartbeats are now sent at an interval equal to 1/2 of the negotiated idle connection timeout. RabbitMQ's default timeout value is 60 seconds, so heartbeats will be sent at a 30 second interval. In addition, Pika's check for an idle connection will be done at an interval equal to the timeout value plus 5 seconds to allow for delays. This results in an interval of 65 seconds by default.
-
-API changes from previous versions:
-
-pika/channel.py
-
-basic_consume
-exchange_declare
-queue_bind
-queue_declare
-basic_cancel
-basic_get
-basic_qos
-basic_recover
-confirm_delivery
-exchange_bind
-exchange_delete
-exchange_unbind
-flow
-queue_delete
-queue_purge
-queue_unbind
-
 
 0.11.2 2017-11-30
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -69,10 +69,10 @@ queue_declare
 basic_cancel
 basic_get
 basic_qos
-
-TODO:
 basic_recover
 confirm_delivery
+
+TODO:
 exchange_bind
 exchange_delete
 exchange_unbind

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -58,6 +58,13 @@ Please see `examples/basic_consumer_threaded.py` for an example. As always, `Sel
 
 Heartbeats are now sent at an interval equal to 1/2 of the negotiated idle connection timeout. RabbitMQ's default timeout value is 60 seconds, so heartbeats will be sent at a 30 second interval. In addition, Pika's check for an idle connection will be done at an interval equal to the timeout value plus 5 seconds to allow for delays. This results in an interval of 65 seconds by default.
 
+API changes from previous versions:
+
+pika/channel.py
+
+basic_consume
+queue_declare
+
 0.11.2 2017-11-30
 -----------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,6 +67,21 @@ exchange_declare
 queue_bind
 queue_declare
 
+TODO:
+basic_cancel
+basic_get
+basic_qos
+basic_recover
+confirm_delivery
+exchange_bind
+exchange_delete
+exchange_unbind
+flow
+queue_delete
+queue_purge
+queue_unbind
+
+
 0.11.2 2017-11-30
 -----------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -67,10 +67,10 @@ exchange_declare
 queue_bind
 queue_declare
 basic_cancel
-
-TODO:
 basic_get
 basic_qos
+
+TODO:
 basic_recover
 confirm_delivery
 exchange_bind

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -71,12 +71,12 @@ basic_get
 basic_qos
 basic_recover
 confirm_delivery
-
-TODO:
 exchange_bind
 exchange_delete
 exchange_unbind
 flow
+
+TODO:
 queue_delete
 queue_purge
 queue_unbind

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -66,9 +66,9 @@ basic_consume
 exchange_declare
 queue_bind
 queue_declare
+basic_cancel
 
 TODO:
-basic_cancel
 basic_get
 basic_qos
 basic_recover

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -64,6 +64,7 @@ pika/channel.py
 
 basic_consume
 queue_declare
+exchange_declare
 
 0.11.2 2017-11-30
 -----------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,8 +63,9 @@ API changes from previous versions:
 pika/channel.py
 
 basic_consume
-queue_declare
 exchange_declare
+queue_bind
+queue_declare
 
 0.11.2 2017-11-30
 -----------------

--- a/docs/examples/tls_mutual_authentication.rst
+++ b/docs/examples/tls_mutual_authentication.rst
@@ -1,7 +1,7 @@
 TLS parameters example
 ======================
 
-This example demonstrates a TLS session with RabbitMQ using mutual authentication (server and client authentication). It was tested against RabbitMQ 3.7.4, using Python 3.6.5 and Pika 1.0.0b1.
+This example demonstrates a TLS session with RabbitMQ using mutual authentication (server and client authentication). It was tested against RabbitMQ 3.7.4, using Python 3.6.5 and Pika 1.0.0.
 
 See `the RabbitMQ TLS/SSL documentation <https://www.rabbitmq.com/ssl.html>`_ for certificate generation and RabbitMQ TLS configuration. Please note that the `RabbitMQ TLS (x509 certificate) authentication mechanism <https://github.com/rabbitmq/rabbitmq-auth-mechanism-ssl>`_ must be enabled for these examples to work.
 

--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -1,14 +1,34 @@
 Version History
 ===============
 
-1.0.0b1 2018-12-31
+1.0.0b2 2019-01-22
 ------------------
 
 `GitHub milestone <https://github.com/pika/pika/milestone/8>`_
 
-- `AsyncioConnection`, `TornadoConnection` and `TwistedProtocolConnection` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
-- `BlockingConnection.consume` now returns `(None, None, None)` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
-- Python `3.7` support (`Issue <https://github.com/pika/pika/issues/1107>`_)
+- ``AsyncioConnection`, ``TornadoConnection`` and ``TwistedProtocolConnection`` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
+- ``BlockingConnection.consume`` now returns ``(None, None, None)`` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
+- Python 3.7 support (`Issue <https://github.com/pika/pika/issues/1107>`_)
+
+
+**IMPORTANT**: The signature of the following methods has changed from Pika 0.13.0. In general, the callback parameter that indicates completion of the method has been moved to the end of the parameter list to be consistent with other parts of Pika's API and with other libraries in general.
+
+- ``basic_cancel``
+- ``basic_consume``
+- ``basic_get``
+- ``basic_qos``
+- ``basic_recover``
+- ``confirm_delivery``
+- ``exchange_bind``
+- ``exchange_declare``
+- ``exchange_delete``
+- ``exchange_unbind``
+- ``flow``
+- ``queue_bind``
+- ``queue_declare``
+- ``queue_delete``
+- ``queue_purge``
+- ``queue_unbind``
 
 0.12.0 2018-06-19
 -----------------

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.0b1'
+__version__ = '1.0.0b2'
 
 import logging
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1642,9 +1642,12 @@ class BlockingChannel(object):
             consumer_tag is already present.
 
         """
+        if not isinstance(queue, compat.basestring):
+            raise TypeError('queue must be a str or unicode str, but got %r' %
+                            (queue,))
         if not callable(on_message_callback):
-            raise ValueError('callback on_message_callback must be callable; got %r'
-                             % on_message_callback)
+            raise TypeError('callback on_message_callback must be callable; got %r'
+                            % on_message_callback)
 
         return self._basic_consume_impl(
             queue=queue,

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -2552,6 +2552,9 @@ class BlockingChannel(object):
           `spec.Queue.DeclareOk`
 
         """
+        if not isinstance(queue, compat.basestring):
+            raise TypeError('queue must be a str or unicode str, but got %r' %
+                            (queue,))
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
                 declare_ok_result:
             self._impl.queue_declare(

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -2630,6 +2630,12 @@ class BlockingChannel(object):
           `spec.Queue.BindOk`
 
         """
+        if not isinstance(queue, compat.basestring):
+            raise TypeError('queue must be a str or unicode str, but got %r' %
+                            (queue,))
+        if not isinstance(exchange, compat.basestring):
+            raise TypeError('exchange must be a str or unicode str, but got %r' %
+                            (exchange,))
         with _CallbackResult(
             self._MethodFrameCallbackResultArgs) as bind_ok_result:
             self._impl.queue_bind(queue=queue,

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -2430,6 +2430,9 @@ class BlockingChannel(object):
           `spec.Exchange.DeclareOk`
 
         """
+        if not isinstance(exchange, compat.basestring):
+            raise TypeError('exchange must be a str or unicode str, but got %r' %
+                            (exchange,))
         with _CallbackResult(
             self._MethodFrameCallbackResultArgs) as declare_ok_result:
             self._impl.exchange_declare(

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -24,14 +24,11 @@ import logging
 import threading
 import time
 
-import pika.channel
-
-from pika.adapters.utils import connection_workflow
-from pika import compat
-import pika.connection
-from pika import exceptions
-
+import pika.compat as compat
+import pika.exceptions as exceptions
 import pika.spec
+import pika.validators as validators
+from pika.adapters.utils import connection_workflow
 
 # NOTE: import SelectConnection after others to avoid circular depenency
 from pika.adapters import select_connection
@@ -706,9 +703,7 @@ class BlockingConnection(object):
         :returns: opaque timer id
 
         """
-        if not callable(callback):
-            raise TypeError(
-                'callback must be a callable, but got %r' % (callback,))
+        validators.require_callback(callback)
 
         evt = _TimerEvt(callback=callback)
         timer_id = self._impl._adapter_add_timeout(
@@ -1642,13 +1637,8 @@ class BlockingChannel(object):
             consumer_tag is already present.
 
         """
-        if not isinstance(queue, compat.basestring):
-            raise TypeError('queue must be a str or unicode str, but got %r' %
-                            (queue,))
-        if not callable(on_message_callback):
-            raise TypeError('callback on_message_callback must be callable; got %r'
-                            % on_message_callback)
-
+        validators.require_string(queue, 'queue')
+        validators.require_callback(on_message_callback, 'on_message_callback')
         return self._basic_consume_impl(
             queue=queue,
             on_message_callback=on_message_callback,
@@ -2172,9 +2162,7 @@ class BlockingChannel(object):
         """
         assert not self._basic_getempty_result
 
-        if not isinstance(queue, compat.basestring):
-            raise TypeError('queue must be a str or unicode str, but got %r' %
-                            (queue,))
+        validators.require_string(queue, 'queue')
 
         # NOTE: nested with for python 2.6 compatibility
         with _CallbackResult(self._RxMessageArgs) as get_ok_result:
@@ -2434,9 +2422,7 @@ class BlockingChannel(object):
           `spec.Exchange.DeclareOk`
 
         """
-        if not isinstance(exchange, compat.basestring):
-            raise TypeError('exchange must be a str or unicode str, but got %r' %
-                            (exchange,))
+        validators.require_string(exchange, 'exchange')
         with _CallbackResult(
             self._MethodFrameCallbackResultArgs) as declare_ok_result:
             self._impl.exchange_declare(
@@ -2559,9 +2545,7 @@ class BlockingChannel(object):
           `spec.Queue.DeclareOk`
 
         """
-        if not isinstance(queue, compat.basestring):
-            raise TypeError('queue must be a str or unicode str, but got %r' %
-                            (queue,))
+        validators.require_string(queue, 'queue')
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
                 declare_ok_result:
             self._impl.queue_declare(
@@ -2634,12 +2618,8 @@ class BlockingChannel(object):
           `spec.Queue.BindOk`
 
         """
-        if not isinstance(queue, compat.basestring):
-            raise TypeError('queue must be a str or unicode str, but got %r' %
-                            (queue,))
-        if not isinstance(exchange, compat.basestring):
-            raise TypeError('exchange must be a str or unicode str, but got %r' %
-                            (exchange,))
+        validators.require_string(queue, 'queue')
+        validators.require_string(exchange, 'exchange')
         with _CallbackResult(
             self._MethodFrameCallbackResultArgs) as bind_ok_result:
             self._impl.queue_bind(queue=queue,

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -2172,6 +2172,10 @@ class BlockingChannel(object):
         """
         assert not self._basic_getempty_result
 
+        if not isinstance(queue, compat.basestring):
+            raise TypeError('queue must be a str or unicode str, but got %r' %
+                            (queue,))
+
         # NOTE: nested with for python 2.6 compatibility
         with _CallbackResult(self._RxMessageArgs) as get_ok_result:
             with self._basic_getempty_result:

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -367,6 +367,7 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(queue, 'queue')
         self._require_callback(callback)
         if self._on_getok_callback is not None:
             raise exceptions.DuplicateGetOkCallback()

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -12,6 +12,7 @@ import uuid
 import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
+import pika.validators as validators
 from pika.compat import basestring, unicode_type, dictkeys, is_integer
 
 
@@ -59,7 +60,7 @@ class Channel(object):
         if not isinstance(channel_number, int):
             raise exceptions.InvalidChannelNumber
 
-        self._validate_rpc_completion_callback(on_open_callback)
+        validators.rpc_completion_callback(on_open_callback)
 
         self.channel_number = channel_number
         self.callbacks = connection.callbacks
@@ -222,9 +223,9 @@ class Channel(object):
         :raises ValueError:
 
         """
-        self._require_string(consumer_tag, 'consumer_tag')
+        validators.require_string(consumer_tag, 'consumer_tag')
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
 
         if consumer_tag in self._cancelled:
             # We check for cancelled first, because basic_cancel removes
@@ -302,10 +303,10 @@ class Channel(object):
         :raises ValueError:
 
         """
-        self._require_string(queue, 'queue')
-        self._require_callback(on_message_callback)
+        validators.require_string(queue, 'queue')
+        validators.require_callback(on_message_callback)
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
 
         # If a consumer tag was not passed, create one
         if not consumer_tag:
@@ -367,8 +368,8 @@ class Channel(object):
         :raises ValueError:
 
         """
-        self._require_string(queue, 'queue')
-        self._require_callback(callback)
+        validators.require_string(queue, 'queue')
+        validators.require_callback(callback)
         if self._on_getok_callback is not None:
             raise exceptions.DuplicateGetOkCallback()
         self._on_getok_callback = callback
@@ -469,9 +470,9 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
-        self._validate_zero_or_greater('prefetch_size', prefetch_size)
-        self._validate_zero_or_greater('prefetch_count', prefetch_count)
+        validators.rpc_completion_callback(callback)
+        validators.zero_or_greater('prefetch_size', prefetch_size)
+        validators.zero_or_greater('prefetch_count', prefetch_count)
         return self._rpc(spec.Basic.Qos(prefetch_size, prefetch_count,
                                         all_channels),
                          callback, [spec.Basic.QosOk])
@@ -509,7 +510,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
         return self._rpc(spec.Basic.Recover(requeue), callback,
                          [spec.Basic.RecoverOk])
 
@@ -577,7 +578,7 @@ class Channel(object):
                              'to receieve Basic.Ack/Basic.Nack notifications')
 
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
 
         if not (self.connection.publisher_confirms and
                 self.connection.basic_nack):
@@ -622,7 +623,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         return self._rpc(spec.Exchange.Bind(0, destination, source, routing_key,
                                             nowait, arguments or dict()),
                          callback, [spec.Exchange.BindOk] if not nowait
@@ -661,9 +662,9 @@ class Channel(object):
         :raises ValueError:
 
         """
-        self._require_string(exchange, 'exchange')
+        validators.require_string(exchange, 'exchange')
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         return self._rpc(spec.Exchange.Declare(0, exchange, exchange_type,
                                                passive, durable, auto_delete,
                                                internal, nowait,
@@ -685,7 +686,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         return self._rpc(spec.Exchange.Delete(0, exchange, if_unused, nowait),
                          callback, [spec.Exchange.DeleteOk] if not nowait
                          else [])
@@ -710,7 +711,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         return self._rpc(spec.Exchange.Unbind(0, destination, source,
                                               routing_key, nowait, arguments),
                          callback,
@@ -731,7 +732,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
         self._on_flowok_callback = callback
         self._rpc(spec.Channel.Flow(active), self._on_flowok,
                   [spec.Channel.FlowOk])
@@ -789,10 +790,10 @@ class Channel(object):
         :raises ValueError:
 
         """
-        self._require_string(queue, 'queue')
-        self._require_string(exchange, 'exchange')
+        validators.require_string(queue, 'queue')
+        validators.require_string(exchange, 'exchange')
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         if routing_key is None:
             routing_key = queue
         return self._rpc(spec.Queue.Bind(0, queue, exchange, routing_key,
@@ -829,9 +830,9 @@ class Channel(object):
         :raises ValueError:
 
         """
-        self._require_string(queue, 'queue')
+        validators.require_string(queue, 'queue')
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
 
         if queue:
             condition = (spec.Queue.DeclareOk, {'queue': queue})
@@ -860,7 +861,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         replies = [spec.Queue.DeleteOk] if not nowait else []
         return self._rpc(spec.Queue.Delete(0, queue, if_unused, if_empty,
                                            nowait),
@@ -876,7 +877,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        nowait = self._validate_rpc_completion_callback(callback)
+        nowait = validators.rpc_completion_callback(callback)
         replies = [spec.Queue.PurgeOk] if not nowait else []
         return self._rpc(spec.Queue.Purge(0, queue, nowait), callback, replies)
 
@@ -900,7 +901,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
         if routing_key is None:
             routing_key = queue
         return self._rpc(spec.Queue.Unbind(0, queue, exchange, routing_key,
@@ -915,7 +916,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
         return self._rpc(spec.Tx.Commit(), callback, [spec.Tx.CommitOk])
 
     def tx_rollback(self, callback=None):
@@ -926,7 +927,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
         return self._rpc(spec.Tx.Rollback(), callback, [spec.Tx.RollbackOk])
 
     def tx_select(self, callback=None):
@@ -939,7 +940,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
-        self._validate_rpc_completion_callback(callback)
+        validators.rpc_completion_callback(callback)
         return self._rpc(spec.Tx.Select(), callback, [spec.Tx.SelectOk])
 
     # Internal methods
@@ -1449,70 +1450,6 @@ class Channel(object):
 
         """
         LOGGER.error('Unexpected frame: %r', frame_value)
-
-    @staticmethod
-    def _require_string(value, value_name):
-        """Require that value is a string
-
-        :raises: TypeError
-
-        """
-        if not isinstance(value, basestring):
-            raise TypeError('%s must be a str or unicode str, but got %r' %
-                            (value_name, value,))
-
-    @staticmethod
-    def _require_callback(callback):
-        """Require that callback is callable and is not None
-
-        :raises: TypeError
-
-        """
-        if not callable(callback):
-            raise TypeError(
-                'Callback must be callable, but got %r' % (callback,))
-
-    @staticmethod
-    def _require_callback(callback):
-        """Require that callback is callable and is not None
-
-        :raises: TypeError
-
-        """
-        if not callable(callback):
-            raise TypeError(
-                'Callback must be callable, but got %r' % (callback,))
-
-    @staticmethod
-    def _validate_rpc_completion_callback(callback):
-        """Verify callback is callable if not None
-
-        :returns: boolean indicating nowait
-        :raises: TypeError
-
-        """
-        if callback is None:
-            # No callback means we will not expect a response
-            # i.e. nowait=True
-            return True
-
-        if callable(callback):
-            # nowait=False
-            return False
-        else:
-            raise TypeError(
-                'Completion callback must be callable if not None')
-
-    def _validate_zero_or_greater(self, name, value):
-        """Verify that value is zero or greater. If not, 'name'
-        will be used in error message
-
-        :raises: ValueError
-
-        """
-        if int(value) < 0:
-            errmsg = '{} must be >= 0, but got {}'.format(name, value)
-            raise ValueError(errmsg)
 
 
 class ContentFrameAssembler(object):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -12,7 +12,7 @@ import uuid
 import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
-from pika.compat import unicode_type, dictkeys, is_integer
+from pika.compat import basestring, unicode_type, dictkeys, is_integer
 
 
 LOGGER = logging.getLogger(__name__)
@@ -301,6 +301,7 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(queue, 'queue')
         self._require_callback(on_message_callback)
         self._raise_if_not_open()
         self._validate_rpc_completion_callback(callback)
@@ -1442,6 +1443,28 @@ class Channel(object):
 
         """
         LOGGER.error('Unexpected frame: %r', frame_value)
+
+    @staticmethod
+    def _require_string(value, value_name):
+        """Require that value is a string
+
+        :raises: TypeError
+
+        """
+        if not isinstance(value, basestring):
+            raise TypeError('%s must be a str or unicode str, but got %r' %
+                            (value_name, value,))
+
+    @staticmethod
+    def _require_callback(callback):
+        """Require that callback is callable and is not None
+
+        :raises: TypeError
+
+        """
+        if not callable(callback):
+            raise TypeError(
+                'Callback must be callable, but got %r' % (callback,))
 
     @staticmethod
     def _require_callback(callback):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -222,6 +222,7 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(consumer_tag, 'consumer_tag')
         self._raise_if_not_open()
         nowait = self._validate_rpc_completion_callback(callback)
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -824,6 +824,7 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(queue, 'queue')
         self._raise_if_not_open()
         nowait = self._validate_rpc_completion_callback(callback)
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -861,6 +861,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
+        validators.require_string(queue, 'queue')
         nowait = validators.rpc_completion_callback(callback)
         replies = [spec.Queue.DeleteOk] if not nowait else []
         return self._rpc(spec.Queue.Delete(0, queue, if_unused, if_empty,
@@ -877,6 +878,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
+        validators.require_string(queue, 'queue')
         nowait = validators.rpc_completion_callback(callback)
         replies = [spec.Queue.PurgeOk] if not nowait else []
         return self._rpc(spec.Queue.Purge(0, queue, nowait), callback, replies)
@@ -901,6 +903,7 @@ class Channel(object):
 
         """
         self._raise_if_not_open()
+        validators.require_string(queue, 'queue')
         validators.rpc_completion_callback(callback)
         if routing_key is None:
             routing_key = queue

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -787,6 +787,8 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(queue, 'queue')
+        self._require_string(exchange, 'exchange')
         self._raise_if_not_open()
         nowait = self._validate_rpc_completion_callback(callback)
         if routing_key is None:

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -659,6 +659,7 @@ class Channel(object):
         :raises ValueError:
 
         """
+        self._require_string(exchange, 'exchange')
         self._raise_if_not_open()
         nowait = self._validate_rpc_completion_callback(callback)
         return self._rpc(spec.Exchange.Declare(0, exchange, exchange_type,

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -5,7 +5,7 @@ import re
 import socket
 import sys as _sys
 
-PY2 = _sys.version_info < (3,)
+PY2 = _sys.version_info.major == 2
 PY3 = not PY2
 RE_NUM = re.compile(r'(\d+).+')
 
@@ -29,7 +29,7 @@ try:
 except AttributeError:
     SOL_TCP = socket.IPPROTO_TCP
 
-if not PY2:
+if PY3:
     # these were moved around for Python 3
     from urllib.parse import (quote as url_quote, unquote as url_unquote,
                               urlencode, parse_qs as url_parse_qs,

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -1,3 +1,5 @@
+from pika.compat import basestring
+
 def require_string(value, value_name):
     """Require that value is a string
 

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -1,5 +1,6 @@
 from pika.compat import basestring
 
+
 def require_string(value, value_name):
     """Require that value is a string
 
@@ -7,8 +8,11 @@ def require_string(value, value_name):
 
     """
     if not isinstance(value, basestring):
-        raise TypeError('%s must be a str or unicode str, but got %r' %
-                        (value_name, value,))
+        raise TypeError('%s must be a str or unicode str, but got %r' % (
+            value_name,
+            value,
+        ))
+
 
 def require_callback(callback, callback_name='callback'):
     """Require that callback is callable and is not None
@@ -17,9 +21,11 @@ def require_callback(callback, callback_name='callback'):
 
     """
     if not callable(callback):
-        raise TypeError(
-            'callback %s must be callable, but got %r' %
-            (callback_name, callback,))
+        raise TypeError('callback %s must be callable, but got %r' % (
+            callback_name,
+            callback,
+        ))
+
 
 def rpc_completion_callback(callback):
     """Verify callback is callable if not None
@@ -37,8 +43,8 @@ def rpc_completion_callback(callback):
         # nowait=False
         return False
     else:
-        raise TypeError(
-            'completion callback must be callable if not None')
+        raise TypeError('completion callback must be callable if not None')
+
 
 def zero_or_greater(name, value):
     """Verify that value is zero or greater. If not, 'name'

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -1,0 +1,49 @@
+def require_string(value, value_name):
+    """Require that value is a string
+
+    :raises: TypeError
+
+    """
+    if not isinstance(value, basestring):
+        raise TypeError('%s must be a str or unicode str, but got %r' %
+                        (value_name, value,))
+
+def require_callback(callback):
+    """Require that callback is callable and is not None
+
+    :raises: TypeError
+
+    """
+    if not callable(callback):
+        raise TypeError(
+            'Callback must be callable, but got %r' % (callback,))
+
+def rpc_completion_callback(callback):
+    """Verify callback is callable if not None
+
+    :returns: boolean indicating nowait
+    :raises: TypeError
+
+    """
+    if callback is None:
+        # No callback means we will not expect a response
+        # i.e. nowait=True
+        return True
+
+    if callable(callback):
+        # nowait=False
+        return False
+    else:
+        raise TypeError(
+            'Completion callback must be callable if not None')
+
+def zero_or_greater(name, value):
+    """Verify that value is zero or greater. If not, 'name'
+    will be used in error message
+
+    :raises: ValueError
+
+    """
+    if int(value) < 0:
+        errmsg = '{} must be >= 0, but got {}'.format(name, value)
+        raise ValueError(errmsg)

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -8,7 +8,7 @@ def require_string(value, value_name):
         raise TypeError('%s must be a str or unicode str, but got %r' %
                         (value_name, value,))
 
-def require_callback(callback):
+def require_callback(callback, callback_name='callback'):
     """Require that callback is callable and is not None
 
     :raises: TypeError
@@ -16,7 +16,8 @@ def require_callback(callback):
     """
     if not callable(callback):
         raise TypeError(
-            'Callback must be callable, but got %r' % (callback,))
+            'callback %s must be callable, but got %r' %
+            (callback_name, callback,))
 
 def rpc_completion_callback(callback):
     """Verify callback is callable if not None

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -38,7 +38,7 @@ def rpc_completion_callback(callback):
         return False
     else:
         raise TypeError(
-            'Completion callback must be callable if not None')
+            'completion callback must be callable if not None')
 
 def zero_or_greater(name, value):
     """Verify that value is zero or greater. If not, 'name'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ long_description = ('Pika is a pure-Python implementation of the AMQP 0-9-1 '
 
 setuptools.setup(
     name='pika',
-    version='1.0.0b1',
+    version='1.0.0b2',
     description='Pika Python AMQP Client Library',
     long_description=open('README.rst').read(),
     maintainer='Gavin M. Roy',

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -361,7 +361,7 @@ class TestUsingInvalidQueueArgument(BlockingTestCaseBase):
         """
         connection = self._connect()
         ch = connection.channel()
-        with self.assertRaises(AssertionError):
+        with self.assertRaises(TypeError):
             ch.queue_declare(queue=[1, 2, 3])
 
 

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -72,6 +72,10 @@ class BlockingChannelTests(unittest.TestCase):
                                 'queue',
                                 'exchange')
 
+    def test_basic_cancel_legacy_parameter(self):
+        with self.assertRaises(TypeError):
+            self.obj.basic_cancel(mock.Mock(), 'tag')
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -47,6 +47,17 @@ class BlockingChannelTests(unittest.TestCase):
     def test_init_initial_value_buback_return(self):
         self.assertIsNone(self.obj._puback_return)
 
+    def test_basic_consume_legacy_parameter_queue(self):
+        # This is for the unlikely scenario where only
+        # the first parameter is updated
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume('queue',
+                                   'whoops this should be a callback')
+
+    def test_basic_consume_legacy_parameter_callback(self):
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume(mock.Mock(), 'queue')
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -66,6 +66,12 @@ class BlockingChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.exchange_declare(mock.Mock(), 'exchange')
 
+    def test_queue_bind_legacy_parameter_callback(self):
+        with self.assertRaises(TypeError):
+            self.obj.queue_bind(mock.Mock(),
+                                'queue',
+                                'exchange')
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -58,6 +58,10 @@ class BlockingChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.basic_consume(mock.Mock(), 'queue')
 
+    def test_queue_declare_legacy_parameter_callback(self):
+        with self.assertRaises(TypeError):
+            self.obj.queue_declare(mock.Mock(), 'queue')
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -62,6 +62,10 @@ class BlockingChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.queue_declare(mock.Mock(), 'queue')
 
+    def test_exchange_declare_legacy_parameter_callback(self):
+        with self.assertRaises(TypeError):
+            self.obj.exchange_declare(mock.Mock(), 'exchange')
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -76,6 +76,10 @@ class BlockingChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.basic_cancel(mock.Mock(), 'tag')
 
+    def test_basic_get_legacy_parameter(self):
+        with self.assertRaises(TypeError):
+            self.obj.basic_get(mock.Mock())
+
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.obj._impl._generate_consumer_tag.return_value = 'ctag0'

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -305,16 +305,11 @@ class ChannelTests(unittest.TestCase):
                           callback=mock_callback)
 
     @mock.patch('pika.channel.Channel._raise_if_not_open')
-    @mock.patch('pika.channel.Channel._require_callback')
-    def test_basic_consume_calls_raise_if_not_open(self,
-                                                   require,
-                                                   raise_if_not_open):
+    def test_basic_consume_calls_raise_if_not_open(self, raise_if_not_open):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()
-        self.obj.basic_consume('test-queue', mock_on_msg_callback,
-                               callback=mock_callback)
-        require.assert_called_once_with(mock_on_msg_callback)
+        self.obj.basic_consume('test-queue', mock_on_msg_callback, callback=mock_callback)
         raise_if_not_open.assert_called_once_with()
 
     def test_basic_consume_consumer_tag_no_completion_callback(self):
@@ -413,12 +408,10 @@ class ChannelTests(unittest.TestCase):
                                         'consumer_tag': consumer_tag
                                     })])
 
-    @mock.patch('pika.channel.Channel._require_callback')
-    def test_basic_get_calls_require_callback(self, require):
+    def test_basic_get_requires_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        mock_callback = mock.Mock()
-        self.obj.basic_get('test-queue', mock_callback)
-        require.assert_called_once_with(mock_callback)
+        with self.assertRaises(TypeError):
+            self.obj.basic_get('test-queue', None)
 
     @mock.patch('pika.channel.Channel._send_method')
     def test_basic_get_callback(self, _unused):
@@ -1615,13 +1608,6 @@ class ChannelTests(unittest.TestCase):
     def test_raise_if_not_open_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
                           self.obj._raise_if_not_open)
-
-    def test_validate_callback_raises_value_error_not_callable(
-            self):
-        self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError,
-                          self.obj._validate_rpc_completion_callback,
-                          'foo')
 
     def test_no_side_effects_from_send_method_error(self):
         self.obj._set_state(self.obj.OPEN)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -319,6 +319,40 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.confirm_delivery(callback_mock, True)
 
+    def test_exchange_bind_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.exchange_bind(callback_mock,
+                                   'destination',
+                                   'source',
+                                   'routing_key',
+                                   True)
+
+    def test_exchange_delete_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.exchange_delete(callback_mock,
+                                     'exchange',
+                                     True)
+
+    def test_exchange_unbind_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.exchange_unbind(callback_mock,
+                                     'destination',
+                                     'source',
+                                     'routing_key',
+                                     True)
+
+    def test_flow_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.flow(callback_mock, True)
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -254,7 +254,6 @@ class ChannelTests(unittest.TestCase):
         # This is for the unlikely scenario where only
         # the first parameter is updated
         self.obj._set_state(self.obj.OPEN)
-        callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
             self.obj.basic_consume('queue',
                                    'whoops this should be a callback')
@@ -264,6 +263,12 @@ class ChannelTests(unittest.TestCase):
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
             self.obj.basic_consume(callback_mock, 'queue')
+
+    def test_queue_declare_legacy_parameter_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.queue_declare(callback_mock, 'queue')
 
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -308,6 +308,17 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.basic_recover(callback_mock, True)
 
+    def test_confirm_delivery_legacy_no_parameters(self):
+        self.obj._set_state(self.obj.OPEN)
+        with self.assertRaises(TypeError):
+            self.obj.confirm_delivery()
+
+    def test_confirm_delivery_legacy_nowait_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.confirm_delivery(callback_mock, True)
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -296,6 +296,12 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.basic_get(callback_mock)
 
+    def test_basic_qos_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_get(callback_mock, 0, 0, False)
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -353,6 +353,32 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.flow(callback_mock, True)
 
+    def test_queue_delete_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.queue_delete(callback_mock,
+                                  'queue',
+                                  True,
+                                  True)
+
+    def test_queue_unbind_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.queue_unbind(callback_mock,
+                                  'queue',
+                                  'exchange',
+                                  'routing_key')
+
+    def test_queue_purge_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.queue_purge(callback_mock,
+                                  'queue',
+                                  True)
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -302,6 +302,12 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.basic_get(callback_mock, 0, 0, False)
 
+    def test_basic_recover_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_recover(callback_mock, True)
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -250,6 +250,21 @@ class ChannelTests(unittest.TestCase):
         self.obj.basic_cancel(consumer_tag, callback=callback_mock)
         self.assertFalse(rpc.called)
 
+    def test_basic_consume_legacy_parameter_queue(self):
+        # This is for the unlikely scenario where only
+        # the first parameter is updated
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume('queue',
+                                   'whoops this should be a callback')
+
+    def test_basic_consume_legacy_parameter_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_consume(callback_mock, 'queue')
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -284,6 +284,12 @@ class ChannelTests(unittest.TestCase):
                                 'queue',
                                 'exchange')
 
+    def test_basic_cancel_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_cancel(callback_mock, 'tag')
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -270,6 +270,12 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.queue_declare(callback_mock, 'queue')
 
+    def test_exchange_declare_legacy_parameter_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.exchange_declare(callback_mock, 'exchange')
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -276,6 +276,14 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.exchange_declare(callback_mock, 'exchange')
 
+    def test_queue_bind_legacy_parameter_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.queue_bind(callback_mock,
+                                'queue',
+                                'exchange')
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()
@@ -916,7 +924,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_queue_bind_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.queue_bind, None,
+                          self.obj.queue_bind, '',
                           'foo', 'bar', 'baz')
 
     def test_queue_bind_raises_value_error_on_invalid_callback(self):

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -290,6 +290,12 @@ class ChannelTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             self.obj.basic_cancel(callback_mock, 'tag')
 
+    def test_basic_get_legacy_parameter(self):
+        self.obj._set_state(self.obj.OPEN)
+        callback_mock = mock.Mock()
+        with self.assertRaises(TypeError):
+            self.obj.basic_get(callback_mock)
+
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()


### PR DESCRIPTION
Fixes #977

Raise helpful exceptions if legacy parameter ordering is used after upgrading to Pika 1.0.0