### PR TITLE
Update blocking_consume_recover_multiple_hosts.rst

### DIFF
--- a/docs/examples/blocking_consume_recover_multiple_hosts.rst
+++ b/docs/examples/blocking_consume_recover_multiple_hosts.rst
@@ -41,7 +41,7 @@ connection errors::
             ## This queue is intentionally non-durable. See http://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
             ## to learn more.
             channel.queue_declare('recovery-example', durable = False, auto_delete = True)
-            channel.basic_consume('recovery-example', on_message)
+            channel.basic_consume(on_message, 'recovery-example')
             try:
                 channel.start_consuming()
             except KeyboardInterrupt:
@@ -97,7 +97,7 @@ In this example the `retry` decorator is used to set up recovery with delay::
         ## This queue is intentionally non-durable. See http://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
         ## to learn more.
         channel.queue_declare('recovery-example', durable = False, auto_delete = True)
-        channel.basic_consume('recovery-example', on_message)
+        channel.basic_consume(on_message, 'recovery-example')
 
         try:
             channel.start_consuming()


### PR DESCRIPTION
According to the documentation: 
basic_consume(self, consumer_callback, queue, no_ack=False, exclusive=False, consumer_tag=None, arguments=None)
first arg for basic_consume must be callback