### PR TITLE
Speed up CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,13 +90,13 @@ after_success:
 
 jobs:
   include:
+    - python: pypy3
+    - python: pypy
     - python: 2.7
     - python: 3.4
     - python: 3.5
     - python: 3.6
     - python: 3.7-dev
-    - python: pypy
-    - python: pypy3
     - stage: coverage
       python: 3.6
       services: []


### PR DESCRIPTION
Latest master: https://travis-ci.org/pika/pika/builds/396543612
Ran for 24 min 57 sec

The build jobs all take about 3-4 minutes, except PyPy and PyPy3 which are about 12 and 19 minutes. 

Travis CI builds up to 5 parallel jobs. By having the slow ones last, they're a bottleneck and means there are idle runners whilst we wait for those slow ones to end.

Putting the slow ones first mean we can make the most of the parallel jobs and the whole build job will complete quicker.

Here's a representation of each job, one star per minute. Latest master:

```
****
****
****
****
****
    ************
    *******************
12345678901234567890123 = 23 minutes
```

In theory, re-ordering means they run only as long as the slowest job, about 18% quicker:

```
*******************
************
****
****
****
    ****
    ****
1234567890123456789 = 19 minutes
```
