### PR TITLE
Allow None argument for remove_timeout

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -213,7 +213,9 @@ class _Timer(object):
         # NOTE removing from the heap is difficult, so we just deactivate the
         # timeout and garbage-collect it at a later time; see discussion
         # in http://docs.python.org/library/heapq.html
-        if timeout.callback is None:
+        if timeout is None:
+            LOGGER.warning('remove_timeout: ignoring  NoneType timeout')
+        elif timeout.callback is None:
             LOGGER.warning(
                 'remove_timeout: timeout was already removed or called %r',
                 timeout)


### PR DESCRIPTION
Fix for #1084 

I tried to make the minimal modification while allowing a `timeout=None` argument to `_Timer.remove_timeout`.
- This seemed the best place to put it because this is the end of the `remove_timout` cascade of calls and where all the logic happens.
- A targeted exception for the NoneType seems most inline with the rest of the code.

yapf is happy, no coverage change