### PR TITLE
Make it clear that heartbeats are not the only source of connection timeouts

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -331,6 +331,12 @@ class Parameters(object):  # pylint: disable=R0902
             connection tuning or callable which is invoked during connection tuning.
             None to accept broker's value. 0 turns heartbeat off. Defaults to
             `DEFAULT_HEARTBEAT_TIMEOUT`.
+
+        Note: The connection may still be timed out by the broker, regardless of the
+              heartbeat setting, if the client takes too long to accept new messages.
+              Setting `prefetch_count` to 1 on the channel is one way to prevent this
+              from happening. See the `Channel.basic_qos()` method.
+
         :rtype: integer, None or callable
 
         """


### PR DESCRIPTION
The `heartbeat` parameter documentation doesn't make it clear that the broker may still close a connection due to inactivity even if heartbeats are disabled (or large). Without prior knowledge, this behavior is kind of unexpected (but makes sense once you're aware of it).

This PR adds a note about this to the documentation. See also #1093 and #753.