### PR TITLE
Twisted channel: relay the consumer_tags property

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -274,6 +274,10 @@ class TwistedChannel(object):
     def flow_active(self):
         return self._channel.flow_active
 
+    @property
+    def consumer_tags(self):
+        return self._channel.consumer_tags
+
     # Deferred-equivalents of public Channel methods
 
     def callback_deferred(self, deferred, replies):

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -271,7 +271,7 @@ class TwistedChannelTestCase(TestCase):
         # Check the simple attribute passthroughs
         attributes = (
             "channel_number", "connection", "is_closed", "is_closing",
-            "is_open", "flow_active",
+            "is_open", "flow_active", "consumer_tags",
         )
         for name in attributes:
             value = "testvalue-{}".format(name)


### PR DESCRIPTION
After the Twisted refactoring, a `consumer_tags` property was no longer exposed. This commit fixes it.