### PR TITLE
Travis CI: Upgrade from Python 3.7 pre-release to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,8 @@ jobs:
     - python: 3.4
     - python: 3.5
     - python: 3.6
-    - python: 3.7-dev
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
     - stage: coverage
       if: fork = false OR type != pull_request
       python: 3.6

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -617,7 +617,7 @@ class URLParametersTests(_ParametersTestsBase):
             test_params['backpressure_detection'] = backpressure
             virtual_host = '/'
             query_string = urlencode(test_params)
-            test_url = ('amqps://myuser:mypass@www.test.com:5678/%s?%s' % (
+            test_url = ('amqp://myuser:mypass@www.test.com:5678/%s?%s' % (
                 url_quote(virtual_host, safe=''),
                 query_string,
             ))


### PR DESCRIPTION
Partial fix to  #1107

Upgrade to the production version of Python 3.7 in alignment with travis-ci/travis-ci#9069

Also see the note about outdated Python versions on Trusty at:
* https://docs.travis-ci.com/user/languages/python/#development-releases-support