### PR TITLE
pika: Don't automatically import twisted and tornado.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Version History
 
 `GitHub milestone <https://github.com/pika/pika/milestone/8>`_
 
+- `AsyncioConnection`, `TornadoConnection` and `TwistedProtocolConnection` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
 - `BlockingConnection.consume` now returns `(None, None, None)` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
 
 0.12.0 2018-06-19

--- a/README.rst
+++ b/README.rst
@@ -135,11 +135,13 @@ adapter-specific mechanism:
       connection.add_callback_threadsafe(functools.partial(ack_message, channel, delivery_tag))
 
 - When using a non-blocking connection adapter, such as
-  :py:class:`pika.AsyncioConnection` or :py:class:`pika.SelectConnection`, you
-  use the underlying asynchronous framework's native API for requesting an
-  ioloop-bound callback from another thread. For example, `SelectConnection`'s
-  `IOLoop` provides `add_callback_threadsafe()`, `Tornado`'s `IOLoop` has
-  `add_callback()`, while `asyncio`'s event loop exposes `call_soon_threadsafe()`.
+:py:class:`pika.adapters.asyncio_connection.AsyncioConnection` or
+:py:class:`pika.SelectConnection`, you use the underlying asynchronous
+framework's native API for requesting an ioloop-bound callback from
+another thread. For example, `SelectConnection`'s `IOLoop` provides
+`add_callback_threadsafe()`, `Tornado`'s `IOLoop` has
+`add_callback()`, while `asyncio`'s event loop exposes
+`call_soon_threadsafe()`.
 
 This threadsafe callback request mechanism may also be used to delegate
 publishing of messages, etc., from a background thread to the connection adapter's
@@ -223,14 +225,17 @@ Extending to support additional I/O frameworks
 ----------------------------------------------
 New non-blocking adapters may be implemented in either of the following ways:
 
-- By subclassing :py:class:`pika.adapters.base_connection.BaseConnection` and
-  implementing its abstract method(s) and passing BaseConnection's constructor
-  an implementation of
+- By subclassing
+  :py:class:`pika.adapters.base_connection.BaseConnection` and
+  implementing its abstract method(s) and passing BaseConnection's
+  constructor an implementation of
   :py.class:`pika.adapters.utils.nbio_interface.AbstractIOServices`.
-  `BaseConnection` implements `pika.connection.connection.Connection`'s pure
-  virtual methods, including internally-initiated connection logic. For
-  examples, refer to the implementations of
-  :py:class:`pika.AsyncioConnection` and :py:class:`pika.TornadoConnection`.
+  `BaseConnection` implements
+  `pika.connection.connection.Connection`'s pure virtual methods,
+  including internally-initiated connection logic. For examples, refer
+  to the implementations of
+  :py:class:`pika.adapters.asyncio_connection.AsyncioConnection` and
+  :py:class:`pika.adapters.tornado_connection.TornadoConnection`.
 - By subclassing :py:class:`pika.connection.connection.Connection` and
   implementing its abstract method(s). This approach facilitates implementation
   of of custom connection-establishment and transport mechanisms. For an example,

--- a/docs/examples/asyncio_consumer.rst
+++ b/docs/examples/asyncio_consumer.rst
@@ -59,8 +59,8 @@ consumer.py::
 
             """
             LOGGER.info('Connecting to %s', self._url)
-            return adapters.AsyncioConnection(pika.URLParameters(self._url),
-                                              self.on_connection_open)
+            return adapters.asyncio_connection.AsyncioConnection(pika.URLParameters(self._url),
+                                                                 self.on_connection_open)
 
         def close_connection(self):
             """This method closes the connection to RabbitMQ."""

--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -53,8 +53,8 @@ consumer.py::
 
             """
             LOGGER.info('Connecting to %s', self._url)
-            return adapters.TornadoConnection(pika.URLParameters(self._url),
-                                              self.on_connection_open)
+            return adapters.tornado_connection.TornadoConnection(pika.URLParameters(self._url),
+                                                                 self.on_connection_open)
 
         def close_connection(self):
             """This method closes the connection to RabbitMQ."""

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -13,11 +13,8 @@ from pika.connection import SSLOptions
 from pika.credentials import PlainCredentials
 from pika.spec import BasicProperties
 
-from pika.adapters import AsyncioConnection
 from pika.adapters import BaseConnection
 from pika.adapters import BlockingConnection
 from pika.adapters import SelectConnection
-from pika.adapters import TornadoConnection
-from pika.adapters import TwistedProtocolConnection
 
 from pika.adapters.utils.connection_workflow import AMQPConnectionWorkflow

--- a/pika/adapters/__init__.py
+++ b/pika/adapters/__init__.py
@@ -19,20 +19,3 @@ from pika.adapters.base_connection import BaseConnection
 from pika.adapters.blocking_connection import BlockingConnection
 from pika.adapters.select_connection import SelectConnection
 from pika.adapters.select_connection import IOLoop
-
-# Dynamically handle 3rd party library dependencies for optional imports
-try:
-    from pika.adapters.asyncio_connection import AsyncioConnection
-except ImportError:
-    AsyncioConnection = None
-
-try:
-    from pika.adapters.tornado_connection import TornadoConnection
-except ImportError:
-    TornadoConnection = None
-
-try:
-    from pika.adapters.twisted_connection import TwistedProtocolConnection
-except ImportError:
-    TwistedProtocolConnection = None
-

--- a/tests/acceptance/async_test_base.py
+++ b/tests/acceptance/async_test_base.py
@@ -360,10 +360,10 @@ class AsyncAdapters(object):
     def test_with_tornado(self):
         """TornadoConnection"""
         ioloop_factory = None
-        if adapters.TornadoConnection is not None:
+        if adapters.tornado_connection.TornadoConnection is not None:
             import tornado.ioloop
             ioloop_factory = tornado.ioloop.IOLoop
-        self.start(adapters.TornadoConnection, ioloop_factory)
+        self.start(adapters.tornado_connection.TornadoConnection, ioloop_factory)
 
     @unittest.skipIf(sys.version_info < (3, 4),
                      'Asyncio is available only with Python 3.4+')
@@ -371,8 +371,8 @@ class AsyncAdapters(object):
     def test_with_asyncio(self):
         """AsyncioConnection"""
         ioloop_factory = None
-        if adapters.AsyncioConnection is not None:
+        if adapters.asyncio_connection.AsyncioConnection is not None:
             import asyncio
             ioloop_factory = asyncio.new_event_loop
 
-        self.start(adapters.AsyncioConnection, ioloop_factory)
+        self.start(adapters.asyncio_connection.AsyncioConnection, ioloop_factory)


### PR DESCRIPTION
Previously, the pika.adapters convenience import logic would end up
importing Twisted, Tornado, and AsyncIO if they are present in the
current Python environment, regardless of whether the user intended to
use them.

While the convenience names of e.g. `pika.TornadoConnection` (rather
than the more verbose pika.adapters.TornadoConnection`) were nice,
this had the downside of making importing pika expensive in those
environments; on my system, twisted added 150ms and tornado 10ms to
the based ~40ms import time for pika.

We fix this by removing those convenience imports; now, a user needs
to explicitly import pika.adapters.tornado_connection (aka plan to
actually use the relevant adapter feature) in order to end up
importing those large third-party modules.

Fixes #1128.

---------------------------

Pull request is still work-in-progress; while it's possible I didn't make any mistakes, this is at this point untested.  I opened a PR at this point in development just to get CI to run.
