### PR TITLE
Fix examples for new API

### DIFF
--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -211,8 +211,8 @@ class ExampleConsumer(object):
                     self.EXCHANGE, queue_name, self.ROUTING_KEY)
         cb = functools.partial(self.on_bindok,
                                userdata=queue_name)
-        self._channel.queue_bind(queue=queue_name,
-                                 exchange=self.EXCHANGE,
+        self._channel.queue_bind(queue_name,
+                                 self.EXCHANGE,
                                  routing_key=self.ROUTING_KEY,
                                  callback=cb)
 
@@ -240,8 +240,8 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Issuing consumer related RPC commands')
         self.add_on_cancel_callback()
-        self._consumer_tag = self._channel.basic_consume(queue=self.QUEUE,
-                                                         callback=self.on_message)
+        self._consumer_tag = self._channel.basic_consume(self.QUEUE,
+                                                         self.on_message)
 
     def add_on_cancel_callback(self):
         """Add a callback that will be invoked if RabbitMQ cancels the consumer
@@ -301,8 +301,7 @@ class ExampleConsumer(object):
             LOGGER.info('Sending a Basic.Cancel RPC command to RabbitMQ')
             cb = functools.partial(self.on_cancelok,
                                    userdata=self._consumer_tag)
-            self._channel.basic_cancel(consumer_tag=self._consumer_tag,
-                                       callback=cb)
+            self._channel.basic_cancel(self._consumer_tag, cb)
 
     def on_cancelok(self, unused_frame, userdata):
         """This method is invoked by pika when RabbitMQ acknowledges the

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -202,7 +202,7 @@ class ExamplePublisher(object):
                     self.EXCHANGE, self.QUEUE, self.ROUTING_KEY)
         self._channel.queue_bind(self.QUEUE,
                                  self.EXCHANGE,
-                                 self.ROUTING_KEY,
+                                 routing_key=self.ROUTING_KEY,
                                  callback=self.on_bindok)
 
     def on_bindok(self, unused_frame):
@@ -233,7 +233,7 @@ class ExamplePublisher(object):
 
         """
         LOGGER.info('Issuing Confirm.Select RPC command')
-        self._channel.confirm_delivery(ack_nack_callback=self.on_delivery_confirmation)
+        self._channel.confirm_delivery(self.on_delivery_confirmation)
 
     def on_delivery_confirmation(self, method_frame):
         """Invoked by pika when RabbitMQ responds to a Basic.Publish RPC


### PR DESCRIPTION
The asynchronous consumer example does not work in the current master branch.

I installed the ``pika`` Python project after downloading the current master from Github.
``` console
(venv) $ python
Python 3.6.4 (v3.6.4:d48ecebad5, Dec 18 2017, 21:07:28) 
[GCC 4.2.1 (Apple Inc. build 5666) (dot 3)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pika
>>> pika.__version__
'1.0.0b1'
```

After starting an RabbitMQ server I then tried to run the examples ``asynchronous_consumer_example.py`` and ``asynchronous_publisher_example.py`` where I encountered errors that stopped the consumer from running. A snippet of the error is shown below.

``` python
Traceback (most recent call last):
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/adapters/utils/io_services_utils.py", line 1037, in _on_socket_readable
    self._consume()
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/adapters/utils/io_services_utils.py", line 796, in _consume
    self._protocol.data_received(data)
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/adapters/base_connection.py", line 492, in _proto_data_received
    self._on_data_available(data)
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/connection.py", line 2075, in _on_data_available
    self._process_frame(frame_value)
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/connection.py", line 2224, in _process_frame
    if self._process_callbacks(frame_value):
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/connection.py", line 2205, in _process_callbacks
    frame_value)  # Args
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/callback.py", line 60, in wrapper
    return function(*tuple(args), **kwargs)
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/callback.py", line 92, in wrapper
    return function(*args, **kwargs)
  File "/path/to/my/venv/lib/python3.6/site-packages/pika/callback.py", line 236, in process
    callback(*args, **keywords)
  File "asynchronous_consumer_example.py", line 229, in on_bindok
    self.start_consuming()
  File "asynchronous_consumer_example.py", line 244, in start_consuming
    callback=self.on_message)
TypeError: basic_consume() missing 1 required positional argument: 'on_message_callback'
```

Upon further investigation it looks like the ``pika`` v1.0 API changes some method signatures in the ``channel`` object and these changes have not been reflected in at least the two example files I was trying to run.

This merge request proposes changes that fix the two example files so they work with the new API exposed by ``pika``. The changes are relatively trivial.

Additional non-functional (i.e. style) changes were introduced after running ``yapf`` over the two modified files as requested in the *Code Formatting* section of this project's ``CONTRIBUTING.md`` guidelines file.