### PR TITLE
Remove contributing instruction requesting use of yapf tool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,8 +59,3 @@ If you would like to run TLS/SSL tests, use the following procedure:
     PIKA_TEST_TLS=true nosetests
     ```
 
-
-## Code Formatting
-
-Please format your code using [yapf](http://pypi.python.org/pypi/yapf)
-with ``google`` style prior to issuing your pull request.


### PR DESCRIPTION
I proposed some changes in #1135 and followed the contributing guide which requested that code be formatted using the yapf formatter. This introduced many file modifications that were not related to the actual change. The files in question likely had not been formatted with the yapf tool and there must not be style compliance checks in the CI chain.

These non-functional (i.e. style) changes add lots of noise to the proposed change making it harder for reviewers to consider the changes.

This merge request updates the contributing instructions to remove the request asking contributors to format their proposed change using yapf. This merge request is being raised as requested by this review [comment](https://github.com/pika/pika/pull/1135#issuecomment-436041657).

#### Recommendation
I personally think that a better long term solution would be to adopt a code formatter such as [black](https://black.readthedocs.io/en/stable/) and integrate it into the CI chain. The process would likely involve raising a separate merge request that:
- Adds ``black`` as a dev dependency
- Removes ``yapf`` as a dev dependency
- Applies the black formatter over the whole code base. It would use and accept the default 
  output (irrespective of whether you agree with all of its style, it is not worth wasting time 
  arguing about trivial style preferences). 
- Adds a stage in the CI chain, prior to executing tests, that runs the formatting check (e.g. 
  ``black --check``) to ensure code style is compliant. 

With such a process in place you don't need to worry about this aspect ever again.