### PR TITLE
Remove warnings when invalid SSL URL params are used

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,8 @@ Version History
 - ``queue_purge``
 - ``queue_unbind``
 
+**IMPORTANT**: When specifying TLS / SSL options, the ``SSLOptions`` class must be used, and a ``dict`` is no longer supported.
+
 0.12.0 2018-06-19
 -----------------
 


### PR DESCRIPTION
Fixes #1156 

In short, this PR removes unnecessary file checks and warnings and instead lets the `SSLContext` instance throw exceptions if items are specified but not present.

Tested with the following script and RabbitMQ configs:

[tls_mutual_auth.config.txt](https://github.com/pika/pika/files/2805756/tls_mutual_auth.config.txt)
[tls_mutual_auth_ex.py.txt](https://github.com/pika/pika/files/2805757/tls_mutual_auth_ex.py.txt)
