### PR TITLE
Rename all_channels to global_qos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Version History
 - ``AsyncioConnection``, ``TornadoConnection`` and ``TwistedProtocolConnection`` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
 - ``BlockingConnection.consume`` now returns ``(None, None, None)`` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
 - Python 3.7 support (`Issue <https://github.com/pika/pika/issues/1107>`_)
+- ``all_channels`` parameter of the ``Channel.basic_qos`` method renamed to ``global_qos``
 
 
 **IMPORTANT**: The signature of the following methods has changed from Pika 0.13.0. In general, the callback parameter that indicates completion of the method has been moved to the end of the parameter list to be consistent with other parts of Pika's API and with other libraries in general.

--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -6,9 +6,10 @@ Version History
 
 `GitHub milestone <https://github.com/pika/pika/milestone/8>`_
 
-- ``AsyncioConnection`, ``TornadoConnection`` and ``TwistedProtocolConnection`` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
+- ``AsyncioConnection``, ``TornadoConnection`` and ``TwistedProtocolConnection`` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
 - ``BlockingConnection.consume`` now returns ``(None, None, None)`` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
 - Python 3.7 support (`Issue <https://github.com/pika/pika/issues/1107>`_)
+- ``all_channels`` parameter of the ``Channel.basic_qos`` method renamed to ``global_qos``
 
 
 **IMPORTANT**: The signature of the following methods has changed from Pika 0.13.0. In general, the callback parameter that indicates completion of the method has been moved to the end of the parameter list to be consistent with other parts of Pika's API and with other libraries in general.

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -2303,7 +2303,7 @@ class BlockingChannel(object):
                                      immediate=immediate)
             self._flush_output()
 
-    def basic_qos(self, prefetch_size=0, prefetch_count=0, all_channels=False):
+    def basic_qos(self, prefetch_size=0, prefetch_count=0, global_qos=False):
         """Specify quality of service. This method requests a specific quality
         of service. The QoS can be specified for the current channel or for all
         channels on the connection. The client can request that messages be sent
@@ -2328,14 +2328,15 @@ class BlockingChannel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored if the no-ack
                                    option is set in the consumer.
-        :param bool all_channels: Should the QoS apply to all channels
+        :param bool global_qos:    Should the QoS apply to all consumers on the
+                                   Channel
 
         """
         with _CallbackResult() as qos_ok_result:
             self._impl.basic_qos(callback=qos_ok_result.signal_once,
                                  prefetch_size=prefetch_size,
                                  prefetch_count=prefetch_count,
-                                 all_channels=all_channels)
+                                 global_qos=global_qos)
             self._flush_output(qos_ok_result.is_ready)
 
     def basic_recover(self, requeue=False):

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -577,7 +577,7 @@ class TwistedChannel(object):
     def basic_qos(self,
                   prefetch_size=0,
                   prefetch_count=0,
-                  all_channels=False):
+                  global_qos=False):
         """Specify quality of service. This method requests a specific quality
         of service. The QoS can be specified for the current channel or for all
         channels on the connection. The client can request that messages be
@@ -603,7 +603,8 @@ class TwistedChannel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool all_channels: Should the QoS apply to all channels
+        :param bool global_qos:    Should the QoS apply to all consumers on the
+                                   Channel
         :return: Deferred that fires on the Basic.QosOk response
         :rtype: Deferred
 
@@ -611,7 +612,7 @@ class TwistedChannel(object):
         return self._wrap_channel_method("basic_qos")(
             prefetch_size=prefetch_size,
             prefetch_count=prefetch_count,
-            all_channels=all_channels,
+            global_qos=global_qos,
         )
 
     def basic_reject(self, delivery_tag, requeue=True):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -438,7 +438,7 @@ class Channel(object):
     def basic_qos(self,
                   prefetch_size=0,
                   prefetch_count=0,
-                  all_channels=False,
+                  global_qos=False,
                   callback=None):
         """Specify quality of service. This method requests a specific quality
         of service. The QoS can be specified for the current channel or for all
@@ -464,7 +464,8 @@ class Channel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool all_channels: Should the QoS apply to all channels
+        :param bool global_qos:    Should the QoS apply to all consumers on the
+                                   Channel
         :param callable callback: The callback to call for Basic.QosOk response
         :raises ValueError:
 
@@ -474,7 +475,7 @@ class Channel(object):
         validators.zero_or_greater('prefetch_size', prefetch_size)
         validators.zero_or_greater('prefetch_count', prefetch_count)
         return self._rpc(spec.Basic.Qos(prefetch_size, prefetch_count,
-                                        all_channels),
+                                        global_qos),
                          callback, [spec.Basic.QosOk])
 
     def basic_reject(self, delivery_tag, requeue=True):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1782,7 +1782,7 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
         self.assertEqual(frame.method.message_count, 2)
 
         # Configure QoS for one message
-        ch.basic_qos(prefetch_size=0, prefetch_count=1, all_channels=False)
+        ch.basic_qos(prefetch_size=0, prefetch_count=1, global_qos=False)
 
         # Create a consumer
         rx_messages = []
@@ -1908,7 +1908,7 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
 
         # Configure QoS for one message so that the 2nd message will be
         # delivered only after the 1st one is ACKed
-        ch.basic_qos(prefetch_size=0, prefetch_count=1, all_channels=False)
+        ch.basic_qos(prefetch_size=0, prefetch_count=1, global_qos=False)
 
         # Create a consumer
         rx_messages = []
@@ -2006,7 +2006,7 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
 
         # Configure QoS for one message so that the 2nd message will be
         # delivered only after the 1st one is ACKed
-        ch.basic_qos(prefetch_size=0, prefetch_count=1, all_channels=False)
+        ch.basic_qos(prefetch_size=0, prefetch_count=1, global_qos=False)
 
         # Create a consumer
         rx_messages = []

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -450,7 +450,7 @@ class TwistedChannelTestCase(TestCase):
         kwargs = {"prefetch_size": 2}
         d = self.channel.basic_qos(**kwargs)
         # Defaults
-        kwargs.update(dict(prefetch_count=0, all_channels=False))
+        kwargs.update(dict(prefetch_count=0, global_qos=False))
         self._test_wrapped_func(self.pika_channel.basic_qos, kwargs, True)
         return d
 


### PR DESCRIPTION
Fixes #1145 

`global` is a keyword, FYI