### PR TITLE
Assert if select_connection's poller close is called while it's still running. Implement reenrancy tests IOLoopStartReentrancyNotAllowedTestSelect and IOLoopCloseBeforeStartReturnsTestSelect

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -629,6 +629,8 @@ class _PollerBase(pika.compat.AbstractBase):  # pylint: disable=R0902
         # Unregister and close ioloop-interrupt socket pair; mutual exclusion is
         # necessary to avoid race condition with `wake_threadsafe` executing in
         # another thread's context
+        assert not self._running, 'Cannot call close() before start() unwinds.'
+
         with self._waking_mutex:
             if self._w_interrupt is not None:
                 self.remove_handler(


### PR DESCRIPTION
This is minor mop-up after pull request #1177

Assert if select_connection's poller close is called while the poller is still running. @lukebakken - this restores the API's behavior which helps developers quickly find out when their app is doing this incorrect behavior, which would otherwise put the poller in a bad state.

This restores the simple test that validates the close/start behavior described above: IOLoopCloseBeforeStartReturnsTestSelect.

Implement reentrancy test for poller.start() IOLoopStartReentrancyNotAllowedTestSelect
