### PR TITLE
Improve docstrings consistency

### DIFF
--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -92,7 +92,7 @@ consumer.py::
             been established. It passes the handle to the connection object in
             case we need it, but in this case, we'll just mark it unused.
 
-            :type unused_connection: pika.SelectConnection
+            :param pika.SelectConnection _unused_connection: The connection
 
             """
             LOGGER.info('Connection opened')
@@ -237,7 +237,7 @@ consumer.py::
             :param pika.channel.Channel unused_channel: The channel object
             :param pika.Spec.Basic.Deliver: basic_deliver method
             :param pika.Spec.BasicProperties: properties
-            :param str|unicode body: The message body
+            :param bytes body: The message body
 
             """
             LOGGER.info('Received message # %s from %s: %s',

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -77,7 +77,7 @@ class ExampleConsumer(object):
         been established. It passes the handle to the connection object in
         case we need it, but in this case, we'll just mark it unused.
 
-        :type unused_connection: pika.SelectConnection
+        :param pika.SelectConnection _unused_connection: The connection
 
         """
         LOGGER.info('Connection opened')
@@ -87,8 +87,8 @@ class ExampleConsumer(object):
         """This method is called by pika if the connection to RabbitMQ
         can't be established.
 
-        :type unused_connection: pika.SelectConnection
-        :type err: Exception
+        :param pika.SelectConnection _unused_connection: The connection
+        :param Exception err: The error
 
         """
         LOGGER.error('Connection open failed: %s', err)
@@ -308,7 +308,7 @@ class ExampleConsumer(object):
         :param pika.channel.Channel _unused_channel: The channel object
         :param pika.Spec.Basic.Deliver: basic_deliver method
         :param pika.Spec.BasicProperties: properties
-        :param str|unicode body: The message body
+        :param bytes body: The message body
 
         """
         LOGGER.info('Received message # %s from %s: %s',

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -68,7 +68,7 @@ class ExamplePublisher(object):
         been established. It passes the handle to the connection object in
         case we need it, but in this case, we'll just mark it unused.
 
-        :type unused_connection: pika.SelectConnection
+        :param pika.SelectConnection _unused_connection: The connection
 
         """
         LOGGER.info('Connection opened')
@@ -78,8 +78,8 @@ class ExamplePublisher(object):
         """This method is called by pika if the connection to RabbitMQ
         can't be established.
 
-        :type unused_connection: pika.SelectConnection
-        :type err: Exception
+        :param pika.SelectConnection _unused_connection: The connection
+        :param Exception err: The error
 
         """
         LOGGER.error('Connection open failed, reopening in 5 seconds: %s', err)

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -79,7 +79,8 @@ class ExampleConsumer(object):
         been established. It passes the handle to the connection object in
         case we need it, but in this case, we'll just mark it unused.
 
-        :type unused_connection: pika.adapters.asyncio_connection.AsyncioConnection
+        :param pika.adapters.asyncio_connection.AsyncioConnection _unused_connection:
+           The connection
 
         """
         LOGGER.info('Connection opened')
@@ -89,8 +90,9 @@ class ExampleConsumer(object):
         """This method is called by pika if the connection to RabbitMQ
         can't be established.
 
-        :type unused_connection: pika.adapters.asyncio_connection.AsyncioConnection
-        :type err: Exception
+        :param pika.adapters.asyncio_connection.AsyncioConnection _unused_connection:
+           The connection
+        :param Exception err: The error
 
         """
         LOGGER.error('Connection open failed: %s', err)
@@ -310,7 +312,7 @@ class ExampleConsumer(object):
         :param pika.channel.Channel _unused_channel: The channel object
         :param pika.Spec.Basic.Deliver: basic_deliver method
         :param pika.Spec.BasicProperties: properties
-        :param str|unicode body: The message body
+        :param bytes body: The message body
 
         """
         LOGGER.info('Received message # %s from %s: %s',

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -271,7 +271,6 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
     def cancel(self):
         """Cancel pending operation
 
-
         :returns: False if was already done or cancelled; True otherwise
         :rtype: bool
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -131,8 +131,7 @@ class BaseConnection(connection.Connection):
             `connection_workflow.AbstractAMQPConnectionWorkflow` interface;
             defaults to a `connection_workflow.AMQPConnectionWorkflow` instance
             with default values for optional args.
-
-        :return: Connection workflow instance in use. The user should limit
+        :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
 
@@ -159,8 +158,7 @@ class BaseConnection(connection.Connection):
             with default values for optional args.
         :param callable on_done: as defined in
             :py:meth:`connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
-
-        :return: Connection workflow instance in use. The user should limit
+        :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
 
@@ -191,10 +189,11 @@ class BaseConnection(connection.Connection):
     @property
     def ioloop(self):
         """
-        :return: the native I/O loop instance underlying async services selected
+        :returns: the native I/O loop instance underlying async services selected
             by user or the default selected by the specialized connection
             adapter (e.g., Twisted reactor, `asyncio.SelectorEventLoop`,
             `select_connection.IOLoop`, etc.)
+        :rtype: object
         """
         return self._nbio.get_native_ioloop()
 
@@ -433,14 +432,13 @@ class BaseConnection(connection.Connection):
 
     def _proto_eof_received(self):  # pylint: disable=R0201
         """Called after the remote peer shuts its write end of the connection.
-
         :py:class:`.utils.nbio_interface.AbstractStreamProtocol` implementation.
 
-        :return: A falsy value (including None) will cause the transport to
+        :returns: A falsy value (including None) will cause the transport to
             close itself, resulting in an eventual `connection_lost()` call
             from the transport. If a truthy value is returned, it will be the
             protocol's responsibility to close/abort the transport.
-        :rtype: falsy | truthy
+        :rtype: falsy|truthy
         :raises Exception: Exception-based exception on error
 
         """

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -75,7 +75,7 @@ class SelectConnection(BaseConnection):
         """Create a new instance of the Connection object.
 
         :param pika.connection.Parameters parameters: Connection parameters
-        :param method on_open_callback: Method to call on connection open
+        :param callable on_open_callback: Method to call on connection open
         :param None | method on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`: on_open_error_callback(Connection, exception).
@@ -137,7 +137,7 @@ class SelectConnection(BaseConnection):
 
     def _get_write_buffer_size(self):
         """
-        :return: Current size of output data buffered by the transport
+        :returns: Current size of output data buffered by the transport
         :rtype: int
         """
         return self._transport.get_write_buffer_size()
@@ -239,9 +239,9 @@ class _Timer(object):
             Manager cancels the timer upon dispatch of the callback.
 
         :param float delay: Non-negative number of seconds from now until
-                            expiration
-        :param method callback: The callback method, having the signature
-                                `callback()`
+            expiration
+        :param callable callback: The callback method, having the signature
+            `callback()`
 
         :rtype: _Timeout
         :raises ValueError, TypeError
@@ -396,7 +396,8 @@ class IOLoop(AbstractSelectorIOLoop):
         :param process_timeouts: Function for processing timeouts for use by the
                                  poller
 
-        :returns: the instantiated poller instance supporting `_PollerBase` API
+        :returns: The instantiated poller instance supporting `_PollerBase` API
+        :rtype: object
         """
 
         poller = None
@@ -433,10 +434,10 @@ class IOLoop(AbstractSelectorIOLoop):
         timeout.
 
         :param float delay: The number of seconds to wait to call callback
-        :param method callback: The callback method
+        :param callable callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
-        :rtype: opaque
+        :rtype: object
 
         """
         return self._timer.call_later(delay, callback)
@@ -460,7 +461,7 @@ class IOLoop(AbstractSelectorIOLoop):
         ioloop that is running in a different thread via
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
-        :param method callback: The callback method
+        :param callable callback: The callback method
 
         """
         if not callable(callback):
@@ -509,7 +510,7 @@ class IOLoop(AbstractSelectorIOLoop):
         """Start watching the given file descriptor for events
 
         :param int fd: The file descriptor
-        :param method handler: When requested event(s) occur,
+        :param callable handler: When requested event(s) occur,
             `handler(fd, events)` will be called.
         :param int events: The event mask using READ, WRITE, ERROR.
 
@@ -676,6 +677,7 @@ class _PollerBase(pika.compat.AbstractBase):  # pylint: disable=R0902
 
         :returns: maximum number of self.POLL_TIMEOUT_MULT-scaled time units
                   to wait for IO events
+        :rtype: int
 
         """
         delay = self._get_wait_seconds()
@@ -690,7 +692,7 @@ class _PollerBase(pika.compat.AbstractBase):  # pylint: disable=R0902
         """Add a new fileno to the set to be monitored
 
         :param int fileno: The file descriptor
-        :param method handler: What is called when an event happens
+        :param callable handler: What is called when an event happens
         :param int events: The event mask using READ, WRITE, ERROR
 
         """
@@ -742,6 +744,7 @@ class _PollerBase(pika.compat.AbstractBase):  # pylint: disable=R0902
         :param int events: The event mask (READ, WRITE, ERROR)
 
         :returns: a 2-tuple (events_cleared, events_set)
+        :rtype: tuple
         """
         events_cleared = 0
         events_set = 0

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -23,26 +23,27 @@ class TornadoConnection(base_connection.BaseConnection):
                  custom_ioloop=None,
                  internal_connection_workflow=True):
         """Create a new instance of the TornadoConnection class, connecting
-        to RabbitMQ automatically
+        to RabbitMQ automatically.
 
-        :param pika.connection.Parameters parameters: Connection parameters
-        :param on_open_callback: The method to call when the connection is open
-        :type on_open_callback: method
-        :param None | method on_open_error_callback: Called if the connection
+        :param pika.connection.Parameters|None parameters: The connection
+            parameters
+        :param callable|None on_open_callback: The method to call when the
+            connection is open
+        :param callable|None on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
-            `Connection.close()`: on_open_error_callback(Connection, exception).
-        :param None | method on_close_callback: Called when a previously fully
+            `Connection.close()`:
+            on_open_error_callback(Connection, exception)
+        :param callable|None on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
-            user or broker or exception of another type that describes the cause
-            of connection failure.
-        :param None | ioloop.IOLoop |
-            nbio_interface.AbstractIOServices custom_ioloop:
-                Override using the global IOLoop in Tornado
+            user or broker or exception of another type that describes the
+            cause of connection failure
+        :param ioloop.IOLoop|nbio_interface.AbstractIOServices|None custom_ioloop:
+            Override using the global IOLoop in Tornado
         :param bool internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
-            connection workflow via the `create_connection()` factory.
+            connection workflow via the `create_connection()` factory
 
         """
         if isinstance(custom_ioloop, nbio_interface.AbstractIOServices):

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -58,7 +58,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
         The Deferred will errback if the queue is closed.
 
-        :return: Deferred that fires with the next item.
+        :returns: Deferred that fires with the next item.
         :rtype: Deferred
 
         """
@@ -302,7 +302,7 @@ class TwistedChannel(object):
             channel: this TwistedChannel
             method: pika.spec.Basic.Return
             properties: pika.spec.BasicProperties
-            body: str, unicode, or bytes (python 3.x)
+            body: bytes
 
         """
         self._channel.add_on_return_callback(
@@ -353,7 +353,7 @@ class TwistedChannel(object):
         associated with that consumer.
 
         :param str consumer_tag: Identifier for the consumer
-        :return: Deferred that fires on the Basic.CancelOk response
+        :returns: Deferred that fires on the Basic.CancelOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -380,18 +380,16 @@ class TwistedChannel(object):
         http://www.rabbitmq.com/confirms.html
         http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
-        :param queue: The queue to consume from. Use the empty string to
+        :param str queue: The queue to consume from. Use the empty string to
             specify the most recent server-named queue for this channel.
-        :type queue: str or unicode
         :param bool auto_ack: if set to True, automatic acknowledgement mode
             will be used (see http://www.rabbitmq.com/confirms.html). This
             corresponds with the 'no_ack' parameter in the basic.consume AMQP
             0.9.1 method
         :param bool exclusive: Don't allow other consumers on the queue
-        :param consumer_tag: Specify your own consumer tag
-        :type consumer_tag: str or unicode
+        :param str consumer_tag: Specify your own consumer tag
         :param dict arguments: Custom key/value pair arguments for the consumer
-        :return: Deferred that fires with a tuple
+        :returns: Deferred that fires with a tuple
             ``(queue_object, consumer_tag)``.  The queue object is an instance
             of :class:`ClosableDeferredQueue`, where data received from
             the queue will be stored. Clients should use its
@@ -401,7 +399,7 @@ class TwistedChannel(object):
              - channel: this TwistedChannel
              - method: pika.spec.Basic.Deliver
              - properties: pika.spec.BasicProperties
-             - body: str, unicode, or bytes (python 3.x)
+             - body: bytes
         :rtype: Deferred
 
         """
@@ -461,18 +459,17 @@ class TwistedChannel(object):
         This method wraps :meth:`Channel.basic_get
         <pika.channel.Channel.basic_get>`.
 
-        :param queue: The queue from which to get a message. Use the empty
+        :param str queue: The queue from which to get a message. Use the empty
                       string to specify the most recent server-named queue
                       for this channel.
-        :type queue: str or unicode
         :param bool auto_ack: Tell the broker to not expect a reply
-        :return: Deferred that fires with a namedtuple whose attributes are:
+        :returns: Deferred that fires with a namedtuple whose attributes are:
             channel: this TwistedChannel
             method: pika.spec.Basic.GetOk
             properties: pika.spec.BasicProperties
-            body: str, unicode, or bytes (python 3.x)
+            body: bytes
             If the queue is empty, None will be returned.
-        :rtype: Deferred(ReceivedMessage|None)
+        :rtype: Deferred
         :raises pika.exceptions.DuplicateGetOkCallback:
 
         """
@@ -542,18 +539,14 @@ class TwistedChannel(object):
 
         http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
-        :param exchange: The exchange to publish to
-        :type exchange: str or unicode
-        :param routing_key: The routing key to bind on
-        :type routing_key: str or unicode
-        :param body: The message body
-        :type body: str or unicode
+        :param str exchange: The exchange to publish to
+        :param str routing_key: The routing key to bind on
+        :param bytes body: The message body
         :param pika.spec.BasicProperties properties: Basic.properties
         :param bool mandatory: The mandatory flag
-        :return: A Deferred that fires with the result of the channel's
+        :returns: A Deferred that fires with the result of the channel's
             basic_publish.
         :rtype: Deferred
-
         :raises UnroutableError: raised when a message published in
             publisher-acknowledgments mode (see
             `BlockingChannel.confirm_delivery`) is returned via `Basic.Return`
@@ -607,7 +600,7 @@ class TwistedChannel(object):
                                    have enabled the no-ack option.
         :param bool global_qos:    Should the QoS apply to all consumers on the
                                    Channel
-        :return: Deferred that fires on the Basic.QosOk response
+        :returns: Deferred that fires on the Basic.QosOk response
         :rtype: Deferred
 
         """
@@ -642,7 +635,7 @@ class TwistedChannel(object):
                              original recipient. If True, the server will
                              attempt to requeue the message, potentially then
                              delivering it to an alternative subscriber.
-        :return: Deferred that fires on the Basic.RecoverOk response
+        :returns: Deferred that fires on the Basic.RecoverOk response
         :rtype: Deferred
 
         """
@@ -670,7 +663,7 @@ class TwistedChannel(object):
         For more information see:
             http://www.rabbitmq.com/confirms.html#publisher-confirms
 
-        :return: Deferred that fires on the Confirm.SelectOk response
+        :returns: Deferred that fires on the Confirm.SelectOk response
         :rtype: Deferred
 
         """
@@ -748,8 +741,7 @@ class TwistedChannel(object):
         :param pika.Channel channel: our self._impl channel
         :param pika.spec.Basic.Return method:
         :param pika.spec.BasicProperties properties: message properties
-        :param body: returned message body; empty string if no body
-        :type body: str, unicode
+        :param bytes body: returned message body; empty string if no body
 
         """
         assert isinstance(message.method, spec.Basic.Return), message.method
@@ -770,16 +762,12 @@ class TwistedChannel(object):
                       arguments=None):
         """Bind an exchange to another exchange.
 
-        :param destination: The destination exchange to bind
-        :type destination: str or unicode
-        :param source: The source exchange to bind to
-        :type source: str or unicode
-        :param routing_key: The routing key to bind on
-        :type routing_key: str or unicode
-        :param arguments: Custom key/value pair arguments for the binding
-        :type arguments: dict
+        :param str destination: The destination exchange to bind
+        :param str source: The source exchange to bind to
+        :param str routing_key: The routing key to bind on
+        :param dict arguments: Custom key/value pair arguments for the binding
         :raises ValueError:
-        :return: Deferred that fires on the Exchange.BindOk response
+        :returns: Deferred that fires on the Exchange.BindOk response
         :rtype: Deferred
 
         """
@@ -807,11 +795,9 @@ class TwistedChannel(object):
         exchange does not already exist, the server MUST raise a channel
         exception with reply code 404 (not found).
 
-        :param exchange: The exchange name consists of a non-empty
-        :type exchange: str or unicode
-                                     sequence of these characters: letters,
-                                     digits, hyphen, underscore, period, or
-                                     colon.
+        :param str exchange: The exchange name consists of a non-empty sequence
+            of these characters: letters, digits, hyphen, underscore, period,
+            or colon
         :param str exchange_type: The exchange type to use
         :param bool passive: Perform a declare or just check to see if it
             exists
@@ -819,7 +805,7 @@ class TwistedChannel(object):
         :param bool auto_delete: Remove when no more queues are bound to it
         :param bool internal: Can only be published to by other exchanges
         :param dict arguments: Custom key/value pair arguments for the exchange
-        :return: Deferred that fires on the Exchange.DeclareOk response
+        :returns: Deferred that fires on the Exchange.DeclareOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -837,10 +823,9 @@ class TwistedChannel(object):
     def exchange_delete(self, exchange=None, if_unused=False):
         """Delete the exchange.
 
-        :param exchange: The exchange name
-        :type exchange: str or unicode
+        :param str exchange: The exchange name
         :param bool if_unused: only delete if the exchange is unused
-        :return: Deferred that fires on the Exchange.DeleteOk response
+        :returns: Deferred that fires on the Exchange.DeleteOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -857,14 +842,11 @@ class TwistedChannel(object):
                         arguments=None):
         """Unbind an exchange from another exchange.
 
-        :param destination: The destination exchange to unbind
-        :type destination: str or unicode
-        :param source: The source exchange to unbind from
-        :type source: str or unicode
-        :param routing_key: The routing key to unbind
-        :type routing_key: str or unicode
+        :param str destination: The destination exchange to unbind
+        :param str source: The source exchange to unbind from
+        :param str routing_key: The routing key to unbind
         :param dict arguments: Custom key/value pair arguments for the binding
-        :return: Deferred that fires on the Exchange.UnbindOk response
+        :returns: Deferred that fires on the Exchange.UnbindOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -885,8 +867,8 @@ class TwistedChannel(object):
         http://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
         :param bool active: Turn flow on or off
-        :return: Deferred that fires with the channel flow state
-        :rtype: Deferred(bool)
+        :returns: Deferred that fires with the channel flow state
+        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -899,14 +881,11 @@ class TwistedChannel(object):
     def queue_bind(self, queue, exchange, routing_key=None, arguments=None):
         """Bind the queue to the specified exchange
 
-        :param queue: The queue to bind to the exchange
-        :type queue: str or unicode
-        :param exchange: The source exchange to bind to
-        :type exchange: str or unicode
-        :param routing_key: The routing key to bind on
-        :type routing_key: str or unicode
+        :param str queue: The queue to bind to the exchange
+        :param str exchange: The source exchange to bind to
+        :param str routing_key: The routing key to bind on
         :param dict arguments: Custom key/value pair arguments for the binding
-        :return: Deferred that fires on the Queue.BindOk response
+        :returns: Deferred that fires on the Queue.BindOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -933,17 +912,15 @@ class TwistedChannel(object):
         Use an empty string as the queue name for the broker to auto-generate
         one
 
-        :param queue: The queue name
-        :type queue: str or unicode; if empty string, the broker will create a
-          unique queue name;
+        :param str queue: The queue name; if empty string, the broker will
+            create a unique queue name
         :param bool passive: Only check to see if the queue exists
         :param bool durable: Survive reboots of the broker
         :param bool exclusive: Only allow access by the current connection
         :param bool auto_delete: Delete after consumer cancels or disconnects
         :param dict arguments: Custom key/value arguments for the queue
-        :return: Deferred that fires on the Queue.DeclareOk response
+        :returns: Deferred that fires on the Queue.DeclareOk response
         :rtype: Deferred
-          Queue.DeclareOk
         :raises ValueError:
 
         """
@@ -964,11 +941,10 @@ class TwistedChannel(object):
         <pika.channel.Channel.queue_delete>`, and removes the reference to the
         queue object after it gets deleted on the server.
 
-        :param queue: The queue to delete
-        :type queue: str or unicode
+        :param str queue: The queue to delete
         :param bool if_unused: only delete if it's unused
         :param bool if_empty: only delete if the queue is empty
-        :return: Deferred that fires on the Queue.DeleteOk response
+        :returns: Deferred that fires on the Queue.DeleteOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -992,9 +968,8 @@ class TwistedChannel(object):
     def queue_purge(self, queue):
         """Purge all of the messages from the specified queue
 
-        :param queue: The queue to purge
-        :type queue: str or unicode
-        :return: Deferred that fires on the Queue.PurgeOk response
+        :param str queue: The queue to purge
+        :returns: Deferred that fires on the Queue.PurgeOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -1008,14 +983,11 @@ class TwistedChannel(object):
                      arguments=None):
         """Unbind a queue from an exchange.
 
-        :param queue: The queue to unbind from the exchange
-        :type queue: str or unicode
-        :param exchange: The source exchange to bind from
-        :type exchange: str or unicode
-        :param routing_key: The routing key to unbind
-        :type routing_key: str or unicode
+        :param str queue: The queue to unbind from the exchange
+        :param str exchange: The source exchange to bind from
+        :param str routing_key: The routing key to unbind
         :param dict arguments: Custom key/value pair arguments for the binding
-        :return: Deferred that fires on the Queue.UnbindOk response
+        :returns: Deferred that fires on the Queue.UnbindOk response
         :rtype: Deferred
         :raises ValueError:
 
@@ -1030,9 +1002,8 @@ class TwistedChannel(object):
     def tx_commit(self):
         """Commit a transaction.
 
-        :return: Deferred that fires on the Tx.CommitOk response
+        :returns: Deferred that fires on the Tx.CommitOk response
         :rtype: Deferred
-
         :raises ValueError:
 
         """
@@ -1041,9 +1012,8 @@ class TwistedChannel(object):
     def tx_rollback(self):
         """Rollback a transaction.
 
-        :return: Deferred that fires on the Tx.RollbackOk response
+        :returns: Deferred that fires on the Tx.RollbackOk response
         :rtype: Deferred
-
         :raises ValueError:
 
         """
@@ -1054,7 +1024,7 @@ class TwistedChannel(object):
         standard transactions. The client must use this method at least once on
         a channel before using the Commit or Rollback methods.
 
-        :return: Deferred that fires on the Tx.SelectOk response
+        :returns: Deferred that fires on the Tx.SelectOk response
         :rtype: Deferred
         :raises ValueError:
 

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -162,6 +162,7 @@ class _AsyncServiceAsyncHandle(AbstractIOReference):
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
+        :rtype: bool
 
         """
         return self._cancel()
@@ -741,7 +742,8 @@ class _AsyncTransportBase(  # pylint: disable=W0223
 
     def get_write_buffer_size(self):
         """
-        :return: Current size of output data buffered by the transport
+        :returns: Current size of output data buffered by the transport
+        :rtype: int
         """
         return self._tx_buffered_byte_count
 
@@ -835,7 +837,8 @@ class _AsyncTransportBase(  # pylint: disable=W0223
 
         :param sock: stream or SSL socket
         :param max_bytes: maximum number of bytes to receive
-        :return: received data or empty bytes uppon end of file
+        :returns: received data or empty bytes uppon end of file
+        :rtype: bytes
         :raises: whatever the corresponding `sock.recv()` raises except socket
                  error with errno.EINTR
 
@@ -849,7 +852,8 @@ class _AsyncTransportBase(  # pylint: disable=W0223
 
         :param sock: stream or SSL socket
         :param data: data bytes to send
-        :return: number of bytes actually sent
+        :returns: number of bytes actually sent
+        :rtype: int
         :raises: whatever the corresponding `sock.send()` raises except socket
                  error with errno.EINTR
 

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -101,8 +101,7 @@ class AbstractIOServices(pika.compat.AbstractBase):
               the connection it is more efficient to use the
               `ioloop.call_later()` method with a delay of 0.
 
-        :param method callback: The callback method; must be callable.
-        :return: None
+        :param callable callback: The callback method; must be callable.
         """
         raise NotImplementedError
 
@@ -116,7 +115,7 @@ class AbstractIOServices(pika.compat.AbstractBase):
         be called first.
 
         :param float delay: The number of seconds to wait to call callback
-        :param method callback: The callback method
+        :param callable callback: The callback method
         :returns: A handle that can be used to cancel the request.
         :rtype: AbstractTimerReference
 
@@ -239,6 +238,7 @@ class AbstractFileDescriptorServices(pika.compat.AbstractBase):
 
         :param fd: file descriptor
         :returns: True if reader was removed; False if none was registered.
+        :rtype: bool
 
         """
         raise NotImplementedError
@@ -270,6 +270,7 @@ class AbstractFileDescriptorServices(pika.compat.AbstractBase):
 
         :param fd: file descriptor
         :returns: True if reader was removed; False if none was registered.
+        :rtype: bool
 
         """
         raise NotImplementedError
@@ -281,8 +282,6 @@ class AbstractTimerReference(pika.compat.AbstractBase):
     @abc.abstractmethod
     def cancel(self):
         """Cancel callback. If already cancelled, has no affect.
-
-        :returns: None
         """
         raise NotImplementedError
 
@@ -336,11 +335,11 @@ class AbstractStreamProtocol(pika.compat.AbstractBase):
     def eof_received(self):
         """Called after the remote peer shuts its write end of the connection.
 
-        :return: A falsy value (including None) will cause the transport to
+        :returns: A falsy value (including None) will cause the transport to
             close itself, resulting in an eventual `connection_lost()` call
             from the transport. If a truthy value is returned, it will be the
             protocol's responsibility to close/abort the transport.
-        :rtype: falsy | truthy
+        :rtype: falsy|truthy
         :raises Exception: Exception-based exception on error
         """
         raise NotImplementedError
@@ -413,7 +412,8 @@ class AbstractStreamTransport(pika.compat.AbstractBase):
     @abc.abstractmethod
     def get_write_buffer_size(self):
         """
-        :return: Current size of output data buffered by the transport
+        :returns: Current size of output data buffered by the transport
+        :rtype: int
         """
         raise NotImplementedError
 

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -87,10 +87,10 @@ class AbstractSelectorIOLoop(object):
         timeout.
 
         :param float delay: The number of seconds to wait to call callback
-        :param method callback: The callback method
+        :param callable callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
-        :rtype: opaque
+        :rtype: object
 
         """
 
@@ -114,7 +114,7 @@ class AbstractSelectorIOLoop(object):
         ioloop that is running in a different thread via
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
-        :param method callback: The callback method
+        :param callable callback: The callback method
 
         """
 
@@ -123,7 +123,7 @@ class AbstractSelectorIOLoop(object):
         """Start watching the given file descriptor for events
 
         :param int fd: The file descriptor
-        :param method handler: When requested event(s) occur,
+        :param callable handler: When requested event(s) occur,
             `handler(fd, events)` will be called.
         :param int events: The event mask using READ, WRITE, ERROR.
 
@@ -453,6 +453,7 @@ class _SelectorIOLoopIOHandle(nbio_interface.AbstractIOReference):
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
+        :rtype: bool
 
         """
         return self._cancel()

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -37,8 +37,7 @@ class Method(AMQPObject):
         be carried as attributes of the class.
 
         :param pika.frame.Properties properties: AMQP Basic Properties
-        :param body: The message body
-        :type body: str or unicode
+        :param bytes body: The message body
 
         """
         self._properties = properties # pylint: disable=W0201

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -16,8 +16,8 @@ def name_or_value(value):
     """Will take Frame objects, classes, etc and attempt to return a valid
     string identifier for them.
 
-    :param value: The value to sanitize
-    :type value:  pika.amqp_object.AMQPObject|pika.frame.Frame|int|unicode|str
+    :param pika.amqp_object.AMQPObject|pika.frame.Frame|int|str value: The
+        value to sanitize
     :rtype: str
 
     """
@@ -128,11 +128,9 @@ class CallbackManager(object):
         CallbackManager will restrict processing of the callback to only
         the calling function/object that you specify.
 
-        :param prefix: Categorize the callback
-        :type prefix: str or int
-        :param key: The key for the callback
-        :type key: object or str or dict
-        :param method callback: The callback to call
+        :param str|int prefix: Categorize the callback
+        :param str|dict key: The key for the callback
+        :param callable callback: The callback to call
         :param bool one_shot: Remove this callback after it is called
         :param object only_caller: Only allow one_caller value to call the
                                    event that fires the callback.
@@ -191,10 +189,8 @@ class CallbackManager(object):
     def pending(self, prefix, key):
         """Return count of callbacks for a given prefix or key or None
 
-        :param prefix: Categorize the callback
-        :type prefix: str or int
-        :param key: The key for the callback
-        :type key: object or str or dict
+        :param str|int prefix: Categorize the callback
+        :param object|str|dict key: The key for the callback
         :rtype: None or int
 
         """
@@ -210,10 +206,8 @@ class CallbackManager(object):
         require a specific function to call CallbackManager.process will
         not be processed.
 
-        :param prefix: Categorize the callback
-        :type prefix: str or int
-        :param key: The key for the callback
-        :type key: object or str or dict
+        :param str|int prefix: Categorize the callback
+        :param object|str|int key: The key for the callback
         :param object caller: Who is firing the event
         :param list args: Any optional arguments
         :param dict keywords: Optional keyword arguments
@@ -252,7 +246,7 @@ class CallbackManager(object):
 
         :param str or int prefix: The prefix for keeping track of callbacks with
         :param str key: The callback key
-        :param method callback_value: The method defined to call on callback
+        :param callable callback_value: The method defined to call on callback
         :param dict arguments: Optional arguments to check
         :rtype: bool
 
@@ -312,7 +306,7 @@ class CallbackManager(object):
     def _callback_dict(self, callback, one_shot, only_caller, arguments):
         """Return the callback dictionary.
 
-        :param method callback: The callback to call
+        :param callable callback: The callback to call
         :param bool one_shot: Remove this callback after it is called
         :param object only_caller: Only allow one_caller value to call the
                                    event that fires the callback.

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -176,7 +176,7 @@ class Channel(object):
                                 channel: pika.Channel
                                 method: pika.spec.Basic.Return
                                 properties: pika.spec.BasicProperties
-                                body: str, unicode, or bytes (python 3.x)
+                                body: bytes
 
         """
         self.callbacks.add(self.channel_number, '_on_return', callback, False)
@@ -279,26 +279,25 @@ class Channel(object):
         http://www.rabbitmq.com/confirms.html
         http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
-        :param queue: The queue to consume from. Use the empty string to specify the
-                      most recent server-named queue for this channel.
-        :type queue: str or unicode
-        :param callable on_message_callback: The function to call when consuming
-            with the signature on_message_callback(channel, method, properties, body), where
-                                channel: pika.Channel
-                                method: pika.spec.Basic.Deliver
-                                properties: pika.spec.BasicProperties
-                                body: str, unicode, or bytes (python 3.x)
-        :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
-                              (see http://www.rabbitmq.com/confirms.html). This corresponds
-                              with the 'no_ack' parameter in the basic.consume AMQP 0.9.1
-                              method
+        :param str queue: The queue to consume from. Use the empty string to
+            specify the most recent server-named queue for this channel
+        :param callable on_message_callback: The function to call when
+            consuming with the signature
+            on_message_callback(channel, method, properties, body), where
+                channel: pika.Channel
+                method: pika.spec.Basic.Deliver
+                properties: pika.spec.BasicProperties
+                body: bytes
+        :param bool auto_ack: if set to True, automatic acknowledgement mode
+            will be used (see http://www.rabbitmq.com/confirms.html).
+            This corresponds with the 'no_ack' parameter in the basic.consume
+            AMQP 0.9.1 method
         :param bool exclusive: Don't allow other consumers on the queue
-        :param consumer_tag: Specify your own consumer tag
-        :type consumer_tag: str or unicode
+        :param str consumer_tag: Specify your own consumer tag
         :param dict arguments: Custom key/value pair arguments for the consumer
         :param callable callback: callback(pika.frame.Method) for method
           Basic.ConsumeOk.
-        :return: Consumer tag which may be used to cancel the consumer.
+        :returns: Consumer tag which may be used to cancel the consumer.
         :rtype: str
         :raises ValueError:
 
@@ -356,16 +355,15 @@ class Channel(object):
 
         http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
 
-        :param queue: The queue from which to get a message. Use the empty
-                      string to specify the most recent server-named queue
-                      for this channel.
-        :type queue: str or unicode
+        :param str queue: The queue from which to get a message. Use the empty
+            string to specify the most recent server-named queue for this
+            channel
         :param callable callback: The callback to call with a message that has
             the signature callback(channel, method, properties, body), where:
             channel: pika.Channel
             method: pika.spec.Basic.GetOk
             properties: pika.spec.BasicProperties
-            body: str, unicode, or bytes (python 3.x)
+            body: bytes
         :param bool auto_ack: Tell the broker to not expect a reply
         :raises ValueError:
 
@@ -416,12 +414,9 @@ class Channel(object):
 
         http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
-        :param exchange: The exchange to publish to
-        :type exchange: str or unicode
-        :param routing_key: The routing key to bind on
-        :type routing_key: str or unicode
-        :param body: The message body
-        :type body: str or unicode
+        :param str exchange: The exchange to publish to
+        :param str routing_key: The routing key to bind on
+        :param bytes body: The message body
         :param pika.spec.BasicProperties properties: Basic.properties
         :param bool mandatory: The mandatory flag
 
@@ -614,12 +609,9 @@ class Channel(object):
                       callback=None):
         """Bind an exchange to another exchange.
 
-        :param destination: The destination exchange to bind
-        :type destination: str or unicode
-        :param source: The source exchange to bind to
-        :type source: str or unicode
-        :param routing_key: The routing key to bind on
-        :type routing_key: str or unicode
+        :param str destination: The destination exchange to bind
+        :param str source: The source exchange to bind to
+        :param str routing_key: The routing key to bind on
         :param dict arguments: Custom key/value pair arguments for the binding
         :param callable callback: The callback to call on Exchange.BindOk
         :raises ValueError:
@@ -652,11 +644,9 @@ class Channel(object):
         exchange does not already exist, the server MUST raise a channel
         exception with reply code 404 (not found).
 
-        :param exchange: The exchange name consists of a non-empty
-        :type exchange: str or unicode
-                                     sequence of these characters: letters,
-                                     digits, hyphen, underscore, period, or
-                                     colon.
+        :param str exchange: The exchange name consists of a non-empty sequence
+            of these characters: letters, digits, hyphen, underscore, period,
+            or colon
         :param str exchange_type: The exchange type to use
         :param bool passive: Perform a declare or just check to see if it exists
         :param bool durable: Survive a reboot of RabbitMQ
@@ -679,8 +669,7 @@ class Channel(object):
     def exchange_delete(self, exchange=None, if_unused=False, callback=None):
         """Delete the exchange.
 
-        :param exchange: The exchange name
-        :type exchange: str or unicode
+        :param str exchange: The exchange name
         :param bool if_unused: only delete if the exchange is unused
         :param callable callback: The function to call on Exchange.DeleteOk
         :raises ValueError:
@@ -700,12 +689,9 @@ class Channel(object):
                         callback=None):
         """Unbind an exchange from another exchange.
 
-        :param destination: The destination exchange to unbind
-        :type destination: str or unicode
-        :param source: The source exchange to unbind from
-        :type source: str or unicode
-        :param routing_key: The routing key to unbind
-        :type routing_key: str or unicode
+        :param str destination: The destination exchange to unbind
+        :param str source: The source exchange to unbind from
+        :param str routing_key: The routing key to unbind
         :param dict arguments: Custom key/value pair arguments for the binding
         :param callable callback: The callback to call on Exchange.UnbindOk
         :raises ValueError:
@@ -780,12 +766,9 @@ class Channel(object):
                    callback=None):
         """Bind the queue to the specified exchange
 
-        :param queue: The queue to bind to the exchange
-        :type queue: str or unicode
-        :param exchange: The source exchange to bind to
-        :type exchange: str or unicode
-        :param routing_key: The routing key to bind on
-        :type routing_key: str or unicode
+        :param str queue: The queue to bind to the exchange
+        :param str exchange: The source exchange to bind to
+        :param str routing_key: The routing key to bind on
         :param dict arguments: Custom key/value pair arguments for the binding
         :param callable callback: The callback to call on Queue.BindOk
         :raises ValueError:
@@ -818,9 +801,8 @@ class Channel(object):
         Use an empty string as the queue name for the broker to auto-generate
         one
 
-        :param queue: The queue name
-        :type queue: str or unicode; if empty string, the broker will create a
-          unique queue name;
+        :param str queue: The queue name; if empty string, the broker will
+            create a unique queue name
         :param bool passive: Only check to see if the queue exists
         :param bool durable: Survive reboots of the broker
         :param bool exclusive: Only allow access by the current connection
@@ -853,8 +835,7 @@ class Channel(object):
                      callback=None):
         """Delete a queue from the broker.
 
-        :param queue: The queue to delete
-        :type queue: str or unicode
+        :param str queue: The queue to delete
         :param bool if_unused: only delete if it's unused
         :param bool if_empty: only delete if the queue is empty
         :param callable callback: The callback to call on Queue.DeleteOk
@@ -872,8 +853,7 @@ class Channel(object):
     def queue_purge(self, queue, callback=None):
         """Purge all of the messages from the specified queue
 
-        :param queue: The queue to purge
-        :type queue: str or unicode
+        :param str queue: The queue to purge
         :param callable callback: The callback to call on Queue.PurgeOk
         :raises ValueError:
 
@@ -892,12 +872,9 @@ class Channel(object):
                      callback=None):
         """Unbind a queue from an exchange.
 
-        :param queue: The queue to unbind from the exchange
-        :type queue: str or unicode
-        :param exchange: The source exchange to bind from
-        :type exchange: str or unicode
-        :param routing_key: The routing key to unbind
-        :type routing_key: str or unicode
+        :param str queue: The queue to unbind from the exchange
+        :param str exchange: The source exchange to bind from
+        :param str routing_key: The routing key to unbind
         :param dict arguments: Custom key/value pair arguments for the binding
         :param callable callback: The callback to call on Queue.UnbindOk
         :raises ValueError:
@@ -1011,6 +988,7 @@ class Channel(object):
         retrieve the cookie that it set via `_set_cookie`
 
         :returns: opaque cookie value that was set via `_set_cookie`
+        :rtype: object
 
         """
         return self._cookie
@@ -1155,8 +1133,7 @@ class Channel(object):
 
         :param pika.frame.Method method_frame: The method frame received
         :param pika.frame.Header header_frame: The header frame received
-        :param body: The body received
-        :type body: str or unicode
+        :param bytes body: The body received
 
         """
         consumer_tag = method_frame.method.consumer_tag
@@ -1220,8 +1197,7 @@ class Channel(object):
 
         :param pika.frame.Method method_frame: The method frame received
         :param pika.frame.Header header_frame: The header frame received
-        :param body: The body received
-        :type body: str or unicode
+        :param bytes body: The body received
 
         """
         if self._on_getok_callback is not None:
@@ -1258,8 +1234,7 @@ class Channel(object):
 
         :param pika.frame.Method method_frame: The Basic.Return frame
         :param pika.frame.Header header_frame: The content header frame
-        :param body: The message body
-        :type body: str or unicode
+        :param bytes body: The message body
 
         """
         if not self.callbacks.process(self.channel_number, '_on_return', self,
@@ -1334,9 +1309,8 @@ class Channel(object):
 
         :param pika.amqp_object.Method method: The AMQP method to invoke
         :param callable callback: The callback for the RPC response
-        :param acceptable_replies: A (possibly empty) sequence of
+        :param list|None acceptable_replies: A (possibly empty) sequence of
             replies this RPC call expects or None
-        :type acceptable_replies: list or None
 
         """
         assert method.synchronous, (

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -91,6 +91,7 @@ if PY3:
         """
         :param dict dct:
         :returns: an iterator of the values of a dictionary
+        :rtype: iterator
         """
         return dct.values()
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -147,8 +147,9 @@ class Parameters(object):  # pylint: disable=R0902
     @property
     def blocked_connection_timeout(self):
         """
-        :returns: None or float blocked connection timeout. Defaults to
+        :returns: blocked connection timeout. Defaults to
             `DEFAULT_BLOCKED_CONNECTION_TIMEOUT`.
+        :rtype: float|None
 
         """
         return self._blocked_connection_timeout
@@ -198,10 +199,10 @@ class Parameters(object):  # pylint: disable=R0902
     @property
     def client_properties(self):
         """
-        :returns: None or dict of client properties used to override the fields
-            in the default client poperties reported  to RabbitMQ via
-            `Connection.StartOk` method. Defaults to
-            `DEFAULT_CLIENT_PROPERTIES`.
+        :returns: client properties used to override the fields in the default
+            client poperties reported  to RabbitMQ via `Connection.StartOk`
+            method. Defaults to `DEFAULT_CLIENT_PROPERTIES`.
+        :rtype: dict|None
 
         """
         return self._client_properties
@@ -227,6 +228,7 @@ class Parameters(object):  # pylint: disable=R0902
         """
         :returns: number of socket connection attempts. Defaults to
             `DEFAULT_CONNECTION_ATTEMPTS`. See also `retry_delay`.
+        :rtype: int
 
         """
         return self._connection_attempts
@@ -272,6 +274,7 @@ class Parameters(object):  # pylint: disable=R0902
         """
         :returns: desired maximum AMQP frame size to use. Defaults to
             `DEFAULT_FRAME_MAX`.
+        :rtype: int
 
         """
         return self._frame_max
@@ -304,7 +307,7 @@ class Parameters(object):  # pylint: disable=R0902
             connection tuning or callable which is invoked during connection tuning.
             None to accept broker's value. 0 turns heartbeat off. Defaults to
             `DEFAULT_HEARTBEAT_TIMEOUT`.
-        :rtype: integer, None or callable
+        :rtype: int|callable|None
 
         """
         return self._heartbeat
@@ -414,7 +417,7 @@ class Parameters(object):  # pylint: disable=R0902
         """
         :returns: socket connect timeout in seconds. Defaults to
             `DEFAULT_SOCKET_TIMEOUT`. The value None disables this timeout.
-        :rtype: float | None
+        :rtype: float|None
 
         """
         return self._socket_timeout
@@ -493,6 +496,7 @@ class Parameters(object):  # pylint: disable=R0902
         """
         :returns: rabbitmq virtual host name. Defaults to
             `DEFAULT_VIRTUAL_HOST`.
+        :rtype: str
 
         """
         return self._virtual_host
@@ -584,7 +588,7 @@ class ConnectionParameters(Parameters):
             (TCP/[SSL]/AMQP) bring-up timeout in seconds. It's recommended to
             set this value higher than `socket_timeout`.
         :param str locale: Set the locale value
-        :param blocked_connection_timeout: If not None,
+        :param int|float|None blocked_connection_timeout: If not None,
             the value is a non-negative timeout, in seconds, for the
             connection to remain blocked (triggered by Connection.Blocked from
             broker); if the timeout expires before connection becomes unblocked,
@@ -592,7 +596,6 @@ class ConnectionParameters(Parameters):
             mechanism for informing client app about the closed connection:
             passing `ConnectionBlockedTimeout` exception to on_close_callback
             in asynchronous adapters or raising it in `BlockingConnection`.
-        :type blocked_connection_timeout: None, int, float
         :param client_properties: None or dict of client properties used to
             override the fields in the default client properties reported to
             RabbitMQ via `Connection.StartOk` method.
@@ -1011,7 +1014,7 @@ class Connection(pika.compat.AbstractBase):
 
         :param pika.connection.Parameters parameters: Read-only connection
             parameters.
-        :param method on_open_callback: Called when the connection is opened:
+        :param callable on_open_callback: Called when the connection is opened:
             on_open_callback(connection)
         :param None | method on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
@@ -1160,7 +1163,7 @@ class Connection(pika.compat.AbstractBase):
         a fully-open connection was closed by user or broker or exception of
         another type that describes the cause of connection closure/failure.
 
-        :param method callback: Callback to call on close, having the signature:
+        :param callable callback: Callback to call on close, having the signature:
             callback(pika.connection.Connection, exception)
 
         """
@@ -1180,7 +1183,7 @@ class Connection(pika.compat.AbstractBase):
 
         See also `ConnectionParameters.blocked_connection_timeout`.
 
-        :param method callback: Callback to call on `Connection.Blocked`,
+        :param callable callback: Callback to call on `Connection.Blocked`,
             having the signature `callback(connection, pika.frame.Method)`,
             where the method frame's `method` member is of type
             `pika.spec.Connection.Blocked`
@@ -1198,7 +1201,7 @@ class Connection(pika.compat.AbstractBase):
         connection gets unblocked (`Connection.Unblocked` frame is received from
         RabbitMQ) letting publishers know it's ok to start publishing again.
 
-        :param method callback: Callback to call on
+        :param callable callback: Callback to call on
             `Connection.Unblocked`, having the signature
             `callback(connection, pika.frame.Method)`, where the method frame's
             `method` member is of type `pika.spec.Connection.Unblocked`
@@ -1215,7 +1218,7 @@ class Connection(pika.compat.AbstractBase):
         """Add a callback notification when the connection has opened. The
         callback will be passed the connection instance as its only arg.
 
-        :param method callback: Callback to call when open
+        :param callable callback: Callback to call when open
 
         """
         validators.require_callback(callback)
@@ -1227,7 +1230,7 @@ class Connection(pika.compat.AbstractBase):
         The callback method should accept the connection instance that could not
         connect, and either a string or an exception as its second arg.
 
-        :param method callback: Callback to call when can't connect, having
+        :param callable callback: Callback to call when can't connect, having
             the signature _(Connection, Exception)
         :param bool remove_default: Remove default exception raising callback
 
@@ -1246,9 +1249,9 @@ class Connection(pika.compat.AbstractBase):
 
         :param int channel_number: The channel number to use, defaults to the
                                    next available.
-        :param method on_open_callback: The callback when the channel is opened.
-            The callback will be invoked with the `Channel` instance as its only
-            argument.
+        :param callable on_open_callback: The callback when the channel is
+            opened.  The callback will be invoked with the `Channel` instance
+            as its only argument.
         :rtype: pika.channel.Channel
 
         """
@@ -1399,11 +1402,11 @@ class Connection(pika.compat.AbstractBase):
         specified number of seconds have elapsed, using a timer, or a
         thread, or similar.
 
-        :param float | int delay: The number of seconds to wait to call
-            callback
-        :param method callback: The callback will be called without args.
-        :return: Handle that can be passed to `_adapter_remove_timeout()` to
+        :param float|int delay: The number of seconds to wait to call callback
+        :param callable callback: The callback will be called without args.
+        :returns: Handle that can be passed to `_adapter_remove_timeout()` to
             cancel the callback.
+        :rtype: object
 
         """
         raise NotImplementedError
@@ -1426,7 +1429,7 @@ class Connection(pika.compat.AbstractBase):
          other manipulations of the connection must be performed from the
          connection's thread.
 
-        :param method callback: The callback method; must be callable.
+        :param callable callback: The callback method; must be callable.
 
         """
         raise NotImplementedError
@@ -1552,9 +1555,9 @@ class Connection(pika.compat.AbstractBase):
         back the method specified by on_open_callback
 
         :param int channel_number: The channel number to use
-        :param method on_open_callback: The callback when the channel is opened.
-            The callback will be invoked with the `Channel` instance as its only
-            argument.
+        :param callable on_open_callback: The callback when the channel is
+            opened.  The callback will be invoked with the `Channel` instance
+            as its only argument.
 
         """
         LOGGER.debug('Creating channel %s', channel_number)
@@ -1882,6 +1885,7 @@ class Connection(pika.compat.AbstractBase):
             broker; 0 (zero) to disable heartbeat.
 
         :returns: the value of the heartbeat timeout to use and return to broker
+        :rtype: int
         """
         if client_value is None:
             # Accept server's limit
@@ -2090,8 +2094,8 @@ class Connection(pika.compat.AbstractBase):
     def _process_frame(self, frame_value):
         """Process an inbound frame from the socket.
 
-        :param frame_value: The frame to process
-        :type frame_value: pika.frame.Frame | pika.frame.Method
+        :param pika.frame.Frame|pika.frame.Method frame_value: The frame to
+            process
 
         """
         # Will receive a frame type of -1 if protocol version mismatch
@@ -2148,7 +2152,7 @@ class Connection(pika.compat.AbstractBase):
 
         :param int channel_number: The channel number for the RPC call
         :param pika.amqp_object.Method method: The method frame to call
-        :param method callback: The callback for the RPC response
+        :param callable callback: The callback for the RPC response
         :param list acceptable_replies: The replies this RPC call expects
 
         """
@@ -2206,8 +2210,8 @@ class Connection(pika.compat.AbstractBase):
         """This appends the fully generated frame to send to the broker to the
         output buffer which will be then sent via the connection adapter.
 
-        :param frame_value: The frame to write
-        :type frame_value:  pika.frame.Frame|pika.frame.ProtocolHeader
+        :param pika.frame.Frame|pika.frame.ProtocolHeader frame_value: The
+            frame to write
         :raises: exceptions.ConnectionClosed
 
         """

--- a/pika/data.py
+++ b/pika/data.py
@@ -16,8 +16,7 @@ def encode_short_string(pieces, value):
     returning the size of the encoded value.
 
     :param list pieces: Already encoded values
-    :param value: String value to encode
-    :type value: str or unicode
+    :param str value: String value to encode
     :rtype: int
 
     """

--- a/pika/diagnostic_utils.py
+++ b/pika/diagnostic_utils.py
@@ -12,7 +12,8 @@ def create_log_exception_decorator(logger):
     the decorated function
 
     :param logging.Logger logger:
-    :return: the decorator
+    :returns: the decorator
+    :rtype: callable
 
     Usage example
 
@@ -32,7 +33,8 @@ def create_log_exception_decorator(logger):
         """The decorator returned by the parent function
 
         :param func: function to be wrapped
-        :return: the function wrapper
+        :returns: the function wrapper
+        :rtype: callable
         """
 
         @functools.wraps(func)
@@ -44,7 +46,8 @@ def create_log_exception_decorator(logger):
 
             :param args: positional args passed to wrapped function
             :param kwargs: keyword args passed to wrapped function
-            :return: whatever the wrapped function returns
+            :returns: whatever the wrapped function returns
+            :rtype: object
             """
             try:
                 return func(*args, **kwargs)

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -229,9 +229,8 @@ class UnroutableError(AMQPChannelError):
 
     def __init__(self, messages):
         """
-        :param messages: sequence of returned unroutable messages
-        :type messages: sequence of `blocking_connection.ReturnedMessage`
-           objects
+        :param sequence(blocking_connection.ReturnedMessage) messages: Sequence
+            of returned unroutable messages
         """
         super(UnroutableError, self).__init__(
             "%s unroutable message(s) returned" % (len(messages)))
@@ -252,9 +251,8 @@ class NackError(AMQPChannelError):
 
     def __init__(self, messages):
         """
-        :param messages: sequence of returned unroutable messages
-        :type messages: sequence of `blocking_connection.ReturnedMessage`
-            objects
+        :param sequence(blocking_connection.ReturnedMessage) messages: Sequence
+            of returned unroutable messages
         """
         super(NackError,
               self).__init__("%s message(s) NACKed" % (len(messages)))

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -35,6 +35,7 @@ def rpc_completion_callback(callback):
     """Verify callback is callable if not None
 
     :returns: boolean indicating nowait
+    :rtype: bool
     :raises: TypeError
 
     """

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -98,10 +98,8 @@ class ParametersTestsBase(unittest.TestCase):
         """Assert that the given parameters object has the default parameter
         values.
 
-        :param params: verify that the given params instance has all default
-           property values
-        :type params: one of the classes based on `pika.connection.Parameters`
-
+        :param pika.connection.Parameters params: Verify that the given params
+            instance has all default property values
         """
         for name, expected_value in dict_iteritems(
                 self.get_default_properties()):


### PR DESCRIPTION
This PR will:

- use `:param <type> <name>: <description>` consistently instead of both `:param <type> <name>: <description>` and `:param <name>: <description>\n:type <name>: <type>`;
- use `:returns:` consistently instead of both `:return:` and `:returns:`;
- add missing `:rtype: <type>`.