### PR TITLE
Update doc string to reference correct param name

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -571,7 +571,7 @@ class ConnectionParameters(Parameters):
         :param pika.credentials.Credentials credentials: auth credentials
         :param int channel_max: Maximum number of channels to allow
         :param int frame_max: The maximum byte size for an AMQP frame
-        :param int|None|callable value: Controls AMQP heartbeat timeout negotiation
+        :param int|None|callable heartbeat: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called


### PR DESCRIPTION
## Proposed Changes
The doc string for `ConnectionParameters` appears to have the incorrect name for the description of the `heartbeat` keyword.

Found while looking through `help(ConnectionParameters)` in a REPL, specifically looking to find which values `ConnectionParameters` would accept for the `heartbeat` keyword.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

As this is a one-word change in a doc string, I have opted to not run the tests locally or add/change test coverage.