### PR TITLE
add consumer_tags property to BlockingChannel

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1303,6 +1303,15 @@ class BlockingChannel(object):
         """
         return self._impl.is_open
 
+    @property
+    def consumer_tags(self):
+        """Property method that returns a list of currently active consumers
+
+        :rtype: list
+
+        """
+        return compat.dictkeys(self._consumer_infos)
+
     _ALWAYS_READY_WAITERS = ((lambda: True),)
 
     def _flush_output(self, *waiters):

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1305,7 +1305,8 @@ class BlockingChannel(object):
 
     @property
     def consumer_tags(self):
-        """Property method that returns a list of currently active consumers
+        """Property method that returns a list of consumer tags for active
+        consumers
 
         :rtype: list
 

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -113,3 +113,12 @@ class BlockingChannelTests(unittest.TestCase):
             chan.close()
         chan._impl.close.assert_called_with(
             reply_code=0, reply_text='Normal shutdown')
+
+    def test_consumer_tags_property(self):
+        with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
+            self.assertEqual(0, len(self.obj.consumer_tags))
+            self.obj._impl._generate_consumer_tag.return_value = 'ctag0'
+            self.obj._impl.basic_consume.return_value = 'ctag0'
+            self.obj.basic_consume('queue', mock.Mock())
+            self.assertEqual(1, len(self.obj.consumer_tags))
+            self.assertIn('ctag0', self.obj.consumer_tags)


### PR DESCRIPTION
* add consumer_tags property to BlockingChannel, duplicating code from Channel, but retrieving from self._consumer_infos
* add test_consumer_tags_property unit test
* formatted with yapf 0.27 using `yapf --style google -i tests/unit/blocking_channel_tests.py pika/adapters/blocking_connection.py`; formatter only changed code which already existed and did not appear to change format of newly-written code
* tested with `nosetests`; tests are clean on my local machine except for an import error regarding tornado.ioloop which I attribute to a versioning difference on my local machine

## Proposed Changes

Add add `consumer_tags` property to `BlockingChannel` to mirror the same property already in the regular `Channel` as discussed on the [forum](https://groups.google.com/d/msg/pika-python/LfWiLokiG1c/qo_Q8ZpyAgAJ).

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue from the [forum](https://groups.google.com/d/msg/pika-python/LfWiLokiG1c/qo_Q8ZpyAgAJ))
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

I have a test failure which I believe is unrelated, so I'm creating the pull request anyway. Consider tail of the test output:
```
======================================================================
ERROR: Failure: ImportError (No module named tornado.ioloop)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/lib/python2.7/dist-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/home/keithb/dev/pika/tests/unit/io_services_test_stubs_test.py", line 14, in <module>
    import tornado.ioloop
ImportError: No module named tornado.ioloop

----------------------------------------------------------------------
Ran 507 tests in 14.007s

FAILED (errors=1)
```
