### PR TITLE
fix doc for global_qos param in channel.basic_qos()

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -2272,8 +2272,8 @@ class BlockingChannel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored if the no-ack
                                    option is set in the consumer.
-        :param bool global_qos:    Should the QoS apply to all consumers on the
-                                   Channel
+        :param bool global_qos:    Should the QoS apply to all channels on the
+                                   connection.
 
         """
         with _CallbackResult() as qos_ok_result:

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -601,8 +601,8 @@ class TwistedChannel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool global_qos:    Should the QoS apply to all consumers on the
-                                   Channel
+        :param bool global_qos:    Should the QoS apply to all channels on the
+                                   connection.
         :returns: Deferred that fires on the Basic.QosOk response
         :rtype: Deferred
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -457,8 +457,8 @@ class Channel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool global_qos:    Should the QoS apply to all consumers on the
-                                   Channel
+        :param bool global_qos:    Should the QoS apply to all channels on the
+                                   connection.
         :param callable callback: The callback to call for Basic.QosOk response
         :raises ValueError:
 


### PR DESCRIPTION
## Proposed Changes

Description for `channel.basic_qos()` method states that 

> The QoS can be specified for the current channel or for all channels on the connection.

This is correct. However, later, the `basic_qos` parameter which is responsible for this choice, is documented as follows:

> Should the QoS apply to all Consumers on the Channel

This is incorrect and also contradicts the description of the very same method, leading to confusion.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

None.
