### PR TITLE
Small improvements in documentation formatting.

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -718,12 +718,10 @@ class BlockingConnection(object):
 
         For example, a thread may request a call to the
         `BlockingChannel.basic_ack` method of a `BlockingConnection` that is
-        running in a different thread via
+        running in a different thread via::
 
-        ```
-        connection.add_callback_threadsafe(
-            functools.partial(channel.basic_ack, delivery_tag=...))
-        ```
+            connection.add_callback_threadsafe(
+                functools.partial(channel.basic_ack, delivery_tag=...))
 
         NOTE: if you know that the requester is running on the same thread as
         the connection it is more efficient to use the

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1002,10 +1002,10 @@ class _ReturnedMessageEvt(_ChannelPendingEvt):
         """
         :param callable callback: user's callback, having the signature
             callback(channel, method, properties, body), where
-                                channel: pika.Channel
-                                method: pika.spec.Basic.Return
-                                properties: pika.spec.BasicProperties
-                                body: bytes
+             - channel: pika.Channel
+             - method: pika.spec.Basic.Return
+             - properties: pika.spec.BasicProperties
+             - body: bytes
         :param pika.Channel channel:
         :param pika.spec.Basic.Return method:
         :param pika.spec.BasicProperties properties:
@@ -1071,10 +1071,10 @@ class _ConsumerInfo(object):
         :param callable on_message_callback: The function for dispatching messages to
             user, having the signature:
             on_message_callback(channel, method, properties, body)
-                channel: BlockingChannel
-                method: spec.Basic.Deliver
-                properties: spec.BasicProperties
-                body: bytes
+             - channel: BlockingChannel
+             - method: spec.Basic.Deliver
+             - properties: spec.BasicProperties
+             - body: bytes
         :param callable alternate_event_sink: if specified, _ConsumerDeliveryEvt
             and _ConsumerCancellationEvt objects will be diverted to this
             callback instead of being deposited in the channel's
@@ -1569,10 +1569,10 @@ class BlockingChannel(object):
 
         :param callable callback: The method to call on callback with the
             signature callback(channel, method, properties, body), where
-            channel: pika.Channel
-            method: pika.spec.Basic.Return
-            properties: pika.spec.BasicProperties
-            body: bytes
+             - channel: pika.Channel
+             - method: pika.spec.Basic.Return
+             - properties: pika.spec.BasicProperties
+             - body: bytes
 
         """
         self._impl.add_on_return_callback(
@@ -1605,10 +1605,10 @@ class BlockingChannel(object):
         :param callable on_message_callback: Required function for dispatching messages
             to user, having the signature:
             on_message_callback(channel, method, properties, body)
-                channel: BlockingChannel
-                method: spec.Basic.Deliver
-                properties: spec.BasicProperties
-                body: bytes
+             - channel: BlockingChannel
+             - method: spec.Basic.Deliver
+             - properties: spec.BasicProperties
+             - body: bytes
         :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
                               (see http://www.rabbitmq.com/confirms.html). This corresponds
                               with the 'no_ack' parameter in the basic.consume AMQP 0.9.1
@@ -1733,10 +1733,10 @@ class BlockingChannel(object):
             the cancellation (this is done instead of via consumer's callback in
             order to prevent reentrancy/recursion. Each message is four-tuple:
             (channel, method, properties, body)
-                channel: BlockingChannel
-                method: spec.Basic.Deliver
-                properties: spec.BasicProperties
-                body: bytes
+             - channel: BlockingChannel
+             - method: spec.Basic.Deliver
+             - properties: spec.BasicProperties
+             - body: bytes
         :rtype: list
         """
         try:
@@ -1891,7 +1891,7 @@ class BlockingChannel(object):
         broker.
 
         Example:
-
+        ::
             for method, properties, body in channel.consume('queue'):
                 print body
                 channel.basic_ack(method.delivery_tag)

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -467,10 +467,10 @@ class TwistedChannel(object):
                       for this channel.
         :param bool auto_ack: Tell the broker to not expect a reply
         :returns: Deferred that fires with a namedtuple whose attributes are:
-            channel: this TwistedChannel
-            method: pika.spec.Basic.GetOk
-            properties: pika.spec.BasicProperties
-            body: bytes
+             - channel: this TwistedChannel
+             - method: pika.spec.Basic.GetOk
+             - properties: pika.spec.BasicProperties
+             - body: bytes
             If the queue is empty, None will be returned.
         :rtype: Deferred
         :raises pika.exceptions.DuplicateGetOkCallback:

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -172,10 +172,10 @@ class Channel(object):
         :param callable callback: The function to call, having the signature
                                 callback(channel, method, properties, body)
                                 where
-                                channel: pika.Channel
-                                method: pika.spec.Basic.Return
-                                properties: pika.spec.BasicProperties
-                                body: bytes
+                                 - channel: pika.Channel
+                                 - method: pika.spec.Basic.Return
+                                 - properties: pika.spec.BasicProperties
+                                 - body: bytes
 
         """
         self.callbacks.add(self.channel_number, '_on_return', callback, False)
@@ -282,10 +282,10 @@ class Channel(object):
         :param callable on_message_callback: The function to call when
             consuming with the signature
             on_message_callback(channel, method, properties, body), where
-                channel: pika.Channel
-                method: pika.spec.Basic.Deliver
-                properties: pika.spec.BasicProperties
-                body: bytes
+             - channel: pika.Channel
+             - method: pika.spec.Basic.Deliver
+             - properties: pika.spec.BasicProperties
+             - body: bytes
         :param bool auto_ack: if set to True, automatic acknowledgement mode
             will be used (see http://www.rabbitmq.com/confirms.html).
             This corresponds with the 'no_ack' parameter in the basic.consume
@@ -357,10 +357,10 @@ class Channel(object):
             channel
         :param callable callback: The callback to call with a message that has
             the signature callback(channel, method, properties, body), where:
-            channel: pika.Channel
-            method: pika.spec.Basic.GetOk
-            properties: pika.spec.BasicProperties
-            body: bytes
+             - channel: pika.Channel
+             - method: pika.spec.Basic.GetOk
+             - properties: pika.spec.BasicProperties
+             - body: bytes
         :param bool auto_ack: Tell the broker to not expect a reply
         :raises ValueError:
 


### PR DESCRIPTION
## Proposed Changes

- Reformatted all references to callback types to actually render as lists. Also unified the format
- Reformatted some code blocks that caught my eye.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

I didn't actually run the tests locally, but Travis seems to be satisfied. I rendered the documentation using `make html` in the `docs` directory. Everything seemed to be fine around the spots that I touched.

I did also noticed that some docstrings had different indenting styles (eg. `BlockingChannel.basic_ack` vs `BlockingChannel.basic_qos` vs `BlockingChannel.basic_cancel`) but I do not find any guidance on the style for docstrings.

Similar to above, I noticed some class names and return types without the code markers but chose to leave them be due to the same reasoning.
