### PR TITLE
Update Changelog to reflect renamed BlockingConnection method

### DIFF
--- a/docs/version_history.rst
+++ b/docs/version_history.rst
@@ -21,6 +21,7 @@ Version History
 
 - ``AsyncioConnection``, ``TornadoConnection`` and ``TwistedProtocolConnection`` are no longer auto-imported (`PR <https://github.com/pika/pika/pull/1129>`_)
 - ``BlockingConnection.consume`` now returns ``(None, None, None)`` when inactivity timeout is reached (`PR <https://github.com/pika/pika/pull/899>`_)
+- ``BlockingConnection.add_timeout`` renamed to ``BlockingConnection.call_later``
 - Python 3.7 support (`Issue <https://github.com/pika/pika/issues/1107>`_)
 - ``all_channels`` parameter of the ``Channel.basic_qos`` method renamed to ``global_qos``
 - ``global_`` parameter of the ``Basic.Qos`` spec class renamed to ``global_qos``


### PR DESCRIPTION
## Proposed Changes
After going through the process of updating from pika 0.13 to pika 1.1, I thought adding this line to the changelog would save future users a Google search.

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
