### PR TITLE
Correct Type

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -172,7 +172,7 @@ class Channel(object):
         :param callable callback: The function to call, having the signature
                                 callback(channel, method, properties, body)
                                 where
-                                 - channel: pika.Channel
+                                 - channel: pika.channel.Channel
                                  - method: pika.spec.Basic.Return
                                  - properties: pika.spec.BasicProperties
                                  - body: bytes
@@ -282,7 +282,7 @@ class Channel(object):
         :param callable on_message_callback: The function to call when
             consuming with the signature
             on_message_callback(channel, method, properties, body), where
-             - channel: pika.Channel
+             - channel: pika.channel.Channel
              - method: pika.spec.Basic.Deliver
              - properties: pika.spec.BasicProperties
              - body: bytes
@@ -357,7 +357,7 @@ class Channel(object):
             channel
         :param callable callback: The callback to call with a message that has
             the signature callback(channel, method, properties, body), where:
-             - channel: pika.Channel
+             - channel: pika.channel.Channel
              - method: pika.spec.Basic.GetOk
              - properties: pika.spec.BasicProperties
              - body: bytes


### PR DESCRIPTION
Documentation was pointing to an incorrect class path.

## Proposed Changes

A minor change to the documentation. I was attempting to add type hinting to some of my code and noticed the path `pika.Channel` should be `pika.channel.Channel`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc.
