### PR TITLE
Fix RecursionError on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 
 env:
   global:
-    - RABBITMQ_VERSION=3.8.0
+    - RABBITMQ_VERSION=3.8.2
     - RABBITMQ_DOWNLOAD_URL="https://github.com/rabbitmq/rabbitmq-server/releases/download/v$RABBITMQ_VERSION/rabbitmq-server-generic-unix-$RABBITMQ_VERSION.tar.xz"
     - RABBITMQ_TAR="rabbitmq-$RABBITMQ_VERSION.tar.xz"
     - PATH=$HOME/.local/bin:$PATH
@@ -71,6 +71,8 @@ jobs:
     - python: 3.6
     - python: 3.7
       dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    - python: 3.8
+      dist: xenial
     - stage: coverage
       if: fork = false OR type != pull_request
       python: 3.6

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -118,6 +118,9 @@ if PY3:
         serialized as `l` instead of `I`
         """
 
+        def __str__(self):
+            return str(int(self))
+
         def __repr__(self):
             return str(self) + 'L'
 


### PR DESCRIPTION
Reported here:

https://groups.google.com/d/topic/pika-python/JL014cAQ0ic/discussion

Code to test:

```
import pika

connection = pika.BlockingConnection()
channel = connection.channel()
method_frame, header_frame, body = channel.basic_get('test')
if method_frame:
    print(method_frame, header_frame, body)
    print(repr(header_frame.headers["timestamp_in_ms"]))
    channel.basic_ack(method_frame.delivery_tag)
else:
    print('No message returned')
```

Steps:

* Create queue `test` and publish a message to it with a `timestamp_in_ms` header using a number value like `1234567890`
* Run the above script using Python `3.8.0`. Without these changes, it'll crash.