### PR TITLE
ready return TwistedProtocolConnection instance as before

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1224,6 +1224,7 @@ class TwistedProtocolConnection(protocol.Protocol):
     def connectionReady(self):
         """This method will be called when the underlying connection is ready.
         """
+        return self
 
     def _on_connection_ready(self, _connection):
         d, self.ready = self.ready, None

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1193,6 +1193,11 @@ class TwistedProtocolConnection(protocol.Protocol):
         return d.addCallback(TwistedChannel)
 
     @property
+    def is_open(self):
+        # For compatibility with previous releases.
+        return self._impl.is_open
+
+    @property
     def is_closed(self):
         # For compatibility with previous releases.
         return self._impl.is_closed

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -11,6 +11,7 @@
 # pylint: disable=E1101
 
 """twisted adapter test"""
+import functools
 import unittest
 
 import mock
@@ -677,7 +678,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         d = self.conn.ready
         self.conn._on_connection_ready("testresult")
         self.assertTrue(d.called)
-        d.addCallback(self.assertIsNone)
+        d.addCallback(functools.partial(self.assertIsInstance, cls=TwistedProtocolConnection))
         return d
 
     def test_on_connection_ready_twice(self):


### PR DESCRIPTION
## Proposed Changes

#1108 changed behavior of `TwistedProtocolConnection.ready` as it originally return the connection instance https://github.com/pika/pika/pull/1108/files#diff-f4958571e7beaeebd50f967e48ce9e59L435

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pika/pika/1276)
<!-- Reviewable:end -->
