### PR TITLE
Issue 1286 - Fixes for possible race condition between selector_ioloop and writer

### DIFF
--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -1018,11 +1018,16 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
         assert data, ('_AsyncPlaintextTransport.write(): empty data from user.',
                       data, self._state)
 
-        if not self.get_write_buffer_size():
-            self._nbio.set_writer(self._sock.fileno(), self._on_socket_writable)
-            _LOGGER.debug('Turned on writability watcher: %s', self._sock)
+        # NOTE: Modify code to write data to buffer before setting writer.
+        # Otherwise a race condition can occur where ioloop executes writer 
+        # while buffer is still empty. 
+        setWriter = True if not self.get_write_buffer_size() else False
 
         self._buffer_tx_data(data)
+
+        if setWriter:
+            self._nbio.set_writer(self._sock.fileno(), self._on_socket_writable)
+            _LOGGER.debug('Turned on writability watcher: %s', self._sock)
 
     @_log_exceptions
     def _on_socket_readable(self):

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -325,13 +325,16 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         else:
             if callbacks.writer is None:
                 assert callbacks.reader is not None
+                # NOTE: Set the writer func before setting the mask!
+                # Otherwise a race condition can occur where ioloop tries to
+                # call writer when it is still None.
+                callbacks.writer = on_writable
                 self._loop.update_handler(
                     fd, self._readable_mask | self._writable_mask)
                 LOGGER.debug('set_writer(%s, _) updated handler RdWr', fd)
             else:
                 LOGGER.debug('set_writer(%s, _) replacing writer', fd)
-
-            callbacks.writer = on_writable
+                callbacks.writer = on_writable
 
     def remove_writer(self, fd):
         """Implement


### PR DESCRIPTION
## Proposed Changes

As mentioned in https://github.com/pika/pika/issues/1286, there's a possible race condition between the selector_ioloop and the publisher thread.  This fix ensures that the write handler is set before enabling the selector mask, and the tx buffer is filled before enabling the selector to write out the data to the socket.

Refer to the issue comments for more details of what this fixes, including debug logs and stack traces.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes issue #1286 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x ] I have read the `CONTRIBUTING.md` document
- [x ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

Because this issue appears to be caused by a race condition and is not easily reproducible, I haven't added any test cases.  All I can do is verify that after applying the change to our one system that was exhibiting the issue, we no longer see the issue.

