### PR TITLE
Removed warnings filter while encoding integer

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -2,7 +2,6 @@
 import struct
 import decimal
 import calendar
-import warnings
 
 from datetime import datetime
 
@@ -133,16 +132,14 @@ def encode_value(pieces, value): # pylint: disable=R0911
         pieces.append(struct.pack('>cq', b'l', value))
         return 9
     elif isinstance(value, int):
-        with warnings.catch_warnings():
-            warnings.filterwarnings('error')
-            try:
-                packed = struct.pack('>ci', b'I', value)
-                pieces.append(packed)
-                return 5
-            except (struct.error, DeprecationWarning):
-                packed = struct.pack('>cq', b'l', long(value))
-                pieces.append(packed)
-                return 9
+        try:
+            packed = struct.pack('>ci', b'I', value)
+            pieces.append(packed)
+            return 5
+        except struct.error:
+            packed = struct.pack('>cq', b'l', long(value))
+            pieces.append(packed)
+            return 9
     elif isinstance(value, decimal.Decimal):
         value = value.normalize()
         if value.as_tuple().exponent < 0:


### PR DESCRIPTION
## Proposed Changes

From #1285, while encoding an integer, all warnings are filtered and raised as exceptions. This affects all threads, not just the current thread, which can cause warnings to be raised as exceptions in other threads, where they aren't expected.

The reason for this change in the first place was to ensure compatibility with Python 2.6, which raises a `DeprecationWarning` when an integer larger than a 32-bit signed integer is passed in. This has been changed from Python 2.7 to raise `struct.error` instead. Since Python 2.6 is no longer supported (by Pika and everyone else) this can be removed, and we can rely on catching `struct.error`.

Python 2.6.6 in Docker (WSL2)

```
>>> struct.pack('>ci', b'I', 2147483648)
__main__:1: DeprecationWarning: 'i' format requires -2147483648 <= number <= 2147483647
'I\x80\x00\x00\x00'
```

Python 3.6 on WSL2
```
>>> import struct
>>> import warnings
>>> warnings.filterwarnings('error')
>>> struct.pack('>ci', b'I', 2147483648)
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    struct.pack('>ci', b'I', 2147483648)
struct.error: 'i' format requires -2147483648 <= number <= 2147483647
```
## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1285)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

My change is minor, and since I'm removing an error/race-condition, there isn't much I can really test. I can verify that the change is running at my workplace on multiple production systems and fixes the issues we were having with this race-condition.
