### PR TITLE
docs: fix simple typo, shoudl -> should

### DIFF
--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -506,7 +506,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                 'exchange_exchange_bindings': False
             }
         }
-        #This will be called, but shoudl not be implmented here, just mock it
+        #This will be called, but should not be implmented here, just mock it
         self.connection._flush_outbound = mock.Mock()
         self.connection._adapter_emit_data = mock.Mock()
         self.connection._on_connection_start(method_frame)


### PR DESCRIPTION
There is a small typo in tests/unit/connection_tests.py.

Should read `should` rather than `shoudl`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md