### PR TITLE
Fix case 2 from #1298

### DIFF
--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -643,6 +643,19 @@ class TwistedProtocolConnectionTestCase(TestCase):
         d.addCallback(check)
         return d
 
+    @deferred(timeout=5.0)
+    def test_channel_errback_if_connection_closed(self):
+        # Verify calls to channel() that haven't had their callback invoked
+        # errback when the connection closes.
+        self.conn._on_connection_ready("dummy")
+
+        d = self.conn.channel()
+
+        self.conn._on_connection_closed("test conn", RuntimeError("testing"))
+
+        self.assertEqual(len(self.conn._calls), 0)
+        return self.assertFailure(d, RuntimeError)
+
     def test_dataReceived(self):
         # Verify that the data is transmitted to the callback method.
         self.conn.dataReceived("testdata")


### PR DESCRIPTION
## Proposed Changes

Fixes case 2 from #1298.
`TwistedProtocolConnection` now have the same mechanism that `TwistedChannel` uses to errback pending calls when a channel is closed.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #1298)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments
