### PR TITLE
Log basic.return events at debug level

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1234,8 +1234,8 @@ class Channel(object):
         if not self.callbacks.process(self.channel_number, '_on_return', self,
                                       self, method_frame.method,
                                       header_frame.properties, body):
-            LOGGER.warning('Basic.Return received from server (%r, %r)',
-                           method_frame.method, header_frame.properties)
+            LOGGER.debug('Basic.Return received from server (%r, %r)',
+                          method_frame.method, header_frame.properties)
 
     def _on_selectok(self, method_frame):
         """Called when the broker sends a Confirm.SelectOk frame

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1562,20 +1562,6 @@ class ChannelTests(unittest.TestCase):
             self.obj.channel_number, '_on_return', self.obj, self.obj,
             method_value.method, header_value.properties, body_value)
 
-    @mock.patch('logging.Logger.warning')
-    def test_onreturn_warning(self, warning):
-        method_value = frame.Method(1,
-                                    spec.Basic.Return(999, 'Reply Text',
-                                                      'exchange_value',
-                                                      'routing.key'))
-        header_value = frame.Header(1, 10, spec.BasicProperties())
-        body_value = frame.Body(1, b'0123456789')
-        self.obj.callbacks.process.return_value = False
-        self.obj._on_return(method_value, header_value, body_value)
-        warning.assert_called_with(
-            'Basic.Return received from server (%r, %r)', method_value.method,
-            header_value.properties)
-
     @mock.patch('pika.channel.Channel._rpc')
     def test_on_synchronous_complete(self, rpc):
         mock_callback = mock.Mock()


### PR DESCRIPTION
Supersedes #1281.

This warning has been around for about 8 years so I think it was intentional. However, it can result in sensitive information from messages logged, and generally no other client produces this warning or logs messages except at `debug` level (e.g. as part of logging all outgoing and inbound frames).

@gmr @lukebakken should we change the warning to a debug log entry?