### PR TITLE
Fix TLS server authentication example

### DIFF
--- a/docs/examples/tls_server_authentication.rst
+++ b/docs/examples/tls_server_authentication.rst
@@ -4,7 +4,7 @@ This examples demonstrates a TLS session with RabbitMQ using server authenticati
 
 It was tested against RabbitMQ 3.6.10, using Python 3.6.1 and pre-release Pika `0.11.0`
 
-Note the use of `ssl_version=ssl.PROTOCOL_TLSv1`. The recent versions of RabbitMQ disable older versions of
+Note the use of `ssl.PROTOCOL_TLSv1_2`. The recent versions of RabbitMQ disable older versions of
 SSL due to security vulnerabilities.
 
 See https://www.rabbitmq.com/ssl.html for certificate creation and rabbitmq SSL configuration instructions.
@@ -18,7 +18,7 @@ tls_example.py::
 
     logging.basicConfig(level=logging.INFO)
 
-    context = ssl.SSLContext(ssl.PROTOCOL_TLSv2)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
     context.verify_mode = ssl.CERT_REQUIRED
     context.load_verify_locations('/Users/me/tls-gen/basic/testca/cacert.pem')
 


### PR DESCRIPTION
## Proposed Changes

The correct identifier for TLS 1.2 is `ssl.PROTOCOL_TLSv1_2`, not
`ssl.PROTOCOL_TLSv2`. Previously, this example was failing with the
following error:

    AttributeError: module 'ssl' has no attribute 'PROTOCOL_TLSv2'

## Types of Changes
- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments
