### PR TITLE
Added a DeliveryMode enum to remove magic numbers

### DIFF
--- a/docs/examples/blocking_delivery_confirmations.rst
+++ b/docs/examples/blocking_delivery_confirmations.rst
@@ -23,7 +23,7 @@ The following code demonstrates how to turn on delivery confirmations with the B
                               routing_key='test',
                               body='Hello World!',
                               properties=pika.BasicProperties(content_type='text/plain',
-                                                              delivery_mode=1)):
+                                                              delivery_mode=pika.DeliveryMode.Transient)):
         print('Message publish was confirmed')
     except pika.exceptions.UnroutableError:
         print('Message could not be confirmed')

--- a/docs/examples/blocking_publish_mandatory.rst
+++ b/docs/examples/blocking_publish_mandatory.rst
@@ -24,7 +24,7 @@ The following example demonstrates how to check if a message is delivered by set
                               routing_key='test',
                               body='Hello World!',
                               properties=pika.BasicProperties(content_type='text/plain',
-                                                              delivery_mode=1),
+                                                              delivery_mode=pika.DeliveryMode.Transient),
                               mandatory=True)
         print('Message was published')
     except pika.exceptions.UnroutableError:

--- a/docs/examples/comparing_publishing_sync_async.rst
+++ b/docs/examples/comparing_publishing_sync_async.rst
@@ -17,7 +17,7 @@ In the following example, a connection is made to RabbitMQ listening to port *56
                         'test_routing_key',
                         'message body value',
                         pika.BasicProperties(content_type='text/plain',
-                                             delivery_mode=1))
+                                             delivery_mode=pika.DeliveryMode.Transient))
 
   connection.close()
 
@@ -38,7 +38,7 @@ In contrast, using :py:meth:`pika.adapters.select_connection.SelectConnection` a
                                 'test_routing_key',
                                 'message body value',
                                 pika.BasicProperties(content_type='text/plain',
-                                                     delivery_mode=1))
+                                                     delivery_mode=pika.DeliveryMode.Transient))
 
         connection.close()
 

--- a/examples/confirmation.py
+++ b/examples/confirmation.py
@@ -3,7 +3,7 @@
 
 import logging
 import pika
-from pika import spec
+from pika import spec, DeliveryMode
 
 ITERATIONS = 100
 
@@ -24,7 +24,8 @@ def on_channel_open(channel):
     for _iteration in range(0, ITERATIONS):
         channel.basic_publish(
             'test', 'test.confirm', 'message body value',
-            pika.BasicProperties(content_type='text/plain', delivery_mode=1))
+            pika.BasicProperties(content_type='text/plain',
+                                 delivery_mode=DeliveryMode.Transient))
         published += 1
 
 
@@ -45,8 +46,8 @@ def on_delivery_confirmation(frame):
 
 parameters = pika.URLParameters(
     'amqp://guest:guest@localhost:5672/%2F?connection_attempts=50')
-connection = pika.SelectConnection(
-    parameters=parameters, on_open_callback=on_open)
+connection = pika.SelectConnection(parameters=parameters,
+                                   on_open_callback=on_open)
 
 try:
     connection.ioloop.start()

--- a/examples/publish.py
+++ b/examples/publish.py
@@ -3,6 +3,7 @@
 
 import logging
 import pika
+from pika import DeliveryMode
 from pika.exchange_type import ExchangeType
 
 logging.basicConfig(level=logging.DEBUG)
@@ -11,30 +12,32 @@ credentials = pika.PlainCredentials('guest', 'guest')
 parameters = pika.ConnectionParameters('localhost', credentials=credentials)
 connection = pika.BlockingConnection(parameters)
 channel = connection.channel()
-channel.exchange_declare(
-    exchange="test_exchange",
-    exchange_type=ExchangeType.direct,
-    passive=False,
-    durable=True,
-    auto_delete=False)
+channel.exchange_declare(exchange="test_exchange",
+                         exchange_type=ExchangeType.direct,
+                         passive=False,
+                         durable=True,
+                         auto_delete=False)
 
 print("Sending message to create a queue")
 channel.basic_publish(
     'test_exchange', 'standard_key', 'queue:group',
-    pika.BasicProperties(content_type='text/plain', delivery_mode=1))
+    pika.BasicProperties(content_type='text/plain',
+                         delivery_mode=DeliveryMode.Transient))
 
 connection.sleep(5)
 
 print("Sending text message to group")
 channel.basic_publish(
     'test_exchange', 'group_key', 'Message to group_key',
-    pika.BasicProperties(content_type='text/plain', delivery_mode=1))
+    pika.BasicProperties(content_type='text/plain',
+                         delivery_mode=DeliveryMode.Transient))
 
 connection.sleep(5)
 
 print("Sending text message")
 channel.basic_publish(
     'test_exchange', 'standard_key', 'Message to standard_key',
-    pika.BasicProperties(content_type='text/plain', delivery_mode=1))
+    pika.BasicProperties(content_type='text/plain',
+                         delivery_mode=DeliveryMode.Transient))
 
 connection.close()

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -33,7 +33,7 @@ from twisted.python import log
 from twisted.internet import reactor
 
 import pika
-from pika import spec
+from pika import spec, DeliveryMode
 from pika.adapters import twisted_connection
 from pika.exchange_type import ExchangeType
 
@@ -176,7 +176,7 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
             exchange_type=ExchangeType.topic,
             durable=True,
             auto_delete=False)
-        prop = spec.BasicProperties(delivery_mode=2)
+        prop = spec.BasicProperties(delivery_mode=DeliveryMode.Persistent)
         try:
             yield self._channel.basic_publish(
                 exchange=exchange,

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -12,6 +12,7 @@ from pika.connection import URLParameters
 from pika.connection import SSLOptions
 from pika.credentials import PlainCredentials
 from pika.spec import BasicProperties
+from pika.delivery_mode import DeliveryMode
 
 from pika import adapters
 from pika.adapters import BaseConnection

--- a/pika/delivery_mode.py
+++ b/pika/delivery_mode.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class DeliveryMode(Enum):
+    Transient = 1
+    Persistent = 2

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -16,6 +16,7 @@ from pika import amqp_object
 from pika import data
 from pika.compat import str_or_bytes, unicode_type
 from pika.exchange_type import ExchangeType
+from pika.delivery_mode import DeliveryMode
 
 # Python 3 support for str object
 str = bytes
@@ -2079,7 +2080,10 @@ class BasicProperties(amqp_object.Properties):
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
-        self.delivery_mode = delivery_mode
+        if isinstance(delivery_mode, DeliveryMode):
+            self.delivery_mode = delivery_mode.value
+        else:
+            self.delivery_mode = delivery_mode
         self.priority = priority
         self.correlation_id = correlation_id
         self.reply_to = reply_to

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -4,7 +4,7 @@ Tests for pika.frame
 """
 import unittest
 
-from pika import exceptions, frame, spec
+from pika import exceptions, frame, spec, DeliveryMode
 
 
 class FrameTests(unittest.TestCase):
@@ -28,7 +28,9 @@ class FrameTests(unittest.TestCase):
         self.assertEqual(basic_ack.marshal(), self.BASIC_ACK)
 
     def headers_marshal_test(self):
-        header = frame.Header(1, 100, spec.BasicProperties(delivery_mode=2))
+        header = frame.Header(
+            1, 100,
+            spec.BasicProperties(delivery_mode=DeliveryMode.Persistent))
         self.assertEqual(header.marshal(), self.CONTENT_HEADER)
 
     def body_marshal_test(self):
@@ -76,8 +78,8 @@ class FrameTests(unittest.TestCase):
         self.assertIsInstance(frame_value.properties, spec.BasicProperties)
 
     def decode_frame_decoding_failure_test(self):
-        self.assertEqual(
-            frame.decode_frame(b'\x01\x00\x01\x00\x00\xce'), (0, None))
+        self.assertEqual(frame.decode_frame(b'\x01\x00\x01\x00\x00\xce'),
+                         (0, None))
 
     def decode_frame_decoding_no_end_byte_test(self):
         self.assertEqual(frame.decode_frame(self.BASIC_ACK[:-1]), (0, None))


### PR DESCRIPTION
Instead of looking up whether you have to set delivery_mode=1 or
delivery_mode=2, you can now more explicitly set it using
DeliveryMode.Persistent or DeliveryMode.Transient.

## Proposed Changes

Adding a DeliveryMode enum so that you can write the code without having to look up what magic number you have to use. IDE support will allow you to start typing `DeliveryMode.` and it will show you the options, so you don't even have to remember the exact names.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

