### PR TITLE
updated async consumer and publisher to run in seprate thread

### DIFF
--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -6,6 +6,7 @@ import logging
 import time
 import pika
 from pika.exchange_type import ExchangeType
+from threading import Thread
 
 LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
               '-35s %(lineno) -5d: %(message)s')
@@ -391,13 +392,14 @@ class ExampleConsumer(object):
             LOGGER.info('Stopped')
 
 
-class ReconnectingExampleConsumer(object):
+class ReconnectingExampleConsumer(Thread):
     """This is an example consumer that will reconnect if the nested
     ExampleConsumer indicates that a reconnect is necessary.
 
     """
 
     def __init__(self, amqp_url):
+        Thread.__init__(self)
         self._reconnect_delay = 0
         self._amqp_url = amqp_url
         self._consumer = ExampleConsumer(self._amqp_url)


### PR DESCRIPTION
## Proposed Changes

Async publisher and consumer examples have been updated to run in a separate  thread. The async publisher now uses task queues to publish messages to RabbitMQ.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc.
