### PR TITLE
use channel.connection instead of passing in the connection for simplification in the threaded consumer example

### DIFF
--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -27,20 +27,20 @@ def ack_message(ch, delivery_tag):
         pass
 
 
-def do_work(conn, ch, delivery_tag, body):
+def do_work(ch, delivery_tag, body):
     thread_id = threading.get_ident()
     LOGGER.info('Thread id: %s Delivery tag: %s Message body: %s', thread_id,
                 delivery_tag, body)
     # Sleeping to simulate 10 seconds of work
     time.sleep(10)
     cb = functools.partial(ack_message, ch, delivery_tag)
-    conn.add_callback_threadsafe(cb)
+    ch.connection.add_callback_threadsafe(cb)
 
 
 def on_message(ch, method_frame, _header_frame, body, args):
-    (thrds) = args
+    thrds = args
     delivery_tag = method_frame.delivery_tag
-    t = threading.Thread(target=do_work, args=(ch.connection, ch, delivery_tag, body))
+    t = threading.Thread(target=do_work, args=(ch, delivery_tag, body))
     t.start()
     thrds.append(t)
 

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -38,9 +38,9 @@ def do_work(conn, ch, delivery_tag, body):
 
 
 def on_message(ch, method_frame, _header_frame, body, args):
-    (conn, thrds) = args
+    (thrds) = args
     delivery_tag = method_frame.delivery_tag
-    t = threading.Thread(target=do_work, args=(conn, ch, delivery_tag, body))
+    t = threading.Thread(target=do_work, args=(ch.connection, ch, delivery_tag, body))
     t.start()
     thrds.append(t)
 
@@ -68,7 +68,7 @@ channel.queue_bind(
 channel.basic_qos(prefetch_count=1)
 
 threads = []
-on_message_callback = functools.partial(on_message, args=(connection, threads))
+on_message_callback = functools.partial(on_message, args=(threads))
 channel.basic_consume('standard', on_message_callback)
 
 try:


### PR DESCRIPTION
## Proposed Changes

i find in the `examples/basic_consumer_threaded.py` passing in the connection might be unnecessary, as the channel object holds an instance of the connection already. Removing connecton argument makes the logic a little easier to follow, at least to me.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

this is a rather simple change in an example app.