### PR TITLE
Update basic_qos docstring to reflect the RabbitMQ behavior of global…

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -435,11 +435,12 @@ class Channel(object):
                   global_qos=False,
                   callback=None):
         """Specify quality of service. This method requests a specific quality
-        of service. The QoS can be specified for the current channel or for all
-        channels on the connection. The client can request that messages be sent
-        in advance so that when the client finishes processing a message, the
-        following message is already held locally, rather than needing to be
-        sent down the channel. Prefetching gives a performance improvement.
+        of service. The client can request that messages be sent in advance
+        so that when the client finishes processing a message, the following
+        message is already held locally, rather than needing to be sent down
+        the channel. The QoS can be applied separately to each new consumer on
+        channel or shared across all consumers on the channel. Prefetching
+        gives a performance improvement.
 
         :param int prefetch_size:  This field specifies the prefetch window
                                    size. The server will send a message in
@@ -458,8 +459,8 @@ class Channel(object):
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool global_qos:    Should the QoS apply to all channels on the
-                                   connection.
+        :param bool global_qos:    Should the QoS be shared across all
+                                   consumers on the channel.
         :param callable callback: The callback to call for Basic.QosOk response
         :raises ValueError:
 


### PR DESCRIPTION
…_qos parameter rather than AMQP 0-9-1 behavior.

See https://www.rabbitmq.com/consumer-prefetch.html

## Proposed Changes

The docstring for Channel.basic_qos was incorrect. It looks like it was written with respect to AMQP 0-9-1, but RabbitMQ has a different behavior of the global_qos option in its implementation. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

