### PR TITLE
Remove obsolete dependency on the mock package

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,7 +1,6 @@
 coverage
 codecov
 gevent
-mock
 nose
 nose2
 tornado

--- a/tests/acceptance/enforce_one_basicget_test.py
+++ b/tests/acceptance/enforce_one_basicget_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import MagicMock
+from unittest.mock import MagicMock
 from pika.frame import Method, Header
 from pika.exceptions import DuplicateGetOkCallback
 from pika.channel import Channel

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -14,7 +14,7 @@
 import functools
 import unittest
 
-import mock
+from unittest import mock
 from nose.twistedtools import reactor, deferred
 from twisted.internet import defer, error as twisted_error
 from twisted.python.failure import Failure

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -9,12 +9,8 @@ import sys
 import logging
 import platform
 import unittest
+from unittest import mock
 import uuid
-
-try:
-    from unittest import mock  # pylint: disable=C0412
-except ImportError:
-    import mock
 
 import pika
 import pika.compat

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -5,7 +5,7 @@ Tests for pika.base_connection.BaseConnection
 
 import socket
 import unittest
-import mock
+from unittest import mock
 
 import pika
 import pika.tcp_socket_opts

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -1,12 +1,11 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 """
 Tests for pika.adapters.blocking_connection.BlockingChannel
 
 """
 from collections import deque
 import unittest
-
-import mock
+from unittest import mock
 
 from pika.adapters import blocking_connection
 from pika import channel

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -1,12 +1,11 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 """
 Tests for pika.adapters.blocking_connection.BlockingConnection
 
 """
 import unittest
-
-import mock
-from mock import patch
+from unittest import mock
+from unittest.mock import patch
 
 import pika
 from pika.adapters import blocking_connection

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -1,12 +1,11 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 """
 Tests for pika.callback
 
 """
 import logging
 import unittest
-
-import mock
+from unittest import mock
 
 from pika import callback, frame, spec
 

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -6,11 +6,7 @@ import logging
 import sys
 import unittest
 import warnings
-
-try:
-    from unittest import mock  # pylint: disable=C0412
-except ImportError:
-    import mock
+from unittest import mock
 
 from pika import channel, connection, exceptions, frame, spec
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -12,16 +12,10 @@ Tests for pika.connection.Connection
 # Suppress pylint messages concerning invalid method name
 # pylint: disable=C0103
 
-try:
-    import mock
-except ImportError:
-    from unittest import mock  # pylint: disable=E0611
-
 import random
 import platform
 import unittest
-
-import mock
+from unittest import mock
 
 from pika import connection, channel, credentials, exceptions, frame, spec
 import pika

--- a/tests/unit/credentials_tests.py
+++ b/tests/unit/credentials_tests.py
@@ -3,8 +3,7 @@ Tests for pika.credentials
 
 """
 import unittest
-
-import mock
+from unittest import mock
 
 from pika import credentials, spec
 

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -3,8 +3,7 @@ Tests for pika.heartbeat
 
 """
 import unittest
-
-import mock
+from unittest import mock
 
 from pika import connection, frame, heartbeat
 import pika.exceptions

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -19,11 +19,7 @@ import sys
 import time
 import threading
 import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pika
 from pika import compat

--- a/tests/unit/select_connection_timer_tests.py
+++ b/tests/unit/select_connection_timer_tests.py
@@ -7,8 +7,7 @@ Tests for SelectConnection _Timer and _Timeout classes
 import math
 import time
 import unittest
-
-import mock
+from unittest import mock
 
 import pika.compat
 from pika.adapters import select_connection

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -8,11 +8,7 @@ import sys
 import threading
 import time
 import unittest
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
+from unittest import mock
 
 import pika.compat
 

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -3,8 +3,7 @@ Tests for pika.adapters.tornado_connection
 
 """
 import unittest
-
-import mock
+from unittest import mock
 
 from pika.adapters import tornado_connection
 from pika.adapters.utils import selector_ioloop_adapter


### PR DESCRIPTION
## Proposed Changes

The "mock" package is a backport of Python 3.4's unittest.mock.  Now
that we only support Python 3.4+, this dependency can be removed.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

In order to package pika properly on modern Fedora-based distributions (incl. CentOS, RHEL),
we have to get rid of the "mock" dependency.
See https://fedoraproject.org/wiki/Changes/DeprecatePythonMock
