### PR TITLE
Add support for RabbitMQ's update_secret extension 

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -766,6 +766,21 @@ class BlockingConnection(object):
 
         del self._ready_events[index_to_remove]
 
+    def update_secret(self, new_secret, reason):
+        """RabbitMQ AMQP extension - This method updates the secret used to authenticate this connection. 
+        It is used when secrets have an expiration date and need to be renewed, like OAuth 2 tokens.
+
+        :param string new_secret: The new secret
+        :param string reason: The reason for the secret update
+
+        :raises pika.exceptions.ConnectionWrongStateError: if connection is
+            not open.
+        """
+
+        result = _CallbackResult()
+        self._impl.update_secret(new_secret, reason, result.signal_once)
+        self._flush_output(result.is_ready)
+
     def close(self, reply_code=200, reply_text='Normal shutdown'):
         """Disconnect from RabbitMQ. If there are any open channels, it will
         attempt to close them prior to fully disconnecting. Channels which

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -489,6 +489,18 @@ class TestCreateConnectionAndAsynchronouslyAbortDefaultConnectionWorkflow(
         self.connection._nbio.add_callback_threadsafe(workflow.abort)
 
 
+class TestUpdateSecret(AsyncTestCase, AsyncAdapters):
+    DESCRIPTION = "Update secret and receive confirmation"
+
+    def begin(self, channel):
+        self.connection.update_secret(
+            "new_secret", "reason", self.on_secret_update)
+
+    def on_secret_update(self, frame):
+        self.assertIsInstance(frame.method, spec.Connection.UpdateSecretOk)
+        self.stop()
+
+
 class TestConfirmSelect(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Receive confirmation of Confirm.Select"
 

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -300,6 +300,50 @@ class TestLostConnectionResultsInIsClosedConnectionAndChannel(BlockingTestCaseBa
         self.assertTrue(connection.is_closed)
 
 
+class TestUpdateSecret(BlockingTestCaseBase):
+    def test(self):
+        connection = self._connect()
+        channel = connection.channel()
+
+        # Update secret
+        connection.update_secret("new_secret", "reason")
+
+        # Now check is_open/is_closed on channel and connection
+        self.assertTrue(channel.is_open)
+        self.assertFalse(channel.is_closed)
+        self.assertTrue(connection.is_open)
+        self.assertFalse(connection.is_closed)
+
+
+class TestUpdateSecretOnClosedRaisesWrongState(BlockingTestCaseBase):
+    def test(self):
+        connection = self._connect()
+
+        # Close Connection
+        connection.close()
+
+        # Attempt to update secret
+        with self.assertRaises(pika.exceptions.ConnectionWrongStateError):
+            connection.update_secret("new_secret", "reason")
+
+        # Now check is_open/is_closed on channel and connection
+        self.assertFalse(connection.is_open)
+        self.assertTrue(connection.is_closed)
+
+
+class TestUpdateSecretExpectsStrings(BlockingTestCaseBase):
+    def test(self):
+        connection = self._connect()
+
+        # Attempt to update secret with integer as new_secret
+        with self.assertRaises(AssertionError):
+            connection.update_secret(1, "reason")
+
+        # Attempt to update secret with integer as reason
+        with self.assertRaises(AssertionError):
+            connection.update_secret("new_secret", 1)
+
+
 class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
     def test(self):
         """BlockingConnection: ConnectionClosed raised when creating exchange with invalid type"""  # pylint: disable=C0301

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -287,6 +287,33 @@ class BlockingConnectionTests(unittest.TestCase):
         blocking_connection.select_connection,
         'SelectConnection',
         spec_set=SelectConnectionTemplate)
+    def test_update_secret(self, select_connection_class_mock):
+        impl_mock = select_connection_class_mock.return_value
+        impl_mock.is_closed = False
+        impl_mock.is_open = True
+        impl_mock._transport = None
+
+        with mock.patch.object(blocking_connection.BlockingConnection,
+                               '_create_connection',
+                               return_value=impl_mock):
+            connection = blocking_connection.BlockingConnection('params')
+
+        with mock.patch.object(blocking_connection._CallbackResult,
+                               'is_ready',
+                               return_value=True):
+            connection.update_secret("new_secret", "reason")
+
+        self.assertEqual(
+            select_connection_class_mock.return_value.update_secret.call_args.args[0], "new_secret")
+        self.assertEqual(
+            select_connection_class_mock.return_value.update_secret.call_args.args[1], "reason")
+        self.assertEqual(
+            len(select_connection_class_mock.return_value.update_secret.call_args.args), 3)
+
+    @patch.object(
+        blocking_connection.select_connection,
+        'SelectConnection',
+        spec_set=SelectConnectionTemplate)
     @patch.object(
         blocking_connection,
         'BlockingChannel',


### PR DESCRIPTION
## Proposed Changes

Support RabbitMQ's update_secret extension (https://rabbitmq.com/amqp-0-9-1-reference.html#connection.update-secret) that allows for secrets (e.g., oauth2 tokens) to be updated. Hence new (not yet expired) secrets can be provided without the need to re-establish the connection. This is especially benefitial when using authorization plugins like rabbitmq_auth_backend_oauth2.

Issue #1335

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments 