### PR TITLE
Update connection module to use TLS v1.2 as fallback

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -903,9 +903,9 @@ class URLParameters(Parameters):
             #
             # SSLContext.load_verify_locations(cafile=None, capath=None, cadata=None)
             try:
-                opt_protocol = ssl.PROTOCOL_TLS
+                opt_protocol = ssl.PROTOCOL_TLS_CLIENT
             except AttributeError:
-                opt_protocol = ssl.PROTOCOL_TLSv1
+                opt_protocol = ssl.PROTOCOL_TLSv1_2
             if 'protocol' in opts:
                 opt_protocol = opts['protocol']
 

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -12,18 +12,16 @@ import pika
 from pika.compat import urlencode, url_quote, dict_iteritems
 from pika import channel, connection, credentials, spec
 
-
 # disable missing-docstring
 # pylint: disable=C0111
 
 # disable invalid-name
 # pylint: disable=C0103
 
-
 # Unordered sequence of connection.Parameters's property getters
 _ALL_PUBLIC_PARAMETERS_PROPERTIES = tuple(
-    attr for attr in vars(connection.Parameters) if not attr.startswith('_')
-    and issubclass(type(getattr(connection.Parameters, attr)), property))
+    attr for attr in vars(connection.Parameters) if not attr.startswith('_') and
+    issubclass(type(getattr(connection.Parameters, attr)), property))
 
 
 class ChildParameters(connection.Parameters):
@@ -641,6 +639,20 @@ class URLParametersTests(ParametersTestsBase):
         params.ssl_options = None
         params.port = params.DEFAULT_PORT
         self.assert_default_parameter_values(params)
+
+    def test_ssl_default_protocol_version_fallback(self):
+        """
+        This test does not set protocol_version option in ssl_options. Instead,
+        it relies on connection.URLParameters class to setup the default, and
+        then it asserts the protocol is what we expected (auto or TLSv1_2)
+        """
+        params = connection.URLParameters(
+            'amqps://foo.bar/some-vhost?ssl_options=%7B%27ca_certs%27%3A%27testdata%2Fcerts%2Fca_certificate.pem%27%7D'
+        )
+        self.assertTrue(
+            params.ssl_options.context.protocol == ssl.PROTOCOL_TLS_CLIENT or
+            params.ssl_options.context.protocol == ssl.PROTOCOL_TLSv1_2,
+            msg='Expected to fallback to a secure protocol')
 
     def test_no_url_scheme_defaults_to_plaintext(self):
         params = connection.URLParameters('//')


### PR DESCRIPTION
## Proposed Changes

URLParameters class parsing SSL options will now default/fallback to a secure
TLS version. The constant `ssl.PROTOCOL_TLS` is deprecated starting in
3.10. Constant `ssl.PROTOCOL_TLS_CLIENT` was introduced in 3.6,
 therefore this change should be backwards compatible.

For those clients out there running 3.4-3.5, there's a constant to fallback to use
TLS v1.2.

Fixes #1385

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

N/A

