### PR TITLE
Update connection module to fix strange character

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1279,7 +1279,7 @@ class Connection(pika.compat.AbstractBase):
         """
         if not self.is_open:
             raise exceptions.ConnectionWrongStateError(
-                'ٍSecret update requires an open connection: %s' % self)
+                'Secret update requires an open connection: %s' % self)
 
         validators.rpc_completion_callback(callback)
         self._rpc(0, spec.Connection.UpdateSecret(new_secret, reason),


### PR DESCRIPTION
## Proposed Changes

There's a funny character in connection module between the `'` and the `S`. It
breaks syntax highlighting in my VIM. It looks like a no-op change, but just in
case, all tests are still green after replacing this character by the UK
keyboard `'` character.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

N/A

