### PR TITLE
Fix typo in example docstring

### DIFF
--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -13,7 +13,7 @@ specify an explicit lower bound for heartbeat timeout.
 
 When RabbitMQ broker is running out of certain resources, such as memory and
 disk space, it may block connections that are performing resource-consuming
-operations, such as publishing messages. Once a connection is blocked, RabbiMQ
+operations, such as publishing messages. Once a connection is blocked, RabbitMQ
 stops reading from that connection's socket, so no commands from the client will
 get through to te broker on that connection until the broker unblocks it. A
 blocked connection may last for an indefinite period of time, stalling the


### PR DESCRIPTION
## Proposed Changes

Just a typo in one of the examples scripts.

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

