### PR TITLE
Shrink the compatibility module and remove Python <3.7 support

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -62,16 +62,13 @@ class _CallbackResult:
         self._values = None
 
     def __bool__(self):
-        """ Called by python runtime to implement truth value testing and the
-        built-in operation bool(); NOTE: python 3.x
+        """Called by python runtime to implement truth value testing and the
+        built-in operation bool()
         """
         return self.is_ready()
 
-    # python 2.x version of __bool__
-    __nonzero__ = __bool__
-
     def __enter__(self):
-        """ Entry into context manager that automatically resets the object
+        """Entry into context manager that automatically resets the object
         on exit; this usage pattern helps garbage-collection by eliminating
         potential circular references.
         """
@@ -94,7 +91,7 @@ class _CallbackResult:
         return self._ready
 
     def signal_once(self, *_args, **_kwargs):
-        """ Set as ready
+        """Set as ready
 
         :raises AssertionError: if result was already signalled
         """
@@ -102,7 +99,7 @@ class _CallbackResult:
         self._ready = True
 
     def set_value_once(self, *args, **kwargs):
-        """ Set as ready with value; the value may be retrieved via the `value`
+        """Set as ready with value; the value may be retrieved via the `value`
         property getter
 
         :raises AssertionError: if result was already set
@@ -623,7 +620,7 @@ class BlockingConnection:
 
             # Limit dispatch to the number of currently ready events to avoid
             # getting stuck in this loop
-            for _ in compat.xrange(len(self._ready_events)):
+            for _ in range(len(self._ready_events)):
                 try:
                     evt = self._ready_events.popleft()
                 except IndexError:
@@ -2093,7 +2090,7 @@ class BlockingChannel:
                 pending_events = self._queue_consumer_generator.pending_events
                 # NOTE `get_waiting_message_count` adjusts for `Basic.Cancel`
                 #      from the server at the end (if any)
-                for _ in compat.xrange(self.get_waiting_message_count()):
+                for _ in range(self.get_waiting_message_count()):
                     evt = pending_events.popleft()
                     self._impl.basic_reject(
                         evt.method.delivery_tag, requeue=True)

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -561,10 +561,9 @@ class _AddressResolver:
 
         """
         try:
-            # NOTE: on python 2.x, can't pass keyword args to getaddrinfo()
-            result = socket.getaddrinfo(self._host, self._port, self._family,
-                                        self._socktype, self._proto,
-                                        self._flags)
+            result = socket.getaddrinfo(host=self._host, port=self._port, family=self._family,
+                                        type=self._socktype, proto=self._proto,
+                                        flags=self._flags)
         except Exception as exc:  # pylint: disable=W0703
             LOGGER.error('Address resolution failed: %r', exc)
             result = exc

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -7,7 +7,7 @@ import logging
 
 from pika import frame
 from pika import amqp_object
-from pika.compat import xrange, canonical_str
+from pika.compat import canonical_str
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def name_or_value(value):
     if isinstance(value, amqp_object.AMQPObject):
         return value.NAME
 
-    # Cast the value to a str (python 2 and python 3); encoding as UTF-8 on Python 2
+    # Cast the value to a string
     return canonical_str(value)
 
 
@@ -253,7 +253,7 @@ class CallbackManager:
         """
         if callback_value:
             offsets_to_remove = list()
-            for offset in xrange(len(self._stack[prefix][key]), 0, -1):
+            for offset in range(len(self._stack[prefix][key]), 0, -1):
                 callback_dict = self._stack[prefix][key][offset - 1]
 
                 if (callback_dict[self.CALLBACK] == callback_value and

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -14,7 +14,7 @@ import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
 import pika.validators as validators
-from pika.compat import unicode_type, dictkeys, is_integer
+from pika.compat import as_bytes, dictkeys, is_integer
 from pika.exchange_type import ExchangeType
 
 LOGGER = logging.getLogger(__name__)
@@ -421,8 +421,7 @@ class Channel:
 
         """
         self._raise_if_not_open()
-        if isinstance(body, unicode_type):
-            body = body.encode('utf-8')
+        body = as_bytes(body)
         properties = properties or spec.BasicProperties()
         self._send_method(
             spec.Basic.Publish(exchange=exchange,

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -1,7 +1,4 @@
-"""The compat module provides various Python 2 / Python 3
-compatibility functions
-
-"""
+"""The compat module provides various compatibility functions"""
 # pylint: disable=C0103
 
 import abc
@@ -11,8 +8,6 @@ import socket
 import sys
 import time
 
-PY2 = sys.version_info.major == 2
-PY3 = not PY2
 RE_NUM = re.compile(r'(\d+).+')
 
 ON_LINUX = sys.platform.startswith("linux")
@@ -22,159 +17,95 @@ ON_WINDOWS = sys.platform == "win32"
 # Portable Abstract Base Class
 AbstractBase = abc.ABCMeta('AbstractBase', (object,), {})
 
-if sys.version_info[:2] < (3, 3):
-    SOCKET_ERROR = socket.error
-else:
-    # socket.error was deprecated and replaced by OSError in python 3.3
-    SOCKET_ERROR = OSError
+SOCKET_ERROR = OSError
 
 try:
     SOL_TCP = socket.SOL_TCP
 except AttributeError:
     SOL_TCP = socket.IPPROTO_TCP
 
-if PY3:
-    # these were moved around for Python 3
-    # pylint: disable=W0611
-    from urllib.parse import (quote as url_quote, unquote as url_unquote,
-                              urlencode, parse_qs as url_parse_qs, urlparse)
-    from io import StringIO
+HAVE_SIGNAL = os.name == 'posix'
 
-    # Python 3 does not have basestring anymore; we include
-    # *only* the str here as this is used for textual data.
-    basestring = (str,)
+_LOCALHOST = '127.0.0.1'
+_LOCALHOST_V6 = '::1'
 
-    # for assertions that the data is either encoded or non-encoded text
-    str_or_bytes = (str, bytes)
+# for assertions that the data is either encoded or non-encoded text
+str_or_bytes = (str, bytes)
 
-    # xrange is gone, replace it with range
-    xrange = range
 
-    # the unicode type is str
-    unicode_type = str
+def time_now():
+    """
+    Returns monotonic time
+    """
+    return time.monotonic()
 
-    def time_now():
-        """
-        Python 3 supports monotonic time
-        """
-        return time.monotonic()
 
-    def dictkeys(dct):
-        """
-        Returns a list of keys of dictionary
+def dictkeys(dct):
+    """
+    Returns a list of keys of dictionary
+    """
 
-        dict.keys returns a view that works like .keys in Python 2
-        *except* any modifications in the dictionary will be visible
-        (and will cause errors if the view is being iterated over while
-        it is modified).
-        """
+    return list(dct.keys())
 
-        return list(dct.keys())
 
-    def dictvalues(dct):
-        """
-        Returns a list of values of a dictionary
+def dictvalues(dct):
+    """
+    Returns a list of values of a dictionary
+    """
+    return list(dct.values())
 
-        dict.values returns a view that works like .values in Python 2
-        *except* any modifications in the dictionary will be visible
-        (and will cause errors if the view is being iterated over while
-        it is modified).
-        """
-        return list(dct.values())
 
-    def dict_iteritems(dct):
-        """
-        Returns an iterator of items (key/value pairs) of a dictionary
+def dict_iteritems(dct):
+    """
+    Returns an iterator of items (key/value pairs) of a dictionary
+    """
+    return dct.items()
 
-        dict.items returns a view that works like .items in Python 2
-        *except* any modifications in the dictionary will be visible
-        (and will cause errors if the view is being iterated over while
-        it is modified).
-        """
-        return dct.items()
 
-    def dict_itervalues(dct):
-        """
-        :param dict dct:
-        :returns: an iterator of the values of a dictionary
-        :rtype: iterator
-        """
-        return dct.values()
+def dict_itervalues(dct):
+    """
+    :param dict dct:
+    :returns: an iterator of the values of a dictionary
+    :rtype: iterator
+    """
+    return dct.values()
 
-    def byte(*args):
-        """
-        This is the same as Python 2 `chr(n)` for bytes in Python 3
 
-        Returns a single byte `bytes` for the given int argument (we
-        optimize it a bit here by passing the positional argument tuple
-        directly to the bytes constructor.
-        """
-        return bytes(args)
+def byte(*args):
+    """
+    Returns a single byte `bytes` for the given int argument (we
+    optimize it a bit here by passing the positional argument tuple
+    directly to the bytes constructor.
+    """
+    return bytes(args)
 
-    class long(int):
-        """
-        A marker class that signifies that the integer value should be
-        serialized as `l` instead of `I`
-        """
 
-        def __str__(self):
-            return str(int(self))
+class long(int):
+    """
+    A marker class that signifies that the integer value should be
+    serialized as `l` instead of `I`
+    """
 
-        def __repr__(self):
-            return str(self) + 'L'
+    def __str__(self):
+        return str(int(self))
 
-    def canonical_str(value):
-        """
-        Return the canonical str value for the string.
-        In both Python 3 and Python 2 this is str.
-        """
+    def __repr__(self):
+        return str(self) + 'L'
 
-        return str(value)
 
-    def is_integer(value):
-        """
-        Is value an integer?
-        """
-        return isinstance(value, int)
-else:
-    from urllib import (quote as url_quote, unquote as url_unquote, urlencode) # pylint: disable=C0412,E0611
-    from urlparse import (parse_qs as url_parse_qs, urlparse) # pylint: disable=E0401
-    from StringIO import StringIO # pylint: disable=E0401
+def canonical_str(value):
+    """
+    Return the canonical str value for the string.
+    """
 
-    basestring = basestring
-    str_or_bytes = basestring
-    xrange = xrange
-    unicode_type = unicode # pylint: disable=E0602
-    dictkeys = dict.keys
-    dictvalues = dict.values
-    dict_iteritems = dict.iteritems # pylint: disable=E1101
-    dict_itervalues = dict.itervalues # pylint: disable=E1101
-    byte = chr
-    long = long
+    return str(value)
 
-    def time_now():
-        """
-        Python 2 does not support monotonic time
-        """
-        return time.time()
 
-    def canonical_str(value):
-        """
-        Returns the canonical string value of the given string.
-        In Python 2 this is the value unchanged if it is an str, otherwise
-        it is the unicode value encoded as UTF-8.
-        """
-
-        try:
-            return str(value)
-        except UnicodeEncodeError:
-            return str(value.encode('utf-8'))
-
-    def is_integer(value):
-        """
-        Is value an integer?
-        """
-        return isinstance(value, (int, long))
+def is_integer(value):
+    """
+    Is value an integer?
+    """
+    return isinstance(value, int)
 
 
 def as_bytes(value):
@@ -201,23 +132,17 @@ def get_linux_version(release_str):
     Gets linux version
     """
     ver_str = release_str.split('-')[0]
-    return tuple(map(to_digit, ver_str.split('.')[:3]))
+    return tuple(map(to_digit, ver_str.split('.', 3)[:3]))
 
-
-HAVE_SIGNAL = os.name == 'posix'
-
-EINTR_IS_EXPOSED = sys.version_info[:2] <= (3, 4)
 
 LINUX_VERSION = None
 if ON_LINUX:
     import platform
     LINUX_VERSION = get_linux_version(platform.release())
 
-_LOCALHOST = '127.0.0.1'
-_LOCALHOST_V6 = '::1'
 
 
-def _nonblocking_socketpair(family=socket.AF_INET,
+def nonblocking_socketpair(family=socket.AF_INET,
                             socket_type=socket.SOCK_STREAM,
                             proto=0):
     """

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -11,6 +11,7 @@ import math
 import numbers
 import platform
 import ssl
+from urllib.parse import unquote as url_unquote, parse_qs as url_parse_qs, urlparse
 
 import pika.callback
 import pika.channel
@@ -21,12 +22,7 @@ import pika.frame as frame
 import pika.heartbeat
 import pika.spec as spec
 import pika.validators as validators
-from pika.compat import (
-    xrange,
-    url_unquote,
-    dictkeys,
-    dict_itervalues,
-    dict_iteritems)
+from pika.compat import (dictkeys, dict_itervalues, dict_iteritems)
 
 PRODUCT = "Pika Python Client Library"
 
@@ -727,15 +723,10 @@ class URLParameters(Parameters):
         self._all_url_query_values = None
 
         # Handle the Protocol scheme
-        #
-        # Fix up scheme amqp(s) to http(s) so urlparse won't barf on python
-        # prior to 2.7. On Python 2.6.9,
-        # `urlparse('amqp://127.0.0.1/%2f?socket_timeout=1')` produces an
-        # incorrect path='/%2f?socket_timeout=1'
         if url[0:4].lower() == 'amqp':
             url = 'http' + url[4:]
 
-        parts = pika.compat.urlparse(url)
+        parts = urlparse(url)
 
         if parts.scheme == 'https':
             # Create default context which will get overridden by the
@@ -767,7 +758,7 @@ class URLParameters(Parameters):
             self.virtual_host = url_unquote(parts.path.split('/')[1])
 
         # Handle query string values, validating and assigning them
-        self._all_url_query_values = pika.compat.url_parse_qs(parts.query)
+        self._all_url_query_values = url_parse_qs(parts.query)
 
         for name, value in dict_iteritems(self._all_url_query_values):
             try:
@@ -1683,7 +1674,7 @@ class Connection(pika.compat.AbstractBase):
         if len(self._channels) >= limit:
             raise exceptions.NoFreeChannels()
 
-        for num in xrange(1, len(self._channels) + 1):
+        for num in range(1, len(self._channels) + 1):
             if num not in self._channels:
                 return num
         return len(self._channels) + 1
@@ -2275,7 +2266,7 @@ class Connection(pika.compat.AbstractBase):
 
         if content[1]:
             chunks = int(math.ceil(float(length) / self._body_max_length))
-            for chunk in xrange(0, chunks):
+            for chunk in range(0, chunks):
                 start = chunk * self._body_max_length
                 end = start + self._body_max_length
                 if end > length:

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -13,7 +13,7 @@ rejected.
 import struct
 from pika import amqp_object
 from pika import data
-from pika.compat import str_or_bytes, unicode_type
+from pika.compat import str_or_bytes, as_bytes
 from pika.exchange_type import ExchangeType
 from pika.delivery_mode import DeliveryMode
 
@@ -107,12 +107,12 @@ class Connection(amqp_object.Class):
             data.encode_table(pieces, self.server_properties)
             assert isinstance(self.mechanisms, str_or_bytes),\
                    'A non-string value was supplied for self.mechanisms'
-            value = self.mechanisms.encode('utf-8') if isinstance(self.mechanisms, unicode_type) else self.mechanisms
+            value = as_bytes(self.mechanisms)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.locales, str_or_bytes),\
                    'A non-string value was supplied for self.locales'
-            value = self.locales.encode('utf-8') if isinstance(self.locales, unicode_type) else self.locales
+            value = as_bytes(self.locales)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -154,7 +154,7 @@ class Connection(amqp_object.Class):
             data.encode_short_string(pieces, self.mechanism)
             assert isinstance(self.response, str_or_bytes),\
                    'A non-string value was supplied for self.response'
-            value = self.response.encode('utf-8') if isinstance(self.response, unicode_type) else self.response
+            value = as_bytes(self.response)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.locale, str_or_bytes),\
@@ -189,7 +189,7 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.challenge, str_or_bytes),\
                    'A non-string value was supplied for self.challenge'
-            value = self.challenge.encode('utf-8') if isinstance(self.challenge, unicode_type) else self.challenge
+            value = as_bytes(self.challenge)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -221,7 +221,7 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.response, str_or_bytes),\
                    'A non-string value was supplied for self.response'
-            value = self.response.encode('utf-8') if isinstance(self.response, unicode_type) else self.response
+            value = as_bytes(self.response)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -470,7 +470,7 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.new_secret, str_or_bytes),\
                 'A non-string value was supplied for self.new_secret'
-            value = self.new_secret.encode('utf-8') if isinstance(self.new_secret, unicode_type) else self.new_secret
+            value = as_bytes(self.new_secret)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.reason, str_or_bytes),\
@@ -553,7 +553,7 @@ class Channel(amqp_object.Class):
             pieces = list()
             assert isinstance(self.channel_id, str_or_bytes),\
                    'A non-string value was supplied for self.channel_id'
-            value = self.channel_id.encode('utf-8') if isinstance(self.channel_id, unicode_type) else self.channel_id
+            value = as_bytes(self.channel_id)
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -2,8 +2,6 @@
 Common validation functions
 """
 
-from pika.compat import basestring
-
 
 def require_string(value, value_name):
     """Require that value is a string
@@ -11,7 +9,7 @@ def require_string(value, value_name):
     :raises: TypeError
 
     """
-    if not isinstance(value, basestring):
+    if not isinstance(value, str):
         raise TypeError('{} must be a str or unicode str, but got {!r}'.format(
             value_name,
             value,

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -2102,13 +2102,11 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
         ch.queue_bind(q2_name, exchange=exg_name, routing_key=q2_routing_key)
 
         # Deposit messages in the queues
-        q1_tx_message_bodies = ['q1_message+%s' % (i,)
-                                for i in pika.compat.xrange(100)]
+        q1_tx_message_bodies = ['q1_message+%s' % (i,) for i in range(100)]
         for message_body in q1_tx_message_bodies:
             ch.basic_publish(exg_name, q1_routing_key, body=message_body, mandatory=True)
 
-        q2_tx_message_bodies = ['q2_message+%s' % (i,)
-                                for i in pika.compat.xrange(150)]
+        q2_tx_message_bodies = ['q2_message+%s' % (i,) for i in range(150)]
         for message_body in q2_tx_message_bodies:
             ch.basic_publish(exg_name, q2_routing_key, body=message_body, mandatory=True)
 
@@ -2693,7 +2691,7 @@ class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
         ch.queue_declare(q_name, auto_delete=False)
         self.addCleanup(lambda: self._connect().channel().queue_delete(q_name))
 
-        for _ in pika.compat.xrange(num_messages_to_publish):
+        for _ in range(num_messages_to_publish):
             # Publish a message to the queue by way of default exchange
             ch.basic_publish(exchange='', routing_key=q_name, body=body)
 

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -7,9 +7,7 @@ import collections
 import errno
 import logging
 import os
-import platform
 import socket
-import time
 import unittest
 
 import pika.compat
@@ -62,7 +60,7 @@ class AsyncServicesTestBase(unittest.TestCase):
         :returns: two-tuple of connected non-blocking sockets
 
         """
-        pair = pika.compat._nonblocking_socketpair()  # pylint: disable=W0212
+        pair = pika.compat.nonblocking_socketpair()
         self.addCleanup(pair[0].close)
         self.addCleanup(pair[1].close)
         return pair
@@ -98,7 +96,7 @@ class AsyncServicesTestBase(unittest.TestCase):
         :return: socket address pair (ip-addr, port) that will refuse connection
 
         """
-        s1, s2 = pika.compat._nonblocking_socketpair()  # pylint: disable=W0212
+        s1, s2 = pika.compat.nonblocking_socketpair()
         s2.close()
         self.addCleanup(s1.close)
         return s1.getsockname()  # pylint: disable=E1101
@@ -755,8 +753,7 @@ class TestStreamConnectorTxRx(StreamingTestBase, IOServicesTestStubs):
     def start(self):
         nbio = self.create_nbio()
 
-        original_data = tuple(
-            os.urandom(1000) for _ in pika.compat.xrange(1000))
+        original_data = tuple(os.urandom(1000) for _ in range(1000))
         original_data_length = sum(len(s) for s in original_data)
 
         my_protocol_bucket = []

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -5,9 +5,7 @@ import datetime
 import functools
 import os
 import select
-import sys
 import logging
-import platform
 import unittest
 from unittest import mock
 import uuid
@@ -255,7 +253,7 @@ class AsyncTestCase(unittest.TestCase):
 class BoundQueueTestCase(AsyncTestCase):
 
     def start(self, adapter, ioloop_factory):
-        # PY3 compat encoding
+        # Encoding
         self.exchange = 'e-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.queue = 'q-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.routing_key = self.__class__.__name__
@@ -372,8 +370,6 @@ class AsyncAdapters(object):
         ioloop_factory = tornado.ioloop.IOLoop
         self.start(TornadoConnection, ioloop_factory)
 
-    @unittest.skipIf(sys.version_info < (3, 4),
-                     'Asyncio is available only with Python 3.4+')
     @run_test_in_thread_with_timeout
     def test_with_asyncio(self):
         """AsyncioConnection"""

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -11,24 +11,17 @@ import multiprocessing
 import os
 import socket
 import struct
+import socketserver
 import sys
 import threading
 import traceback
 
 import pika.compat
 
-if pika.compat.PY3:
 
-    def buffer(object, offset, size):  # pylint: disable=W0622
-        """array etc. have the buffer protocol"""
-        return object[offset:offset + size]
-
-
-try:
-    import SocketServer
-except ImportError:
-    import socketserver as SocketServer  # pylint: disable=F0401
-
+def buffer(object_, offset, size):
+    """array etc. have the buffer protocol"""
+    return object_[offset:offset + size]
 
 def _trace(fmt, *args):
     """Format and output the text to stderr"""
@@ -280,8 +273,8 @@ def _run_server(
     # override some of its class members dynamically
     # NOTE: we add `object` to the base classes because `_ThreadedTCPServer`
     # isn't derived from `object`, which prevents `super` from working properly
-    class _ThreadedTCPServer(SocketServer.ThreadingMixIn,
-                             SocketServer.TCPServer, object):
+    class _ThreadedTCPServer(socketserver.ThreadingMixIn,
+                             socketserver.TCPServer, object):
         """Threaded streaming server for forwarding"""
 
         # Override TCPServer's class members
@@ -313,7 +306,7 @@ def _run_server(
 
 # NOTE: we add `object` to the base classes because `StreamRequestHandler` isn't
 # derived from `object`, which prevents `super` from working properly
-class _TCPHandler(SocketServer.StreamRequestHandler, object):
+class _TCPHandler(socketserver.StreamRequestHandler, object):
     """TCP/IP session handler instantiated by TCPServer upon incoming
     connection. Implements forwarding/echo of the incoming connection.
     """
@@ -375,10 +368,10 @@ class _TCPHandler(SocketServer.StreamRequestHandler, object):
                    remote_dest_sock.getpeername())
         else:
             # Echo set-up
-            # NOTE: Use pika.compat._nonblocking_socketpair() since
+            # NOTE: Use pika.compat.nonblocking_socketpair() since
             # socket.socketpair() isn't available on Windows under python 2 yet.
             remote_dest_sock, remote_src_sock = \
-                    pika.compat._nonblocking_socketpair()
+                    pika.compat.nonblocking_socketpair()
             # We rely on blocking I/O
             remote_dest_sock.setblocking(True)
             remote_src_sock.setblocking(True)

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -22,7 +22,6 @@ class TestGetNativeIOLoop(unittest.TestCase,
 
 """
 
-import sys
 import unittest
 
 from tests.wrappers.threaded_test_wrapper import run_in_thread_with_timeout
@@ -111,8 +110,6 @@ class IOServicesTestStubs(object):
             nbio_factory=lambda: SelectorIOServicesAdapter(native_loop),
             native_loop=native_loop)
 
-    @unittest.skipIf(sys.version_info < (3, 4),
-                     "Asyncio is available only with Python 3.4+")
     @run_in_thread_with_timeout
     def test_with_asyncio_io_services(self):
         # Test entry point for `asyncio` event loop-based io services

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -7,9 +7,10 @@ import copy
 import ssl
 import unittest
 import warnings
+from urllib.parse import quote as url_quote, urlencode
 
 import pika
-from pika.compat import urlencode, url_quote, dict_iteritems
+from pika.compat import dict_iteritems
 from pika import channel, connection, credentials, spec
 
 # disable missing-docstring

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -19,7 +19,6 @@ from unittest import mock
 
 from pika import connection, channel, credentials, exceptions, frame, spec
 import pika
-from pika.compat import xrange
 
 
 def dummy_callback():
@@ -329,7 +328,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
     def test_next_channel_number_returns_lowest_unused(self):
         """_next_channel_number must return lowest available channel number"""
-        for channel_num in xrange(1, 50):
+        for channel_num in range(1, 50):
             self.connection._channels[channel_num] = True
         expectation = random.randint(5, 49)
         del self.connection._channels[expectation]

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -7,7 +7,6 @@ import datetime
 import decimal
 import unittest
 from collections import OrderedDict
-from pika.compat import PY2, PY3
 
 from pika import data, exceptions
 from pika.compat import long
@@ -33,7 +32,7 @@ class DataTests(unittest.TestCase):
         b'\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93'
         )
 
-    FIELD_TBL_ENCODED += b'\x05bytesx\x00\x00\x00\x06foobar' if PY3 else b'\x05bytesS\x00\x00\x00\x06foobar'
+    FIELD_TBL_ENCODED += b'\x05bytesx\x00\x00\x00\x06foobar'
 
     FIELD_TBL_VALUE = OrderedDict(
         [

--- a/tests/unit/diagnostic_utils_test.py
+++ b/tests/unit/diagnostic_utils_test.py
@@ -44,7 +44,7 @@ class DiagnosticUtilsTest(unittest.TestCase):
         self.assertEqual(bucket, [(expected_args, expected_kwargs)])
 
         # Make sure that the original instances were passed through, not copies
-        for i in pika.compat.xrange(len(expected_args)):
+        for i in range(len(expected_args)):
             self.assertIs(bucket[0][0][i], expected_args[i])
 
         for key in pika.compat.dictkeys(expected_kwargs):
@@ -53,7 +53,7 @@ class DiagnosticUtilsTest(unittest.TestCase):
         # Now, repeat without any args/kwargs
         expected_args = tuple()
         expected_kwargs = dict()
-        del bucket[:]  # .clear() doesn't exist in python 2.7
+        bucket.clear()
 
         result = my_func()
 

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -9,7 +9,6 @@ try:
 except ImportError:
     asyncio = None
 
-import sys
 import threading
 import unittest
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -615,10 +615,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         tmr_w.start()
         self.poller.start()
         self.assertTrue(self._eintr_read_handler_is_called)
-        if pika.compat.EINTR_IS_EXPOSED:
-            self.assertEqual(is_resumable_mock.call_count, 1)
-        else:
-            self.assertEqual(is_resumable_mock.call_count, 0)
+        self.assertEqual(is_resumable_mock.call_count, 0)
 
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
@@ -759,7 +756,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         :returns: two-tuple of connected non-blocking sockets
 
         """
-        pair = pika.compat._nonblocking_socketpair()
+        pair = pika.compat.nonblocking_socketpair()
         self.addCleanup(pair[0].close)
         self.addCleanup(pair[1].close)
         return pair
@@ -795,7 +792,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         :return: socket address pair (ip-addr, port) that will refuse connection
 
         """
-        s1, s2 = pika.compat._nonblocking_socketpair()
+        s1, s2 = pika.compat.nonblocking_socketpair()
         s2.close()
         self.addCleanup(s1.close)
         return s1.getsockname()  # pylint: disable=E1101
@@ -879,7 +876,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
                 '%s: setting `ERROR` to all event filters on '
                 'Windows, because its `select()` does not indicate a socket '
                 'that failed to connect as readable or writable.', msg_prefix)
-            for i in pika.compat.xrange(len(requested_eventmasks)):
+            for i in range(len(requested_eventmasks)):
                 requested_eventmasks[i] |= self.ERROR
 
         self.which_events_are_set_with_varying_eventmasks(

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -4,13 +4,12 @@ Tests for threaded_test_wrapper.py
 """
 from __future__ import print_function
 
+from io import StringIO
 import sys
 import threading
 import time
 import unittest
 from unittest import mock
-
-import pika.compat
 
 from tests.wrappers import threaded_test_wrapper
 from tests.wrappers.threaded_test_wrapper import (_ThreadedTestWrapper, run_in_thread_with_timeout)
@@ -47,7 +46,7 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
                 raise SelfCheckExceptionHandling()
 
         # Suppress error output by redirecting to stringio_stderr
-        stringio_stderr = pika.compat.StringIO()
+        stringio_stderr = StringIO()
         try:
             with mock.patch.object(_ThreadedTestWrapper, '_stderr',
                                    stringio_stderr):
@@ -76,7 +75,7 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
 
     def test_handling_of_test_execution_thread_timeout(self):
         # Suppress error output by redirecting to our stringio_stderr object
-        stringio_stderr = pika.compat.StringIO()
+        stringio_stderr = StringIO()
 
         @run_in_thread_with_timeout
         def my_sleeper(*_args, **_kwargs):


### PR DESCRIPTION
## Proposed Changes

Reducing the usage of the `pika.compat` usage. It's really depressing for a first-time contributor to see Python 2 being used nowadays.

I believe/hope that these changes will encourage more people to contribute!

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

On the consistency side. I believe that this repository should:
- Add pre-commit config and inform the contributors to use it. The pre-commit config:
    - Use `black` as its formatter.
    - Use `isort` as its imports reordering handler.
    - (Optional) Use items from `ruff`.
    - (Optional) Use `pydocstyle` for docstrings with the Google style.
    - etc.
- Do an initial run with the pre-commit on all files.
