### PR TITLE
Use sys.platform instead of platform.system()

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,20 +15,20 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [ 3.8, 3.9, '3.10', '3.11'] # TODO add 3.12
         test-tls: [true, false]
     env:
       PIKA_TEST_TLS: ${{ matrix.test-tls }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
           cache-dependency-path: test-requirements.txt
       - name: Cache installers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           # Note: the cache path is relative to the workspace directory
           # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#using-the-cache-action
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [ 3.8, 3.9, '3.10', '3.11'] # TODO add 3.12
     services:
       rabbitmq:
         image: rabbitmq
@@ -56,9 +56,9 @@ jobs:
           - 5672:5672
           - 5671:5671
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -6,24 +6,23 @@ compatibility functions
 
 import abc
 import os
-import platform
 import re
 import socket
-import sys as _sys
+import sys
 import time
 
-PY2 = _sys.version_info.major == 2
+PY2 = sys.version_info.major == 2
 PY3 = not PY2
 RE_NUM = re.compile(r'(\d+).+')
 
-ON_LINUX = platform.system() == 'Linux'
-ON_OSX = platform.system() == 'Darwin'
-ON_WINDOWS = platform.system() == 'Windows'
+ON_LINUX = sys.platform.startswith("linux")
+ON_OSX = sys.platform == "darwin"
+ON_WINDOWS = sys.platform == "win32"
 
 # Portable Abstract Base Class
 AbstractBase = abc.ABCMeta('AbstractBase', (object,), {})
 
-if _sys.version_info[:2] < (3, 3):
+if sys.version_info[:2] < (3, 3):
     SOCKET_ERROR = socket.error
 else:
     # socket.error was deprecated and replaced by OSError in python 3.3
@@ -207,10 +206,11 @@ def get_linux_version(release_str):
 
 HAVE_SIGNAL = os.name == 'posix'
 
-EINTR_IS_EXPOSED = _sys.version_info[:2] <= (3, 4)
+EINTR_IS_EXPOSED = sys.version_info[:2] <= (3, 4)
 
 LINUX_VERSION = None
-if platform.system() == 'Linux':
+if ON_LINUX:
+    import platform
     LINUX_VERSION = get_linux_version(platform.release())
 
 _LOCALHOST = '127.0.0.1'

--- a/testdata/versions.json
+++ b/testdata/versions.json
@@ -1,4 +1,4 @@
 {
-  "erlang": "26.0.2",
-  "rabbitmq": "3.12.2"
+  "erlang": "26.2.5",
+  "rabbitmq": "3.13.3"
 }

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -356,11 +356,11 @@ class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
         exg_name = ("TestInvalidExchangeTypeRaisesConnectionClosed_" +
                     uuid.uuid1().hex)
 
-        with self.assertRaises(pika.exceptions.ConnectionClosed) as ex_cm:
+        with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
             # Attempt to create an exchange with invalid exchange type
             ch.exchange_declare(exg_name, exchange_type='ZZwwInvalid')
 
-        self.assertEqual(ex_cm.exception.args[0], 503)
+        self.assertEqual(ex_cm.exception.args[0], 406)
 
 
 class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):


### PR DESCRIPTION
`platform.system()` is notoriously slow on Windows: https://github.com/python/cpython/issues/95531

This change shaves >100ms off the runtime for `python -c "import pika"` on my machine.