### PR TITLE
Convert utcnow() and utcfromtimestamp()

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -3,7 +3,7 @@ import struct
 import decimal
 import calendar
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from pika import exceptions
 from pika.compat import long, as_bytes
@@ -280,8 +280,8 @@ def decode_value(encoded, offset): # pylint: disable=R0912,R0915
 
     # Timestamp
     elif kind == b'T':
-        value = datetime.utcfromtimestamp(
-            struct.unpack_from('>Q', encoded, offset)[0])
+        value = datetime.fromtimestamp(
+            struct.unpack_from('>Q', encoded, offset)[0], timezone.utc)
         offset += 8
 
     # Field Table

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -1,7 +1,7 @@
 """Base test classes for async_adapter_tests.py
 
 """
-import datetime
+from datetime import datetime, timezone
 import functools
 import os
 import select
@@ -146,7 +146,7 @@ class AsyncTestCase(unittest.TestCase):
         self.fail("AsyncTestCase.begin_test not extended")
 
     def start(self, adapter, ioloop_factory):
-        self.logger.info('start at %s', datetime.datetime.utcnow())
+        self.logger.info('start at %s', datetime.now(timezone.utc))
         self.adapter = adapter or self.ADAPTER
 
         self.connection = self.adapter(self.parameters,
@@ -243,7 +243,7 @@ class AsyncTestCase(unittest.TestCase):
     def on_timeout(self):
         """called when stuck waiting for connection to close"""
         self.logger.error('%s timed out; on_timeout called at %s', self,
-                          datetime.datetime.utcnow())
+                          datetime.now(timezone.utc))
         self.timeout = None  # the dispatcher should have removed it
         self._timed_out = True
         # initiate cleanup

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -3,7 +3,7 @@
 from __future__ import print_function
 
 import array
-from datetime import datetime
+from datetime import datetime, timezone
 import errno
 from functools import partial
 import logging
@@ -364,7 +364,7 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
                 type=self._remote_socket_type,
                 proto=socket.IPPROTO_IP)
             remote_dest_sock.connect(self._remote_addr)
-            _trace("%s _TCPHandler connected to remote %s", datetime.utcnow(),
+            _trace("%s _TCPHandler connected to remote %s", datetime.now(timezone.utc),
                    remote_dest_sock.getpeername())
         else:
             # Echo set-up
@@ -406,7 +406,7 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
         """Forward from src_sock to dest_sock"""
         src_peername = src_sock.getpeername()
 
-        _trace("%s forwarding from %s to %s", datetime.utcnow(), src_peername,
+        _trace("%s forwarding from %s to %s", datetime.now(timezone.utc), src_peername,
                dest_sock.getpeername())
         try:
             # NOTE: python 2.6 doesn't support bytearray with recv_into, so
@@ -424,18 +424,18 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
                         continue
                     elif exc.errno == errno.ECONNRESET:
                         # Source peer forcibly closed connection
-                        _trace("%s errno.ECONNRESET from %s", datetime.utcnow(),
+                        _trace("%s errno.ECONNRESET from %s", datetime.now(timezone.utc),
                                src_peername)
                         break
                     else:
                         _trace("%s Unexpected errno=%s from %s\n%s",
-                               datetime.utcnow(), exc.errno, src_peername,
+                               datetime.now(timezone.utc), exc.errno, src_peername,
                                "".join(traceback.format_stack()))
                         raise
 
                 if not nbytes:
                     # Source input EOF
-                    _trace("%s EOF on %s", datetime.utcnow(), src_peername)
+                    _trace("%s EOF on %s", datetime.now(timezone.utc), src_peername)
                     break
 
                 try:
@@ -444,18 +444,18 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
                     if exc.errno == errno.EPIPE:
                         # Destination peer closed its end of the connection
                         _trace("%s Destination peer %s closed its end of "
-                               "the connection: errno.EPIPE", datetime.utcnow(),
+                               "the connection: errno.EPIPE", datetime.now(timezone.utc),
                                dest_sock.getpeername())
                         break
                     elif exc.errno == errno.ECONNRESET:
                         # Destination peer forcibly closed connection
                         _trace("%s Destination peer %s forcibly closed "
                                "connection: errno.ECONNRESET",
-                               datetime.utcnow(), dest_sock.getpeername())
+                               datetime.now(timezone.utc), dest_sock.getpeername())
                         break
                     else:
                         _trace("%s Unexpected errno=%s in sendall to %s\n%s",
-                               datetime.utcnow(), exc.errno,
+                               datetime.now(timezone.utc), exc.errno,
                                dest_sock.getpeername(), "".join(
                                    traceback.format_stack()))
                         raise
@@ -463,7 +463,7 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
             _trace("forward failed\n%s", "".join(traceback.format_exc()))
             raise
         finally:
-            _trace("%s done forwarding from %s", datetime.utcnow(),
+            _trace("%s done forwarding from %s", datetime.now(timezone.utc),
                    src_peername)
             try:
                 # Let source peer know we're done receiving

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -7,7 +7,7 @@ Tests for SelectConnection IOLoops
 from __future__ import print_function
 
 import errno
-import datetime
+from datetime import datetime, timezone
 import functools
 import logging
 import os
@@ -732,7 +732,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
         def _on_test_timeout():
             """Called when test times out"""
-            LOGGER.info('%s TIMED OUT (%s)', datetime.datetime.utcnow(), self)
+            LOGGER.info('%s TIMED OUT (%s)', datetime.now(timezone.utc), self)
             self.fail('Test timed out')
 
         ioloop.call_later(self.DEFAULT_TEST_TIMEOUT, _on_test_timeout)


### PR DESCRIPTION
Both methods are deprecated, and now result in warnings like

    DeprecationWarning: datetime.datetime.utcfromtimestamp() is
    deprecated and scheduled for removal in a future version. Use
    timezone-aware objects to represent datetimes in UTC:
    datetime.datetime.fromtimestamp(timestamp, datetime.UTC).

and

    DeprecationWarning: datetime.datetime.utcnow() is deprecated and
    scheduled for removal in a future version. Use timezone-aware
    objects to represent datetimes in UTC:
    datetime.datetime.now(datetime.UTC).

An example can be seen in https://gitlab.com/cki-project/cki-lib/-/jobs/7614326286#L166.

While most use of these methods is in test code, there is one instance of datetime.utcfromtimestamp() used during deserialization in data.py that might affect user code.

## Proposed Changes

- `datetime.utcnow() -> datetime.now(timezone.utc)`
- `datetime.utcfromtimestamp(...) -> datetime.fromtimestamp(..., timezone.utc)`

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which resolves DeprecationWarnings)

## Checklist

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)