### PR TITLE
specify your own consumer_tag when using consume() method of BlockingChannel

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1897,7 +1897,8 @@ class BlockingChannel:
                 auto_ack=False,
                 exclusive=False,
                 arguments=None,
-                inactivity_timeout=None):
+                inactivity_timeout=None,
+                consumer_tag=None):
         """Blocking consumption of a queue instead of via a callback. This
         method is a generator that yields each message as a tuple of method,
         properties, and body. The active generator iterator terminates when the
@@ -1930,6 +1931,7 @@ class BlockingChannel:
             the next event arrives. NOTE that timing granularity is limited by
             the timer resolution of the underlying implementation.
             NEW in pika 0.10.0.
+        :param str consumer_tag: Specify your own consumer tag
 
         :yields: tuple(spec.Basic.Deliver, spec.BasicProperties, str or unicode)
 
@@ -1956,7 +1958,8 @@ class BlockingChannel:
             # Need a consumer tag to register consumer info before sending
             # request to broker, because I/O might pick up incoming messages
             # in addition to Basic.Consume-ok
-            consumer_tag = self._impl._generate_consumer_tag()
+            if not consumer_tag:
+                consumer_tag = self._impl._generate_consumer_tag()
 
             self._queue_consumer_generator = _QueueConsumerGeneratorInfo(
                 params, consumer_tag)


### PR DESCRIPTION

When using consume() method of BlockingChannel class, was not possible to define your own consumer_tag
This optional parameter has been added to consume() method
