### PR TITLE
Add time_limit optional argument to be able to inject in start_consuming function.

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1853,7 +1853,7 @@ class BlockingChannel:
 
         return unprocessed_messages
 
-    def start_consuming(self):
+    def start_consuming(self, time_limit=None):
         """Processes I/O events and dispatches timers and `basic_consume`
         callbacks until all consumers are cancelled.
 
@@ -1877,7 +1877,7 @@ class BlockingChannel:
         # Process events as long as consumers exist on this channel
         while self._consumer_infos:
             # This will raise ChannelClosed if channel is closed by broker
-            self._process_data_events(time_limit=None)
+            self._process_data_events(time_limit=time_limit)
 
     def stop_consuming(self, consumer_tag=None):
         """ Cancels all consumers, signalling the `start_consuming` loop to

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1861,6 +1861,8 @@ class BlockingChannel:
         pika callback, because dispatching `basic_consume` callbacks from this
         context would constitute recursion.
 
+        :param int time_limit: time limit of the consume operation
+
         :raises pika.exceptions.ReentrancyError: if called from the scope of a
             `BlockingConnection` or `BlockingChannel` callback
         :raises ChannelClosed: when this channel is closed by broker.


### PR DESCRIPTION
Add time_limit optional argument to be able to inject time_limit in BlockingConnection.start_consuming function

This pull request is necessary because it enhances the "start_consuming" method by adding an optional time_limit parameter, making it more flexible and aligning its functionality with the documented description. The original implementation lacked the ability to specify a time limit, limiting its usability in scenarios requiring controlled operation duration. By introducing this parameter and passing it to "_process_data_events", the method now supports time-bound consumption, which broadens its applicability while maintaining backward compatibility, as the default behavior remains unchanged. This change not only ensures consistency between the code and its documentation but also improves clarity and usability, empowering developers to integrate the method into applications with stricter timing requirements without any disruption to existing workflows.

## Proposed Changes
A simple change to "start_consuming" function to be able to inject time_limit.

## Types of Changes

What types of changes does your code introduce to this project?

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [X] I have read the `CONTRIBUTING.md` document
- [X] All tests pass locally with my changes
- [<No additional tests are required>] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further Comments
No further comment.