### PR TITLE
Fix tests with Python 3.14, except RuntimeError from asyncio.get_event_loop

### DIFF
--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -40,7 +40,11 @@ _SUPPORTED_LOOP_CLASSES = {
 if asyncio is not None:
     if pika.compat.ON_WINDOWS:
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    _SUPPORTED_LOOP_CLASSES.add(asyncio.get_event_loop().__class__)
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+    _SUPPORTED_LOOP_CLASSES.add(loop.__class__)
 
 
 class TestStartCalledFromOtherThreadAndWithVaryingNativeLoops(


### PR DESCRIPTION
Related to https://github.com/pika/pika/issues/1479

## Proposed Changes

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1479)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the
[`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code._

- [ ] I have read the `CONTRIBUTING.md` document
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

I am sorry, I have not read your document. I consider this a trivial change. It makes the tests pass with Python 3.14. I am currently dealing with ~4 thousand packages, so this is extremely drive-by contribution.