### PR TITLE
Remove dead Code Climate config files

### DIFF
--- a/.checkignore
+++ b/.checkignore
@@ -1,5 +1,0 @@
-**/docs
-**/examples
-**/test
-**/utils
-setup.py

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,0 @@
-languages:
-  - python
-exclude_paths:
-  - docs/*
-  - tests/*
-  - utils/*
-  - pika/examples/*
-  - pika/spec.py


### PR DESCRIPTION
## Proposed Changes

Delete `.codeclimate.yml` and `.checkignore`, both last touched in 2015 and no longer serving any purpose.

Evidence the integration is dead:

- No README badge, no GHA workflow, and no `CONTRIBUTING.md` reference either file.
- `.codeclimate.yml` excludes `pika/examples/*`, a path that has not existed in the repo for years (examples live at `examples/`). If the file were actively consumed, the stale path would have been noticed.
- Code Climate Classic's free OSS tier was retired years ago; even if a silent service-side consumer still exists, a missing config is a recoverable state.

No behavioural effect on the build, tests, or ruff lint.

## Types of Changes

- [x] Cosmetics (whitespace, appearance)

This is repo hygiene / dead-config removal. The "cosmetics" category is the closest fit in the template.

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

No tests or documentation apply: this PR only removes dead config files.
