### PR TITLE
Fix `BlockingIOError` from `_read_interrupt` on Windows (GH-1314)

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -20,6 +20,12 @@ from pika.adapters.utils.selector_ioloop_adapter import (
 
 LOGGER = logging.getLogger(__name__)
 
+# Non-blocking socket read/send returns one of these errnos when no data is
+# available or the operation would block. On POSIX systems EAGAIN and
+# EWOULDBLOCK have the same value; on Windows they differ (EWOULDBLOCK is
+# WSAEWOULDBLOCK / 10035), so both must be checked for portable handling.
+_TRY_IO_AGAIN_SOCK_ERROR_CODES = (errno.EAGAIN, errno.EWOULDBLOCK)
+
 # One of select, epoll, kqueue or poll
 SELECT_TYPE = None
 
@@ -665,7 +671,7 @@ class _PollerBase(pika.compat.AbstractBase):  # pylint: disable=R0902
                 # os.write for Windows compatibility
                 self._w_interrupt.send(b'X')
             except pika.compat.SOCKET_ERROR as err:
-                if err.errno != errno.EWOULDBLOCK:
+                if err.errno not in _TRY_IO_AGAIN_SOCK_ERROR_CODES:
                     raise
             except Exception as err:
                 # There's nothing sensible to do here, we'll exit the interrupt
@@ -923,7 +929,7 @@ class _PollerBase(pika.compat.AbstractBase):  # pylint: disable=R0902
             # NOTE Use recv instead of os.read for windows compatibility
             self._r_interrupt.recv(512)  # pylint: disable=E1101
         except pika.compat.SOCKET_ERROR as err:
-            if err.errno != errno.EAGAIN:
+            if err.errno not in _TRY_IO_AGAIN_SOCK_ERROR_CODES:
                 raise
 
 

--- a/tests/unit/select_connection_interrupt_tests.py
+++ b/tests/unit/select_connection_interrupt_tests.py
@@ -1,0 +1,49 @@
+"""Unit test for `_PollerBase._read_interrupt` non-blocking errno handling.
+
+Regression coverage for pika/pika#1314. On Windows, a non-blocking `recv`
+against an empty socket raises `BlockingIOError` with `errno.EWOULDBLOCK`
+(`WSAEWOULDBLOCK`, 10035) rather than `errno.EAGAIN` (11). The interrupt
+handler must swallow both; otherwise a spurious wake or a drained buffer
+kills the poller thread on Windows.
+
+This test uses a real `SelectPoller` and a real non-blocking socket pair,
+so it exercises whatever errno the OS actually raises. On Linux both
+symbols share a value and the test is a no-op guard; on Windows it fails
+against the pre-fix code and passes against the fix.
+
+"""
+
+import unittest
+
+from pika.adapters import select_connection
+
+
+# protected-access
+# pylint: disable=W0212
+
+
+class ReadInterruptHandlesEmptySocket(unittest.TestCase):
+    """`_read_interrupt` must return cleanly when the interrupt fd is empty.
+
+    The interrupt socket pair created by `_PollerBase.__init__` is
+    non-blocking, so calling `_read_interrupt` against an empty read side
+    triggers an OS-native "would block" error. The handler is expected to
+    recognize it and return without propagating.
+    """
+
+    def setUp(self):
+        self._poller = select_connection.SelectPoller(
+            get_wait_seconds=lambda: 0,
+            process_timeouts=lambda: None)
+
+    def tearDown(self):
+        self._poller.close()
+
+    def test_empty_read_does_not_raise(self):
+        # Interrupt socket is created empty by __init__, so this directly
+        # exercises the would-block path. No prior read is needed.
+        self._poller._read_interrupt(None, None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Proposed Changes

Fixes #1314. The `_PollerBase._read_interrupt` handler did a non-blocking `recv()` on the interrupt socket and only swallowed `BlockingIOError` whose errno was `errno.EAGAIN`. That works on POSIX where `EAGAIN == EWOULDBLOCK`, but on Windows the OS raises `BlockingIOError` with errno `errno.EWOULDBLOCK` (`WSAEWOULDBLOCK`, 10035), so the check fails, the exception propagates, and the poller thread dies with:

```
BlockingIOError: [WinError 10035] A non-blocking socket operation could not be completed immediately
```

which is the error originally reported in #1314 and subsequently by other users.

The symmetric site `wake_threadsafe` had the mirror-image asymmetry: it only accepted `errno.EWOULDBLOCK`, coincidentally correct on both Windows and Linux today but fragile in the same class of way.

The fix defines a module-level tuple `_TRY_IO_AGAIN_SOCK_ERROR_CODES = (errno.EAGAIN, errno.EWOULDBLOCK)` and uses it at both sites. This mirrors the existing pattern in `pika/adapters/utils/io_services_utils.py`, which already defines an identically-named tuple for the same reason.

## Regression test

`tests/unit/select_connection_interrupt_tests.py` constructs a real `SelectPoller` and calls `_read_interrupt` against the empty interrupt socket created by `_PollerBase.__init__`. The OS raises whatever "would block" error it natively raises, exercising the real behaviour with no mocking.

Verified on Windows (WSL + native Python, `D:\development\pika\pika`):

- Pre-fix code on `origin/main`: **FAIL** with `BlockingIOError: [WinError 10035]` from `select_connection.py:924`, matching the issue report exactly.
- Post-fix code on this branch: **PASS**.
- Linux: PASS on both pre-fix and post-fix (the OS uses `EAGAIN`, which the pre-fix code already swallowed, so CI on Ubuntu would never have caught this). This is why the bug has lingered since 2021 despite a Windows matrix existing in CI only since later.

## Types of Changes

- [x] Bugfix (non-breaking change which fixes issue #1314)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

No documentation change: this is an internal bug fix with no API-surface impact.
