### PR TITLE
Drop more Python 2 compatibility code

### DIFF
--- a/pika/callback.py
+++ b/pika/callback.py
@@ -7,7 +7,6 @@ import logging
 
 from pika import frame
 from pika import amqp_object
-from pika.compat import canonical_str
 
 LOGGER = logging.getLogger(__name__)
 
@@ -37,7 +36,7 @@ def name_or_value(value):
         return value.NAME
 
     # Cast the value to a string
-    return canonical_str(value)
+    return str(value)
 
 
 def sanitize_prefix(function):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -14,7 +14,7 @@ import pika.frame as frame
 import pika.exceptions as exceptions
 import pika.spec as spec
 import pika.validators as validators
-from pika.compat import as_bytes, is_integer
+from pika.compat import as_bytes
 from pika.exchange_type import ExchangeType
 
 LOGGER = logging.getLogger(__name__)
@@ -486,7 +486,7 @@ class Channel:
 
         """
         self._raise_if_not_open()
-        if not is_integer(delivery_tag):
+        if not isinstance(delivery_tag, int):
             raise TypeError('delivery_tag must be an integer')
         return self._send_method(spec.Basic.Reject(delivery_tag, requeue))
 

--- a/pika/compat.py
+++ b/pika/compat.py
@@ -62,21 +62,6 @@ class long(int):
         return str(self) + 'L'
 
 
-def canonical_str(value):
-    """
-    Return the canonical str value for the string.
-    """
-
-    return str(value)
-
-
-def is_integer(value):
-    """
-    Is value an integer?
-    """
-    return isinstance(value, int)
-
-
 def as_bytes(value):
     """
     Returns value as bytes

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -1,7 +1,5 @@
 """TCP/IP forwarding/echo service for testing."""
 
-from __future__ import print_function
-
 import array
 from datetime import datetime, timezone
 import errno

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -4,8 +4,6 @@ Tests for SelectConnection IOLoops
 
 """
 
-from __future__ import print_function
-
 import errno
 from datetime import datetime, timezone
 import functools

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -2,7 +2,6 @@
 Tests for threaded_test_wrapper.py
 
 """
-from __future__ import print_function
 
 from io import StringIO
 import sys

--- a/tests/wrappers/threaded_test_wrapper.py
+++ b/tests/wrappers/threaded_test_wrapper.py
@@ -4,8 +4,6 @@ deadlock.
 
 """
 
-from __future__ import print_function
-
 import functools
 import os
 import sys

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -8,8 +8,6 @@ https://github.com/rabbitmq/rabbitmq-codegen
 After cloning it run the following to generate a spec.py file:
 python2 ./codegen.py ../../rabbitmq-codegen
 """
-from __future__ import nested_scopes
-
 import os
 import re
 import sys


### PR DESCRIPTION
## Summary

Drop more Python 2 compatibility code. This is a maintainer follow-up to #1528 (by @a-detiste), rebased onto a proper feature branch since the original PR targeted `main` from the contributor's fork `main`.

## Changes

- Remove `canonical_str()` from `pika/compat.py` and replace its one call site in `pika/callback.py` with `str()`
- Remove `is_integer()` from `pika/compat.py` and replace its one call site in `pika/channel.py` with `isinstance(value, int)`
- Remove `from __future__ import print_function` from 3 test files and 1 test helper
- Remove `from __future__ import nested_scopes` from `utils/codegen.py`

See #1559 for the broader Python 2 cleanup effort.

Closes #1528

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
