### PR TITLE
Fix field table type decoding to match RabbitMQ wire format

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -98,10 +98,7 @@ def encode_value(pieces, value): # pylint: disable=R0911
         pieces.append(struct.pack('>cB', b't', int(value)))
         return 2
     elif isinstance(value, long):
-        if value < 0:
-            pieces.append(struct.pack('>cq', b'L', value))
-        else:
-            pieces.append(struct.pack('>cQ', b'l', value))
+        pieces.append(struct.pack('>cq', b'l', value))
         return 9
     elif isinstance(value, int):
         try:
@@ -109,11 +106,7 @@ def encode_value(pieces, value): # pylint: disable=R0911
             pieces.append(packed)
             return 5
         except struct.error:
-            if value < 0:
-                packed = struct.pack('>cq', b'L', long(value))
-            else:
-                packed = struct.pack('>cQ', b'l', long(value))
-            pieces.append(packed)
+            pieces.append(struct.pack('>cq', b'l', long(value)))
             return 9
     elif isinstance(value, decimal.Decimal):
         value = value.normalize()
@@ -189,12 +182,12 @@ def decode_value(encoded, offset): # pylint: disable=R0912,R0915
 
     # Short-Short Int
     elif kind == b'b':
-        value = struct.unpack_from('>B', encoded, offset)[0]
+        value = struct.unpack_from('>b', encoded, offset)[0]
         offset += 1
 
     # Short-Short Unsigned Int
     elif kind == b'B':
-        value = struct.unpack_from('>b', encoded, offset)[0]
+        value = struct.unpack_from('>B', encoded, offset)[0]
         offset += 1
 
     # Short Int
@@ -222,9 +215,10 @@ def decode_value(encoded, offset): # pylint: disable=R0912,R0915
         value = long(struct.unpack_from('>q', encoded, offset)[0])
         offset += 8
 
-    # Long-Long Unsigned Int
+    # Long-Long Int (both 'l' and 'L' are signed per RabbitMQ and the
+    # AMQP 0-9-1 errata; see rabbitmq/rabbitmq-server#1093)
     elif kind == b'l':
-        value = long(struct.unpack_from('>Q', encoded, offset)[0])
+        value = long(struct.unpack_from('>q', encoded, offset)[0])
         offset += 8
 
     # Float

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -15,7 +15,7 @@ from pika.compat import long
 class DataTests(unittest.TestCase):
 
     FIELD_TBL_ENCODED = (
-        b'\x00\x00\x00\xef'
+        b'\x00\x00\x00\xed'
         b'\x05arrayA\x00\x00\x00\x0fI\x00\x00\x00\x01I'
         b'\x00\x00\x00\x02I\x00\x00\x00\x03'
         b'\x07boolvalt\x01'
@@ -25,7 +25,7 @@ class DataTests(unittest.TestCase):
         b'\x06intvalI\x00\x00\x00\x01'
         b'\x06bigint\x6c\x00\x00\x00\x00\x9a\x7e\xc8\x00'
         b'\x07longval\x6c\x00\x00\x00\x00\x36\x65\x26\x55'
-        b'\x09maxLLUINTl\xff\xff\xff\xff\xff\xff\xff\xff'
+        b'\x07neglongl\xff\xff\xff\xff\xff\xff\xff\xff'
         b'\x04nullV'
         b'\x06strvalS\x00\x00\x00\x04Test'
         b'\x0ctimestampvalT\x00\x00\x00\x00Ec)\x92'
@@ -44,7 +44,7 @@ class DataTests(unittest.TestCase):
             ('intval', 1),
             ('bigint', 2592000000),
             ('longval', long(912598613)),
-            ('maxLLUINT', long(2**64-1)),
+            ('neglong', long(-1)),
             ('null', None),
             ('strval', 'Test'),
             ('timestampval', datetime.datetime(2006, 11, 21, 16, 30, 10, tzinfo=datetime.timezone.utc)),
@@ -78,7 +78,7 @@ class DataTests(unittest.TestCase):
     def test_encode_table_bytes(self):
         result = []
         byte_count = data.encode_table(result, self.FIELD_TBL_VALUE)
-        self.assertEqual(byte_count, 243)
+        self.assertEqual(byte_count, 241)
 
     def test_decode_table(self):
         value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
@@ -86,7 +86,30 @@ class DataTests(unittest.TestCase):
 
     def test_decode_table_bytes(self):
         value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
-        self.assertEqual(byte_count, 243)
+        self.assertEqual(byte_count, 241)
+
+    def test_decode_signed_long_negative(self):
+        """Verify that type tag 'l' decodes as signed 64-bit (fixes #1531).
+
+        RabbitMQ encodes negative longs (e.g. x-delay after delivery)
+        with type tag 'l' and signed 64-bit representation.
+        """
+        # Table with x-delay = -30000 encoded as signed 64-bit 'l'
+        input = (
+            b'\x00\x00\x00\x10'
+            b'\x07x-delayl\xff\xff\xff\xff\xff\xff\x8a\xd0'
+        )
+        result, _ = data.decode_table(input, 0)
+        self.assertEqual(result, {'x-delay': long(-30000)})
+
+    def test_encode_decode_negative_long_roundtrip(self):
+        """Verify negative long values round-trip correctly."""
+        table = {'x-delay': long(-30000)}
+        pieces = []
+        data.encode_table(pieces, table)
+        encoded = b''.join(pieces)
+        decoded, _ = data.decode_table(encoded, 0)
+        self.assertEqual(decoded, table)
 
     def test_encode_raises(self):
         self.assertRaises(exceptions.UnsupportedAMQPFieldException,


### PR DESCRIPTION
## Summary

Fix three field table type tag mismatches between pika and RabbitMQ's actual wire format. The AMQP 0-9-1 spec and RabbitMQ disagree on the signedness of several type tags; RabbitMQ follows the Qpid convention as documented in the [AMQP 0-9-1 errata, section 3](https://www.rabbitmq.com/amqp-0-9-1-errata#section_3). Since pika is a RabbitMQ client, it must match RabbitMQ's behavior.

## Changes

**Decode fixes in `pika/data.py`:**
- `l` tag: decode as signed 64-bit (`>q`), not unsigned (`>Q`)
- `b` tag: decode as signed 8-bit (`>b`), not unsigned (`>B`)
- `B` tag: decode as unsigned 8-bit (`>B`), not signed (`>b`)

**Encode fix in `pika/data.py`:**
- Always use `l` tag with signed 64-bit (`>q`) for long values, matching `rabbit_binary_generator.erl`

**Tests in `tests/unit/data_tests.py`:**
- Replace `maxLLUINT` (unsigned 64-bit max) test case with `neglong` (signed -1) since both `l` and `L` are signed per RabbitMQ
- Add `test_decode_signed_long_negative` verifying the exact x-delay scenario from #1531
- Add `test_encode_decode_negative_long_roundtrip` for negative long round-trip

## Verification

Cross-referenced against three sources:
- `rabbit_binary_parser.erl` and `rabbit_binary_generator.erl` in the RabbitMQ server
- `ValueReader.java` in the RabbitMQ Java client
- The [AMQP 0-9-1 errata](https://www.rabbitmq.com/amqp-0-9-1-errata#section_3)

Fixes #1531
