### PR TITLE
Replace `PIKA_TEST_TLS` env with pytest flag

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-﻿name: pika
+name: pika
 
 on:
   push:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,4 +1,4 @@
-name: pika
+﻿name: pika
 
 on:
   push:
@@ -16,8 +16,6 @@ jobs:
       matrix:
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         test-tls: [true, false]
-    env:
-      PIKA_TEST_TLS: ${{ matrix.test-tls }}
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +38,7 @@ jobs:
           python -m pip install --upgrade pip wheel
           pip install -r test-requirements.txt
       - name: Test with pytest
-        run: pytest -v --cov=pika --cov-report=xml
+        run: pytest -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ If you would like to run TLS/SSL tests, use the following procedure:
 * Run the tests indicating that TLS/SSL connections should be used:
 
     ```
-    PIKA_TEST_TLS=true pytest
+    pytest --use-tls
     ```
 
 

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -3,8 +3,8 @@
 """
 from datetime import datetime, timezone
 import functools
-import os
 import select
+import sys
 import logging
 import unittest
 from unittest import mock
@@ -82,10 +82,7 @@ stop_on_error_in_async_test_case_method = make_stop_on_error_with_self()
 
 
 def enable_tls():
-    if 'PIKA_TEST_TLS' in os.environ and \
-            os.environ['PIKA_TEST_TLS'].lower() == 'true':
-        return True
-    return False
+    return '--use-tls' in sys.argv
 
 
 class AsyncTestCase(unittest.TestCase):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+def pytest_addoption(parser):
+    parser.addoption('--use-tls', action='store_true', default=False,
+                     help='Use TLS for acceptance tests.')


### PR DESCRIPTION
## Proposed Changes

Replace the `PIKA_TEST_TLS` environment variable with a proper pytest CLI flag (`--use-tls`) for enabling TLS in acceptance tests.

The env var approach requires remembering a magic variable name and doesn't integrate with pytest's option system. A CLI flag is discoverable via `pytest --help`, along with other pytest args.

This was previously discussed here https://github.com/pika/pika/issues/1469#issuecomment-2660178439

## Changes

- `tests/conftest.py` - registers `--use-tls` with pytest
- `tests/base/async_test_base.py` - `enable_tls()` reads sys.argv instead of os.environ
- `.github/workflows/main.yaml` - removes `PIKA_TEST_TLS` env, passes `--use-tls` via matrix expression
- `CONTRIBUTING.md` - documents `pytest --use-tls`

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue ##)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction or otherwise)
- [x] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)