### PR TITLE
Support Python 3.7+ in CI and fix `typing_extensions` import

### DIFF
--- a/.github/workflows/legacy-python.yaml
+++ b/.github/workflows/legacy-python.yaml
@@ -1,4 +1,4 @@
-name: pika
+name: pika (legacy Python)
 
 on:
   push:
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
         test-tls: [true, false]
     steps:
       - uses: actions/checkout@v6
@@ -47,11 +47,11 @@ jobs:
           flags: windows,py${{ matrix.python-version }},tls-${{ matrix.test-tls }}
           fail_ci_if_error: false
   build:
-    name: build/test on ubuntu-latest
-    runs-on: ubuntu-latest
+    name: build/test on ubuntu-22.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
     services:
       rabbitmq:
         image: rabbitmq

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
         test-tls: [true, false]
     steps:
       - uses: actions/checkout@v6
@@ -51,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', '3.14' ]
     services:
       rabbitmq:
         image: rabbitmq

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -13,7 +13,6 @@ import select
 import time
 import threading
 from typing import Any, Callable, Optional, Sequence, Set, Tuple, Type, Dict, Union, TYPE_CHECKING
-from typing_extensions import TypedDict
 
 import pika.compat
 
@@ -23,6 +22,7 @@ from pika.adapters.utils.selector_ioloop_adapter import (
     SelectorIOServicesAdapter, AbstractSelectorIOLoop)
 
 if TYPE_CHECKING:
+    from typing_extensions import TypedDict
     from pika import connection
     from pika.adapters.utils import connection_workflow
     import socket

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,4 +6,4 @@ pytest-cov
 pytest-timeout
 tornado
 twisted
-mypy>=1.20
+mypy>=1.20; python_version >= "3.10"


### PR DESCRIPTION
## Summary

- Add Python 3.7, 3.8, and 3.9 to the CI test matrix for both the Linux and Windows jobs, so that what we test matches what `pyproject.toml` advertises via `requires-python = ">=3.7"` and the version classifiers.
- Move `from typing_extensions import TypedDict` inside the `TYPE_CHECKING` block in `select_connection.py`. `TypedDict` is only used in the `POLLER_PARAMS` type alias, which is itself defined under `TYPE_CHECKING`, so the import was running unnecessarily at module load time and created an undeclared runtime dependency on `typing_extensions`.

## Notes

A scan of the source found no other Python 3.7 incompatibilities: no walrus operator, no positional-only parameters, no dict merge operators, no 3.8+ `typing` imports, and `from __future__ import annotations` is already present on every source file.
