### PR TITLE
Fix TypeError in select_connection

### DIFF
--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -1161,6 +1161,7 @@ class KQueuePoller(_PollerBase):
         if events_to_clear & PollEvents.READ:
             kevents.append(
                 select.kevent(  # pyright: ignore[reportAttributeAccessIssue]
+                    fileno,
                     filter=select.
                     KQ_FILTER_READ,  # pyright: ignore[reportAttributeAccessIssue]
                     flags=select.KQ_EV_DELETE)


### PR DESCRIPTION
## Proposed Changes

Recent commit related to [type annotation](https://github.com/pika/pika/pull/1529) caused a regression in select_connection and removed `fileno` argument from `select.kevent` method. 

Error:
```
TypeError: kevent() missing required argument 'ident' (pos 1)
```

The issue is encountered when running the tests locally.

Adding back the `fileno` argument to `select.kevent` method to fix the `TypeError`.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

NA
