### PR TITLE
Update outdated documentation across the pika project

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,9 @@ examples/               # usage examples
 ## Code style
 
 - **Formatter:** [yapf](https://pypi.org/project/yapf/) with Google style.
-  Run `yapf --diff --style google --recursive pika/` to check.
+  Run `yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/` to check.
 - **Linter:** [ruff](https://docs.astral.sh/ruff/). Configuration is in
-  `pyproject.toml` under `[tool.ruff]`. Run `ruff check pika/ tests/ examples/`.
+  `pyproject.toml` under `[tool.ruff]`. Run `ruff check pika/ tests/ examples/ utils/`.
 - **Type checking:** [mypy](https://mypy-lang.org/). Configuration is in
   `mypy.ini`. Run `python -m mypy`.
 - Use single quotes for strings unless the string contains a single quote.
@@ -61,27 +61,27 @@ without corresponding `utils/codegen.py` changes will be rejected.
 
 ## CI workflows
 
+- **Format** (`.github/workflows/yapf.yaml`): runs `yapf` check on every push and pull request.
 - **Lint** (`.github/workflows/lint.yaml`): runs `ruff check` on every push
   and pull request.
 - **Type check** (`.github/workflows/mypy.yaml`): runs `mypy` on every push
   and pull request. Requires `tornado` and `twisted` to be installed so mypy
   can resolve optional-dependency types.
 - **Tests** (`.github/workflows/main.yaml`): runs the full test suite with
-  `pynose` across the Python version matrix. Acceptance tests require a
-  RabbitMQ server (started via Docker in CI). The Windows job runs unit
-  tests only.
+  `pytest` across the Python version matrix. Acceptance tests require a
+  RabbitMQ server (started via Docker in CI).
 
 ## Running tests locally
 
 ```bash
 # Unit tests only (no RabbitMQ needed)
-pynose tests/unit/
+pytest tests/unit/
 
 # All tests (requires RabbitMQ running on localhost)
-pynose
+pytest
 
 # Single test file
-pynose tests/unit/select_connection_interrupt_tests.py -v
+pytest tests/unit/select_connection_interrupt_tests.py -v
 ```
 
 ## PR conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,8 +68,10 @@ without corresponding `utils/codegen.py` changes will be rejected.
   and pull request. Requires `tornado` and `twisted` to be installed so mypy
   can resolve optional-dependency types.
 - **Tests** (`.github/workflows/main.yaml`): runs the full test suite with
-  `pytest` across the Python version matrix. Acceptance tests require a
-  RabbitMQ server (started via Docker in CI).
+  `pytest` on Python 3.10-3.14. Acceptance tests require a RabbitMQ server
+  (started via Docker in CI).
+- **Legacy tests** (`.github/workflows/legacy-python.yaml`): same as above,
+  but for Python 3.7-3.9.
 
 ## Running tests locally
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ If you would like to run TLS/SSL tests, use the following procedure:
 
 ## Code Formatting and Linting
 
-Please format your code using [yapf](https://pypi.python.org/pypi/yapf)
+Please format your code using [yapf](https://pypi.org/project/yapf/)
 with ``google`` style prior to issuing your pull request. *Note: only format those
 lines that you have changed in your pull request. If you format an entire file and
 change code outside of the scope of your PR, it will likely be rejected.*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,6 @@ To install the dependencies needed to run Pika tests, use
     pip install -r test-requirements.txt
 
 
-
 ## Running Tests
 
 To run all test suites, use

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,6 @@ To install the dependencies needed to run Pika tests, use
 
     pip install -r test-requirements.txt
 
-If your environment uses the ``pip3`` command name, run ``pip3 install -r test-requirements.txt`` instead.
 
 
 ## Running Tests
@@ -58,9 +57,12 @@ If you would like to run TLS/SSL tests, use the following procedure:
     ```
 
 
-## Code Formatting
+## Code Formatting and Linting
 
 Please format your code using [yapf](https://pypi.python.org/pypi/yapf)
 with ``google`` style prior to issuing your pull request. *Note: only format those
 lines that you have changed in your pull request. If you format an entire file and
 change code outside of the scope of your PR, it will likely be rejected.*
+
+Please also ensure your code passes [ruff](https://docs.astral.sh/ruff/) linting.
+Both checks run in CI on every push and pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ If you would like to run TLS/SSL tests, use the following procedure:
 
 ## Code Formatting
 
-Please format your code using [yapf](http://pypi.python.org/pypi/yapf)
+Please format your code using [yapf](https://pypi.python.org/pypi/yapf)
 with ``google`` style prior to issuing your pull request. *Note: only format those
 lines that you have changed in your pull request. If you format an entire file and
 change code outside of the scope of your PR, it will likely be rejected.*

--- a/README.rst
+++ b/README.rst
@@ -196,7 +196,7 @@ for connection errors. Here is a very basic example:
         except pika.exceptions.AMQPConnectionError:
             continue
 
-This example can be found in `examples/consume_recover.py`.
+A similar example can be found in `examples/blocking_consume_recover_multiple_hosts.py`.
 
 Generic operation retry libraries such as
 `retry <https://github.com/invl/retry>`_ can be used. Decorators make it
@@ -223,7 +223,6 @@ retries and limiting the number of retries:
 
     consume()
 
-This example can be found in `examples/consume_recover_retry.py`.
 
 For asynchronous adapters, use ``on_close_callback`` to react to connection
 failure events. This callback can be used to clean up and recover the

--- a/README.rst
+++ b/README.rst
@@ -240,7 +240,7 @@ existing functionality **include test coverage**.
 rejected.*
 
 Additionally, please format your code using
-`Yapf <https://pypi.python.org/pypi/yapf>`_ with ``google`` style prior to
+`Yapf <https://pypi.org/project/yapf>`_ with ``google`` style prior to
 issuing your pull request. *Note: only format those lines that you have changed
 in your pull request. If you format an entire file and change code outside of
 the scope of your PR, it will likely be rejected.*
@@ -268,7 +268,7 @@ New non-blocking adapters may be implemented in either of the following ways:
    :target: https://badge.fury.io/py/pika
 
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/pika.svg
-    :target: https://pypi.python.org/pypi/pika
+    :target: https://pypi.org/project/pika
 
 .. |Actions Status| image:: https://github.com/pika/pika/actions/workflows/main.yaml/badge.svg
    :target: https://github.com/pika/pika/actions/workflows/main.yaml

--- a/README.rst
+++ b/README.rst
@@ -74,11 +74,11 @@ Pika provides the following adapters
 - ``pika.SelectConnection`` - asynchronous adapter without third-party
   dependencies.
 - ``pika.adapters.gevent_connection.GeventConnection`` - asynchronous adapter
-  for use with `Gevent <http://www.gevent.org>`_'s I/O loop.
+  for use with `Gevent <https://www.gevent.org>`_'s I/O loop.
 - ``pika.adapters.tornado_connection.TornadoConnection`` - asynchronous adapter
-  for use with `Tornado <http://tornadoweb.org>`_'s I/O loop.
+  for use with `Tornado <https://tornadoweb.org>`_'s I/O loop.
 - ``pika.adapters.twisted_connection.TwistedProtocolConnection`` - asynchronous
-  adapter for use with `Twisted <http://twistedmatrix.com>`_'s I/O loop.
+  adapter for use with `Twisted <https://twistedmatrix.com>`_'s I/O loop.
 
 Multiple connection parameters
 ------------------------------
@@ -240,7 +240,7 @@ existing functionality **include test coverage**.
 rejected.*
 
 Additionally, please format your code using
-`Yapf <http://pypi.python.org/pypi/yapf>`_ with ``google`` style prior to
+`Yapf <https://pypi.python.org/pypi/yapf>`_ with ``google`` style prior to
 issuing your pull request. *Note: only format those lines that you have changed
 in your pull request. If you format an entire file and change code outside of
 the scope of your PR, it will likely be rejected.*
@@ -265,7 +265,7 @@ New non-blocking adapters may be implemented in either of the following ways:
   ``pika.adapters.twisted_connection.TwistedProtocolConnection``.
 
 .. |Version| image:: https://img.shields.io/pypi/v/pika.svg?
-   :target: http://badge.fury.io/py/pika
+   :target: https://badge.fury.io/py/pika
 
 .. |Python versions| image:: https://img.shields.io/pypi/pyversions/pika.svg
     :target: https://pypi.python.org/pypi/pika

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,9 +12,9 @@
     git tag -a -s -u B1B82CC0CF84BA70147EBD05D99DE30E43EAE440 -m 'pika 1.4.0' '1.4.0' && git push --tags
     ```
 * Ensure build is green (if one triggered)
-* Update `CHANGELOG.md`. Be sure to use the `--since-tag 1.3.1` argument:
+* Update `CHANGELOG.md`. Be sure to use the `--since-tag 1.3.2` argument:
     ```
-    github_changelog_generator --token github_pat_MY_TOKEN --user pika --project pika --since-tag 1.3.1
+    github_changelog_generator --token github_pat_MY_TOKEN --user pika --project pika --since-tag 1.3.2
     ```
     Review the generated file for invalid entries
 * Commit changes to `main` branch and push:
@@ -27,14 +27,14 @@
     python -m build --sdist --wheel --outdir dist/ .
 
     # This creates the release on GitHub:
-    gh release create '1.4.0' --notes 'https://pypi.org/project/pika/1.4.0/ | [GitHub milestone](https://github.com/pika/pika/milestone/20?closed=1)' ./dist/*
+    gh release create '1.4.0' --notes 'https://pypi.org/project/pika/1.4.0/ | [GitHub milestone](https://github.com/pika/pika/milestone/23?closed=1)' ./dist/*
     ```
 * Ensure the publish build succeeded. Example success output looks like this:
     ```
-    Checking dist/pika-1.4.0-py2.py3-none-any.whl: PASSED
+    Checking dist/pika-1.4.0-py3-none-any.whl: PASSED
     Checking dist/pika-1.4.0.tar.gz: PASSED
     Uploading distributions to https://upload.pypi.org/legacy/
-    Uploading pika-1.4.0-py2.py3-none-any.whl
+    Uploading pika-1.4.0-py3-none-any.whl
     ...
     ...
     ...
@@ -46,7 +46,7 @@
 * Ensure the release works!
   * Start RabbitMQ
     ```
-    docker run --pull --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:3-management-alpine
+    docker run --pull --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:4-management-alpine
     ```
   * Run example Pika program
     ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 project = 'pika'
-copyright = '2009-2025, Tony Garnock-Jones, Gavin M. Roy, Pivotal Software, Inc and contributors.'
+copyright = '2009-2026, Tony Garnock-Jones, Gavin M. Roy, Pivotal Software, Inc and contributors.'
 
 import pika
 release = pika.__version__

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,8 +8,8 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode',
 
 intersphinx_mapping = {'python': ('https://docs.python.org/3/',
                                   'https://docs.python.org/3/objects.inv'),
-                       'tornado': ('http://www.tornadoweb.org/en/stable/',
-                                   'http://www.tornadoweb.org/en/stable/objects.inv')}
+                       'tornado': ('https://www.tornadoweb.org/en/stable/',
+                                   'https://www.tornadoweb.org/en/stable/objects.inv')}
 
 templates_path = ['_templates']
 
@@ -17,7 +17,7 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 project = 'pika'
-copyright = '2009-2017, Tony Garnock-Jones, Gavin M. Roy, Pivotal Software, Inc and contributors.'
+copyright = '2009-2025, Tony Garnock-Jones, Gavin M. Roy, Pivotal Software, Inc and contributors.'
 
 import pika
 release = pika.__version__
@@ -29,6 +29,6 @@ add_module_names = True
 show_authors = True
 pygments_style = 'sphinx'
 modindex_common_prefix = ['pika']
-html_theme = 'default'
+html_theme = 'alabaster'
 html_static_path = ['_static']
 htmlhelp_basename = 'pikadoc'

--- a/docs/examples/asynchronous_consumer_example.rst
+++ b/docs/examples/asynchronous_consumer_example.rst
@@ -7,4 +7,4 @@ connection and will shutdown if RabbitMQ cancels the consumer or closes the
 channel. While it may look intimidating, each method is very short and
 represents a individual actions that a consumer can do.
 
-`Asynchronous Consumer Example <https://github.com/pika/pika/blob/master/examples/asynchronous_consumer_example.py>`_
+`Asynchronous Consumer Example <https://github.com/pika/pika/blob/main/examples/asynchronous_consumer_example.py>`_

--- a/docs/examples/asynchronous_publisher_example.rst
+++ b/docs/examples/asynchronous_publisher_example.rst
@@ -7,4 +7,4 @@ RabbitMQ closes the connection and will shutdown if RabbitMQ closes the
 channel. While it may look intimidating, each method is very short and
 represents a individual actions that a publisher can do.
 
-`Asynchronous Publisher Example <https://github.com/pika/pika/blob/master/examples/asynchronous_publisher_example.py>`_
+`Asynchronous Publisher Example <https://github.com/pika/pika/blob/main/examples/asynchronous_publisher_example.py>`_

--- a/docs/examples/asyncio_consumer.rst
+++ b/docs/examples/asyncio_consumer.rst
@@ -9,4 +9,4 @@ the connection and will shutdown if RabbitMQ cancels the consumer or closes the
 channel. While it may look intimidating, each method is very short and
 represents a individual actions that a consumer can do.
 
-`Asyncio Consumer Example <https://github.com/pika/pika/blob/master/examples/asyncio_consumer_example.py>`_
+`Asyncio Consumer Example <https://github.com/pika/pika/blob/main/examples/asyncio_consumer_example.py>`_

--- a/docs/examples/blocking_consume_recover_multiple_hosts.rst
+++ b/docs/examples/blocking_consume_recover_multiple_hosts.rst
@@ -3,7 +3,7 @@ Using the Blocking Connection with connection recovery with multiple hosts
 
 .. _example_blocking_basic_consume_recover_multiple_hosts:
 
-RabbitMQ nodes can be `clustered <http://www.rabbitmq.com/clustering.html>`_.
+RabbitMQ nodes can be `clustered <https://www.rabbitmq.com/clustering.html>`_.
 In the absence of failure clients can connect to any node and perform any operation.
 In case a node fails, stops, or becomes unavailable, clients should be able to
 connect to another node and continue.
@@ -38,7 +38,7 @@ connection errors::
             connection = pika.BlockingConnection(all_endpoints)
             channel = connection.channel()
             channel.basic_qos(prefetch_count=1)
-            ## This queue is intentionally non-durable. See http://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
+            ## This queue is intentionally non-durable. See https://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
             ## to learn more.
             channel.queue_declare('recovery-example', durable = False, auto_delete = True)
             channel.basic_consume('recovery-example', on_message)
@@ -94,7 +94,7 @@ In this example the `retry` decorator is used to set up recovery with delay::
         channel = connection.channel()
         channel.basic_qos(prefetch_count=1)
 
-        ## This queue is intentionally non-durable. See http://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
+        ## This queue is intentionally non-durable. See https://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
         ## to learn more.
         channel.queue_declare('recovery-example', durable = False, auto_delete = True)
         channel.basic_consume('recovery-example', on_message)

--- a/docs/examples/blocking_consume_recover_multiple_hosts.rst
+++ b/docs/examples/blocking_consume_recover_multiple_hosts.rst
@@ -38,8 +38,7 @@ connection errors::
             connection = pika.BlockingConnection(all_endpoints)
             channel = connection.channel()
             channel.basic_qos(prefetch_count=1)
-            ## This queue is intentionally non-durable. See https://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
-            ## to learn more.
+            ## This queue is intentionally non-durable.
             channel.queue_declare('recovery-example', durable = False, auto_delete = True)
             channel.basic_consume('recovery-example', on_message)
             try:
@@ -94,8 +93,7 @@ In this example the `retry` decorator is used to set up recovery with delay::
         channel = connection.channel()
         channel.basic_qos(prefetch_count=1)
 
-        ## This queue is intentionally non-durable. See https://www.rabbitmq.com/ha.html#non-mirrored-queue-behavior-on-node-failure
-        ## to learn more.
+        ## This queue is intentionally non-durable.
         channel.queue_declare('recovery-example', durable = False, auto_delete = True)
         channel.basic_consume('recovery-example', on_message)
 

--- a/docs/examples/tornado_consumer.rst
+++ b/docs/examples/tornado_consumer.rst
@@ -1,6 +1,6 @@
 Tornado consumer example
 ========================
-The following example implements a consumer using the :class:`Tornado adapter <pika.adapters.tornado_connection.TornadoConnection>` for the `Tornado framework <http://tornadoweb.org>`_ that will respond to RPC commands sent from RabbitMQ. For example, it will reconnect if RabbitMQ closes the connection and will shutdown if RabbitMQ cancels the consumer or closes the channel. While it may look intimidating, each method is very short and represents a individual actions that a consumer can do.
+The following example implements a consumer using the :class:`Tornado adapter <pika.adapters.tornado_connection.TornadoConnection>` for the `Tornado framework <https://tornadoweb.org>`_ that will respond to RPC commands sent from RabbitMQ. For example, it will reconnect if RabbitMQ closes the connection and will shutdown if RabbitMQ cancels the consumer or closes the channel. While it may look intimidating, each method is very short and represents a individual actions that a consumer can do.
 
 consumer.py::
 

--- a/docs/examples/twisted_example.rst
+++ b/docs/examples/twisted_example.rst
@@ -2,4 +2,4 @@ Twisted consumer example
 ========================
 Example of writing an application using the :py:class:`Twisted connection adapter <pika.adapters.twisted_connection.TwistedProtocolConnection>`::.
 
-`Twisted Example <https://github.com/pika/pika/blob/master/examples/twisted_service.py>`_
+`Twisted Example <https://github.com/pika/pika/blob/main/examples/twisted_service.py>`_

--- a/docs/examples/using_urlparameters.rst
+++ b/docs/examples/using_urlparameters.rst
@@ -38,7 +38,6 @@ If you're looking to tweak other parameters, such as enabling heartbeats, simply
 
 Options that are available as query string values:
 
-- backpressure_detection: Pass in a value of *t* to enable backpressure detection, it is disabled by default.
 - channel_max: Alter the default channel maximum by passing in a 32-bit integer value here.
 - client_properties: A dictionary of client properties to override::
 

--- a/docs/examples/using_urlparameters.rst
+++ b/docs/examples/using_urlparameters.rst
@@ -56,11 +56,11 @@ Options that are available as query string values:
    - keyfile
    - ssl_version
 
-For information on what the ssl_options can be set to reference the `official Python documentation <http://docs.python.org/3/library/ssl.html>`_. Here is an example of setting the client certificate and key::
+For information on what the ssl_options can be set to reference the `official Python documentation <https://docs.python.org/3/library/ssl.html>`_. Here is an example of setting the client certificate and key::
 
   amqp://www-data:rabbit_pwd@rabbit1/web_messages?heartbeat=30&ssl_options=%7B%27keyfile%27%3A+%27%2Fetc%2Fssl%2Fmykey.pem%27%2C+%27certfile%27%3A+%27%2Fetc%2Fssl%2Fmycert.pem%27%7D
 
-The following example demonstrates how to generate the ssl_options string with `Python's urllib <http://docs.python.org/3/library/urllib.html>`_::
+The following example demonstrates how to generate the ssl_options string with `Python's urllib <https://docs.python.org/3/library/urllib.html>`_::
 
     from urllib.parse import urlencode
     urlencode({'ssl_options': {'certfile': '/etc/ssl/mycert.pem', 'keyfile': '/etc/ssl/mykey.pem'}})

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,15 +6,13 @@ If you have not developed with Pika or RabbitMQ before, the :doc:`intro` documen
 
 Installing Pika
 ---------------
-Pika is available for download via PyPI and may be installed using easy_install or pip::
+Pika is available for download via PyPI and may be installed using pip::
 
     pip install pika
 
-or::
+To install from source::
 
-    easy_install pika
-
-To install from source, run "python setup.py install" in the root source directory.
+    pip install .
 
 Using Pika
 ----------

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -117,21 +117,3 @@ Example::
 Connection Parameters
 ---------------------
 There are two types of connection parameter classes in Pika to allow you to pass the connection information into a connection adapter, :class:`ConnectionParameters <pika.connection.ConnectionParameters>` and :class:`URLParameters <pika.connection.URLParameters>`. Both classes share the same default connection values.
-
-
-.. _intro_to_backpressure:
-
-TCP Backpressure
-----------------
-
-As of RabbitMQ 2.0, client side `Channel.Flow <http://www.rabbitmq.com/amqp-0-9-1-quickref.html#channel.flow>`_ has been removed [#f1]_. Instead, the RabbitMQ broker uses TCP Backpressure to slow your client if it is delivering messages too fast. If you pass in backpressure_detection into your connection parameters, Pika attempts to help you handle this situation by providing a mechanism by which you may be notified if Pika has noticed too many frames have yet to be delivered. By registering a callback function with the :py:meth:`add_backpressure_callback <pika.connection.Connection.add_backpressure_callback>` method of any connection adapter, your function will be called when Pika sees that a backlog of 10 times the average frame size you have been sending has been exceeded. You may tweak the notification multiplier value by calling the :py:meth:`set_backpressure_multiplier <pika.connection.Connection.set_backpressure_multiplier>` method passing any integer value.
-
-Example::
-
-    import pika
-
-    parameters = pika.URLParameters('amqp://guest:guest@rabbit-server1:5672/%2F?backpressure_detection=t')
-
-.. rubric:: Footnotes
-
-.. [#f1] "more effective flow control mechanism that does not require cooperation from clients and reacts quickly to prevent the broker from exhausting memory - see http://lists.rabbitmq.com/pipermail/rabbitmq-announce/attachments/20100825/2c672695/attachment.txt

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -38,7 +38,7 @@ Example::
 Continuation-Passing Style
 --------------------------
 
-Interfacing with Pika asynchronously is done by passing in callback methods you would like to have invoked when a certain event completes. For example, if you are going to declare a queue, you pass in a method that will be called when the RabbitMQ server returns a `Queue.DeclareOk <http://www.rabbitmq.com/amqp-0-9-1-quickref.html#queue.declare>`_ response.
+Interfacing with Pika asynchronously is done by passing in callback methods you would like to have invoked when a certain event completes. For example, if you are going to declare a queue, you pass in a method that will be called when the RabbitMQ server returns a `Queue.DeclareOk <https://www.rabbitmq.com/amqp-0-9-1-quickref.html#queue.declare>`_ response.
 
 In our example below we use the following five easy steps:
 

--- a/docs/modules/adapters/index.rst
+++ b/docs/modules/adapters/index.rst
@@ -67,8 +67,8 @@ adapter's thread.
 Connection recovery
 -------------------
 
-The Pika library requires connection recovery to be performed by the application 
-code and strive to make it a straightforward process. Pika falls into the second category.
+Pika requires connection recovery to be performed by the application code and
+strives to make it a straightforward process.
 
 Different connection adapters take different approaches to connection recovery.
 
@@ -95,7 +95,7 @@ for connection errors. Here is a very basic example:
         except pika.exceptions.AMQPConnectionError:
             continue
 
-This example can be found in `examples/consume_recover.py`.
+A similar example can be found in `examples/blocking_consume_recover_multiple_hosts.py`.
 
 Generic operation retry libraries such as
 `retry <https://github.com/invl/retry>`_ can be used. Decorators make it
@@ -122,7 +122,6 @@ retries and limiting the number of retries:
 
     consume()
 
-This example can be found in `examples/consume_recover_retry.py`.
 
 For asynchronous adapters, use ``on_close_callback`` to react to connection
 failure events. This callback can be used to clean up and recover the

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -308,7 +308,7 @@ class BlockingConnection:
     connection when client makes a resource-consuming request on that connection
     or its channel (e.g., `Basic.Publish`); subsequently, RabbitMQ suspsends
     processing requests from that connection until the affected resources are
-    restored. See http://www.rabbitmq.com/connection-blocked.html. This
+    restored. See https://www.rabbitmq.com/connection-blocked.html. This
     may impact `BlockingConnection` and `BlockingChannel` operations in a
     way that users might not be expecting. For example, if the user dispatches
     `BlockingChannel.basic_publish` in non-publisher-confirmation mode while
@@ -1313,7 +1313,7 @@ class BlockingChannel:
         self._basic_consume_ok_result = _CallbackResult()
 
         # Receives args from Basic.GetEmpty response
-        #  http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
+        #  https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
         self._basic_getempty_result = _CallbackResult(
             self._MethodFrameCallbackResultArgs)
 
@@ -1631,7 +1631,7 @@ class BlockingChannel:
 
         For more information, please reference:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
         :param bool active: Turn flow on (True) or off (False)
         :returns: True if broker will start or continue sending; False if not
@@ -1705,7 +1705,7 @@ class BlockingChannel:
         `BlockingChannel.start_consuming`.
 
         For more information about Basic.Consume, see:
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
         :param str queue: The queue from which to consume
         :param callable on_message_callback: Required function for dispatching messages
@@ -1716,7 +1716,7 @@ class BlockingChannel:
             - properties: spec.BasicProperties
             - body: bytes
         :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
-                              (see http://www.rabbitmq.com/confirms.html). This corresponds
+                              (see https://www.rabbitmq.com/confirms.html). This corresponds
                               with the 'no_ack' parameter in the basic.consume AMQP 0.9.1
                               method
         :param bool exclusive: Don't allow other consumers on the queue
@@ -2305,7 +2305,7 @@ class BlockingChannel:
 
         For more information on basic_publish and what the parameters do, see:
 
-            http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
+            https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
         NOTE: mandatory may be enabled even without delivery
           confirmation, but in the absence of delivery confirmation the

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -190,7 +190,7 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
     """
     # Gevent's READ and WRITE masks are defined as 1 and 2 respectively. No
     # ERROR mask is defined.
-    # See http://www.gevent.org/api/gevent.hub.html#gevent._interfaces.ILoop.io
+    # See https://www.gevent.org/api/gevent.hub.html#gevent._interfaces.ILoop.io
     READ = 1  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
     WRITE = 2  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
     ERROR = 0  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
@@ -381,7 +381,7 @@ class _GeventAddressResolver:
     """Performs getaddrinfo asynchronously Gevent's configured resolver in a
     separate greenlet and invoking the provided callback with the result.
 
-    See: http://www.gevent.org/dns.html
+    See: https://www.gevent.org/dns.html
     """
     __slots__ = (
         '_loop',

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -306,7 +306,7 @@ class _Timer:
         """
         # NOTE removing from the heap is difficult, so we just deactivate the
         # timeout and garbage-collect it at a later time; see discussion
-        # in http://docs.python.org/library/heapq.html
+        # in https://docs.python.org/library/heapq.html
         if timeout.callback is None:
             LOGGER.debug(
                 'remove_timeout: timeout was already removed or called %r',

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -413,14 +413,14 @@ class TwistedChannel:
         consumer_tag, one will be automatically generated for you.
 
         For more information on basic_consume, see:
-        Tutorial 2 at http://www.rabbitmq.com/getstarted.html
-        http://www.rabbitmq.com/confirms.html
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
+        Tutorial 2 at https://www.rabbitmq.com/getstarted.html
+        https://www.rabbitmq.com/confirms.html
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
         :param str queue: The queue to consume from. Use the empty string to
             specify the most recent server-named queue for this channel.
         :param bool auto_ack: if set to True, automatic acknowledgement mode
-            will be used (see http://www.rabbitmq.com/confirms.html). This
+            will be used (see https://www.rabbitmq.com/confirms.html). This
             corresponds with the 'no_ack' parameter in the basic.consume AMQP
             0.9.1 method
         :param bool exclusive: Don't allow other consumers on the queue
@@ -496,7 +496,7 @@ class TwistedChannel:
         a second time until the callback is executed.  For more information on
         basic_get and its parameters, see:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
 
         This method wraps :meth:`Channel.basic_get
         <pika.channel.Channel.basic_get>`.
@@ -582,7 +582,7 @@ class TwistedChannel:
 
         For more information on basic_publish and what the parameters do, see:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
         :param str exchange: The exchange to publish to
         :param str routing_key: The routing key to bind on
@@ -612,7 +612,7 @@ class TwistedChannel:
         if not self._delivery_confirmation:
             return defer.succeed(result)
         else:
-            # See http://www.rabbitmq.com/confirms.html#publisher-confirms
+            # See https://www.rabbitmq.com/confirms.html#publisher-confirms
             self._delivery_message_id += 1
             self._deliveries[self._delivery_message_id] = defer.Deferred()
             return self._deliveries[self._delivery_message_id]
@@ -711,7 +711,7 @@ class TwistedChannel:
         rejected (Basic.Ack, Basic.Nack) from the broker to the publisher.
 
         For more information see:
-            http://www.rabbitmq.com/confirms.html#publisher-confirms
+            https://www.rabbitmq.com/confirms.html#publisher-confirms
 
         :returns: Deferred that fires on the Confirm.SelectOk response
         :rtype: Deferred
@@ -933,7 +933,7 @@ class TwistedChannel:
         Returns a Deferred that will fire with a bool indicating the channel
         flow state. For more information, please reference:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
         :param bool active: Turn flow on or off
         :returns: Deferred that fires with the channel flow state

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -325,9 +325,9 @@ class Channel:
         the consumer tag.
 
         For more information on basic_consume, see:
-        Tutorial 2 at http://www.rabbitmq.com/getstarted.html
-        http://www.rabbitmq.com/confirms.html
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
+        Tutorial 2 at https://www.rabbitmq.com/getstarted.html
+        https://www.rabbitmq.com/confirms.html
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
         :param str queue: The queue to consume from. Use the empty string to
             specify the most recent server-named queue for this channel
@@ -339,7 +339,7 @@ class Channel:
             - properties: pika.spec.BasicProperties
             - body: bytes
         :param bool auto_ack: if set to True, automatic acknowledgement mode
-            will be used (see http://www.rabbitmq.com/confirms.html).
+            will be used (see https://www.rabbitmq.com/confirms.html).
             This corresponds with the 'no_ack' parameter in the basic.consume
             AMQP 0.9.1 method
         :param bool exclusive: Don't allow other consumers on the queue
@@ -406,7 +406,7 @@ class Channel:
         a second time until the callback is executed.  For more information on
         basic_get and its parameters, see:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
 
         :param str queue: The queue from which to get a message. Use the empty
             string to specify the most recent server-named queue for this
@@ -468,7 +468,7 @@ class Channel:
         """Publish to the channel with the given exchange, routing key and body.
         For more information on basic_publish and what the parameters do, see:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
         :param str exchange: The exchange to publish to
         :param str routing_key: The routing key to bind on
@@ -807,7 +807,7 @@ class Channel:
         expect a bool in response indicating channel flow state. For more
         information, please reference:
 
-        http://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
+        https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
         :param bool active: Turn flow on or off
         :param callable callback: callback(bool) upon completion

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1605,7 +1605,7 @@ class Connection(pika.compat.AbstractBase):  # type: ignore
                 'exchange_exchange_bindings': True,
                 'publisher_confirms': True
             },
-            'information': 'See http://pika.rtfd.org',
+            'information': 'See https://pika.rtfd.org',
             'version': pika.__version__
         }
 

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -411,7 +411,7 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
             # NOTE: python 2.6 doesn't support bytearray with recv_into, so
             # we use array.array instead; this is only okay as long as the
             # array instance isn't shared across threads. See
-            # http://bugs.python.org/issue7827 and
+            # https://bugs.python.org/issue7827 and
             # groups.google.com/forum/#!topic/comp.lang.python/M6Pqr-KUjQw
             rx_buf = array.array("B", [0] * self._SOCK_RX_BUF_SIZE)
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -440,7 +440,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                 'exchange_exchange_bindings': True,
                 'publisher_confirms': True
             },
-            'information': 'See http://pika.rtfd.org',
+            'information': 'See https://pika.rtfd.org',
             'version': pika.__version__
         }
         self.assertDictEqual(self.connection._client_properties, expectation)


### PR DESCRIPTION
## Proposed Changes
Recently we added support for lint check(ruff), format check(yapf), type annotations(mypy) check and so on. However the documentation is not updated accordingly across the project. We intend to re-visit all files/comments in the pika project and keep-up based on the latest state of project.

1. Update `AGENTS.md` documentation
2. Remove TCP backpressure section from `docs/intro.rst`
3. Update pika branch from `master` to `main` in all occurrences in `docs/examples/*.rst`
4. Update `http` to `https` in all occurrences across the project
5. Update Pika install steps in `docs/index.rst`
6. Update `‎CONTRIBUTING.md`, `README.rst‎`, `RELEASE.md‎` documentations
7. Update `docs/conf.py‎`

## Types of Changes

- [ ] Bugfix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation (correction, fixes #1568 )
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further Comments

This is an ongoing effort until code changes are incorporated in [1.4.0](https://github.com/pika/pika/milestone/23) and it needs documentation update.
