### PR TITLE
Add Hatch dev environment and scripts

### DIFF
--- a/.github/workflows/legacy-python.yaml
+++ b/.github/workflows/legacy-python.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install hatch
+          pip install hatch "virtualenv<21.0.0
       - name: Test with pytest
         run: hatch run test -- -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage to Codecov
@@ -69,7 +69,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install hatch
+          pip install hatch "virtualenv<21.0.0"
       - name: Test with pytest
         run: hatch run test -- -v --cov=pika --cov-report=xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/legacy-python.yaml
+++ b/.github/workflows/legacy-python.yaml
@@ -23,7 +23,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: test-requirements.txt
       - name: Cache installers
         uses: actions/cache@v5
         with:
@@ -65,7 +64,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: test-requirements.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/legacy-python.yaml
+++ b/.github/workflows/legacy-python.yaml
@@ -36,9 +36,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r test-requirements.txt
+          pip install hatch
       - name: Test with pytest
-        run: pytest -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
+        run: hatch run test -- -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
@@ -69,9 +69,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r test-requirements.txt
+          pip install hatch
       - name: Test with pytest
-        run: pytest -v --cov=pika --cov-report=xml
+        run: hatch run test -- -v --cov=pika --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/legacy-python.yaml
+++ b/.github/workflows/legacy-python.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install hatch "virtualenv<21.0.0
+          pip install hatch "virtualenv<21.0.0"
       - name: Test with pytest
         run: hatch run test -- -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage to Codecov

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,10 +19,6 @@ jobs:
         with:
           python-version: '3.10'
       - name: Run ruff check
-        uses: astral-sh/ruff-action@v3
-        with:
-          src: >-
-            pika
-            tests
-            examples
-            utils
+        run: |
+          pip install hatch
+          hatch run lint

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: test-requirements.txt
       - name: Cache installers
         uses: actions/cache@v5
         with:
@@ -65,7 +64,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: test-requirements.txt
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,9 +36,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r test-requirements.txt
+          pip install hatch
       - name: Test with pytest
-        run: pytest -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
+        run: hatch run test -- -v --cov=pika --cov-report=xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:
@@ -69,9 +69,9 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip wheel
-          pip install -r test-requirements.txt
+          pip install hatch
       - name: Test with pytest
-        run: pytest -v --cov=pika --cov-report=xml
+        run: hatch run test -- -v --cov=pika --cov-report=xml
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v6
         with:

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - run: pip install mypy tornado twisted
-      - run: python -m mypy
+      - run: pip install hatch
+      - run: hatch run typecheck

--- a/.github/workflows/yapf.yaml
+++ b/.github/workflows/yapf.yaml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: '3.10'
-      - name: Install yapf
-        run: pip install yapf
+      - name: Install hatch
+        run: pip install hatch
       - name: Run yapf
-        run: yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/
+        run: hatch run fmt-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,11 +27,11 @@ examples/               # usage examples
 ## Code style
 
 - **Formatter:** [yapf](https://pypi.org/project/yapf/) with Google style.
-  Run `yapf --diff --style google --recursive pika/` to check.
+  Run `hatch run fmt-check` to check, `hatch run fmt` to format in place.
 - **Linter:** [ruff](https://docs.astral.sh/ruff/). Configuration is in
-  `pyproject.toml` under `[tool.ruff]`. Run `ruff check pika/ tests/ examples/`.
+  `pyproject.toml` under `[tool.ruff]`. Run `hatch run lint`.
 - **Type checking:** [mypy](https://mypy-lang.org/). Configuration is in
-  `mypy.ini`. Run `python -m mypy`.
+  `mypy.ini`. Run `hatch run typecheck`.
 - Use single quotes for strings unless the string contains a single quote.
 - No trailing whitespace. Check before committing.
 
@@ -73,15 +73,24 @@ without corresponding `utils/codegen.py` changes will be rejected.
 
 ## Running tests locally
 
+Install [Hatch](https://hatch.pypa.io/) if you do not have it:
+
+```bash
+pipx install hatch
+```
+
+Run tests with Hatch (it creates the environment and installs dependencies
+automatically):
+
 ```bash
 # Unit tests only (no RabbitMQ needed)
-pynose tests/unit/
+hatch run unit
 
 # All tests (requires RabbitMQ running on localhost)
-pynose
+hatch run test
 
-# Single test file
-pynose tests/unit/select_connection_interrupt_tests.py -v
+# Start RabbitMQ via Docker
+hatch run rabbitmq
 ```
 
 ## PR conventions

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,7 @@ Install [Hatch](https://hatch.pypa.io/) if you do not have it:
 pipx install hatch
 ```
 
-Run tests with Hatch (it creates the environment and installs dependencies
-automatically):
+Run tests with Hatch (it creates the environment and installs dependencies automatically):
 
 ```bash
 # Unit tests only (no RabbitMQ needed)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ If you would like to run TLS/SSL tests, use the following procedure:
 * Run the tests indicating that TLS/SSL connections should be used:
 
     ```
-    pytest --use-tls
+    hatch run test -- --use-tls
     ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ Install [Hatch](https://hatch.pypa.io/), which manages the development environme
 
     pipx install hatch
 
-If you do not have ``pipx``, you can use ``pip install hatch`` instead. Hatch will install all required dependencies when you first run a script, so no separate ``pip install -r test-requirements.txt`` step is needed.
+If you do not have ``pipx``, you can use ``pip install hatch`` instead. Hatch will install all required dependencies when you first run a script.
 
 
 ## Running Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,26 +11,31 @@ of being accepted.*
 
 ## Prerequisites
 
-Pika test suite has a couple of requirements:
-
- * Dependencies from `test-requirements.txt` are installed
- * A RabbitMQ node with all defaults is running on `localhost:5672`
+To run the full test suite, a RabbitMQ node with all defaults must be running on `localhost:5672`. Use `hatch run rabbitmq` to start one via Docker, or provide your own.
 
 
 ## Installing Dependencies
 
-To install the dependencies needed to run Pika tests, use
+Install [Hatch](https://hatch.pypa.io/), which manages the development environment and dependencies automatically:
 
-    pip install -r test-requirements.txt
+    pipx install hatch
 
-If your environment uses the ``pip3`` command name, run ``pip3 install -r test-requirements.txt`` instead.
+If you do not have ``pipx``, you can use ``pip install hatch`` instead. Hatch will install all required dependencies when you first run a script, so no separate ``pip install -r test-requirements.txt`` step is needed.
 
 
 ## Running Tests
 
 To run all test suites, use
 
-    pytest
+    hatch run test
+
+To run unit tests only (no RabbitMQ required), use
+
+    hatch run unit
+
+To start RabbitMQ via Docker for acceptance tests, use
+
+    hatch run rabbitmq
 
 Note that some tests are OS-specific (e.g. epoll on Linux
 or kqueue on MacOS and BSD). Those will be skipped
@@ -58,9 +63,21 @@ If you would like to run TLS/SSL tests, use the following procedure:
     ```
 
 
-## Code Formatting
+## Code Formatting and Linting
 
-Please format your code using [yapf](http://pypi.python.org/pypi/yapf)
+Please format your code using [yapf](https://pypi.python.org/pypi/yapf)
 with ``google`` style prior to issuing your pull request. *Note: only format those
 lines that you have changed in your pull request. If you format an entire file and
 change code outside of the scope of your PR, it will likely be rejected.*
+
+    hatch run fmt
+
+To verify formatting without modifying files (mirrors CI), use
+
+    hatch run fmt-check
+
+Please also ensure your code passes [ruff](https://docs.astral.sh/ruff/) linting:
+
+    hatch run lint
+
+Both checks run in CI on every push and pull request.

--- a/examples/async_as_callback.py
+++ b/examples/async_as_callback.py
@@ -17,6 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 def sync(f):
+
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         return asyncio.get_event_loop().run_until_complete(f(*args, **kwargs))
@@ -49,6 +50,7 @@ class RabbitMQConfig(BaseModel):
 
 
 class BasicPikaClient:
+
     def __init__(self):
         self.username = "username"
         self.password = "password"
@@ -95,9 +97,10 @@ class BasicPikaClient:
         self.channel.close()
         self.connection.close()
 
-    def declare_queue(
-        self, queue_name, exclusive: bool = False, max_priority: int = 10
-    ):
+    def declare_queue(self,
+                      queue_name,
+                      exclusive: bool = False,
+                      max_priority: int = 10):
         self.check_connection()
         logger.debug(f"Trying to declare queue({queue_name})...")
         self.channel.queue_declare(
@@ -107,25 +110,28 @@ class BasicPikaClient:
             arguments={"x-max-priority": max_priority},
         )
 
-    def declare_exchange(self, exchange_name: str, exchange_type: str = "direct"):
+    def declare_exchange(self,
+                         exchange_name: str,
+                         exchange_type: str = "direct"):
         self.check_connection()
-        self.channel.exchange_declare(
-            exchange=exchange_name, exchange_type=exchange_type
-        )
+        self.channel.exchange_declare(exchange=exchange_name,
+                                      exchange_type=exchange_type)
 
     def bind_queue(self, exchange_name: str, queue_name: str, routing_key: str):
         self.check_connection()
-        self.channel.queue_bind(
-            exchange=exchange_name, queue=queue_name, routing_key=routing_key
-        )
+        self.channel.queue_bind(exchange=exchange_name,
+                                queue=queue_name,
+                                routing_key=routing_key)
 
-    def unbind_queue(self, exchange_name: str, queue_name: str, routing_key: str):
-        self.channel.queue_unbind(
-            queue=queue_name, exchange=exchange_name, routing_key=routing_key
-        )
+    def unbind_queue(self, exchange_name: str, queue_name: str,
+                     routing_key: str):
+        self.channel.queue_unbind(queue=queue_name,
+                                  exchange=exchange_name,
+                                  routing_key=routing_key)
 
 
 class BasicMessageSender(BasicPikaClient):
+
     def encode_message(self, body: Dict, encoding_type: str = "bytes"):
         if encoding_type == "bytes":
             return msgpack.packb(body)
@@ -156,6 +162,7 @@ class BasicMessageSender(BasicPikaClient):
 
 
 class BasicMessageReceiver(BasicPikaClient):
+
     def __init__(self):
         super().__init__()
         self.channel_tag = None
@@ -168,8 +175,7 @@ class BasicMessageReceiver(BasicPikaClient):
 
     def get_message(self, queue_name: str, auto_ack: bool = False):
         method_frame, header_frame, body = self.channel.basic_get(
-            queue=queue_name, auto_ack=auto_ack
-        )
+            queue=queue_name, auto_ack=auto_ack)
         if method_frame:
             logger.debug(f"{method_frame}, {header_frame}, {body}")
             return method_frame, header_frame, body
@@ -180,8 +186,7 @@ class BasicMessageReceiver(BasicPikaClient):
     def consume_messages(self, queue, callback):
         self.check_connection()
         self.channel_tag = self.channel.basic_consume(
-            queue=queue, on_message_callback=callback, auto_ack=True
-        )
+            queue=queue, on_message_callback=callback, auto_ack=True)
         logger.debug(" [*] Waiting for messages. To exit press CTRL+C")
         self.channel.start_consuming()
 
@@ -194,6 +199,7 @@ class BasicMessageReceiver(BasicPikaClient):
 
 
 class MyConsumer(BasicMessageReceiver):
+
     @sync
     async def consume(self, channel, method, properties, body):
         body = self.decode_message(body=body)
@@ -209,9 +215,9 @@ def create_consumer():
     worker = MyConsumer()
     worker.declare_queue(queue_name="myqueue")
     worker.declare_exchange(exchange_name="myexchange")
-    worker.bind_queue(
-        exchange_name="myexchange", queue_name="myqueue", routing_key="randomkey"
-    )
+    worker.bind_queue(exchange_name="myexchange",
+                      queue_name="myqueue",
+                      routing_key="randomkey")
     worker.consume_messages(queue="myqueue", callback=worker.consume)
 
 

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -177,12 +177,11 @@ class ExampleConsumer(object):
         LOGGER.info('Declaring exchange: %s', exchange_name)
         # Note: using functools.partial is not required, it is demonstrating
         # how arbitrary data can be passed to the callback when it is called
-        cb = functools.partial(
-            self.on_exchange_declareok, userdata=exchange_name)
-        self._channel.exchange_declare(
-            exchange=exchange_name,
-            exchange_type=self.EXCHANGE_TYPE,
-            callback=cb)
+        cb = functools.partial(self.on_exchange_declareok,
+                               userdata=exchange_name)
+        self._channel.exchange_declare(exchange=exchange_name,
+                                       exchange_type=self.EXCHANGE_TYPE,
+                                       callback=cb)
 
     def on_exchange_declareok(self, _unused_frame, userdata):
         """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
@@ -222,11 +221,10 @@ class ExampleConsumer(object):
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, queue_name,
                     self.ROUTING_KEY)
         cb = functools.partial(self.on_bindok, userdata=queue_name)
-        self._channel.queue_bind(
-            queue_name,
-            self.EXCHANGE,
-            routing_key=self.ROUTING_KEY,
-            callback=cb)
+        self._channel.queue_bind(queue_name,
+                                 self.EXCHANGE,
+                                 routing_key=self.ROUTING_KEY,
+                                 callback=cb)
 
     def on_bindok(self, _unused_frame, userdata):
         """Invoked by pika when the Queue.Bind method has completed. At this
@@ -246,8 +244,8 @@ class ExampleConsumer(object):
         with different prefetch values to achieve desired performance.
 
         """
-        self._channel.basic_qos(
-            prefetch_count=self._prefetch_count, callback=self.on_basic_qos_ok)
+        self._channel.basic_qos(prefetch_count=self._prefetch_count,
+                                callback=self.on_basic_qos_ok)
 
     def on_basic_qos_ok(self, _unused_frame):
         """Invoked by pika when the Basic.QoS method has completed. At this
@@ -332,8 +330,8 @@ class ExampleConsumer(object):
         """
         if self._channel:
             LOGGER.info('Sending a Basic.Cancel RPC command to RabbitMQ')
-            cb = functools.partial(
-                self.on_cancelok, userdata=self._consumer_tag)
+            cb = functools.partial(self.on_cancelok,
+                                   userdata=self._consumer_tag)
             self._channel.basic_cancel(self._consumer_tag, cb)
 
     def on_cancelok(self, _unused_frame, userdata):

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -181,12 +181,11 @@ class ExampleConsumer(object):
         LOGGER.info('Declaring exchange: %s', exchange_name)
         # Note: using functools.partial is not required, it is demonstrating
         # how arbitrary data can be passed to the callback when it is called
-        cb = functools.partial(
-            self.on_exchange_declareok, userdata=exchange_name)
-        self._channel.exchange_declare(
-            exchange=exchange_name,
-            exchange_type=self.EXCHANGE_TYPE,
-            callback=cb)
+        cb = functools.partial(self.on_exchange_declareok,
+                               userdata=exchange_name)
+        self._channel.exchange_declare(exchange=exchange_name,
+                                       exchange_type=self.EXCHANGE_TYPE,
+                                       callback=cb)
 
     def on_exchange_declareok(self, _unused_frame, userdata):
         """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
@@ -226,11 +225,10 @@ class ExampleConsumer(object):
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, queue_name,
                     self.ROUTING_KEY)
         cb = functools.partial(self.on_bindok, userdata=queue_name)
-        self._channel.queue_bind(
-            queue_name,
-            self.EXCHANGE,
-            routing_key=self.ROUTING_KEY,
-            callback=cb)
+        self._channel.queue_bind(queue_name,
+                                 self.EXCHANGE,
+                                 routing_key=self.ROUTING_KEY,
+                                 callback=cb)
 
     def on_bindok(self, _unused_frame, userdata):
         """Invoked by pika when the Queue.Bind method has completed. At this
@@ -250,8 +248,8 @@ class ExampleConsumer(object):
         with different prefetch values to achieve desired performance.
 
         """
-        self._channel.basic_qos(
-            prefetch_count=self._prefetch_count, callback=self.on_basic_qos_ok)
+        self._channel.basic_qos(prefetch_count=self._prefetch_count,
+                                callback=self.on_basic_qos_ok)
 
     def on_basic_qos_ok(self, _unused_frame):
         """Invoked by pika when the Basic.QoS method has completed. At this
@@ -337,8 +335,8 @@ class ExampleConsumer(object):
         """
         if self._channel:
             LOGGER.info('Sending a Basic.Cancel RPC command to RabbitMQ')
-            cb = functools.partial(
-                self.on_cancelok, userdata=self._consumer_tag)
+            cb = functools.partial(self.on_cancelok,
+                                   userdata=self._consumer_tag)
             self._channel.basic_cancel(self._consumer_tag, cb)
 
     def on_cancelok(self, _unused_frame, userdata):

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -48,20 +48,21 @@ def on_message(ch, method_frame, _header_frame, body, args):
 credentials = pika.PlainCredentials('guest', 'guest')
 # Note: sending a short heartbeat to prove that heartbeats are still
 # sent even though the worker simulates long-running work
-parameters = pika.ConnectionParameters(
-    'localhost', credentials=credentials, heartbeat=5)
+parameters = pika.ConnectionParameters('localhost',
+                                       credentials=credentials,
+                                       heartbeat=5)
 connection = pika.BlockingConnection(parameters)
 
 channel = connection.channel()
-channel.exchange_declare(
-    exchange="test_exchange",
-    exchange_type=ExchangeType.direct,
-    passive=False,
-    durable=True,
-    auto_delete=False)
+channel.exchange_declare(exchange="test_exchange",
+                         exchange_type=ExchangeType.direct,
+                         passive=False,
+                         durable=True,
+                         auto_delete=False)
 channel.queue_declare(queue="standard", auto_delete=True)
-channel.queue_bind(
-    queue="standard", exchange="test_exchange", routing_key="standard_key")
+channel.queue_bind(queue="standard",
+                   exchange="test_exchange",
+                   routing_key="standard_key")
 # Note: prefetch is set to 1 here as an example only and to keep the number of threads created
 # to a reasonable amount. In production you will want to test with different prefetch values
 # to find which one provides the best performance and usability for your solution

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -5,7 +5,6 @@ import functools
 import random
 import pika
 from pika.exchange_type import ExchangeType
-
 """
 This module implements a client that connects to multiple RabbitMQ brokers
 distributed across different ports (5672, 5673, 5674) and consumes messages
@@ -37,12 +36,15 @@ def on_message(ch, method_frame, _header_frame, body, userdata=None):
 
 credentials = pika.PlainCredentials('guest', 'guest')
 
-params1 = pika.ConnectionParameters(
-    'localhost', port=5672, credentials=credentials)
-params2 = pika.ConnectionParameters(
-    'localhost', port=5673, credentials=credentials)
-params3 = pika.ConnectionParameters(
-    'localhost', port=5674, credentials=credentials)
+params1 = pika.ConnectionParameters('localhost',
+                                    port=5672,
+                                    credentials=credentials)
+params2 = pika.ConnectionParameters('localhost',
+                                    port=5673,
+                                    credentials=credentials)
+params3 = pika.ConnectionParameters('localhost',
+                                    port=5674,
+                                    credentials=credentials)
 params_all = [params1, params2, params3]
 
 # Infinite loop
@@ -51,21 +53,19 @@ while True:
         random.shuffle(params_all)
         connection = pika.BlockingConnection(params_all)
         channel = connection.channel()
-        channel.exchange_declare(
-            exchange='test_exchange',
-            exchange_type=ExchangeType.direct,
-            passive=False,
-            durable=True,
-            auto_delete=False)
+        channel.exchange_declare(exchange='test_exchange',
+                                 exchange_type=ExchangeType.direct,
+                                 passive=False,
+                                 durable=True,
+                                 auto_delete=False)
         channel.queue_declare(queue='standard', auto_delete=True)
-        channel.queue_bind(
-            queue='standard',
-            exchange='test_exchange',
-            routing_key='standard_key')
+        channel.queue_bind(queue='standard',
+                           exchange='test_exchange',
+                           routing_key='standard_key')
         channel.basic_qos(prefetch_count=1)
 
-        on_message_callback = functools.partial(
-            on_message, userdata='on_message_userdata')
+        on_message_callback = functools.partial(on_message,
+                                                userdata='on_message_userdata')
         channel.basic_consume('standard', on_message_callback)
 
         try:

--- a/examples/consume.py
+++ b/examples/consume.py
@@ -13,7 +13,8 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 
 def on_message(chan, method_frame, header_frame, body, userdata=None):
     """Called when a message is received. Log message and ack it."""
-    LOGGER.info('Delivery properties: %s, message metadata: %s', method_frame, header_frame)
+    LOGGER.info('Delivery properties: %s, message metadata: %s', method_frame,
+                header_frame)
     LOGGER.info('Userdata: %s, message body: %s', userdata, body)
     chan.basic_ack(delivery_tag=method_frame.delivery_tag)
 
@@ -25,19 +26,19 @@ def main():
     connection = pika.BlockingConnection(parameters)
 
     channel = connection.channel()
-    channel.exchange_declare(
-        exchange='test_exchange',
-        exchange_type=ExchangeType.direct,
-        passive=False,
-        durable=True,
-        auto_delete=False)
+    channel.exchange_declare(exchange='test_exchange',
+                             exchange_type=ExchangeType.direct,
+                             passive=False,
+                             durable=True,
+                             auto_delete=False)
     channel.queue_declare(queue='standard', auto_delete=True)
-    channel.queue_bind(
-        queue='standard', exchange='test_exchange', routing_key='standard_key')
+    channel.queue_bind(queue='standard',
+                       exchange='test_exchange',
+                       routing_key='standard_key')
     channel.basic_qos(prefetch_count=1)
 
-    on_message_callback = functools.partial(
-        on_message, userdata='on_message_userdata')
+    on_message_callback = functools.partial(on_message,
+                                            userdata='on_message_userdata')
     channel.basic_consume('standard', on_message_callback)
 
     try:

--- a/examples/consumer_queued.py
+++ b/examples/consumer_queued.py
@@ -18,15 +18,17 @@ main_channel = connection.channel()
 consumer_channel = connection.channel()
 bind_channel = connection.channel()
 
-main_channel.exchange_declare(exchange='com.micex.sten', exchange_type=ExchangeType.direct)
-main_channel.exchange_declare(
-    exchange='com.micex.lasttrades', exchange_type=ExchangeType.direct)
+main_channel.exchange_declare(exchange='com.micex.sten',
+                              exchange_type=ExchangeType.direct)
+main_channel.exchange_declare(exchange='com.micex.lasttrades',
+                              exchange_type=ExchangeType.direct)
 
 queue = main_channel.queue_declare('', exclusive=True).method.queue
 queue_tickers = main_channel.queue_declare('', exclusive=True).method.queue
 
-main_channel.queue_bind(
-    exchange='com.micex.sten', queue=queue, routing_key='order.stop.create')
+main_channel.queue_bind(exchange='com.micex.sten',
+                        queue=queue,
+                        routing_key='order.stop.create')
 
 
 def process_buffer():
@@ -44,10 +46,9 @@ def process_buffer():
                 continue
 
             print('got ticker %s, gonna bind it...' % ticker)
-            bind_channel.queue_bind(
-                exchange='com.micex.lasttrades',
-                queue=queue_tickers,
-                routing_key=str(ticker))
+            bind_channel.queue_bind(exchange='com.micex.lasttrades',
+                                    queue=queue_tickers,
+                                    routing_key=str(ticker))
             print('ticker %s binded ok' % ticker)
     finally:
         lock.release()

--- a/examples/consumer_simple.py
+++ b/examples/consumer_simple.py
@@ -15,15 +15,17 @@ main_channel = connection.channel()
 consumer_channel = connection.channel()
 bind_channel = connection.channel()
 
-main_channel.exchange_declare(exchange='com.micex.sten', exchange_type=ExchangeType.direct)
-main_channel.exchange_declare(
-    exchange='com.micex.lasttrades', exchange_type=ExchangeType.direct)
+main_channel.exchange_declare(exchange='com.micex.sten',
+                              exchange_type=ExchangeType.direct)
+main_channel.exchange_declare(exchange='com.micex.lasttrades',
+                              exchange_type=ExchangeType.direct)
 
 queue = main_channel.queue_declare('', exclusive=True).method.queue
 queue_tickers = main_channel.queue_declare('', exclusive=True).method.queue
 
-main_channel.queue_bind(
-    exchange='com.micex.sten', queue=queue, routing_key='order.stop.create')
+main_channel.queue_bind(exchange='com.micex.sten',
+                        queue=queue,
+                        routing_key='order.stop.create')
 
 
 def hello():
@@ -43,10 +45,9 @@ def callback(_ch, _method, _properties, body):
         return
 
     print('got ticker %s, gonna bind it...' % ticker)
-    bind_channel.queue_bind(
-        exchange='com.micex.lasttrades',
-        queue=queue_tickers,
-        routing_key=str(ticker))
+    bind_channel.queue_bind(exchange='com.micex.lasttrades',
+                            queue=queue_tickers,
+                            routing_key=str(ticker))
     print('ticker %s binded ok' % ticker)
 
 

--- a/examples/direct_reply_to.py
+++ b/examples/direct_reply_to.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0111,C0103,R0205
-
 """
 This example demonstrates RabbitMQ's "Direct reply-to" usage via
 `pika.BlockingConnection`. See https://www.rabbitmq.com/direct-reply-to.html
@@ -26,8 +25,9 @@ def main():
 
         # Set up server
 
-        channel.queue_declare(
-            queue=SERVER_QUEUE, exclusive=True, auto_delete=True)
+        channel.queue_declare(queue=SERVER_QUEUE,
+                              exclusive=True,
+                              auto_delete=True)
         channel.basic_consume(SERVER_QUEUE, on_server_rx_rpc_request)
 
         # Set up client
@@ -42,10 +42,9 @@ def main():
         # Client must create its consumer with auto_ack=True, because the reply-to
         # queue isn't real.
 
-        channel.basic_consume(
-            'amq.rabbitmq.reply-to',
-            on_client_rx_reply_from_server,
-            auto_ack=True)
+        channel.basic_consume('amq.rabbitmq.reply-to',
+                              on_client_rx_reply_from_server,
+                              auto_ack=True)
         channel.basic_publish(
             exchange='',
             routing_key=SERVER_QUEUE,

--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=C0111,C0103,R0205
-
 """
 This example demonstrates explicit setting of heartbeat and blocked connection
 timeouts.
@@ -29,8 +28,8 @@ import pika
 def main():
 
     # NOTE: These paramerers work with all Pika connection types
-    params = pika.ConnectionParameters(
-        heartbeat=600, blocked_connection_timeout=300)
+    params = pika.ConnectionParameters(heartbeat=600,
+                                       blocked_connection_timeout=300)
 
     conn = pika.BlockingConnection(params)
 

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -7,6 +7,7 @@ from pika import ConnectionParameters, BlockingConnection, PlainCredentials
 
 
 class Publisher(threading.Thread):
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.daemon = True

--- a/examples/producer.py
+++ b/examples/producer.py
@@ -12,9 +12,10 @@ connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))
 main_channel = connection.channel()
 
-main_channel.exchange_declare(exchange='com.micex.sten', exchange_type=ExchangeType.direct)
-main_channel.exchange_declare(
-    exchange='com.micex.lasttrades', exchange_type=ExchangeType.direct)
+main_channel.exchange_declare(exchange='com.micex.sten',
+                              exchange_type=ExchangeType.direct)
+main_channel.exchange_declare(exchange='com.micex.lasttrades',
+                              exchange_type=ExchangeType.direct)
 
 tickers = {
     'MXSE.EQBR.LKOH': (1933, 1940),

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -58,18 +58,18 @@ class PikaService(service.MultiService):
         f = PikaFactory(self.parameters)
         if self.parameters.ssl_options:
             s = ssl.ClientContextFactory()
-            serv = internet.SSLClient( # pylint: disable=E1101
+            serv = internet.SSLClient(  # pylint: disable=E1101
                 host=self.parameters.host,
                 port=self.parameters.port,
                 factory=f,
                 contextFactory=s)
         else:
-            serv = internet.TCPClient( # pylint: disable=E1101
+            serv = internet.TCPClient(  # pylint: disable=E1101
                 host=self.parameters.host,
                 port=self.parameters.port,
                 factory=f)
         serv.factory = f
-        f.service = serv # pylint: disable=W0201
+        f.service = serv  # pylint: disable=W0201
         name = '%s%s:%d' % ('ssl:' if self.parameters.ssl_options else '',
                             self.parameters.host, self.parameters.port)
         serv.__repr__ = lambda: '<AMQP Connection to %s>' % name
@@ -119,14 +119,14 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
         yield self._channel.queue_declare(queue=routing_key, durable=True)
         if exchange:
             yield self._channel.queue_bind(queue=routing_key, exchange=exchange)
-            yield self._channel.queue_bind(
-                queue=routing_key, exchange=exchange, routing_key=routing_key)
+            yield self._channel.queue_bind(queue=routing_key,
+                                           exchange=exchange,
+                                           routing_key=routing_key)
 
         (
             queue,
             _consumer_tag,
-        ) = yield self._channel.basic_consume(
-            queue=routing_key, auto_ack=False)
+        ) = yield self._channel.basic_consume(queue=routing_key, auto_ack=False)
         d = queue.get()
         d.addCallback(self._read_item, queue, callback)
         d.addErrback(self._read_item_err)
@@ -143,9 +143,9 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
             msg,
         ) = item
 
-        log.msg(
-            '%s (%s): %s' % (deliver.exchange, deliver.routing_key, repr(msg)),
-            system='Pika:<=')
+        log.msg('%s (%s): %s' %
+                (deliver.exchange, deliver.routing_key, repr(msg)),
+                system='Pika:<=')
         d = defer.maybeDeferred(callback, item)
         d.addCallbacks(lambda _: channel.basic_ack(deliver.delivery_tag),
                        lambda _: channel.basic_nack(deliver.delivery_tag))
@@ -168,21 +168,18 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
     @inlineCallbacks
     def send_message(self, exchange, routing_key, msg):
         """Send a single message."""
-        log.msg(
-            '%s (%s): %s' % (exchange, routing_key, repr(msg)),
-            system='Pika:=>')
-        yield self._channel.exchange_declare(
-            exchange=exchange,
-            exchange_type=ExchangeType.topic,
-            durable=True,
-            auto_delete=False)
+        log.msg('%s (%s): %s' % (exchange, routing_key, repr(msg)),
+                system='Pika:=>')
+        yield self._channel.exchange_declare(exchange=exchange,
+                                             exchange_type=ExchangeType.topic,
+                                             durable=True,
+                                             auto_delete=False)
         prop = spec.BasicProperties(delivery_mode=DeliveryMode.Persistent)
         try:
-            yield self._channel.basic_publish(
-                exchange=exchange,
-                routing_key=routing_key,
-                body=msg,
-                properties=prop)
+            yield self._channel.basic_publish(exchange=exchange,
+                                              routing_key=routing_key,
+                                              body=msg,
+                                              properties=prop)
         except Exception as error:  # pylint: disable=W0703
             log.msg('Error while sending message: %s' % error, system=self.name)
 
@@ -205,14 +202,14 @@ class PikaFactory(protocol.ReconnectingClientFactory):
         self.client = PikaProtocol(self, self.parameters)
         return self.client
 
-    def clientConnectionLost(self, connector, reason): # pylint: disable=W0221
+    def clientConnectionLost(self, connector, reason):  # pylint: disable=W0221
         log.msg('Lost connection.  Reason: %s' % reason.value, system=self.name)
         protocol.ReconnectingClientFactory.clientConnectionLost(
             self, connector, reason)
 
     def clientConnectionFailed(self, connector, reason):
-        log.msg(
-            'Connection failed. Reason: %s' % reason.value, system=self.name)
+        log.msg('Connection failed. Reason: %s' % reason.value,
+                system=self.name)
         protocol.ReconnectingClientFactory.clientConnectionFailed(
             self, connector, reason)
 
@@ -231,10 +228,10 @@ class PikaFactory(protocol.ReconnectingClientFactory):
 application = service.Application("pikaapplication")
 
 ps = PikaService(
-    pika.ConnectionParameters(
-        host="localhost",
-        virtual_host="/",
-        credentials=pika.PlainCredentials("guest", "guest")))
+    pika.ConnectionParameters(host="localhost",
+                              virtual_host="/",
+                              credentials=pika.PlainCredentials(
+                                  "guest", "guest")))
 ps.setServiceParent(application)
 
 
@@ -244,7 +241,7 @@ class TestService(service.Service):
         super().__init__()
         self.amqp = None
 
-    def task(self, _msg): # pylint: disable=R0201
+    def task(self, _msg):  # pylint: disable=R0201
         """
         Method for a time consuming task.
 
@@ -259,7 +256,7 @@ class TestService(service.Service):
         self.amqp.send_message('foobar', 'response', msg[3])
 
     def startService(self):
-        amqp_service = self.parent.getServiceNamed("amqp") # pylint: disable=E1111,E1121
+        amqp_service = self.parent.getServiceNamed("amqp")  # pylint: disable=E1111,E1121
         self.amqp = amqp_service.getFactory()
         self.amqp.read_messages("foobar", "request1", self.respond)
         self.amqp.read_messages("foobar", "request2", self.respond)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,30 @@ packages = ["pika", "pika.adapters", "pika.adapters.utils"]
 [tool.setuptools.package-data]
 "*" = ["LICENSE", "README.rst"]
 
+[tool.hatch.envs.default]
+dependencies = [
+    "coverage",
+    "codecov",
+    "gevent",
+    "pytest>=7.0.0",
+    "pytest-cov",
+    "pytest-timeout",
+    "tornado",
+    "twisted",
+    "mypy>=1.20; python_version >= '3.10'",
+    "ruff",
+    "yapf",
+]
+
+[tool.hatch.envs.default.scripts]
+fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/"
+fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/"
+lint = "ruff check pika/ tests/ examples/ utils/"
+typecheck = "python -m mypy"
+unit = "pytest tests/unit/"
+test = "pytest"
+rabbitmq = "docker run --pull always --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:management-alpine"
+
 [tool.pytest.ini_options]
 minversion = "7.0"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,8 +88,8 @@ dependencies = [
 ]
 
 [tool.hatch.envs.default.scripts]
-fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/"
-fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/"
+fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
+fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
 lint = "ruff check pika/ tests/ examples/ utils/"
 typecheck = "python -m mypy"
 unit = "pytest tests/unit/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ lint = "ruff check pika/ tests/ examples/ utils/"
 typecheck = "python -m mypy"
 unit = "pytest tests/unit/"
 test = "pytest"
-rabbitmq = "docker run --pull always --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:management-alpine"
+rabbitmq = "docker run --name pika-rabbitmq --pull always --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:management-alpine"
 
 [tool.pytest.ini_options]
 minversion = "7.0"

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,0 @@
-coverage
-codecov
-gevent
-pytest>=7.0.0
-pytest-cov
-pytest-timeout
-tornado
-twisted
-mypy>=1.20; python_version >= "3.10"

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -1,4 +1,3 @@
-
 # too-many-lines
 # pylint: disable=C0302
 
@@ -17,7 +16,6 @@
 # invalid-name
 # pylint: disable=C0103
 
-
 import functools
 import socket
 import threading
@@ -32,7 +30,8 @@ from pika.exchange_type import ExchangeType
 import pika.frame
 
 from tests.base import async_test_base
-from tests.base.async_test_base import (AsyncTestCase, BoundQueueTestCase, AsyncAdapters)
+from tests.base.async_test_base import (AsyncTestCase, BoundQueueTestCase,
+                                        AsyncAdapters)
 
 
 class TestA_Connect(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
@@ -42,8 +41,7 @@ class TestA_Connect(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
         self.stop()
 
 
-class TestConstructAndImmediatelyCloseConnection(AsyncTestCase,
-                                                 AsyncAdapters):
+class TestConstructAndImmediatelyCloseConnection(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Construct and immediately close connection."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -59,8 +57,7 @@ class TestConstructAndImmediatelyCloseConnection(AsyncTestCase,
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_open_error(connection, error):
-            self.assertIsInstance(error,
-                                  pika.exceptions.ConnectionOpenAborted)
+            self.assertIsInstance(error, pika.exceptions.ConnectionOpenAborted)
             self.stop()
 
         conn = connection_class(params,
@@ -79,7 +76,6 @@ class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
 
         params = self.new_connection_params()
 
-
         class MyConnectionClass(base_class):
             # Cause an exception if _on_stream_connected doesn't exist
             base_class._on_stream_connected  # pylint: disable=W0104
@@ -90,10 +86,8 @@ class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
                 # of the connection
                 self._nbio.add_callback_threadsafe(self.close)
 
-                return super(MyConnectionClass, self)._on_stream_connected(
-                    *args,
-                    **kwargs)
-
+                return super(MyConnectionClass,
+                             self)._on_stream_connected(*args, **kwargs)
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_opened(connection):
@@ -132,18 +126,17 @@ class TestSocketConnectTimeoutWithTinySocketTimeout(AsyncTestCase,
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_open_error(connection, error):
-            self.assertIsInstance(error,
-                                  pika.exceptions.AMQPConnectionError)
+            self.assertIsInstance(error, pika.exceptions.AMQPConnectionError)
             self.stop()
 
-        connection_class(
-            params,
-            on_open_callback=on_opened,
-            on_open_error_callback=on_open_error,
-            custom_ioloop=self.connection.ioloop)
+        connection_class(params,
+                         on_open_callback=on_opened,
+                         on_open_error_callback=on_open_error,
+                         custom_ioloop=self.connection.ioloop)
 
 
-class TestStackConnectionTimeoutWithTinyStackTimeout(AsyncTestCase, AsyncAdapters):
+class TestStackConnectionTimeoutWithTinyStackTimeout(AsyncTestCase,
+                                                     AsyncAdapters):
     DESCRIPTION = "Force stack bring-up timeout with very tiny stack_timeout."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -168,11 +161,10 @@ class TestStackConnectionTimeoutWithTinyStackTimeout(AsyncTestCase, AsyncAdapter
                         exception))
             self.stop(error)
 
-        connection_class(
-            params,
-            on_open_callback=on_opened,
-            on_open_error_callback=on_open_error,
-            custom_ioloop=self.connection.ioloop)
+        connection_class(params,
+                         on_open_callback=on_opened,
+                         on_open_error_callback=on_open_error,
+                         custom_ioloop=self.connection.ioloop)
 
 
 class TestCreateConnectionViaDefaultConnectionWorkflow(AsyncTestCase,
@@ -196,12 +188,10 @@ class TestCreateConnectionViaDefaultConnectionWorkflow(AsyncTestCase,
                                   pika.exceptions.ConnectionClosedByClient)
             self.stop()
 
-        workflow = connection_class.create_connection(configs,
-                                                      on_done,
+        workflow = connection_class.create_connection(configs, on_done,
                                                       self.connection.ioloop)
         self.assertIsInstance(
-            workflow,
-            connection_workflow.AbstractAMQPConnectionWorkflow)
+            workflow, connection_workflow.AbstractAMQPConnectionWorkflow)
 
 
 class TestCreateConnectionViaCustomConnectionWorkflow(AsyncTestCase,
@@ -238,7 +228,6 @@ class TestCreateConnectionViaCustomConnectionWorkflow(AsyncTestCase,
                 result.i_was_here = MyWorkflow
                 super(MyWorkflow, self)._report_completion_and_cleanup(result)
 
-
         original_workflow = MyWorkflow()
         workflow = connection_class.create_connection(
             configs,
@@ -250,8 +239,7 @@ class TestCreateConnectionViaCustomConnectionWorkflow(AsyncTestCase,
 
 
 class TestCreateConnectionMultipleConfigsDefaultConnectionWorkflow(
-        AsyncTestCase,
-        AsyncAdapters):
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Connect via adapter's create_connection() method with multiple configs."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -288,13 +276,11 @@ class TestCreateConnectionMultipleConfigsDefaultConnectionWorkflow(
                                                       on_done,
                                                       self.connection.ioloop)
         self.assertIsInstance(
-            workflow,
-            connection_workflow.AbstractAMQPConnectionWorkflow)
+            workflow, connection_workflow.AbstractAMQPConnectionWorkflow)
 
 
 class TestCreateConnectionRetriesWithDefaultConnectionWorkflow(
-        AsyncTestCase,
-        AsyncAdapters):
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Connect via adapter's create_connection() method with multiple retries."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -337,8 +323,7 @@ class TestCreateConnectionRetriesWithDefaultConnectionWorkflow(
 
                 logger.info('Start of retry cycle detected.')
 
-                super(MyConnectionClass, self).__init__(parameters,
-                                                        *args,
+                super(MyConnectionClass, self).__init__(parameters, *args,
                                                         **kwargs)
 
         @async_test_base.make_stop_on_error_with_self(self)
@@ -357,13 +342,11 @@ class TestCreateConnectionRetriesWithDefaultConnectionWorkflow(
             self.stop()
 
         MyConnectionClass.create_connection([first_config, second_config],
-                                            on_done,
-                                            self.connection.ioloop)
+                                            on_done, self.connection.ioloop)
 
 
 class TestCreateConnectionConnectionWorkflowSocketConnectionFailure(
-        AsyncTestCase,
-        AsyncAdapters):
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Connect via adapter's create_connection() fails to connect socket."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -381,20 +364,19 @@ class TestCreateConnectionConnectionWorkflowSocketConnectionFailure(
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(exc):
             self.assertIsInstance(
-                exc,
-                connection_workflow.AMQPConnectionWorkflowFailed)
+                exc, connection_workflow.AMQPConnectionWorkflowFailed)
             self.assertIsInstance(
                 exc.exceptions[-1],
                 connection_workflow.AMQPConnectorSocketConnectError)
             self.stop()
 
-        connection_class.create_connection([bad_params,],
-                                           on_done,
-                                           self.connection.ioloop)
+        connection_class.create_connection([
+            bad_params,
+        ], on_done, self.connection.ioloop)
 
 
-class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(AsyncTestCase,
-                                                               AsyncAdapters):
+class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "AMQP handshake timeout handling in adapter's create_connection()."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -416,35 +398,29 @@ class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(AsyncTestCase,
                 connector = workflow._connector  # type: connection_workflow.AMQPConnector
                 connector._stack_timeout_ref.cancel()
                 connector._stack_timeout_ref = connector._nbio.call_later(
-                    0,
-                    connector._on_overall_timeout)
+                    0, connector._on_overall_timeout)
 
-                return super(MyConnectionClass, self)._on_stream_connected(
-                    *args,
-                    **kwargs)
+                return super(MyConnectionClass,
+                             self)._on_stream_connected(*args, **kwargs)
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(error):
             self.assertIsInstance(
-                error,
-                connection_workflow.AMQPConnectionWorkflowFailed)
+                error, connection_workflow.AMQPConnectionWorkflowFailed)
             self.assertIsInstance(
                 error.exceptions[-1],
                 connection_workflow.AMQPConnectorAMQPHandshakeError)
-            self.assertIsInstance(
-                error.exceptions[-1].exception,
-                connection_workflow.AMQPConnectorStackTimeout)
+            self.assertIsInstance(error.exceptions[-1].exception,
+                                  connection_workflow.AMQPConnectorStackTimeout)
 
             self.stop()
 
-        workflow = MyConnectionClass.create_connection([params],
-                                                       on_done,
+        workflow = MyConnectionClass.create_connection([params], on_done,
                                                        self.connection.ioloop)
 
 
 class TestCreateConnectionAndImmediatelyAbortDefaultConnectionWorkflow(
-        AsyncTestCase,
-        AsyncAdapters):
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Immediately abort workflow initiated via adapter's create_connection()."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -455,19 +431,16 @@ class TestCreateConnectionAndImmediatelyAbortDefaultConnectionWorkflow(
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(exc):
             self.assertIsInstance(
-                exc,
-                connection_workflow.AMQPConnectionWorkflowAborted)
+                exc, connection_workflow.AMQPConnectionWorkflowAborted)
             self.stop()
 
-        workflow = connection_class.create_connection(configs,
-                                                      on_done,
+        workflow = connection_class.create_connection(configs, on_done,
                                                       self.connection.ioloop)
         workflow.abort()
 
 
 class TestCreateConnectionAndAsynchronouslyAbortDefaultConnectionWorkflow(
-        AsyncTestCase,
-        AsyncAdapters):
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Asyncrhonously abort workflow initiated via adapter's create_connection()."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -478,12 +451,10 @@ class TestCreateConnectionAndAsynchronouslyAbortDefaultConnectionWorkflow(
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(exc):
             self.assertIsInstance(
-                exc,
-                connection_workflow.AMQPConnectionWorkflowAborted)
+                exc, connection_workflow.AMQPConnectionWorkflowAborted)
             self.stop()
 
-        workflow = connection_class.create_connection(configs,
-                                                      on_done,
+        workflow = connection_class.create_connection(configs, on_done,
                                                       self.connection.ioloop)
         self.connection._nbio.add_callback_threadsafe(workflow.abort)
 
@@ -492,8 +463,8 @@ class TestUpdateSecret(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Update secret and receive confirmation"
 
     def begin(self, channel):
-        self.connection.update_secret(
-            "new_secret", "reason", self.on_secret_update)
+        self.connection.update_secret("new_secret", "reason",
+                                      self.on_secret_update)
 
     def on_secret_update(self, frame):
         self.assertIsInstance(frame.method, spec.Connection.UpdateSecretOk)
@@ -522,11 +493,12 @@ class TestBlockingNonBlockingBlockingRPCWontStall(AsyncTestCase, AsyncAdapters):
 
     def begin(self, channel):
         # Queue declaration params table: queue name, nowait value
-        self._expected_queue_params = (
-            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, False),
-            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, True),
-            ("blocking-non-blocking-stall-check-" + uuid.uuid1().hex, False)
-        )
+        self._expected_queue_params = (("blocking-non-blocking-stall-check-" +
+                                        uuid.uuid1().hex, False),
+                                       ("blocking-non-blocking-stall-check-" +
+                                        uuid.uuid1().hex, True),
+                                       ("blocking-non-blocking-stall-check-" +
+                                        uuid.uuid1().hex, False))
 
         self._declared_queue_names = []
 
@@ -563,8 +535,7 @@ class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
 
     def on_queue_declared(self, frame):
         for i in range(0, 100):
-            msg_body = '{}:{}:{}'.format(self.__class__.__name__, i,
-                                         time_now())
+            msg_body = '{}:{}:{}'.format(self.__class__.__name__, i, time_now())
             self.channel.basic_publish('', self.queue_name, msg_body)
         self.ctag = self.channel.basic_consume(self.queue_name,
                                                self.on_message,
@@ -596,7 +567,8 @@ class TestExchangeDeclareAndDelete(AsyncTestCase, AsyncAdapters):
 
     def on_exchange_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Exchange.DeclareOk)
-        self.channel.exchange_delete(self.name, callback=self.on_exchange_delete)
+        self.channel.exchange_delete(self.name,
+                                     callback=self.on_exchange_delete)
 
     def on_exchange_delete(self, frame):
         self.assertIsInstance(frame.method, spec.Exchange.DeleteOk)
@@ -673,8 +645,8 @@ class TestNoDeadlockWhenClosingChannelWithPendingBlockedRequestsAndConcurrentCha
         self.fail("Should not have received an Exchange.DeclareOk")
 
 
-class TestClosingAChannelPermitsBlockedRequestToComplete(AsyncTestCase,
-                                                         AsyncAdapters):
+class TestClosingAChannelPermitsBlockedRequestToComplete(
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Closing a channel permits blocked requests to complete."
 
     @async_test_base.stop_on_error_in_async_test_case_method
@@ -725,7 +697,8 @@ class TestQueueUnnamedDeclareAndDelete(AsyncTestCase, AsyncAdapters):
     @async_test_base.stop_on_error_in_async_test_case_method
     def on_queue_declared(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
-        self.channel.queue_delete(frame.method.queue, callback=self.on_queue_delete)
+        self.channel.queue_delete(frame.method.queue,
+                                  callback=self.on_queue_delete)
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def on_queue_delete(self, frame):
@@ -750,7 +723,8 @@ class TestQueueNamedDeclareAndDelete(AsyncTestCase, AsyncAdapters):
         self.assertIsInstance(frame.method, spec.Queue.DeclareOk)
         # Frame's method's queue is encoded (impl detail)
         self.assertEqual(frame.method.queue, self._q_name)
-        self.channel.queue_delete(frame.method.queue, callback=self.on_queue_delete)
+        self.channel.queue_delete(frame.method.queue,
+                                  callback=self.on_queue_delete)
 
     def on_queue_delete(self, frame):
         self.assertIsInstance(frame.method, spec.Queue.DeleteOk)
@@ -786,7 +760,6 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
     def on_bad_result(self, frame):
         self.channel.queue_delete(self._q_name)
         raise AssertionError("Should not have received a Queue.DeclareOk")
-
 
 
 class TestTX1_Select(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
@@ -957,9 +930,9 @@ class TestBlockedConnectionTimesOut(AsyncTestCase, AsyncAdapters):  # pylint: di
         # Simulate Connection.Blocked
         channel.connection._on_connection_blocked(
             channel.connection,
-            pika.frame.Method(0,
-                              spec.Connection.Blocked(
-                                  'Testing blocked connection timeout')))
+            pika.frame.Method(
+                0,
+                spec.Connection.Blocked('Testing blocked connection timeout')))
 
     def on_closed(self, connection, error):
         """called when the connection has finished closing"""
@@ -986,14 +959,14 @@ class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):  # pylint: di
         # Simulate Connection.Blocked
         channel.connection._on_connection_blocked(
             channel.connection,
-            pika.frame.Method(0,
-                              spec.Connection.Blocked(
-                                  'Testing blocked connection unblocks')))
+            pika.frame.Method(
+                0,
+                spec.Connection.Blocked('Testing blocked connection unblocks')))
 
         # Simulate Connection.Unblocked
         channel.connection._on_connection_unblocked(
-            channel.connection,
-            pika.frame.Method(0, spec.Connection.Unblocked()))
+            channel.connection, pika.frame.Method(0,
+                                                  spec.Connection.Unblocked()))
 
         # Schedule shutdown after blocked connection timeout would expire
         channel.connection._adapter_call_later(0.005, self.on_cleanup_timer)
@@ -1007,7 +980,8 @@ class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):  # pylint: di
         super(TestBlockedConnectionUnblocks, self).on_closed(connection, error)
 
 
-class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
+class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(
+        AsyncTestCase, AsyncAdapters):
     DESCRIPTION = (
         "Test _adapter_add_callback_threadsafe request before ioloop starts.")
 
@@ -1021,15 +995,15 @@ class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(AsyncTestCase, AsyncAda
         self.connection._adapter_add_callback_threadsafe(
             self.on_requested_callback)
 
-        return super(
-            TestAddCallbackThreadsafeRequestBeforeIOLoopStarts, self)._run_ioloop(
-                *args, **kwargs)
+        return super(TestAddCallbackThreadsafeRequestBeforeIOLoopStarts,
+                     self)._run_ioloop(*args, **kwargs)
 
     def start(self, *args, **kwargs):  # pylint: disable=W0221
         self.loop_thread_ident = threading.current_thread().ident
         self.my_start_time = None
         self.got_callback = False
-        super(TestAddCallbackThreadsafeRequestBeforeIOLoopStarts, self).start(*args, **kwargs)
+        super(TestAddCallbackThreadsafeRequestBeforeIOLoopStarts,
+              self).start(*args, **kwargs)
         self.assertTrue(self.got_callback)
 
     def begin(self, channel):
@@ -1050,7 +1024,8 @@ class TestAddCallbackThreadsafeFromIOLoopThread(AsyncTestCase, AsyncAdapters):
         self.loop_thread_ident = threading.current_thread().ident
         self.my_start_time = None
         self.got_callback = False
-        super(TestAddCallbackThreadsafeFromIOLoopThread, self).start(*args, **kwargs)
+        super(TestAddCallbackThreadsafeFromIOLoopThread,
+              self).start(*args, **kwargs)
         self.assertTrue(self.got_callback)
 
     def begin(self, channel):
@@ -1075,15 +1050,15 @@ class TestAddCallbackThreadsafeFromAnotherThread(AsyncTestCase, AsyncAdapters):
         self.loop_thread_ident = threading.current_thread().ident
         self.my_start_time = None
         self.got_callback = False
-        super(TestAddCallbackThreadsafeFromAnotherThread, self).start(*args, **kwargs)
+        super(TestAddCallbackThreadsafeFromAnotherThread,
+              self).start(*args, **kwargs)
         self.assertTrue(self.got_callback)
 
     def begin(self, channel):
         self.my_start_time = time_now()
         # Request a callback from ioloop while executing in another thread
         timer = threading.Timer(
-            0,
-            lambda: channel.connection._adapter_add_callback_threadsafe(
+            0, lambda: channel.connection._adapter_add_callback_threadsafe(
                 self.on_requested_callback))
         self.addCleanup(timer.cancel)
         timer.start()
@@ -1107,22 +1082,23 @@ class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
         my_start_time = time_now()
         self.stop_ioloop_only()
 
-        super(
-            TestIOLoopStopBeforeIOLoopStarts, self)._run_ioloop(*args, **kwargs)
+        super(TestIOLoopStopBeforeIOLoopStarts,
+              self)._run_ioloop(*args, **kwargs)
 
         self.assertLess(time_now() - my_start_time, 0.25)
 
         # Resume I/O loop to facilitate normal course of events and closure
         # of connection in order to prevent reporting of a socket resource leak
         # from an unclosed connection.
-        super(
-            TestIOLoopStopBeforeIOLoopStarts, self)._run_ioloop(*args, **kwargs)
+        super(TestIOLoopStopBeforeIOLoopStarts,
+              self)._run_ioloop(*args, **kwargs)
 
     def begin(self, channel):
         self.stop()
 
 
-class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
+class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(
+        AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103
     DESCRIPTION = "Test viability of multiple timeouts with same deadline and callback"
 
     def begin(self, channel):

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -34,7 +34,6 @@ from tests.misc.test_utils import retry_assertion
 # Disable warning Invalid variable name
 # pylint: disable=C0103
 
-
 LOGGER = logging.getLogger(__name__)
 
 PARAMS_URL_TEMPLATE = (
@@ -54,9 +53,7 @@ class BlockingTestCaseBase(unittest.TestCase):
                  impl_class=None):
         parameters = pika.URLParameters(url)
 
-        return self._connect_params(parameters,
-                                    connection_class,
-                                    impl_class)
+        return self._connect_params(parameters, connection_class, impl_class)
 
     def _connect_params(self,
                         parameters,
@@ -69,8 +66,9 @@ class BlockingTestCaseBase(unittest.TestCase):
 
         # We use impl's timer directly in order to get a callback regardless
         # of BlockingConnection's event dispatch modality
-        connection._impl._adapter_call_later(self.TIMEOUT, # pylint: disable=E1101
-                                             self._on_test_timeout)
+        connection._impl._adapter_call_later(
+            self.TIMEOUT,  # pylint: disable=E1101
+            self._on_test_timeout)
 
         # Patch calls into I/O loop to fail test if exceptions are
         # leaked back through SelectConnection or the I/O loop.
@@ -92,6 +90,7 @@ class BlockingTestCaseBase(unittest.TestCase):
         # Patch calls into I/O loop to fail test if exceptions are
         # leaked back through SelectConnection or the I/O loop.
         real_poll = connection._impl.ioloop.poll
+
         def my_poll(*args, **kwargs):
             try:
                 return real_poll(*args, **kwargs)
@@ -103,6 +102,7 @@ class BlockingTestCaseBase(unittest.TestCase):
         self.addCleanup(setattr, connection._impl.ioloop, 'poll', real_poll)
 
         real_process_timeouts = connection._impl.ioloop.process_timeouts
+
         def my_process_timeouts(*args, **kwargs):
             try:
                 return real_process_timeouts(*args, **kwargs)
@@ -123,10 +123,8 @@ class BlockingTestCaseBase(unittest.TestCase):
         LOGGER.info('%s TIMED OUT (%s)', datetime.now(timezone.utc), self)
         self.fail('Test timed out')
 
-    @retry_assertion(TIMEOUT/2)
-    def _assert_exact_message_count_with_retries(self,
-                                                 channel,
-                                                 queue,
+    @retry_assertion(TIMEOUT / 2)
+    def _assert_exact_message_count_with_retries(self, channel, queue,
                                                  expected_count):
         frame = channel.queue_declare(queue, passive=True)
         self.assertEqual(frame.method.message_count, expected_count)
@@ -229,6 +227,7 @@ class TestMultiCloseConnectionRaisesWrongState(BlockingTestCaseBase):
 
 
 class TestConnectionContextManagerClosesConnection(BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: connection context manager closes connection"""
         with self._connect() as connection:
@@ -238,7 +237,9 @@ class TestConnectionContextManagerClosesConnection(BlockingTestCaseBase):
         self.assertTrue(connection.is_closed)
 
 
-class TestConnectionContextManagerExitSurvivesClosedConnection(BlockingTestCaseBase):
+class TestConnectionContextManagerExitSurvivesClosedConnection(
+        BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: connection context manager exit survives closed connection"""
         with self._connect() as connection:
@@ -249,9 +250,12 @@ class TestConnectionContextManagerExitSurvivesClosedConnection(BlockingTestCaseB
         self.assertTrue(connection.is_closed)
 
 
-class TestConnectionContextManagerClosesConnectionAndPassesOriginalException(BlockingTestCaseBase):
+class TestConnectionContextManagerClosesConnectionAndPassesOriginalException(
+        BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: connection context manager closes connection and passes original exception"""  # pylint: disable=C0301
+
         class MyException(Exception):
             pass
 
@@ -264,7 +268,9 @@ class TestConnectionContextManagerClosesConnectionAndPassesOriginalException(Blo
         self.assertTrue(connection.is_closed)
 
 
-class TestConnectionContextManagerClosesConnectionAndPassesSystemException(BlockingTestCaseBase):
+class TestConnectionContextManagerClosesConnectionAndPassesSystemException(
+        BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: connection context manager closes connection and passes system exception"""  # pylint: disable=C0301
         with self.assertRaises(SystemExit):
@@ -275,7 +281,9 @@ class TestConnectionContextManagerClosesConnectionAndPassesSystemException(Block
         self.assertTrue(connection.is_closed)
 
 
-class TestLostConnectionResultsInIsClosedConnectionAndChannel(BlockingTestCaseBase):
+class TestLostConnectionResultsInIsClosedConnectionAndChannel(
+        BlockingTestCaseBase):
+
     def test(self):
         connection = self._connect()
         channel = connection.channel()
@@ -295,6 +303,7 @@ class TestLostConnectionResultsInIsClosedConnectionAndChannel(BlockingTestCaseBa
 
 
 class TestUpdateSecret(BlockingTestCaseBase):
+
     def test(self):
         connection = self._connect()
         channel = connection.channel()
@@ -310,6 +319,7 @@ class TestUpdateSecret(BlockingTestCaseBase):
 
 
 class TestUpdateSecretOnClosedRaisesWrongState(BlockingTestCaseBase):
+
     def test(self):
         connection = self._connect()
 
@@ -326,6 +336,7 @@ class TestUpdateSecretOnClosedRaisesWrongState(BlockingTestCaseBase):
 
 
 class TestUpdateSecretExpectsStrings(BlockingTestCaseBase):
+
     def test(self):
         connection = self._connect()
 
@@ -339,6 +350,7 @@ class TestUpdateSecretExpectsStrings(BlockingTestCaseBase):
 
 
 class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: ConnectionClosed raised when creating exchange with invalid type"""  # pylint: disable=C0301
         # This test exploits behavior specific to RabbitMQ whereby the broker
@@ -365,9 +377,8 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestCreateAndCloseConnectionWithChannelAndConsumer_q' +
-            uuid.uuid1().hex)
+        q_name = ('TestCreateAndCloseConnectionWithChannelAndConsumer_q' +
+                  uuid.uuid1().hex)
 
         body1 = 'a' * 1024
 
@@ -378,8 +389,11 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
         ch.basic_publish(exchange='', routing_key=q_name, body=body1)
 
         # Create a consumer that uses automatic ack mode
-        ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
-                         exclusive=False, arguments=None)
+        ch.basic_consume(q_name,
+                         lambda *x: None,
+                         auto_ack=True,
+                         exclusive=False,
+                         arguments=None)
 
         connection.close()
         self.assertTrue(connection.is_closed)
@@ -393,6 +407,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
 
 
 class TestUsingInvalidQueueArgument(BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection raises expected exception when invalid queue parameter is used
         """
@@ -407,11 +422,12 @@ class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
     def test(self):
         """BlockingConnection resets properly on TCP/IP drop during channel()
         """
-        with ForwardServer(remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+        with ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
+                                        DEFAULT_PARAMS.port),
                            local_linger_args=(1, 0)) as fwd:
 
-            self.connection = self._connect(
-                PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]})
+            self.connection = self._connect(PARAMS_URL_TEMPLATE %
+                                            {"port": fwd.server_address[1]})
 
         # Once outside the context, the connection is broken
 
@@ -429,11 +445,12 @@ class TestNoAccessToConnectionAfterConnectionLost(BlockingTestCaseBase):
     def test(self):
         """BlockingConnection no access file descriptor after StreamLostError
         """
-        with ForwardServer(remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
+        with ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
+                                        DEFAULT_PARAMS.port),
                            local_linger_args=(1, 0)) as fwd:
 
-            self.connection = self._connect(
-                PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]})
+            self.connection = self._connect(PARAMS_URL_TEMPLATE %
+                                            {"port": fwd.server_address[1]})
 
         # Once outside the context, the connection is broken
 
@@ -467,8 +484,8 @@ class TestConnectWithDownedBroker(BlockingTestCaseBase):
         sock.close()
 
         with self.assertRaises(pika.exceptions.AMQPConnectionError):
-            self.connection = self._connect(
-                PARAMS_URL_TEMPLATE % {"port": port})
+            self.connection = self._connect(PARAMS_URL_TEMPLATE %
+                                            {"port": port})
 
 
 class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
@@ -476,9 +493,9 @@ class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_START
         """
-        fwd = ForwardServer(
-            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
-            local_linger_args=(1, 0))
+        fwd = ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
+                                         DEFAULT_PARAMS.port),
+                            local_linger_args=(1, 0))
 
         fwd.start()
         self.addCleanup(lambda: fwd.stop() if fwd.running else None)
@@ -488,13 +505,12 @@ class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
 
             def _on_connection_start(self, *args, **kwargs):  # pylint: disable=W0221
                 fwd.stop()
-                return super(MySelectConnection, self)._on_connection_start(
-                    *args, **kwargs)
+                return super(MySelectConnection,
+                             self)._on_connection_start(*args, **kwargs)
 
         with self.assertRaises(pika.exceptions.ProbableAuthenticationError):
-            self._connect(
-                PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
-                impl_class=MySelectConnection)
+            self._connect(PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
+                          impl_class=MySelectConnection)
 
 
 class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
@@ -502,9 +518,9 @@ class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_TUNE
         """
-        fwd = ForwardServer(
-            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
-            local_linger_args=(1, 0))
+        fwd = ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
+                                         DEFAULT_PARAMS.port),
+                            local_linger_args=(1, 0))
         fwd.start()
         self.addCleanup(lambda: fwd.stop() if fwd.running else None)
 
@@ -513,13 +529,12 @@ class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
 
             def _on_connection_tune(self, *args, **kwargs):  # pylint: disable=W0221
                 fwd.stop()
-                return super(MySelectConnection, self)._on_connection_tune(
-                    *args, **kwargs)
+                return super(MySelectConnection,
+                             self)._on_connection_tune(*args, **kwargs)
 
         with self.assertRaises(pika.exceptions.ProbableAccessDeniedError):
-            self._connect(
-                PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
-                impl_class=MySelectConnection)
+            self._connect(PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
+                          impl_class=MySelectConnection)
 
 
 class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
@@ -527,9 +542,9 @@ class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
     def test(self):
         """ BlockingConnection TCP/IP connection loss in CONNECTION_PROTOCOL
         """
-        fwd = ForwardServer(
-            remote_addr=(DEFAULT_PARAMS.host, DEFAULT_PARAMS.port),
-            local_linger_args=(1, 0))
+        fwd = ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
+                                         DEFAULT_PARAMS.port),
+                            local_linger_args=(1, 0))
 
         fwd.start()
         self.addCleanup(lambda: fwd.stop() if fwd.running else None)
@@ -539,8 +554,8 @@ class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
 
             def _on_stream_connected(self, *args, **kwargs):  # pylint: disable=W0221
                 fwd.stop()
-                return super(MySelectConnection, self)._on_stream_connected(
-                    *args, **kwargs)
+                return super(MySelectConnection,
+                             self)._on_stream_connected(*args, **kwargs)
 
         with self.assertRaises(pika.exceptions.IncompatibleProtocolError):
             self._connect(PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
@@ -583,10 +598,9 @@ class TestConnectionRegisterForBlockAndUnblock(BlockingTestCaseBase):
             lambda conn, frame: blocked_buffer.append((conn, frame)))
         # Simulate dispatch of blocked connection
         blocked_frame = pika.frame.Method(
-            0,
-            pika.spec.Connection.Blocked('reason'))
+            0, pika.spec.Connection.Blocked('reason'))
         connection._impl._process_frame(blocked_frame)
-        connection.sleep(0) # facilitate dispatch of pending events
+        connection.sleep(0)  # facilitate dispatch of pending events
         self.assertEqual(len(blocked_buffer), 1)
         conn, frame = blocked_buffer[0]
         self.assertIs(conn, connection)
@@ -598,7 +612,7 @@ class TestConnectionRegisterForBlockAndUnblock(BlockingTestCaseBase):
         # Simulate dispatch of unblocked connection
         unblocked_frame = pika.frame.Method(0, pika.spec.Connection.Unblocked())
         connection._impl._process_frame(unblocked_frame)
-        connection.sleep(0) # facilitate dispatch of pending events
+        connection.sleep(0)  # facilitate dispatch of pending events
         self.assertEqual(len(unblocked_buffer), 1)
         conn, frame = unblocked_buffer[0]
         self.assertIs(conn, connection)
@@ -692,9 +706,8 @@ class TestAddTimeoutRemoveTimeout(BlockingTestCaseBase):
         # Test timer completion
         start_time = time_now()
         rx_callback = []
-        timer_id = connection.call_later(
-            0.005,
-            lambda: rx_callback.append(time_now()))
+        timer_id = connection.call_later(0.005,
+                                         lambda: rx_callback.append(time_now()))
         while not rx_callback:
             connection.process_data_events(time_limit=None)
 
@@ -705,12 +718,10 @@ class TestAddTimeoutRemoveTimeout(BlockingTestCaseBase):
         # Test removing triggered timeout
         connection.remove_timeout(timer_id)
 
-
         # Test aborted timer
         rx_callback = []
-        timer_id = connection.call_later(
-            0.001,
-            lambda: rx_callback.append(time_now()))
+        timer_id = connection.call_later(0.001,
+                                         lambda: rx_callback.append(time_now()))
         connection.remove_timeout(timer_id)
         connection.process_data_events(time_limit=0.1)
         self.assertFalse(rx_callback)
@@ -720,7 +731,8 @@ class TestAddTimeoutRemoveTimeout(BlockingTestCaseBase):
         repr(evt)
 
 
-class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(BlockingTestCaseBase):
+class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(
+        BlockingTestCaseBase):
 
     def test(self):
         """BlockingConnection viability of multiple timeouts with same deadline and callback"""
@@ -753,9 +765,10 @@ class TestRemoveTimeoutFromTimeoutCallback(BlockingTestCaseBase):
         connection = self._connect()
 
         # Test timer completion
-        timer_id1 = connection.call_later(5, lambda: 0/0)
+        timer_id1 = connection.call_later(5, lambda: 0 / 0)
 
         rx_timer2 = []
+
         def on_timer2():
             connection.remove_timeout(timer_id1)
             connection.remove_timeout(timer_id2)
@@ -808,7 +821,6 @@ class TestConnectionProperties(BlockingTestCaseBase):
         self.assertFalse(connection.is_open)
         self.assertFalse(connection._impl.is_closing)
         self.assertTrue(connection.is_closed)
-
 
 
 class TestCreateAndCloseChannel(BlockingTestCaseBase):
@@ -896,12 +908,15 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
             ch.basic_publish(src_exg_name, routing_key, body='', mandatory=True)
 
         # Bind the exchanges
-        frame = ch.exchange_bind(destination=dest_exg_name, source=src_exg_name,
+        frame = ch.exchange_bind(destination=dest_exg_name,
+                                 source=src_exg_name,
                                  routing_key=routing_key)
         self.assertIsInstance(frame.method, pika.spec.Exchange.BindOk)
 
         # Publish a message via the source exchange
-        ch.basic_publish(src_exg_name, routing_key, body='TestExchangeBindAndUnbind',
+        ch.basic_publish(src_exg_name,
+                         routing_key,
+                         body='TestExchangeBindAndUnbind',
                          mandatory=True)
 
         # Check that the queue now has one message
@@ -952,13 +967,15 @@ class TestQueueDeclareAndDelete(BlockingTestCaseBase):
 
 class TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed(
         BlockingTestCaseBase):
+
     def test(self):
         """BlockingChannel: ChannelClosed raised when passive-declaring unknown queue"""  # pylint: disable=C0301
         connection = self._connect()
         ch = connection.channel()
 
-        q_name = ("TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed_q_"
-                  + uuid.uuid1().hex)
+        q_name = (
+            "TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed_q_" +
+            uuid.uuid1().hex)
 
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
             ch.queue_declare(q_name, passive=True)
@@ -991,7 +1008,8 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Bind the queue to the exchange using routing key
-        frame = ch.queue_bind(q_name, exchange=exg_name,
+        frame = ch.queue_bind(q_name,
+                              exchange=exg_name,
                               routing_key=routing_key)
         self.assertIsInstance(frame.method, pika.spec.Queue.BindOk)
 
@@ -1000,7 +1018,9 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
         self.assertEqual(frame.method.message_count, 0)
 
         # Deposit a message in the queue
-        ch.basic_publish(exg_name, routing_key, body='TestQueueBindAndUnbindAndPurge',
+        ch.basic_publish(exg_name,
+                         routing_key,
+                         body='TestQueueBindAndUnbindAndPurge',
                          mandatory=True)
 
         # Check that the queue now has one message
@@ -1008,13 +1028,15 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
         self.assertEqual(frame.method.message_count, 1)
 
         # Unbind the queue
-        frame = ch.queue_unbind(queue=q_name, exchange=exg_name,
+        frame = ch.queue_unbind(queue=q_name,
+                                exchange=exg_name,
                                 routing_key=routing_key)
         self.assertIsInstance(frame.method, pika.spec.Queue.UnbindOk)
 
         # Verify that the queue is now unreachable via that binding
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(exg_name, routing_key,
+            ch.basic_publish(exg_name,
+                             routing_key,
                              body='TestQueueBindAndUnbindAndPurge-2',
                              mandatory=True)
 
@@ -1049,7 +1071,8 @@ class TestBasicGet(BlockingTestCaseBase):
         # may be delivered synchronously to the queue by publishing it with
         # mandatory=True
         ch.confirm_delivery()
-        LOGGER.info('%s ENABLED PUB-ACKS (%s)', datetime.now(timezone.utc), self)
+        LOGGER.info('%s ENABLED PUB-ACKS (%s)', datetime.now(timezone.utc),
+                    self)
 
         # Declare a new queue
         ch.queue_declare(q_name, exclusive=True)
@@ -1058,17 +1081,21 @@ class TestBasicGet(BlockingTestCaseBase):
         # Verify result of getting a message from an empty queue
         msg = ch.basic_get(q_name, auto_ack=False)
         self.assertTupleEqual(msg, (None, None, None))
-        LOGGER.info('%s GOT FROM EMPTY QUEUE (%s)', datetime.now(timezone.utc), self)
+        LOGGER.info('%s GOT FROM EMPTY QUEUE (%s)', datetime.now(timezone.utc),
+                    self)
 
         body = 'TestBasicGet'
         # Deposit a message in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body=body, mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body=body,
+                         mandatory=True)
         LOGGER.info('%s PUBLISHED (%s)', datetime.now(timezone.utc), self)
 
         # Get the message
         (method, properties, body) = ch.basic_get(q_name, auto_ack=False)
-        LOGGER.info('%s GOT FROM NON-EMPTY QUEUE (%s)', datetime.now(timezone.utc), self)
+        LOGGER.info('%s GOT FROM NON-EMPTY QUEUE (%s)',
+                    datetime.now(timezone.utc), self)
         self.assertIsInstance(method, pika.spec.Basic.GetOk)
         self.assertEqual(method.delivery_tag, 1)
         self.assertFalse(method.redelivered)
@@ -1109,10 +1136,14 @@ class TestBasicReject(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Deposit two messages in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicReject1', mandatory=True)
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicReject2', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicReject1',
+                         mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicReject2',
+                         mandatory=True)
 
         # Get the messages
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
@@ -1152,19 +1183,21 @@ class TestBasicRejectNoRequeue(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Deposit two messages in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicRejectNoRequeue1', mandatory=True)
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicRejectNoRequeue2', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicRejectNoRequeue1',
+                         mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicRejectNoRequeue2',
+                         mandatory=True)
 
         # Get the messages
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicRejectNoRequeue1'))
+        self.assertEqual(rx_body, as_bytes('TestBasicRejectNoRequeue1'))
 
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicRejectNoRequeue2'))
+        self.assertEqual(rx_body, as_bytes('TestBasicRejectNoRequeue2'))
 
         # Nack the second message
         ch.basic_reject(rx_method.delivery_tag, requeue=False)
@@ -1194,10 +1227,14 @@ class TestBasicNack(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Deposit two messages in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicNack1', mandatory=True)
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicNack2', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicNack1',
+                         mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicNack2',
+                         mandatory=True)
 
         # Get the messages
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
@@ -1237,19 +1274,21 @@ class TestBasicNackNoRequeue(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Deposit two messages in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicNackNoRequeue1', mandatory=True)
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicNackNoRequeue2', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicNackNoRequeue1',
+                         mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicNackNoRequeue2',
+                         mandatory=True)
 
         # Get the messages
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicNackNoRequeue1'))
+        self.assertEqual(rx_body, as_bytes('TestBasicNackNoRequeue1'))
 
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicNackNoRequeue2'))
+        self.assertEqual(rx_body, as_bytes('TestBasicNackNoRequeue2'))
 
         # Nack the second message
         ch.basic_nack(rx_method.delivery_tag, requeue=False)
@@ -1279,19 +1318,21 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Deposit two messages in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicNackMultiple1', mandatory=True)
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicNackMultiple2', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicNackMultiple1',
+                         mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicNackMultiple2',
+                         mandatory=True)
 
         # Get the messages
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicNackMultiple1'))
+        self.assertEqual(rx_body, as_bytes('TestBasicNackMultiple1'))
 
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicNackMultiple2'))
+        self.assertEqual(rx_body, as_bytes('TestBasicNackMultiple2'))
 
         # Nack both messages via the "multiple" option
         ch.basic_nack(rx_method.delivery_tag, multiple=True, requeue=True)
@@ -1301,11 +1342,9 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
                                                       queue=q_name,
                                                       expected_count=2)
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicNackMultiple1'))
+        self.assertEqual(rx_body, as_bytes('TestBasicNackMultiple1'))
         (rx_method, _, rx_body) = ch.basic_get(q_name, auto_ack=False)
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicNackMultiple2'))
+        self.assertEqual(rx_body, as_bytes('TestBasicNackMultiple2'))
 
 
 class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
@@ -1320,8 +1359,7 @@ class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestBasicRecoverWithRequeue_q' + uuid.uuid1().hex)
+        q_name = ('TestBasicRecoverWithRequeue_q' + uuid.uuid1().hex)
 
         # Place channel in publisher-acknowledgments mode so that the message
         # may be delivered synchronously to the queue by publishing it with
@@ -1332,10 +1370,14 @@ class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Deposit two messages in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicRecoverWithRequeue1', mandatory=True)
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestBasicRecoverWithRequeue2', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicRecoverWithRequeue1',
+                         mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestBasicRecoverWithRequeue2',
+                         mandatory=True)
 
         rx_messages = []
         num_messages = 0
@@ -1355,12 +1397,10 @@ class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
 
         # Get the messages
         (_, _, rx_body) = rx_messages[0]
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicRecoverWithRequeue1'))
+        self.assertEqual(rx_body, as_bytes('TestBasicRecoverWithRequeue1'))
 
         (_, _, rx_body) = rx_messages[1]
-        self.assertEqual(rx_body,
-                         as_bytes('TestBasicRecoverWithRequeue2'))
+        self.assertEqual(rx_body, as_bytes('TestBasicRecoverWithRequeue2'))
 
 
 class TestTxCommit(BlockingTestCaseBase):
@@ -1381,8 +1421,10 @@ class TestTxCommit(BlockingTestCaseBase):
         self.assertIsInstance(frame.method, pika.spec.Tx.SelectOk)
 
         # Deposit a message in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestTxCommit1', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestTxCommit1',
+                         mandatory=True)
 
         # Verify that queue is still empty
         frame = ch.queue_declare(q_name, passive=True)
@@ -1417,8 +1459,10 @@ class TestTxRollback(BlockingTestCaseBase):
         self.assertIsInstance(frame.method, pika.spec.Tx.SelectOk)
 
         # Deposit a message in the queue via default exchange
-        ch.basic_publish(exchange='', routing_key=q_name,
-                         body='TestTxRollback1', mandatory=True)
+        ch.basic_publish(exchange='',
+                         routing_key=q_name,
+                         body='TestTxRollback1',
+                         mandatory=True)
 
         # Verify that queue is still empty
         frame = ch.queue_declare(q_name, passive=True)
@@ -1433,6 +1477,7 @@ class TestTxRollback(BlockingTestCaseBase):
 
 
 class TestBasicConsumeFromUnknownQueueRaisesChannelClosed(BlockingTestCaseBase):
+
     def test(self):
         """ChannelClosed raised when consuming from unknown queue"""
         connection = self._connect()
@@ -1473,8 +1518,11 @@ class TestPublishAndBasicPublishWithPubacksUnroutable(BlockingTestCaseBase):
             test_name='TestPublishAndBasicPublishWithPubacksUnroutable')
         msg2_properties = pika.spec.BasicProperties(headers=msg2_headers)
         with self.assertRaises(pika.exceptions.UnroutableError) as cm:
-            ch.basic_publish(exg_name, routing_key=routing_key, body='',
-                             properties=msg2_properties, mandatory=True)
+            ch.basic_publish(exg_name,
+                             routing_key=routing_key,
+                             body='',
+                             properties=msg2_properties,
+                             mandatory=True)
         (msg,) = cm.exception.messages
         self.assertIsInstance(msg, blocking_connection.ReturnedMessage)
         self.assertIsInstance(msg.method, pika.spec.Basic.Return)
@@ -1507,7 +1555,10 @@ class TestConfirmDeliveryAfterUnroutableMessage(BlockingTestCaseBase):
         ch.add_on_return_callback(lambda *args: returned_messages.append(args))
 
         # Emit unroutable message without pubacks
-        ch.basic_publish(exg_name, routing_key=routing_key, body='', mandatory=True)
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
+                         body='',
+                         mandatory=True)
 
         # Select delivery confirmations
         ch.confirm_delivery()
@@ -1525,7 +1576,12 @@ class TestConfirmDeliveryAfterUnroutableMessage(BlockingTestCaseBase):
         self.assertEqual(len(ch._pending_events), 0)
 
         # Verify that unroutable message was dispatched
-        ((channel, method, properties, body,),) = returned_messages  # pylint: disable=E0632
+        ((
+            channel,
+            method,
+            properties,
+            body,
+        ),) = returned_messages  # pylint: disable=E0632
         self.assertIs(channel, ch)
         self.assertIsInstance(method, pika.spec.Basic.Return)
         self.assertEqual(method.reply_code, 312)
@@ -1543,9 +1599,8 @@ class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        exg_name = (
-            'TestUnroutableMessageReturnedInNonPubackMode_exg_'
-            + uuid.uuid1().hex)
+        exg_name = ('TestUnroutableMessageReturnedInNonPubackMode_exg_' +
+                    uuid.uuid1().hex)
         routing_key = 'TestUnroutableMessageReturnedInNonPubackMode'
 
         # Declare a new exchange
@@ -1554,12 +1609,17 @@ class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
 
         # Register on-return callback
         returned_messages = []
-        ch.add_on_return_callback(
-            lambda *args: returned_messages.append(args))
+        ch.add_on_return_callback(lambda *args: returned_messages.append(args))
 
         # Emit unroutable messages without pubacks
-        ch.basic_publish(exg_name, routing_key=routing_key, body='msg1', mandatory=True)
-        ch.basic_publish(exg_name, routing_key=routing_key, body='msg2', mandatory=True)
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
+                         body='msg1',
+                         mandatory=True)
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
+                         body='msg2',
+                         mandatory=True)
 
         # Process I/O until Basic.Return are dispatched
         while len(returned_messages) < 2:
@@ -1570,7 +1630,12 @@ class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
         self.assertEqual(len(ch._pending_events), 0)
 
         # Verify returned messages
-        (channel, method, properties, body,) = returned_messages[0]
+        (
+            channel,
+            method,
+            properties,
+            body,
+        ) = returned_messages[0]
         self.assertIs(channel, ch)
         self.assertIsInstance(method, pika.spec.Basic.Return)
         self.assertEqual(method.reply_code, 312)
@@ -1579,7 +1644,12 @@ class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
         self.assertIsInstance(properties, pika.BasicProperties)
         self.assertEqual(body, as_bytes('msg1'))
 
-        (channel, method, properties, body,) = returned_messages[1]
+        (
+            channel,
+            method,
+            properties,
+            body,
+        ) = returned_messages[1]
         self.assertIs(channel, ch)
         self.assertIsInstance(method, pika.spec.Basic.Return)
         self.assertEqual(method.reply_code, 312)
@@ -1597,9 +1667,8 @@ class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        exg_name = (
-            'TestUnroutableMessageReturnedInPubackMode_exg_'
-            + uuid.uuid1().hex)
+        exg_name = ('TestUnroutableMessageReturnedInPubackMode_exg_' +
+                    uuid.uuid1().hex)
         routing_key = 'TestUnroutableMessageReturnedInPubackMode'
 
         # Declare a new exchange
@@ -1611,15 +1680,18 @@ class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
 
         # Register on-return callback
         returned_messages = []
-        ch.add_on_return_callback(
-            lambda *args: returned_messages.append(args))
+        ch.add_on_return_callback(lambda *args: returned_messages.append(args))
 
         # Emit unroutable messages with pubacks
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(exg_name, routing_key=routing_key, body='msg1',
+            ch.basic_publish(exg_name,
+                             routing_key=routing_key,
+                             body='msg1',
                              mandatory=True)
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(exg_name, routing_key=routing_key, body='msg2',
+            ch.basic_publish(exg_name,
+                             routing_key=routing_key,
+                             body='msg2',
                              mandatory=True)
 
         # Verify that unroutable messages are already in pending events
@@ -1638,7 +1710,12 @@ class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
         self.assertEqual(len(ch._pending_events), 0)
 
         # Verify returned messages
-        (channel, method, properties, body,) = returned_messages[0]
+        (
+            channel,
+            method,
+            properties,
+            body,
+        ) = returned_messages[0]
         self.assertIs(channel, ch)
         self.assertIsInstance(method, pika.spec.Basic.Return)
         self.assertEqual(method.reply_code, 312)
@@ -1647,7 +1724,12 @@ class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
         self.assertIsInstance(properties, pika.BasicProperties)
         self.assertEqual(body, as_bytes('msg1'))
 
-        (channel, method, properties, body,) = returned_messages[1]
+        (
+            channel,
+            method,
+            properties,
+            body,
+        ) = returned_messages[1]
         self.assertIs(channel, ch)
         self.assertIsInstance(method, pika.spec.Basic.Return)
         self.assertEqual(method.reply_code, 312)
@@ -1682,7 +1764,8 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
         ch.queue_bind(q_name, exchange=exg_name, routing_key=routing_key)
 
         # Attempt to send an unroutable message in the queue via basic_publish
-        ch.basic_publish(exg_name, routing_key='',
+        ch.basic_publish(exg_name,
+                         routing_key='',
                          body='unroutable-message',
                          mandatory=True)
 
@@ -1690,7 +1773,8 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
         connection.channel().close()
 
         # Deposit a routable message in the queue
-        ch.basic_publish(exg_name, routing_key=routing_key,
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
                          body='routable-message',
                          mandatory=True)
 
@@ -1758,13 +1842,16 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
         msg1_headers = dict(
             test_name='TestPublishAndConsumeWithPubacksAndQosOfOne')
         msg1_properties = pika.spec.BasicProperties(headers=msg1_headers)
-        ch.basic_publish(exg_name, routing_key=routing_key,
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
                          body='via-basic_publish',
                          properties=msg1_properties,
                          mandatory=True)
 
         # Deposit another message in the queue
-        ch.basic_publish(exg_name, routing_key, body='via-publish',
+        ch.basic_publish(exg_name,
+                         routing_key,
+                         body='via-publish',
                          mandatory=True)
 
         # Check that the queue now has two messages
@@ -1776,12 +1863,11 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
 
         # Create a consumer
         rx_messages = []
-        consumer_tag = ch.basic_consume(
-            q_name,
-            lambda *args: rx_messages.append(args),
-            auto_ack=False,
-            exclusive=False,
-            arguments=None)
+        consumer_tag = ch.basic_consume(q_name,
+                                        lambda *args: rx_messages.append(args),
+                                        auto_ack=False,
+                                        exclusive=False,
+                                        arguments=None)
 
         # Wait for first message to arrive
         while not rx_messages:
@@ -1901,13 +1987,14 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
 
         # Create a consumer
         rx_messages = []
-        def ackAndEnqueueMessageViaAnotherThread(rx_ch,
-                                                 rx_method,
-                                                 rx_properties, # pylint: disable=W0613
-                                                 rx_body):
-            LOGGER.debug(
-                '%s: Got message body=%r; delivery-tag=%r',
-                datetime.now(), rx_body, rx_method.delivery_tag)
+
+        def ackAndEnqueueMessageViaAnotherThread(
+                rx_ch,
+                rx_method,
+                rx_properties,  # pylint: disable=W0613
+                rx_body):
+            LOGGER.debug('%s: Got message body=%r; delivery-tag=%r',
+                         datetime.now(), rx_body, rx_method.delivery_tag)
 
             # Request ACK dispatch via add_callback_threadsafe from other
             # thread; if last message, cancel consumer so that start_consuming
@@ -1915,9 +2002,7 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
 
             def processOnConnectionThread():
                 LOGGER.debug('%s: ACKing message body=%r; delivery-tag=%r',
-                             datetime.now(),
-                             rx_body,
-                             rx_method.delivery_tag)
+                             datetime.now(), rx_body, rx_method.delivery_tag)
                 ch.basic_ack(delivery_tag=rx_method.delivery_tag,
                              multiple=False)
                 rx_messages.append(rx_body)
@@ -1925,32 +2010,28 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
                 # NOTE on python3, `b'last-msg' != 'last-msg'`
                 if rx_body == b'last-msg':
                     LOGGER.debug('%s: Canceling consumer consumer-tag=%r',
-                                 datetime.now(),
-                                 rx_method.consumer_tag)
+                                 datetime.now(), rx_method.consumer_tag)
                     rx_ch.basic_cancel(rx_method.consumer_tag)
 
             # Spawn a thread to initiate ACKing
-            timer = threading.Timer(0,
-                                    lambda: connection.add_callback_threadsafe(
-                                        processOnConnectionThread))
+            timer = threading.Timer(
+                0, lambda: connection.add_callback_threadsafe(
+                    processOnConnectionThread))
             self.addCleanup(timer.cancel)
             timer.start()
 
-        consumer_tag = ch.basic_consume(
-            q_name,
-            ackAndEnqueueMessageViaAnotherThread,
-            auto_ack=False,
-            exclusive=False,
-            arguments=None)
+        consumer_tag = ch.basic_consume(q_name,
+                                        ackAndEnqueueMessageViaAnotherThread,
+                                        auto_ack=False,
+                                        exclusive=False,
+                                        arguments=None)
 
         # Wait for both messages
         LOGGER.debug('%s: calling start_consuming(); consumer tag=%r',
-                     datetime.now(),
-                     consumer_tag)
+                     datetime.now(), consumer_tag)
         ch.start_consuming()
         LOGGER.debug('%s: Returned from start_consuming(); consumer tag=%r',
-                     datetime.now(),
-                     consumer_tag)
+                     datetime.now(), consumer_tag)
 
         self.assertEqual(len(rx_messages), 2)
         self.assertEqual(rx_messages[0], b'msg1')
@@ -1998,13 +2079,14 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
 
         # Create a consumer
         rx_messages = []
-        def ackAndEnqueueMessageViaAnotherThread(rx_ch,
-                                                 rx_method,
-                                                 rx_properties, # pylint: disable=W0613
-                                                 rx_body):
-            LOGGER.debug(
-                '%s: Got message body=%r; delivery-tag=%r',
-                datetime.now(), rx_body, rx_method.delivery_tag)
+
+        def ackAndEnqueueMessageViaAnotherThread(
+                rx_ch,
+                rx_method,
+                rx_properties,  # pylint: disable=W0613
+                rx_body):
+            LOGGER.debug('%s: Got message body=%r; delivery-tag=%r',
+                         datetime.now(), rx_body, rx_method.delivery_tag)
 
             # Request ACK dispatch via add_callback_threadsafe from other
             # thread; if last message, cancel consumer so that consumer
@@ -2012,9 +2094,7 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
 
             def processOnConnectionThread():
                 LOGGER.debug('%s: ACKing message body=%r; delivery-tag=%r',
-                             datetime.now(),
-                             rx_body,
-                             rx_method.delivery_tag)
+                             datetime.now(), rx_body, rx_method.delivery_tag)
                 ch.basic_ack(delivery_tag=rx_method.delivery_tag,
                              multiple=False)
                 rx_messages.append(rx_body)
@@ -2022,16 +2102,15 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
                 # NOTE on python3, `b'last-msg' != 'last-msg'`
                 if rx_body == b'last-msg':
                     LOGGER.debug('%s: Canceling consumer consumer-tag=%r',
-                                 datetime.now(),
-                                 rx_method.consumer_tag)
+                                 datetime.now(), rx_method.consumer_tag)
                     # NOTE Need to use cancel() for the consumer generator
                     # instead of basic_cancel()
                     rx_ch.cancel()
 
             # Spawn a thread to initiate ACKing
-            timer = threading.Timer(0,
-                                    lambda: connection.add_callback_threadsafe(
-                                        processOnConnectionThread))
+            timer = threading.Timer(
+                0, lambda: connection.add_callback_threadsafe(
+                    processOnConnectionThread))
             self.addCleanup(timer.cancel)
             timer.start()
 
@@ -2079,11 +2158,17 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
         # Deposit messages in the queues
         q1_tx_message_bodies = ['q1_message+%s' % (i,) for i in range(100)]
         for message_body in q1_tx_message_bodies:
-            ch.basic_publish(exg_name, q1_routing_key, body=message_body, mandatory=True)
+            ch.basic_publish(exg_name,
+                             q1_routing_key,
+                             body=message_body,
+                             mandatory=True)
 
         q2_tx_message_bodies = ['q2_message+%s' % (i,) for i in range(150)]
         for message_body in q2_tx_message_bodies:
-            ch.basic_publish(exg_name, q2_routing_key, body=message_body, mandatory=True)
+            ch.basic_publish(exg_name,
+                             q2_routing_key,
+                             body=message_body,
+                             mandatory=True)
 
         # Create the consumers
         q1_rx_messages = []
@@ -2110,9 +2195,7 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
         self.assertEqual(len(q2_rx_messages), len(q2_tx_message_bodies))
 
         # Verify the messages
-        def validate_messages(rx_messages,
-                              routing_key,
-                              consumer_tag,
+        def validate_messages(rx_messages, routing_key, consumer_tag,
                               tx_message_bodies):
             self.assertEqual(len(rx_messages), len(tx_message_bodies))
 
@@ -2148,7 +2231,7 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
 class TestBasicCancelPurgesPendingConsumerCancellationEvt(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_cancel purges pending _ConsumerCancellationEvt""" # pylint: disable=C0301
+        """BlockingChannel.basic_cancel purges pending _ConsumerCancellationEvt"""  # pylint: disable=C0301
         connection = self._connect()
 
         ch = connection.channel()
@@ -2158,14 +2241,16 @@ class TestBasicCancelPurgesPendingConsumerCancellationEvt(BlockingTestCaseBase):
 
         ch.queue_declare(q_name, exclusive=True)
 
-        ch.basic_publish('', routing_key=q_name, body='via-publish', mandatory=True)
+        ch.basic_publish('',
+                         routing_key=q_name,
+                         body='via-publish',
+                         mandatory=True)
 
         # Create a consumer. Not passing a 'callback' to test client-generated
         # consumer tags
         rx_messages = []
-        consumer_tag = ch.basic_consume(
-            q_name,
-            lambda *args: rx_messages.append(args))
+        consumer_tag = ch.basic_consume(q_name,
+                                        lambda *args: rx_messages.append(args))
 
         # Wait for the published message to arrive, but don't consume it
         while not ch._pending_events:
@@ -2217,16 +2302,17 @@ class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
         ch.queue_bind(q_name, exchange=exg_name, routing_key=routing_key)
 
         # Deposit a message in the queue with mandatory=True
-        msg1_headers = dict(
-            test_name='TestBasicPublishWithoutPubacks')
+        msg1_headers = dict(test_name='TestBasicPublishWithoutPubacks')
         msg1_properties = pika.spec.BasicProperties(headers=msg1_headers)
-        ch.basic_publish(exg_name, routing_key=routing_key,
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
                          body='via-basic_publish_mandatory=True',
                          properties=msg1_properties,
                          mandatory=True)
 
         # Deposit a message in the queue with mandatory=False
-        ch.basic_publish(exg_name, routing_key=routing_key,
+        ch.basic_publish(exg_name,
+                         routing_key=routing_key,
                          body='via-basic_publish_mandatory=False',
                          mandatory=False)
 
@@ -2238,12 +2324,11 @@ class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
         # Create a consumer. Not passing a 'callback' to test client-generated
         # consumer tags
         rx_messages = []
-        consumer_tag = ch.basic_consume(
-            q_name,
-            lambda *args: rx_messages.append(args),
-            auto_ack=False,
-            exclusive=False,
-            arguments=None)
+        consumer_tag = ch.basic_consume(q_name,
+                                        lambda *args: rx_messages.append(args),
+                                        auto_ack=False,
+                                        exclusive=False,
+                                        arguments=None)
 
         # Wait for first message to arrive
         while not rx_messages:
@@ -2318,10 +2403,10 @@ class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        src_q_name = (
-            'TestPublishFromBasicConsumeCallback_src_q' + uuid.uuid1().hex)
-        dest_q_name = (
-            'TestPublishFromBasicConsumeCallback_dest_q' + uuid.uuid1().hex)
+        src_q_name = ('TestPublishFromBasicConsumeCallback_src_q' +
+                      uuid.uuid1().hex)
+        dest_q_name = ('TestPublishFromBasicConsumeCallback_dest_q' +
+                       uuid.uuid1().hex)
 
         # Place channel in publisher-acknowledgments mode so that publishing
         # with mandatory=True will be synchronous
@@ -2339,9 +2424,11 @@ class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
 
         # Create a consumer
         def on_consume(channel, method, props, body):
-            channel.basic_publish(
-                '', routing_key=dest_q_name, body=body,
-                properties=props, mandatory=True)
+            channel.basic_publish('',
+                                  routing_key=dest_q_name,
+                                  body=body,
+                                  properties=props,
+                                  mandatory=True)
             channel.basic_ack(method.delivery_tag)
 
         ch.basic_consume(src_q_name,
@@ -2367,8 +2454,8 @@ class TestStopConsumingFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestStopConsumingFromBasicConsumeCallback_q' + uuid.uuid1().hex)
+        q_name = ('TestStopConsumingFromBasicConsumeCallback_q' +
+                  uuid.uuid1().hex)
 
         # Place channel in publisher-acknowledgments mode so that publishing
         # with mandatory=True will be synchronous
@@ -2422,8 +2509,8 @@ class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestCloseChannelFromBasicConsumeCallback_q' + uuid.uuid1().hex)
+        q_name = ('TestCloseChannelFromBasicConsumeCallback_q' +
+                  uuid.uuid1().hex)
 
         # Place channel in publisher-acknowledgments mode so that publishing
         # with mandatory=True will be synchronous
@@ -2457,7 +2544,6 @@ class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
 
         self.assertTrue(ch.is_closed)
 
-
         # Verify that both messages are present in the queue
         ch = connection.channel()
         _, _, rx_body = ch.basic_get(q_name)
@@ -2475,8 +2561,8 @@ class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestCloseConnectionFromBasicConsumeCallback_q' + uuid.uuid1().hex)
+        q_name = ('TestCloseConnectionFromBasicConsumeCallback_q' +
+                  uuid.uuid1().hex)
 
         # Place channel in publisher-acknowledgments mode so that publishing
         # with mandatory=True will be synchronous
@@ -2512,7 +2598,6 @@ class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
         self.assertTrue(ch.is_closed)
         self.assertTrue(connection.is_closed)
 
-
         # Verify that both messages are present in the queue
         ch = self._connect().channel()
         _, _, rx_body = ch.basic_get(q_name)
@@ -2521,7 +2606,8 @@ class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
         self.assertEqual(rx_body, as_bytes('via-publish2'))
 
 
-class TestStartConsumingRaisesChannelClosedOnSameChannelFailure(BlockingTestCaseBase):
+class TestStartConsumingRaisesChannelClosedOnSameChannelFailure(
+        BlockingTestCaseBase):
 
     def test(self):
         """start_consuming() exits with ChannelClosed exception on same channel failure
@@ -2549,11 +2635,8 @@ class TestStartConsumingRaisesChannelClosedOnSameChannelFailure(BlockingTestCase
         # Schedule a callback that will cause a channel error on the consumer's
         # channel by publishing to an unknown exchange. This will cause the
         # broker to close our channel.
-        connection.add_callback_threadsafe(
-            lambda: ch.basic_publish(
-                exchange=q_name,
-                routing_key='123',
-                body=b'Nope this is wrong'))
+        connection.add_callback_threadsafe(lambda: ch.basic_publish(
+            exchange=q_name, routing_key='123', body=b'Nope this is wrong'))
 
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker):
             ch.start_consuming()
@@ -2568,8 +2651,8 @@ class TestStartConsumingReturnsAfterCancelFromBroker(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestStartConsumingExitsOnCancelFromBroker_q' + uuid.uuid1().hex)
+        q_name = ('TestStartConsumingExitsOnCancelFromBroker_q' +
+                  uuid.uuid1().hex)
 
         # Declare the queue
         ch.queue_declare(q_name, exclusive=True)
@@ -2610,7 +2693,8 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
         LOGGER.info('Published message body size=%s', len(body))
 
         # Consume the message
-        for rx_method, rx_props, rx_body in ch.consume(q_name, auto_ack=False,
+        for rx_method, rx_props, rx_body in ch.consume(q_name,
+                                                       auto_ack=False,
                                                        exclusive=False,
                                                        arguments=None):
             self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
@@ -2703,8 +2787,7 @@ class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestBasicCancelWithNonAckableConsumer_q' + uuid.uuid1().hex)
+        q_name = ('TestBasicCancelWithNonAckableConsumer_q' + uuid.uuid1().hex)
 
         body1 = 'a' * 1024
         body2 = 'b' * 2048
@@ -2722,8 +2805,11 @@ class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
                                                       expected_count=2)
 
         # Create a consumer that uses automatic ack mode
-        consumer_tag = ch.basic_consume(q_name, lambda *x: None, auto_ack=True,
-                                        exclusive=False, arguments=None)
+        consumer_tag = ch.basic_consume(q_name,
+                                        lambda *x: None,
+                                        auto_ack=True,
+                                        exclusive=False,
+                                        arguments=None)
 
         # Wait for all messages to be sent by broker to client
         self._assert_exact_message_count_with_retries(channel=ch,
@@ -2759,8 +2845,7 @@ class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        q_name = (
-            'TestBasicCancelWithAckableConsumer_q' + uuid.uuid1().hex)
+        q_name = ('TestBasicCancelWithAckableConsumer_q' + uuid.uuid1().hex)
 
         body1 = 'a' * 1024
         body2 = 'b' * 2048
@@ -2778,8 +2863,11 @@ class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
                                                       expected_count=2)
 
         # Create an ackable consumer
-        consumer_tag = ch.basic_consume(q_name, lambda *x: None, auto_ack=False,
-                                        exclusive=False, arguments=None)
+        consumer_tag = ch.basic_consume(q_name,
+                                        lambda *x: None,
+                                        auto_ack=False,
+                                        exclusive=False,
+                                        arguments=None)
 
         # Wait for all messages to be sent by broker to client
         self._assert_exact_message_count_with_retries(channel=ch,
@@ -2825,8 +2913,11 @@ class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
         # Consume the events, but don't ack
         rx_messages = []
-        ch.basic_consume(q_name, lambda *args: rx_messages.append(args),
-                         auto_ack=False, exclusive=False, arguments=None)
+        ch.basic_consume(q_name,
+                         lambda *args: rx_messages.append(args),
+                         auto_ack=False,
+                         exclusive=False,
+                         arguments=None)
         while len(rx_messages) != 2:
             connection.process_data_events(time_limit=None)
 
@@ -2871,7 +2962,9 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
         # Consume, but don't ack
         num_messages = 0
-        for rx_method, _, _ in ch.consume(q_name, auto_ack=True, exclusive=False):
+        for rx_method, _, _ in ch.consume(q_name,
+                                          auto_ack=True,
+                                          exclusive=False):
             num_messages += 1
 
             self.assertEqual(rx_method.delivery_tag, num_messages)
@@ -2942,7 +3035,8 @@ class TestConsumeGeneratorInterruptedByCancelFromBroker(BlockingTestCaseBase):
         self.assertIsNone(ch._queue_consumer_generator)
 
 
-class TestConsumeGeneratorCancelEncountersCancelFromBroker(BlockingTestCaseBase):
+class TestConsumeGeneratorCancelEncountersCancelFromBroker(
+        BlockingTestCaseBase):
 
     def test(self):
         """BlockingChannel consume generator cancel called when broker's Cancel is enqueued """
@@ -2967,8 +3061,9 @@ class TestConsumeGeneratorCancelEncountersCancelFromBroker(BlockingTestCaseBase)
                 connection.process_data_events()
 
             # Confirm it's Basic.Cancel
-            self.assertIsInstance(ch._queue_consumer_generator.pending_events[0],
-                                  blocking_connection._ConsumerCancellationEvt)
+            self.assertIsInstance(
+                ch._queue_consumer_generator.pending_events[0],
+                blocking_connection._ConsumerCancellationEvt)
 
             # Now attempt to cancel the consumer generator
             ch.cancel()
@@ -2976,7 +3071,8 @@ class TestConsumeGeneratorCancelEncountersCancelFromBroker(BlockingTestCaseBase)
             self.assertIsNone(ch._queue_consumer_generator)
 
 
-class TestConsumeGeneratorPassesChannelClosedOnSameChannelFailure(BlockingTestCaseBase):
+class TestConsumeGeneratorPassesChannelClosedOnSameChannelFailure(
+        BlockingTestCaseBase):
 
     def test(self):
         """consume() exits with ChannelClosed exception on same channel failure
@@ -2998,11 +3094,8 @@ class TestConsumeGeneratorPassesChannelClosedOnSameChannelFailure(BlockingTestCa
         # Schedule a callback that will cause a channel error on the consumer's
         # channel by publishing to an unknown exchange. This will cause the
         # broker to close our channel.
-        connection.add_callback_threadsafe(
-            lambda: ch.basic_publish(
-                exchange=q_name,
-                routing_key='123',
-                body=b'Nope this is wrong'))
+        connection.add_callback_threadsafe(lambda: ch.basic_publish(
+            exchange=q_name, routing_key='123', body=b'Nope this is wrong'))
 
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker):
             for _ in ch.consume(q_name):
@@ -3042,7 +3135,9 @@ class TestChannelFlow(BlockingTestCaseBase):
         self.assertEqual(frame.method.consumer_count, 1)
 
 
-class TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel(BlockingTestCaseBase):
+class TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel(
+        BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: Declaring queue on closed channel raises ChannelWrongStateError"""
         q_name = (
@@ -3056,6 +3151,7 @@ class TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel(BlockingTestC
 
 
 class TestChannelRaisesWrongStateWhenClosingClosedChannel(BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: Closing closed channel raises ChannelWrongStateError"""
         channel = self._connect().channel()
@@ -3065,6 +3161,7 @@ class TestChannelRaisesWrongStateWhenClosingClosedChannel(BlockingTestCaseBase):
 
 
 class TestChannelContextManagerClosesChannel(BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: chanel context manager exit survives closed channel"""
         with self._connect().channel() as channel:
@@ -3074,6 +3171,7 @@ class TestChannelContextManagerClosesChannel(BlockingTestCaseBase):
 
 
 class TestChannelContextManagerExitSurvivesClosedChannel(BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: chanel context manager exit survives closed channel"""
         with self._connect().channel() as channel:
@@ -3086,6 +3184,7 @@ class TestChannelContextManagerExitSurvivesClosedChannel(BlockingTestCaseBase):
 
 class TestChannelContextManagerDoesNotSuppressChannelClosedByBroker(
         BlockingTestCaseBase):
+
     def test(self):
         """BlockingConnection: chanel context manager doesn't suppress ChannelClosedByBroker exception"""
 

--- a/tests/acceptance/enforce_one_basicget_test.py
+++ b/tests/acceptance/enforce_one_basicget_test.py
@@ -8,6 +8,7 @@ from pika.connection import Connection
 
 
 class OnlyOneBasicGetTestCase(unittest.TestCase):
+
     def setUp(self):
         self.channel = Channel(MagicMock(Connection)(), 0, None)
         self.channel._state = Channel.OPEN
@@ -24,6 +25,7 @@ class OnlyOneBasicGetTestCase(unittest.TestCase):
         self.channel.basic_get('test-queue', self.callback)
         with self.assertRaises(DuplicateGetOkCallback):
             self.channel.basic_get('test-queue', self.callback)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -87,7 +87,10 @@ class AsyncServicesTestBase(unittest.TestCase):
             sock.connect(addr_pair)
         except pika.compat.SOCKET_ERROR as error:
             # EINPROGRESS for posix and EWOULDBLOCK for windows
-            if error.errno not in (errno.EINPROGRESS, errno.EWOULDBLOCK,):
+            if error.errno not in (
+                    errno.EINPROGRESS,
+                    errno.EWOULDBLOCK,
+            ):
                 raise
 
     def get_dead_socket_address(self):
@@ -102,8 +105,7 @@ class AsyncServicesTestBase(unittest.TestCase):
         return s1.getsockname()  # pylint: disable=E1101
 
 
-class TestGetNativeIOLoop(AsyncServicesTestBase,
-                          IOServicesTestStubs):
+class TestGetNativeIOLoop(AsyncServicesTestBase, IOServicesTestStubs):
 
     def start(self):
         native_loop = self.create_nbio().get_native_ioloop()
@@ -144,7 +146,8 @@ class TestCallLaterDoesNotCallAheadOfTime(AsyncServicesTestBase,
         start_time = pika.compat.time_now()
         loop.call_later(0.1, callback)
         loop.run()
-        self.assertGreaterEqual(round(pika.compat.time_now() - start_time, 3), 0.1)
+        self.assertGreaterEqual(round(pika.compat.time_now() - start_time, 3),
+                                0.1)
         self.assertEqual(bucket, ['I was here'])
 
 
@@ -174,8 +177,7 @@ class TestCallLaterCancelTwiceFromOwnCallback(AsyncServicesTestBase,
         self.assertEqual(bucket, ['I was here'])
 
 
-class TestCallLaterCallInOrder(AsyncServicesTestBase,
-                               IOServicesTestStubs):
+class TestCallLaterCallInOrder(AsyncServicesTestBase, IOServicesTestStubs):
 
     def start(self):
         loop = self.create_nbio()
@@ -204,10 +206,8 @@ class TestCallLaterCancelledDoesNotCallBack(AsyncServicesTestBase,
 
 class SocketWatcherTestBase(AsyncServicesTestBase):
 
-    WatcherActivity = collections.namedtuple(
-        "io_services_test_WatcherActivity",
-        ['readable', 'writable'])
-
+    WatcherActivity = collections.namedtuple("io_services_test_WatcherActivity",
+                                             ['readable', 'writable'])
 
     def _check_socket_watchers_fired(self, sock, expected):  # pylint: disable=R0914
         """Registers reader and writer for the given socket, runs the event loop
@@ -221,24 +221,28 @@ class SocketWatcherTestBase(AsyncServicesTestBase):
         nbio = self.create_nbio()  # pylint: disable=E1101
 
         stops_requested = []
+
         def stop_loop():
             if not stops_requested:
                 nbio.stop()
             stops_requested.append(1)
 
         reader_bucket = [False]
+
         def on_readable():
             self.logger.debug('on_readable() called.')
             reader_bucket.append(True)
             stop_loop()
 
         writer_bucket = [False]
+
         def on_writable():
             self.logger.debug('on_writable() called.')
             writer_bucket.append(True)
             stop_loop()
 
         timeout_bucket = []
+
         def on_timeout():
             timeout_bucket.append(True)
             stop_loop()
@@ -263,16 +267,12 @@ class SocketWatcherTestBase(AsyncServicesTestBase):
         if readable != expected.readable:
             raise AssertionError(
                 'Expected readable={!r}, but got {!r} (writable={!r})'.format(
-                    expected.readable,
-                    readable,
-                    writable))
+                    expected.readable, readable, writable))
 
         if writable != expected.writable:
             raise AssertionError(
                 'Expected writable={!r}, but got {!r} (readable={!r})'.format(
-                    expected.writable,
-                    writable,
-                    readable))
+                    expected.writable, writable, readable))
 
 
 class TestSocketWatchersUponConnectionAndNoIncomingData(SocketWatcherTestBase,
@@ -285,9 +285,8 @@ class TestSocketWatchersUponConnectionAndNoIncomingData(SocketWatcherTestBase,
         self._check_socket_watchers_fired(s1, expected)
 
 
-class TestSocketWatchersUponConnectionAndIncomingData(
-        SocketWatcherTestBase,
-        IOServicesTestStubs):
+class TestSocketWatchersUponConnectionAndIncomingData(SocketWatcherTestBase,
+                                                      IOServicesTestStubs):
 
     def start(self):
         s1, s2 = self.create_blocking_socketpair()
@@ -299,6 +298,7 @@ class TestSocketWatchersUponConnectionAndIncomingData(
 
 class TestSocketWatchersWhenFailsToConnect(SocketWatcherTestBase,
                                            IOServicesTestStubs):
+
     def start(self):
         sock = self.create_nonblocking_tcp_socket()
 
@@ -326,8 +326,7 @@ class TestSocketWatchersAfterRemotePeerCloses(SocketWatcherTestBase,
 
 
 class TestSocketWatchersAfterRemotePeerClosesWithIncomingData(
-        SocketWatcherTestBase,
-        IOServicesTestStubs):
+        SocketWatcherTestBase, IOServicesTestStubs):
 
     def start(self):
         s1, s2 = self.create_blocking_socketpair()
@@ -361,8 +360,7 @@ class TestSocketWatchersAfterRemotePeerShutsWrite(SocketWatcherTestBase,
 
 
 class TestSocketWatchersAfterRemotePeerShutsWriteWithIncomingData(
-        SocketWatcherTestBase,
-        IOServicesTestStubs):
+        SocketWatcherTestBase, IOServicesTestStubs):
 
     def start(self):
         s1, s2 = self.create_blocking_socketpair()
@@ -431,11 +429,13 @@ class TestGetaddrinfoWWWGoogleDotComPort80(AsyncServicesTestBase,
         nbio = self.create_nbio()
 
         result_bucket = []
+
         def on_done(result):
             result_bucket.append(result)
             nbio.stop()
 
-        ref = nbio.getaddrinfo('www.google.com', 80,
+        ref = nbio.getaddrinfo('www.google.com',
+                               80,
                                socktype=socket.SOCK_STREAM,
                                on_done=on_done)
 
@@ -474,13 +474,16 @@ class TestGetaddrinfoNonExistentHost(AsyncServicesTestBase,
         nbio = self.create_nbio()
 
         result_bucket = []
+
         def on_done(result):
             result_bucket.append(result)
             nbio.stop()
 
-        ref = nbio.getaddrinfo('www.google.comSSS', 80,
+        ref = nbio.getaddrinfo('www.google.comSSS',
+                               80,
                                socktype=socket.SOCK_STREAM,
-                               proto=socket.IPPROTO_TCP, on_done=on_done)
+                               proto=socket.IPPROTO_TCP,
+                               on_done=on_done)
 
         nbio.run()
 
@@ -506,10 +509,12 @@ class TestGetaddrinfoCancelBeforeLoopRun(AsyncServicesTestBase,
         nbio = self.create_nbio()
 
         on_done_bucket = []
+
         def on_done(result):
             on_done_bucket.append(result)
 
-        ref = nbio.getaddrinfo('www.google.com', 80,
+        ref = nbio.getaddrinfo('www.google.com',
+                               80,
                                socktype=socket.SOCK_STREAM,
                                on_done=on_done)
 
@@ -535,6 +540,7 @@ class TestGetaddrinfoCancelAfterLoopRun(AsyncServicesTestBase,
         nbio = self.create_nbio()
 
         on_done_bucket = []
+
         def on_done(result):
             self.logger.error(
                 'Unexpected completion of cancelled getaddrinfo()')
@@ -546,6 +552,7 @@ class TestGetaddrinfoCancelAfterLoopRun(AsyncServicesTestBase,
         # avoid the race condition wehreby it invokes our completion callback
         # before we had a chance to cancel it.
         cancel_result_bucket = []
+
         def cancel_and_stop_from_loop():
             self.logger.debug('Cancelling getaddrinfo() from loop callback.')
             cancel_result_bucket.append(getaddr_ref.cancel())
@@ -553,7 +560,8 @@ class TestGetaddrinfoCancelAfterLoopRun(AsyncServicesTestBase,
 
         nbio.add_callback_threadsafe(cancel_and_stop_from_loop)
 
-        getaddr_ref = nbio.getaddrinfo('www.google.com', 80,
+        getaddr_ref = nbio.getaddrinfo('www.google.com',
+                                       80,
                                        socktype=socket.SOCK_STREAM,
                                        on_done=on_done)
 
@@ -578,8 +586,8 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
         # Create listener
         lsock = socket.socket(family, socket.SOCK_STREAM)
         self.addCleanup(lsock.close)
-        ipaddr = (pika.compat._LOCALHOST_V6 if family == socket.AF_INET6
-                  else pika.compat._LOCALHOST)
+        ipaddr = (pika.compat._LOCALHOST_V6
+                  if family == socket.AF_INET6 else pika.compat._LOCALHOST)
         lsock.bind((ipaddr, 0))
         lsock.listen(1)
         # NOTE: don't even need to accept for this test, connection completes
@@ -592,7 +600,6 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
 
         return lsock, csock
 
-
     def check_successful_connect(self, family):
         """
         :param IOServicesTestStubs | SocketConnectorTestBase self:
@@ -604,6 +611,7 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
 
         # Initiate connection
         on_done_result_bucket = []
+
         def on_done(result):
             on_done_result_bucket.append(result)
             nbio.stop()
@@ -632,6 +640,7 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
 
         # Initiate connection
         on_done_result_bucket = []
+
         def on_done(result):
             on_done_result_bucket.append(result)
             nbio.stop()
@@ -657,6 +666,7 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
 
         # Initiate connection
         on_done_result_bucket = []
+
         def on_done(result):
             on_done_result_bucket.append(result)
             self.fail('Got done callacks on cancelled connection request.')
@@ -683,8 +693,7 @@ class TestConnectSocketIPv4Success(SocketConnectorTestBase,
         self.check_successful_connect(family=socket.AF_INET)
 
 
-class TestConnectSocketIPv4Fail(SocketConnectorTestBase,
-                                IOServicesTestStubs):
+class TestConnectSocketIPv4Fail(SocketConnectorTestBase, IOServicesTestStubs):
 
     def start(self):
         self.check_failed_connect(socket.AF_INET)
@@ -692,6 +701,7 @@ class TestConnectSocketIPv4Fail(SocketConnectorTestBase,
 
 class TestConnectSocketToDisconnectedPeer(SocketConnectorTestBase,
                                           IOServicesTestStubs):
+
     def start(self):
         """Differs from `TestConnectSocketIPV4Fail` in that this test attempts
         to connect to the address of a socket whose peer had disconnected from
@@ -709,6 +719,7 @@ class TestConnectSocketToDisconnectedPeer(SocketConnectorTestBase,
 
         # Initiate connection
         on_done_result_bucket = []
+
         def on_done(result):
             on_done_result_bucket.append(result)
             nbio.stop()
@@ -724,8 +735,7 @@ class TestConnectSocketToDisconnectedPeer(SocketConnectorTestBase,
         self.assertEqual(connect_ref.cancel(), False)
 
 
-class TestConnectSocketIPv4Cancel(SocketConnectorTestBase,
-                                  IOServicesTestStubs):
+class TestConnectSocketIPv4Cancel(SocketConnectorTestBase, IOServicesTestStubs):
 
     def start(self):
         self.check_cancel_connect(socket.AF_INET)
@@ -814,22 +824,20 @@ class TestStreamConnectorTxRx(StreamingTestBase, IOServicesTestStubs):
                 socket_connect_done_result_bucket.append(result)
 
                 nbio.create_streaming_connection(
-                    TestStreamConnectorTxRxStreamProtocol,
-                    sock,
+                    TestStreamConnectorTxRxStreamProtocol, sock,
                     on_streaming_creation_done)
 
-            nbio.connect_socket(sock,
-                                echo.server_address,
+            nbio.connect_socket(sock, echo.server_address,
                                 on_socket_connect_done)
 
             nbio.run()
 
         self.assertEqual(socket_connect_done_result_bucket, [None])
 
-        my_proto = my_protocol_bucket[0]  # type: TestStreamConnectorTxRxStreamProtocol
+        my_proto = my_protocol_bucket[
+            0]  # type: TestStreamConnectorTxRxStreamProtocol
         transport, protocol = streaming_connection_result_bucket[0]
-        self.assertIsInstance(transport,
-                              nbio_interface.AbstractStreamTransport)
+        self.assertIsInstance(transport, nbio_interface.AbstractStreamTransport)
         self.assertIs(protocol, my_proto)
         self.assertIs(transport, my_proto.transport)
 
@@ -842,8 +850,7 @@ class TestStreamConnectorTxRx(StreamingTestBase, IOServicesTestStubs):
 
 
 class TestStreamConnectorRaisesValueErrorFromUnconnectedSocket(
-        StreamingTestBase,
-        IOServicesTestStubs):
+        StreamingTestBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -934,19 +941,17 @@ class TestStreamConnectorBrokenPipe(StreamingTestBase, IOServicesTestStubs):
             socket_connect_done_result_bucket.append(result)
 
             nbio.create_streaming_connection(
-                TestStreamConnectorTxRxStreamProtocol,
-                sock,
+                TestStreamConnectorTxRxStreamProtocol, sock,
                 on_streaming_creation_done)
 
-        nbio.connect_socket(sock,
-                            echo.server_address,
-                            on_socket_connect_done)
+        nbio.connect_socket(sock, echo.server_address, on_socket_connect_done)
 
         nbio.run()
 
         self.assertEqual(socket_connect_done_result_bucket, [None])
 
-        my_proto = my_protocol_bucket[0]  # type: TestStreamConnectorTxRxStreamProtocol
+        my_proto = my_protocol_bucket[
+            0]  # type: TestStreamConnectorTxRxStreamProtocol
 
         error = my_proto.connection_lost_error_bucket[0]
         self.assertIsInstance(error, pika.compat.SOCKET_ERROR)
@@ -1005,8 +1010,8 @@ class TestStreamConnectorEOFReceived(StreamingTestBase, IOServicesTestStubs):
         local_sock, remote_sock = self.create_nonblocking_socketpair()
         remote_sock.settimeout(10)
 
-        logger.info('created local_sock=%s, remote_sock=%s',
-                    local_sock, remote_sock)
+        logger.info('created local_sock=%s, remote_sock=%s', local_sock,
+                    remote_sock)
 
         def on_streaming_creation_done(result):
             logger.info('on_streaming_creation_done(%r)', result)
@@ -1015,14 +1020,13 @@ class TestStreamConnectorEOFReceived(StreamingTestBase, IOServicesTestStubs):
             # Simulate EOF
             remote_sock.shutdown(socket.SHUT_WR)
 
-        nbio.create_streaming_connection(
-            TestStreamConnectorTxRxStreamProtocol,
-            local_sock,
-            on_streaming_creation_done)
+        nbio.create_streaming_connection(TestStreamConnectorTxRxStreamProtocol,
+                                         local_sock, on_streaming_creation_done)
 
         nbio.run()
 
-        my_proto = my_protocol_bucket[0]  # type: TestStreamConnectorTxRxStreamProtocol
+        my_proto = my_protocol_bucket[
+            0]  # type: TestStreamConnectorTxRxStreamProtocol
 
         self.assertTrue(my_proto.eof_rx)
         self.assertEqual(my_proto.connection_lost_error_bucket, [None])
@@ -1031,6 +1035,7 @@ class TestStreamConnectorEOFReceived(StreamingTestBase, IOServicesTestStubs):
         # First, purge remote sock in case some or all sent data was delivered
         remote_sock.recv(sum(len(chunk) for chunk in original_data))
         self.assertEqual(remote_sock.recv(1), b'')
+
 
 class TestStreamConnectorProtocolInterfaceFailsBase(StreamingTestBase):
     """Base test class for streaming protocol method fails"""
@@ -1063,8 +1068,8 @@ class TestStreamConnectorProtocolInterfaceFailsBase(StreamingTestBase):
         """
         logger = self.logger
 
-        class TestStreamConnectorProtocol(
-                nbio_interface.AbstractStreamProtocol):
+        class TestStreamConnectorProtocol(nbio_interface.AbstractStreamProtocol
+                                         ):
 
             def __init__(self):
                 self.transport = None  # type: nbio_interface.AbstractStreamTransport
@@ -1112,15 +1117,12 @@ class TestStreamConnectorProtocolInterfaceFailsBase(StreamingTestBase):
                                 proto_data_received_exc)
                     raise proto_data_received_exc  # pylint: disable=E0702
 
-        return nbio.create_streaming_connection(
-            TestStreamConnectorProtocol,
-            sock,
-            on_create_done)
+        return nbio.create_streaming_connection(TestStreamConnectorProtocol,
+                                                sock, on_create_done)
 
 
 class TestStreamConnectorProtocolConstructorFails(
-        TestStreamConnectorProtocolInterfaceFailsBase,
-        IOServicesTestStubs):
+        TestStreamConnectorProtocolInterfaceFailsBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -1152,8 +1154,7 @@ class TestStreamConnectorProtocolConstructorFails(
 
 
 class TestStreamConnectorConnectionMadeFails(
-        TestStreamConnectorProtocolInterfaceFailsBase,
-        IOServicesTestStubs):
+        TestStreamConnectorProtocolInterfaceFailsBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -1185,8 +1186,7 @@ class TestStreamConnectorConnectionMadeFails(
 
 
 class TestStreamConnectorEOFReceivedFails(
-        TestStreamConnectorProtocolInterfaceFailsBase,
-        IOServicesTestStubs):
+        TestStreamConnectorProtocolInterfaceFailsBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -1204,7 +1204,6 @@ class TestStreamConnectorEOFReceivedFails(
 
             # Simulate EOF
             remote_sock.shutdown(socket.SHUT_WR)
-
 
         self.linkup_streaming_connection(
             nbio,
@@ -1225,8 +1224,7 @@ class TestStreamConnectorEOFReceivedFails(
 
 
 class TestStreamConnectorDataReceivedFails(
-        TestStreamConnectorProtocolInterfaceFailsBase,
-        IOServicesTestStubs):
+        TestStreamConnectorProtocolInterfaceFailsBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -1244,7 +1242,6 @@ class TestStreamConnectorDataReceivedFails(
 
             # Simulate EOF
             remote_sock.shutdown(socket.SHUT_WR)
-
 
         self.linkup_streaming_connection(
             nbio,
@@ -1267,8 +1264,7 @@ class TestStreamConnectorDataReceivedFails(
 
 
 class TestStreamConnectorAbortTransport(
-        TestStreamConnectorProtocolInterfaceFailsBase,
-        IOServicesTestStubs):
+        TestStreamConnectorProtocolInterfaceFailsBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -1284,10 +1280,7 @@ class TestStreamConnectorAbortTransport(
             # Abort the transport
             result[0].abort()
 
-
-        self.linkup_streaming_connection(nbio,
-                                         local_sock,
-                                         on_linkup_completed)
+        self.linkup_streaming_connection(nbio, local_sock, on_linkup_completed)
 
         nbio.run()
 
@@ -1301,8 +1294,7 @@ class TestStreamConnectorAbortTransport(
 
 
 class TestStreamConnectorCancelLinkup(
-        TestStreamConnectorProtocolInterfaceFailsBase,
-        IOServicesTestStubs):
+        TestStreamConnectorProtocolInterfaceFailsBase, IOServicesTestStubs):
 
     def start(self):
         nbio = self.create_nbio()
@@ -1315,9 +1307,7 @@ class TestStreamConnectorCancelLinkup(
         def on_linkup_completed(result):
             linkup_result_bucket.append(result)
 
-
-        ref = self.linkup_streaming_connection(nbio,
-                                               local_sock,
+        ref = self.linkup_streaming_connection(nbio, local_sock,
                                                on_linkup_completed)
 
         # NOTE: cancel() completes without callback

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -9,7 +9,6 @@
 
 # Suppress no-member: Twisted's reactor methods are not easily discoverable
 # pylint: disable=E1101
-
 """twisted adapter test"""
 import functools
 import unittest
@@ -19,13 +18,15 @@ import pytest
 from twisted.internet import defer, error as twisted_error, reactor
 from twisted.python.failure import Failure
 
-from pika.adapters.twisted_connection import (
-    ClosableDeferredQueue, TwistedChannel,
-    _TwistedConnectionAdapter, TwistedProtocolConnection, _TimerHandle)
+from pika.adapters.twisted_connection import (ClosableDeferredQueue,
+                                              TwistedChannel,
+                                              _TwistedConnectionAdapter,
+                                              TwistedProtocolConnection,
+                                              _TimerHandle)
 from pika import spec
-from pika.exceptions import (
-    AMQPConnectionError, ConsumerCancelled, DuplicateGetOkCallback, NackError,
-    UnroutableError, ChannelClosedByBroker)
+from pika.exceptions import (AMQPConnectionError, ConsumerCancelled,
+                             DuplicateGetOkCallback, NackError, UnroutableError,
+                             ChannelClosedByBroker)
 from pika.frame import Method
 
 
@@ -35,12 +36,14 @@ class TestCase(unittest.TestCase):
     We only want the assertFailure implementation, using the class directly
     hides some assertion errors.
     """
+
     def assertFailure(self, d, *expectedFailures):
         """
         Fail if C{deferred} does not errback with one of C{expectedFailures}.
         Returns the original Deferred with callbacks added. You will need
         to return this Deferred from your test case.
         """
+
         def _cb(ignore):
             raise self.failureException(
                 "did not catch an error, instead got %r" % (ignore,))
@@ -49,9 +52,10 @@ class TestCase(unittest.TestCase):
             if failure.check(*expectedFailures):
                 return failure.value
             else:
-                output = ('\nExpected: %r\nGot:\n%s'
-                          % (expectedFailures, str(failure)))
+                output = ('\nExpected: %r\nGot:\n%s' %
+                          (expectedFailures, str(failure)))
                 raise self.failureException(output)
+
         return d.addCallbacks(_cb, _eb)
 
 
@@ -111,11 +115,24 @@ class TwistedChannelTestCase(TestCase):
         self.channel = TwistedChannel(self.pika_channel)
         # This is only needed on Python2 for functools.wraps to work.
         wrapped = (
-            "basic_cancel", "basic_get", "basic_qos", "basic_recover",
-            "exchange_bind", "exchange_unbind", "exchange_declare",
-            "exchange_delete", "confirm_delivery", "flow",
-            "queue_bind", "queue_declare", "queue_delete", "queue_purge",
-            "queue_unbind", "tx_commit", "tx_rollback", "tx_select",
+            "basic_cancel",
+            "basic_get",
+            "basic_qos",
+            "basic_recover",
+            "exchange_bind",
+            "exchange_unbind",
+            "exchange_declare",
+            "exchange_delete",
+            "confirm_delivery",
+            "flow",
+            "queue_bind",
+            "queue_declare",
+            "queue_delete",
+            "queue_purge",
+            "queue_unbind",
+            "tx_commit",
+            "tx_rollback",
+            "tx_select",
         )
         for meth_name in wrapped:
             getattr(self.pika_channel, meth_name).__name__ = meth_name
@@ -134,9 +151,7 @@ class TwistedChannelTestCase(TestCase):
         self.pika_channel.add_on_close_callback.assert_called_with(
             self.channel._on_channel_closed)
         calls = self.channel._calls = [defer.Deferred()]
-        consumers = self.channel._consumers = {
-            "test-delivery-tag": mock.Mock()
-        }
+        consumers = self.channel._consumers = {"test-delivery-tag": mock.Mock()}
         error = RuntimeError("testing")
         self.channel._on_channel_closed(None, error)
         consumers["test-delivery-tag"].close.assert_called_once_with(error)
@@ -160,11 +175,11 @@ class TwistedChannelTestCase(TestCase):
             queue_get_d = queue.get()
             queue_get_d.addCallback(
                 self.assertEqual,
-                (self.channel, "testmethod", "testprops", "testbody")
-            )
+                (self.channel, "testmethod", "testprops", "testbody"))
             # Simulate reception of a message
             on_message("testchan", "testmethod", "testprops", "testbody")
             return queue_get_d
+
         d.addCallback(check_cb)
         # Simulate a ConsumeOk from the server
         frame = Method(1, spec.Basic.ConsumeOk(consumer_tag="testconsumertag"))
@@ -194,8 +209,8 @@ class TwistedChannelTestCase(TestCase):
         # Verify Deferreds that haven't had their callback invoked errback when
         # the channel closes.
         d = self.channel.basic_consume(queue="testqueue")
-        self.channel._on_channel_closed(
-            self, ChannelClosedByBroker(404, "NOT FOUND"))
+        self.channel._on_channel_closed(self,
+                                        ChannelClosedByBroker(404, "NOT FOUND"))
         self.assertFailure(d, ChannelClosedByBroker)
         assert d.called
 
@@ -206,9 +221,8 @@ class TwistedChannelTestCase(TestCase):
         self.channel._consumers = {
             "test-delivery-tag": queue_obj,
         }
-        self.channel._queue_name_to_consumer_tags["testqueue"] = set([
-            "test-delivery-tag"
-        ])
+        self.channel._queue_name_to_consumer_tags["testqueue"] = set(
+            ["test-delivery-tag"])
         self.channel._calls = set()
         self.pika_channel.queue_delete.__name__ = "queue_delete"
         d = self.channel.queue_delete(queue="testqueue")
@@ -222,6 +236,7 @@ class TwistedChannelTestCase(TestCase):
             close_call_args = queue_obj.close.call_args_list[0][0]
             self.assertEqual(len(close_call_args), 1)
             self.assertTrue(isinstance(close_call_args[0], ConsumerCancelled))
+
         d.addCallback(check)
         # Simulate a server response
         self.assertEqual(len(self.channel._calls), 1)
@@ -285,8 +300,13 @@ class TwistedChannelTestCase(TestCase):
     def test_passthrough(self):
         # Check the simple attribute passthroughs
         attributes = (
-            "channel_number", "connection", "is_closed", "is_closing",
-            "is_open", "flow_active", "consumer_tags",
+            "channel_number",
+            "connection",
+            "is_closed",
+            "is_closing",
+            "is_open",
+            "flow_active",
+            "consumer_tags",
         )
         for name in attributes:
             value = "testvalue-{}".format(name)
@@ -298,22 +318,21 @@ class TwistedChannelTestCase(TestCase):
         d = defer.Deferred()
         replies = [spec.Basic.CancelOk]
         self.channel.callback_deferred(d, replies)
-        self.pika_channel.add_callback.assert_called_with(
-            d.callback, replies)
+        self.pika_channel.add_callback.assert_called_with(d.callback, replies)
 
     def test_add_on_return_callback(self):
         # Check that the deferred contains the right value.
         cb = mock.Mock()
         self.channel.add_on_return_callback(cb)
         self.pika_channel.add_on_return_callback.assert_called_once()
-        self.pika_channel.add_on_return_callback.call_args[0][0](
-            "testchannel", "testmethod", "testprops", "testbody")
+        self.pika_channel.add_on_return_callback.call_args[0][0]("testchannel",
+                                                                 "testmethod",
+                                                                 "testprops",
+                                                                 "testbody")
         cb.assert_called_once()
         self.assertEqual(len(cb.call_args[0]), 1)
-        self.assertEqual(
-            cb.call_args[0][0],
-            (self.channel, "testmethod", "testprops", "testbody")
-        )
+        self.assertEqual(cb.call_args[0][0],
+                         (self.channel, "testmethod", "testprops", "testbody"))
 
     @pytest.mark.timeout(5)
     def test_basic_cancel(self):
@@ -331,18 +350,17 @@ class TwistedChannelTestCase(TestCase):
         def check(result):
             self.assertTrue(isinstance(result, Method))
             queue_obj.close.assert_called_once()
-            self.assertTrue(isinstance(
-                queue_obj.close.call_args[0][0], ConsumerCancelled))
+            self.assertTrue(
+                isinstance(queue_obj.close.call_args[0][0], ConsumerCancelled))
             self.assertEqual(len(self.channel._consumers), 1)
             queue_obj_2.close.assert_not_called()
             self.assertEqual(
-                self.channel._queue_name_to_consumer_tags["testqueue"],
-                set())
+                self.channel._queue_name_to_consumer_tags["testqueue"], set())
+
         d.addCallback(check)
         self.pika_channel.basic_cancel.assert_called_once()
-        self.pika_channel.basic_cancel.call_args[1]["callback"](
-            Method(1, spec.Basic.CancelOk(consumer_tag="test-consumer"))
-        )
+        self.pika_channel.basic_cancel.call_args[1]["callback"](Method(
+            1, spec.Basic.CancelOk(consumer_tag="test-consumer")))
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -352,11 +370,11 @@ class TwistedChannelTestCase(TestCase):
 
         def check(result):
             self.assertTrue(isinstance(result, Method))
+
         d.addCallback(check)
         self.pika_channel.basic_cancel.assert_called_once()
-        self.pika_channel.basic_cancel.call_args[1]["callback"](
-            Method(1, spec.Basic.CancelOk(consumer_tag="test-consumer"))
-        )
+        self.pika_channel.basic_cancel.call_args[1]["callback"](Method(
+            1, spec.Basic.CancelOk(consumer_tag="test-consumer")))
         assert d.called
 
     def test_consumer_cancelled_by_broker(self):
@@ -365,18 +383,16 @@ class TwistedChannelTestCase(TestCase):
             self.channel._on_consumer_cancelled_by_broker)
         queue_obj = mock.Mock()
         self.channel._consumers["test-consumer"] = queue_obj
-        self.channel._queue_name_to_consumer_tags["testqueue"] = set([
-            "test-consumer"])
+        self.channel._queue_name_to_consumer_tags["testqueue"] = set(
+            ["test-consumer"])
         self.channel._on_consumer_cancelled_by_broker(
-            Method(1, spec.Basic.Cancel(consumer_tag="test-consumer"))
-        )
+            Method(1, spec.Basic.Cancel(consumer_tag="test-consumer")))
         queue_obj.close.assert_called_once()
-        self.assertTrue(isinstance(
-            queue_obj.close.call_args[0][0], ConsumerCancelled))
+        self.assertTrue(
+            isinstance(queue_obj.close.call_args[0][0], ConsumerCancelled))
         self.assertEqual(self.channel._consumers, {})
-        self.assertEqual(
-            self.channel._queue_name_to_consumer_tags["testqueue"],
-            set())
+        self.assertEqual(self.channel._queue_name_to_consumer_tags["testqueue"],
+                         set())
 
     @pytest.mark.timeout(5)
     def test_basic_get(self):
@@ -388,21 +404,19 @@ class TwistedChannelTestCase(TestCase):
 
         def check_cb(result):
             self.assertEqual(
-                result,
-                (self.channel, "testmethod", "testprops", "testbody")
-            )
+                result, (self.channel, "testmethod", "testprops", "testbody"))
+
         d.addCallback(check_cb)
         # Simulate reception of a message
-        kwargs["callback"](
-            "testchannel", "testmethod", "testprops", "testbody")
+        kwargs["callback"]("testchannel", "testmethod", "testprops", "testbody")
         assert d.called
 
     def test_basic_get_twice(self):
         # Verify that the basic_get method raises the proper exception when
         # called twice.
         self.channel.basic_get(queue="testqueue")
-        self.assertRaises(
-            DuplicateGetOkCallback, self.channel.basic_get, "testqueue")
+        self.assertRaises(DuplicateGetOkCallback, self.channel.basic_get,
+                          "testqueue")
 
     @pytest.mark.timeout(5)
     def test_basic_get_empty(self):
@@ -418,8 +432,7 @@ class TwistedChannelTestCase(TestCase):
         # Verify that basic_nack is transmitted properly.
         self.channel.basic_nack("testdeliverytag")
         self.pika_channel.basic_nack.assert_called_once_with(
-            delivery_tag="testdeliverytag",
-            multiple=False, requeue=True)
+            delivery_tag="testdeliverytag", multiple=False, requeue=True)
 
     @pytest.mark.timeout(5)
     def test_basic_publish(self):
@@ -427,14 +440,15 @@ class TwistedChannelTestCase(TestCase):
         args = [object()]
         kwargs = {"routing_key": object(), "body": object()}
         d = self.channel.basic_publish(*args, **kwargs)
-        kwargs.update(dict(
-            # Args are converted to kwargs
-            exchange=args[0],
-            # Defaults
-            mandatory=False, properties=None,
-        ))
-        self.pika_channel.basic_publish.assert_called_once_with(
-            **kwargs)
+        kwargs.update(
+            dict(
+                # Args are converted to kwargs
+                exchange=args[0],
+                # Defaults
+                mandatory=False,
+                properties=None,
+            ))
+        self.pika_channel.basic_publish.assert_called_once_with(**kwargs)
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -450,11 +464,9 @@ class TwistedChannelTestCase(TestCase):
 
     def _test_wrapped_func(self, func, kwargs, do_callback=False):
         func.assert_called_once()
-        call_kw = dict(
-            (key, value) for key, value in
-            func.call_args[1].items()
-            if key != "callback"
-        )
+        call_kw = dict((key, value)
+                       for key, value in func.call_args[1].items()
+                       if key != "callback")
         self.assertEqual(kwargs, call_kw)
         if do_callback:
             func.call_args[1]["callback"](do_callback)
@@ -479,8 +491,8 @@ class TwistedChannelTestCase(TestCase):
     def test_basic_recover(self):
         # Verify that basic_recover wraps properly.
         d = self.channel.basic_recover()
-        self._test_wrapped_func(
-            self.pika_channel.basic_recover, {"requeue": False}, True)
+        self._test_wrapped_func(self.pika_channel.basic_recover,
+                                {"requeue": False}, True)
         assert d.called
 
     def test_close(self):
@@ -495,9 +507,8 @@ class TwistedChannelTestCase(TestCase):
         d = self.channel.confirm_delivery()
         self.pika_channel.confirm_delivery.assert_called_once()
         self.assertEqual(
-            self.pika_channel.confirm_delivery.call_args[1][
-                "ack_nack_callback"],
-            self.channel._on_delivery_confirmation)
+            self.pika_channel.confirm_delivery.call_args[1]
+            ["ack_nack_callback"], self.channel._on_delivery_confirmation)
 
         def send_message(_result):
             d = self.channel.basic_publish("testexch", "testrk", "testbody")
@@ -507,6 +518,7 @@ class TwistedChannelTestCase(TestCase):
 
         def check_response(frame_method):
             self.assertTrue(isinstance(frame_method, spec.Basic.Ack))
+
         d.addCallback(send_message)
         d.addCallback(check_response)
         # Simulate Confirm.SelectOk
@@ -528,6 +540,7 @@ class TwistedChannelTestCase(TestCase):
         def check_response(error):
             self.assertIsInstance(error.value, NackError)
             self.assertEqual(len(error.value.messages), 0)
+
         d.addCallback(send_message)
         d.addCallbacks(self.fail, check_response)
         # Simulate Confirm.SelectOk
@@ -544,10 +557,9 @@ class TwistedChannelTestCase(TestCase):
         def send_message(_result):
             d = self.channel.basic_publish("testexch", "testrk", "testbody")
             # Send the Basic.Return frame
-            method = spec.Basic.Return(
-                exchange="testexch", routing_key="testrk")
-            return_cb(self.channel, method,
-                    spec.BasicProperties(), "testbody")
+            method = spec.Basic.Return(exchange="testexch",
+                                       routing_key="testrk")
+            return_cb(self.channel, method, spec.BasicProperties(), "testbody")
             # Send the Basic.Ack frame
             frame = Method(1, spec.Basic.Ack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
@@ -558,6 +570,7 @@ class TwistedChannelTestCase(TestCase):
             self.assertEqual(len(error.value.messages), 1)
             msg = error.value.messages[0]
             self.assertEqual(msg.body, "testbody")
+
         d.addCallbacks(send_message, self.fail)
         d.addCallbacks(self.fail, check_response)
         # Simulate Confirm.SelectOk
@@ -575,10 +588,9 @@ class TwistedChannelTestCase(TestCase):
         def send_message(_result):
             d = self.channel.basic_publish("testexch", "testrk", "testbody")
             # Send the Basic.Return frame
-            method = spec.Basic.Return(
-                exchange="testexch", routing_key="testrk")
-            return_cb(self.channel, method,
-                    spec.BasicProperties(), "testbody")
+            method = spec.Basic.Return(exchange="testexch",
+                                       routing_key="testrk")
+            return_cb(self.channel, method, spec.BasicProperties(), "testbody")
             # Send the Basic.Nack frame
             frame = Method(1, spec.Basic.Nack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
@@ -589,6 +601,7 @@ class TwistedChannelTestCase(TestCase):
             self.assertEqual(len(error.value.messages), 1)
             msg = error.value.messages[0]
             self.assertEqual(msg.body, "testbody")
+
         d.addCallback(send_message)
         d.addCallbacks(self.fail, check_response)
         self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
@@ -612,6 +625,7 @@ class TwistedChannelTestCase(TestCase):
             for is_ok, result in results:
                 self.assertTrue(is_ok)
                 self.assertTrue(isinstance(result, spec.Basic.Ack))
+
         d.addCallback(send_message)
         d.addCallback(check_response)
         self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
@@ -648,8 +662,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         transport = mock.Mock()
         self.conn.connectionMade = mock.Mock()
         self.conn.makeConnection(transport)
-        self.conn._impl.connection_made.assert_called_once_with(
-            transport)
+        self.conn._impl.connection_made.assert_called_once_with(transport)
         self.conn.connectionMade.assert_called_once()
         d = self.conn.ready
         self.conn._on_connection_ready(None)
@@ -665,6 +678,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
 
         def check(result):
             self.assertTrue(isinstance(result, TwistedChannel))
+
         d.addCallback(check)
         assert d.called
 
@@ -717,7 +731,9 @@ class TwistedProtocolConnectionTestCase(TestCase):
         d = self.conn.ready
         self.conn._on_connection_ready("testresult")
         self.assertTrue(d.called)
-        d.addCallback(functools.partial(self.assertIsInstance, cls=TwistedProtocolConnection))
+        d.addCallback(
+            functools.partial(self.assertIsInstance,
+                              cls=TwistedProtocolConnection))
         assert d.called
 
     def test_on_connection_ready_twice(self):
@@ -815,9 +831,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
 class TwistedConnectionAdapterTestCase(TestCase):
 
     def setUp(self):
-        self.conn = _TwistedConnectionAdapter(
-            None, None, None, None, None
-        )
+        self.conn = _TwistedConnectionAdapter(None, None, None, None, None)
 
     def tearDown(self):
         if self.conn._transport is None:
@@ -861,8 +875,8 @@ class TwistedConnectionAdapterTestCase(TestCase):
         transport = mock.Mock()
         self.conn.connection_made(transport)
         self.assertEqual(self.conn._transport, transport)
-        self.assertEqual(
-            self.conn.connection_state, self.conn.CONNECTION_PROTOCOL)
+        self.assertEqual(self.conn.connection_state,
+                         self.conn.CONNECTION_PROTOCOL)
 
     def test_connection_lost(self):
         # Verify that the correct callback is called and that the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
 def pytest_addoption(parser):
-    parser.addoption('--use-tls', action='store_true', default=False,
+    parser.addoption('--use-tls',
+                     action='store_true',
+                     default=False,
                      help='Use TLS for acceptance tests.')

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -21,6 +21,7 @@ def buffer(object_, offset, size):
     """array etc. have the buffer protocol"""
     return object_[offset:offset + size]
 
+
 def _trace(fmt, *args):
     """Format and output the text to stderr"""
     print((fmt % args) + "\n", end="", file=sys.stderr)
@@ -175,15 +176,14 @@ class ForwardServer(object):  # pylint: disable=R0902
 
         self._subproc = mp_ctx.Process(
             target=_run_server,
-            kwargs=dict(
-                local_addr=self._server_addr,
-                local_addr_family=self._server_addr_family,
-                local_socket_type=self._server_socket_type,
-                local_linger_args=self._local_linger_args,
-                remote_addr=self._remote_addr,
-                remote_addr_family=self._remote_addr_family,
-                remote_socket_type=self._remote_socket_type,
-                queue=queue))
+            kwargs=dict(local_addr=self._server_addr,
+                        local_addr_family=self._server_addr_family,
+                        local_socket_type=self._server_socket_type,
+                        local_linger_args=self._local_linger_args,
+                        remote_addr=self._remote_addr,
+                        remote_addr_family=self._remote_addr_family,
+                        remote_socket_type=self._remote_socket_type,
+                        queue=queue))
         self._subproc.daemon = True
         self._subproc.start()
 
@@ -290,8 +290,9 @@ def _run_server(
                 remote_addr_family=remote_addr_family,
                 remote_socket_type=remote_socket_type)
 
-            super(_ThreadedTCPServer, self).__init__(
-                local_addr, handler_class_factory, bind_and_activate=True)
+            super(_ThreadedTCPServer, self).__init__(local_addr,
+                                                     handler_class_factory,
+                                                     bind_and_activate=True)
 
     server = _ThreadedTCPServer()
 
@@ -343,8 +344,9 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
         self._remote_addr_family = remote_addr_family
         self._remote_socket_type = remote_socket_type
 
-        super(_TCPHandler, self).__init__(
-            request=request, client_address=client_address, server=server)
+        super(_TCPHandler, self).__init__(request=request,
+                                          client_address=client_address,
+                                          server=server)
 
     def handle(self):  # pylint: disable=R0912
         """Connect to remote and forward data between local and remote"""
@@ -363,8 +365,8 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
                 type=self._remote_socket_type,
                 proto=socket.IPPROTO_IP)
             remote_dest_sock.connect(self._remote_addr)
-            _trace("%s _TCPHandler connected to remote %s", datetime.now(timezone.utc),
-                   remote_dest_sock.getpeername())
+            _trace("%s _TCPHandler connected to remote %s",
+                   datetime.now(timezone.utc), remote_dest_sock.getpeername())
         else:
             # Echo set-up
             # NOTE: Use pika.compat.nonblocking_socketpair() since
@@ -376,11 +378,11 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
             remote_src_sock.setblocking(True)
 
         try:
-            local_forwarder = threading.Thread(
-                target=self._forward, args=(
-                    local_sock,
-                    remote_dest_sock,
-                ))
+            local_forwarder = threading.Thread(target=self._forward,
+                                               args=(
+                                                   local_sock,
+                                                   remote_dest_sock,
+                                               ))
             local_forwarder.setDaemon(True)
             local_forwarder.start()
 
@@ -405,8 +407,8 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
         """Forward from src_sock to dest_sock"""
         src_peername = src_sock.getpeername()
 
-        _trace("%s forwarding from %s to %s", datetime.now(timezone.utc), src_peername,
-               dest_sock.getpeername())
+        _trace("%s forwarding from %s to %s", datetime.now(timezone.utc),
+               src_peername, dest_sock.getpeername())
         try:
             # NOTE: python 2.6 doesn't support bytearray with recv_into, so
             # we use array.array instead; this is only okay as long as the
@@ -423,18 +425,19 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
                         continue
                     elif exc.errno == errno.ECONNRESET:
                         # Source peer forcibly closed connection
-                        _trace("%s errno.ECONNRESET from %s", datetime.now(timezone.utc),
-                               src_peername)
+                        _trace("%s errno.ECONNRESET from %s",
+                               datetime.now(timezone.utc), src_peername)
                         break
                     else:
                         _trace("%s Unexpected errno=%s from %s\n%s",
-                               datetime.now(timezone.utc), exc.errno, src_peername,
-                               "".join(traceback.format_stack()))
+                               datetime.now(timezone.utc), exc.errno,
+                               src_peername, "".join(traceback.format_stack()))
                         raise
 
                 if not nbytes:
                     # Source input EOF
-                    _trace("%s EOF on %s", datetime.now(timezone.utc), src_peername)
+                    _trace("%s EOF on %s", datetime.now(timezone.utc),
+                           src_peername)
                     break
 
                 try:
@@ -442,21 +445,23 @@ class _TCPHandler(socketserver.StreamRequestHandler, object):
                 except pika.compat.SOCKET_ERROR as exc:
                     if exc.errno == errno.EPIPE:
                         # Destination peer closed its end of the connection
-                        _trace("%s Destination peer %s closed its end of "
-                               "the connection: errno.EPIPE", datetime.now(timezone.utc),
-                               dest_sock.getpeername())
+                        _trace(
+                            "%s Destination peer %s closed its end of "
+                            "the connection: errno.EPIPE",
+                            datetime.now(timezone.utc), dest_sock.getpeername())
                         break
                     elif exc.errno == errno.ECONNRESET:
                         # Destination peer forcibly closed connection
-                        _trace("%s Destination peer %s forcibly closed "
-                               "connection: errno.ECONNRESET",
-                               datetime.now(timezone.utc), dest_sock.getpeername())
+                        _trace(
+                            "%s Destination peer %s forcibly closed "
+                            "connection: errno.ECONNRESET",
+                            datetime.now(timezone.utc), dest_sock.getpeername())
                         break
                     else:
                         _trace("%s Unexpected errno=%s in sendall to %s\n%s",
                                datetime.now(timezone.utc), exc.errno,
-                               dest_sock.getpeername(), "".join(
-                                   traceback.format_stack()))
+                               dest_sock.getpeername(),
+                               "".join(traceback.format_stack()))
                         raise
         except Exception:
             _trace("forward failed\n%s", "".join(traceback.format_exc()))

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -54,8 +54,8 @@ def retry_assertion(timeout_sec, retry_interval_sec=0.1):
                     if (now - start_time) > timeout_sec:
                         logging.exception(
                             'Exceeded retry timeout of %s sec in %s attempts '
-                            'with func %r. Caller\'s stack:\n%s',
-                            timeout_sec, num_attempts, func,
+                            'with func %r. Caller\'s stack:\n%s', timeout_sec,
+                            num_attempts, func,
                             ''.join(traceback.format_stack()))
                         raise
 
@@ -64,11 +64,10 @@ def retry_assertion(timeout_sec, retry_interval_sec=0.1):
 
                     time.sleep(retry_interval_sec)
                 else:
-                    logging.debug('%r succeeded at attempt %s',
-                                  func, num_attempts)
+                    logging.debug('%r succeeded at attempt %s', func,
+                                  num_attempts)
                     return result
 
         return retry_assertion_wrap
 
     return retry_assertion_decorator
-

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -114,8 +114,7 @@ class IOServicesTestStubs(object):
         # implementation.
 
         import asyncio
-        from pika.adapters.asyncio_connection import (
-            _AsyncioIOServicesAdapter)
+        from pika.adapters.asyncio_connection import (_AsyncioIOServicesAdapter)
 
         native_loop = asyncio.new_event_loop()
         self._run_start(

--- a/tests/unit/amqp_object_tests.py
+++ b/tests/unit/amqp_object_tests.py
@@ -4,6 +4,7 @@ from pika import amqp_object
 
 
 class AMQPObjectTests(unittest.TestCase):
+
     def test_base_name(self):
         self.assertEqual(amqp_object.AMQPObject().NAME, 'AMQPObject')
 
@@ -30,6 +31,7 @@ class AMQPObjectTests(unittest.TestCase):
 
 
 class ClassTests(unittest.TestCase):
+
     def test_base_name(self):
         self.assertEqual(amqp_object.Class().NAME, 'Unextended Class')
 
@@ -40,6 +42,7 @@ class ClassTests(unittest.TestCase):
 
 
 class MethodTests(unittest.TestCase):
+
     def test_base_name(self):
         self.assertEqual(amqp_object.Method().NAME, 'Unextended Method')
 
@@ -73,6 +76,6 @@ class MethodTests(unittest.TestCase):
 
 
 class PropertiesTests(unittest.TestCase):
+
     def test_base_name(self):
-        self.assertEqual(amqp_object.Properties().NAME,
-                         'Unextended Properties')
+        self.assertEqual(amqp_object.Properties().NAME, 'Unextended Properties')

--- a/tests/unit/asyncio_connection_tests.py
+++ b/tests/unit/asyncio_connection_tests.py
@@ -8,7 +8,6 @@ import unittest
 
 from pika.adapters.asyncio_connection import _AsyncioIOServicesAdapter
 
-
 # missing-docstring
 # pylint: disable=C0111
 

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -11,7 +11,6 @@ import pika
 import pika.tcp_socket_opts
 from pika.adapters import base_connection
 
-
 # pylint: disable=C0111,W0212,C0103
 
 # If this is missing, set it manually. We need it to test tcp opt setting.
@@ -26,18 +25,19 @@ class ConstructibleBaseConnection(base_connection.BaseConnection):
     that we can instantiate and test it.
 
     """
+
     @classmethod
     def create_connection(cls, *args, **kwargs):  # pylint: disable=W0221
         raise NotImplementedError
 
 
 class BaseConnectionTests(unittest.TestCase):
+
     def setUp(self):
         with mock.patch.object(ConstructibleBaseConnection,
                                '_adapter_connect_stream'):
             self.connection = ConstructibleBaseConnection(
-                None, None, None, None, None,
-                internal_connection_workflow=True)
+                None, None, None, None, None, internal_connection_workflow=True)
             self.connection._set_connection_state(
                 ConstructibleBaseConnection.CONNECTION_OPEN)
 
@@ -46,8 +46,13 @@ class BaseConnectionTests(unittest.TestCase):
         self.assertTrue(text.startswith('<ConstructibleBaseConnection'), text)
 
     def test_should_raise_value_exception_with_no_params_func_instead(self):
-        self.assertRaises(ValueError, ConstructibleBaseConnection,
-                          lambda: True, None, None, None, None,
+        self.assertRaises(ValueError,
+                          ConstructibleBaseConnection,
+                          lambda: True,
+                          None,
+                          None,
+                          None,
+                          None,
                           internal_connection_workflow=True)
 
     def test_tcp_options_with_dict_tcp_options(self):
@@ -62,8 +67,7 @@ class BaseConnectionTests(unittest.TestCase):
             pika.tcp_socket_opts.set_sock_opts(params.tcp_options, sock_mock)
 
             expected = [
-                mock.call.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE,
-                                     1),
+                mock.call.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1),
                 mock.call.setsockopt(socket.SOL_TCP, TCP_KEEPIDLE, 60)
             ]
             self.assertEqual(sock_mock.method_calls, expected)

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -19,17 +19,17 @@ class ChannelTemplate(channel.Channel):
 
 
 class BlockingChannelTests(unittest.TestCase):
+
     @mock.patch(BLOCKING_CONNECTION)
     def _create_connection(self, connection=None):
         return connection
 
     def setUp(self):
         self.connection = self._create_connection()
-        channel_impl_mock = mock.Mock(
-            spec=ChannelTemplate,
-            is_closing=False,
-            is_closed=False,
-            is_open=True)
+        channel_impl_mock = mock.Mock(spec=ChannelTemplate,
+                                      is_closing=False,
+                                      is_closed=False,
+                                      is_open=True)
         self.obj = blocking_connection.BlockingChannel(channel_impl_mock,
                                                        self.connection)
 
@@ -50,8 +50,7 @@ class BlockingChannelTests(unittest.TestCase):
         # This is for the unlikely scenario where only
         # the first parameter is updated
         with self.assertRaises(TypeError):
-            self.obj.basic_consume('queue',
-                                   'whoops this should be a callback')
+            self.obj.basic_consume('queue', 'whoops this should be a callback')
 
     def test_basic_consume_legacy_parameter_callback(self):
         with self.assertRaises(TypeError):
@@ -67,9 +66,7 @@ class BlockingChannelTests(unittest.TestCase):
 
     def test_queue_bind_legacy_parameter_callback(self):
         with self.assertRaises(TypeError):
-            self.obj.queue_bind(mock.Mock(),
-                                'queue',
-                                'exchange')
+            self.obj.queue_bind(mock.Mock(), 'queue', 'exchange')
 
     def test_basic_cancel_legacy_parameter(self):
         with self.assertRaises(TypeError):
@@ -92,10 +89,11 @@ class BlockingChannelTests(unittest.TestCase):
     def test_context_manager(self):
         with self.obj as chan:
             self.assertFalse(chan._impl.close.called)
-        chan._impl.close.assert_called_once_with(
-            reply_code=0, reply_text='Normal shutdown')
+        chan._impl.close.assert_called_once_with(reply_code=0,
+                                                 reply_text='Normal shutdown')
 
     def test_context_manager_does_not_suppress_exception(self):
+
         class TestException(Exception):
             pass
 
@@ -103,15 +101,15 @@ class BlockingChannelTests(unittest.TestCase):
             with self.obj as chan:
                 self.assertFalse(chan._impl.close.called)
                 raise TestException()
-        chan._impl.close.assert_called_once_with(
-            reply_code=0, reply_text='Normal shutdown')
+        chan._impl.close.assert_called_once_with(reply_code=0,
+                                                 reply_text='Normal shutdown')
 
     def test_context_manager_exit_with_closed_channel(self):
         with self.obj as chan:
             self.assertFalse(chan._impl.close.called)
             chan.close()
-        chan._impl.close.assert_called_with(
-            reply_code=0, reply_text='Normal shutdown')
+        chan._impl.close.assert_called_with(reply_code=0,
+                                            reply_text='Normal shutdown')
 
     def test_consumer_tags_property(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -14,7 +14,6 @@ from pika.adapters.utils import nbio_interface
 import pika.channel
 import pika.exceptions
 
-
 # Disable protected-access
 # pylint: disable=W0212
 
@@ -46,10 +45,9 @@ class SelectConnectionTemplate(
 class BlockingConnectionTests(unittest.TestCase):
     """TODO: test properties"""
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_constructor(self, _select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection') as _create_connection_mock:
@@ -60,10 +58,9 @@ class BlockingConnectionTests(unittest.TestCase):
         connection._impl.add_on_close_callback.assert_called_once_with(
             connection._closed_result.set_value_once)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_process_io_for_connection_setup(self,
                                              select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
@@ -71,24 +68,20 @@ class BlockingConnectionTests(unittest.TestCase):
             connection = blocking_connection.BlockingConnection('params')
 
         mock_connection = select_connection_class_mock.return_value
-        with mock.patch.object(select_connection_class_mock,
-                               'create_connection',
-                               side_effect=
-                               lambda configs,
-                                      on_done,
-                                      custom_ioloop: [on_done(mock_connection),
-                                                      custom_ioloop.close(),
-                                                      None][2]):
+        with mock.patch.object(
+                select_connection_class_mock,
+                'create_connection',
+                side_effect=lambda configs, on_done, custom_ioloop:
+            [on_done(mock_connection),
+             custom_ioloop.close(), None][2]):
             result = connection._create_connection(
-                None,
-                select_connection_class_mock)
+                None, select_connection_class_mock)
 
             self.assertIs(result, mock_connection)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_process_io_for_connection_setup_fails_with_open_error(
             self, select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
@@ -98,21 +91,18 @@ class BlockingConnectionTests(unittest.TestCase):
         exc_value = pika.exceptions.AMQPConnectionError('failed')
         with mock.patch.object(select_connection_class_mock,
                                'create_connection',
-                               side_effect=
-                               lambda configs,
-                                      on_done,
-                                      custom_ioloop: on_done(exc_value)):
+                               side_effect=lambda configs, on_done,
+                               custom_ioloop: on_done(exc_value)):
             with self.assertRaises(pika.exceptions.AMQPConnectionError) as cm:
                 connection._create_connection(None,
                                               select_connection_class_mock)
 
             self.assertIs(cm.exception, exc_value)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate,
-        is_closed=False)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate,
+                  is_closed=False)
     def test_flush_output(self, select_connection_class_mock):
         impl_mock = select_connection_class_mock.return_value
         with mock.patch.object(blocking_connection.BlockingConnection,
@@ -133,11 +123,10 @@ class BlockingConnectionTests(unittest.TestCase):
 
         connection._flush_output(lambda: False, lambda: True)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate,
-        is_closed=False)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate,
+                  is_closed=False)
     def test_flush_output_user_initiated_close(self,
                                                select_connection_class_mock):
         impl_mock = select_connection_class_mock.return_value
@@ -147,18 +136,16 @@ class BlockingConnectionTests(unittest.TestCase):
             connection = blocking_connection.BlockingConnection('params')
 
         original_exc = pika.exceptions.ConnectionClosedByClient(200, 'success')
-        connection._closed_result.set_value_once(
-            impl_mock, original_exc)
+        connection._closed_result.set_value_once(impl_mock, original_exc)
 
         connection._flush_output(lambda: False, lambda: True)
 
         self.assertEqual(connection._impl.ioloop.close.call_count, 1)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate,
-        is_closed=False)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate,
+                  is_closed=False)
     def test_flush_output_server_initiated_error_close(
             self, select_connection_class_mock):
 
@@ -168,10 +155,9 @@ class BlockingConnectionTests(unittest.TestCase):
                                return_value=impl_mock):
             connection = blocking_connection.BlockingConnection('params')
 
-        original_exc = pika.exceptions.ConnectionClosedByBroker(404,
-                                                                'not found')
-        connection._closed_result.set_value_once(
-            impl_mock, original_exc)
+        original_exc = pika.exceptions.ConnectionClosedByBroker(
+            404, 'not found')
+        connection._closed_result.set_value_once(impl_mock, original_exc)
 
         with self.assertRaises(pika.exceptions.ConnectionClosedByBroker) as cm:
             connection._flush_output(lambda: False, lambda: True)
@@ -180,14 +166,12 @@ class BlockingConnectionTests(unittest.TestCase):
 
         self.assertEqual(connection._impl.ioloop.close.call_count, 1)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate,
-        is_closed=False)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate,
+                  is_closed=False)
     def test_flush_output_server_initiated_no_error_close(
-            self,
-            select_connection_class_mock):
+            self, select_connection_class_mock):
 
         impl_mock = select_connection_class_mock.return_value
         with mock.patch.object(blocking_connection.BlockingConnection,
@@ -196,9 +180,7 @@ class BlockingConnectionTests(unittest.TestCase):
             connection = blocking_connection.BlockingConnection('params')
 
         original_exc = pika.exceptions.ConnectionClosedByBroker(200, 'ok')
-        connection._closed_result.set_value_once(
-            impl_mock,
-            original_exc)
+        connection._closed_result.set_value_once(impl_mock, original_exc)
 
         impl_mock.is_closed = False
         with self.assertRaises(pika.exceptions.ConnectionClosed) as cm:
@@ -208,10 +190,9 @@ class BlockingConnectionTests(unittest.TestCase):
 
         self.assertEqual(connection._impl.ioloop.close.call_count, 1)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_close(self, select_connection_class_mock):
         impl_mock = select_connection_class_mock.return_value
         impl_mock.is_closed = False
@@ -235,10 +216,9 @@ class BlockingConnectionTests(unittest.TestCase):
         select_connection_class_mock.return_value.close.assert_called_once_with(
             200, 'text')
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_close_with_channel_closed_exception(self,
                                                  select_connection_class_mock):
         impl_mock = select_connection_class_mock.return_value
@@ -249,29 +229,27 @@ class BlockingConnectionTests(unittest.TestCase):
                                return_value=impl_mock):
             connection = blocking_connection.BlockingConnection('params')
 
-        channel1_mock = mock.Mock(
-            is_open=True,
-            close=mock.Mock(
-                side_effect=pika.exceptions.ChannelClosed(-1, 'Just because'),
-                spec_set=pika.channel.Channel.close),
-            spec_set=blocking_connection.BlockingChannel)
+        channel1_mock = mock.Mock(is_open=True,
+                                  close=mock.Mock(
+                                      side_effect=pika.exceptions.ChannelClosed(
+                                          -1, 'Just because'),
+                                      spec_set=pika.channel.Channel.close),
+                                  spec_set=blocking_connection.BlockingChannel)
 
-        channel2_mock = mock.Mock(
-            is_open=True, spec_set=blocking_connection.BlockingChannel)
+        channel2_mock = mock.Mock(is_open=True,
+                                  spec_set=blocking_connection.BlockingChannel)
 
         connection._impl._channels = {
             1:
-            mock.Mock(
-                _get_cookie=mock.Mock(
+                mock.Mock(_get_cookie=mock.Mock(
                     return_value=channel1_mock,
                     spec_set=pika.channel.Channel._get_cookie),
-                spec_set=pika.channel.Channel),
+                          spec_set=pika.channel.Channel),
             2:
-            mock.Mock(
-                _get_cookie=mock.Mock(
+                mock.Mock(_get_cookie=mock.Mock(
                     return_value=channel2_mock,
                     spec_set=pika.channel.Channel._get_cookie),
-                spec_set=pika.channel.Channel)
+                          spec_set=pika.channel.Channel)
         }
 
         with mock.patch.object(blocking_connection.BlockingConnection,
@@ -284,11 +262,11 @@ class BlockingConnectionTests(unittest.TestCase):
             channel2_mock.close.assert_called_once_with(200, 'text')
         impl_mock.close.assert_called_once_with(200, 'text')
 
-    @unittest.skipIf(sys.version_info < (3, 8), "mock args differ on 3.7 and earlier")
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @unittest.skipIf(sys.version_info < (3, 8),
+                     "mock args differ on 3.7 and earlier")
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_update_secret(self, select_connection_class_mock):
         impl_mock = select_connection_class_mock.return_value
         impl_mock.is_closed = False
@@ -306,30 +284,34 @@ class BlockingConnectionTests(unittest.TestCase):
             connection.update_secret("new_secret", "reason")
 
         if sys.version_info < (3, 8):
-            args_0 = select_connection_class_mock.return_value.update_secret.call_args[0]
-            args_1 = select_connection_class_mock.return_value.update_secret.call_args[1]
-            args_len = len(select_connection_class_mock.return_value.update_secret.call_args)
+            args_0 = select_connection_class_mock.return_value.update_secret.call_args[
+                0]
+            args_1 = select_connection_class_mock.return_value.update_secret.call_args[
+                1]
+            args_len = len(select_connection_class_mock.return_value.
+                           update_secret.call_args)
         else:
-            args_0 = select_connection_class_mock.return_value.update_secret.call_args.args[0]
-            args_1 = select_connection_class_mock.return_value.update_secret.call_args.args[1]
-            args_len = len(select_connection_class_mock.return_value.update_secret.call_args.args)
+            args_0 = select_connection_class_mock.return_value.update_secret.call_args.args[
+                0]
+            args_1 = select_connection_class_mock.return_value.update_secret.call_args.args[
+                1]
+            args_len = len(select_connection_class_mock.return_value.
+                           update_secret.call_args.args)
 
         self.assertEqual(args_0, "new_secret")
         self.assertEqual(args_1, "reason")
         self.assertEqual(args_len, 3)
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
-    @patch.object(
-        blocking_connection,
-        'BlockingChannel',
-        spec_set=blocking_connection.BlockingChannel)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection,
+                  'BlockingChannel',
+                  spec_set=blocking_connection.BlockingChannel)
     def test_channel(
-            self,
-            blocking_channel_class_mock,  # pylint: disable=W0613
-            select_connection_class_mock):  # pylint: disable=W0613
+        self,
+        blocking_channel_class_mock,  # pylint: disable=W0613
+        select_connection_class_mock):  # pylint: disable=W0613
 
         impl_mock = select_connection_class_mock.return_value
 
@@ -343,10 +325,9 @@ class BlockingConnectionTests(unittest.TestCase):
                                spec_set=connection._flush_output):
             connection.channel()
 
-    @patch.object(
-        blocking_connection.select_connection,
-        'SelectConnection',
-        spec_set=SelectConnectionTemplate)
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_sleep(self, select_connection_class_mock):  # pylint: disable=W0613
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection'):
@@ -360,9 +341,8 @@ class BlockingConnectionTests(unittest.TestCase):
     def test_connection_blocked_evt(self):
         blocked_buffer = []
         frame = pika.frame.Method(0, pika.spec.Connection.Blocked('reason'))
-        evt = blocking_connection._ConnectionBlockedEvt(
-            blocked_buffer.append,
-            frame)
+        evt = blocking_connection._ConnectionBlockedEvt(blocked_buffer.append,
+                                                        frame)
         repr(evt)
         evt.dispatch()
         self.assertEqual(len(blocked_buffer), 1)
@@ -372,8 +352,7 @@ class BlockingConnectionTests(unittest.TestCase):
         unblocked_buffer = []
         frame = pika.frame.Method(0, pika.spec.Connection.Unblocked())
         evt = blocking_connection._ConnectionUnblockedEvt(
-            unblocked_buffer.append,
-            frame)
+            unblocked_buffer.append, frame)
         repr(evt)
         evt.dispatch()
         self.assertEqual(len(unblocked_buffer), 1)

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -51,16 +51,15 @@ class CallbackTests(unittest.TestCase):
         self.assertEqual(callback.name_or_value(value), self.PREFIX)
 
     def test_name_or_value_basic_consume_object(self):
-        self.assertEqual(
-            callback.name_or_value(spec.Basic.Consume()), self.PREFIX)
+        self.assertEqual(callback.name_or_value(spec.Basic.Consume()),
+                         self.PREFIX)
 
     def test_name_or_value_amqpobject_class(self):
-        self.assertEqual(
-            callback.name_or_value(self.PREFIX_CLASS), self.PREFIX)
+        self.assertEqual(callback.name_or_value(self.PREFIX_CLASS), self.PREFIX)
 
     def test_name_or_value_protocol_header(self):
-        self.assertEqual(
-            callback.name_or_value(frame.ProtocolHeader()), 'ProtocolHeader')
+        self.assertEqual(callback.name_or_value(frame.ProtocolHeader()),
+                         'ProtocolHeader')
 
     def test_name_or_value_method_frame(self):
         value = frame.Method(1, self.PREFIX_CLASS())
@@ -126,8 +125,8 @@ class CallbackTests(unittest.TestCase):
             self.obj._stack[self.PREFIX][self.KEY][0][self.ONLY_CALLER])
 
     def test_add_returns_prefix_value_and_key(self):
-        self.assertEqual(
-            self.obj.add(self.PREFIX, self.KEY, None), (self.PREFIX, self.KEY))
+        self.assertEqual(self.obj.add(self.PREFIX, self.KEY, None),
+                         (self.PREFIX, self.KEY))
 
     def test_add_duplicate_callback(self):
         mock_callback = mock.Mock()
@@ -140,13 +139,13 @@ class CallbackTests(unittest.TestCase):
             add_callback()
             add_callback()
             logger.warning.assert_called_once_with(
-                callback.CallbackManager.DUPLICATE_WARNING,
-                self.PREFIX, self.KEY)
+                callback.CallbackManager.DUPLICATE_WARNING, self.PREFIX,
+                self.KEY)
 
     def test_add_duplicate_callback_returns_prefix_value_and_key(self):
         self.obj.add(self.PREFIX, self.KEY, None)
-        self.assertEqual(
-            self.obj.add(self.PREFIX, self.KEY, None), (self.PREFIX, self.KEY))
+        self.assertEqual(self.obj.add(self.PREFIX, self.KEY, None),
+                         (self.PREFIX, self.KEY))
 
     def test_clear(self):
         self.obj.add(self.PREFIX, self.KEY, None)
@@ -228,20 +227,18 @@ class CallbackTests(unittest.TestCase):
             self.callback_mock)
 
     def test_process_only_caller_fails(self):
-        self.obj.add(
-            self.PREFIX_CLASS,
-            self.KEY,
-            self.callback_mock,
-            only_caller=self.mock_caller)
+        self.obj.add(self.PREFIX_CLASS,
+                     self.KEY,
+                     self.callback_mock,
+                     only_caller=self.mock_caller)
         self.obj.process(self.PREFIX_CLASS, self.KEY, self)
         self.assertFalse(self.callback_mock.called)
 
     def test_process_only_caller_fails_no_removal(self):
-        self.obj.add(
-            self.PREFIX_CLASS,
-            self.KEY,
-            self.callback_mock,
-            only_caller=self.mock_caller)
+        self.obj.add(self.PREFIX_CLASS,
+                     self.KEY,
+                     self.callback_mock,
+                     only_caller=self.mock_caller)
         self.obj.process(self.PREFIX_CLASS, self.KEY, self)
         self.assertEqual(
             self.obj._stack[self.PREFIX][self.KEY][0][self.CALLBACK],
@@ -264,10 +261,9 @@ class CallbackTests(unittest.TestCase):
 
     def test_remove_with_callback_true_empty_stack(self):
         self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
-        self.obj.remove(
-            prefix=self.PREFIX,
-            key=self.KEY,
-            callback_value=self.callback_mock)
+        self.obj.remove(prefix=self.PREFIX,
+                        key=self.KEY,
+                        callback_value=self.callback_mock)
         self.assertDictEqual(self.obj._stack, dict())
 
     def test_remove_with_callback_true_non_empty_stack(self):
@@ -288,8 +284,9 @@ class CallbackTests(unittest.TestCase):
     def test_remove_prefix_key_with_other_key_remains(self):
         other_key = 'Other Key'
         self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
-        self.obj.add(
-            prefix=self.PREFIX_CLASS, key=other_key, callback=self.mock_caller)
+        self.obj.add(prefix=self.PREFIX_CLASS,
+                     key=other_key,
+                     callback=self.mock_caller)
         self.obj.remove(self.PREFIX, self.KEY)
         self.assertIn(other_key, self.obj._stack[self.PREFIX])
 
@@ -315,13 +312,10 @@ class CallbackTests(unittest.TestCase):
 
     def test_should_process_callback_false_argument_fail(self):
         self.obj.clear()
-        self.obj.add(
-            self.PREFIX_CLASS,
-            self.KEY,
-            self.callback_mock,
-            arguments={
-                'foo': 'baz'
-            })
+        self.obj.add(self.PREFIX_CLASS,
+                     self.KEY,
+                     self.callback_mock,
+                     arguments={'foo': 'baz'})
         self.assertFalse(
             self.obj._should_process_callback(self._callback_dict,
                                               self.mock_caller, [{
@@ -358,6 +352,7 @@ class CallbackTests(unittest.TestCase):
             }]))
 
     def test_arguments_match_obj_argument(self):
+
         class TestObj(object):
             foo = 'bar'
 
@@ -366,6 +361,7 @@ class CallbackTests(unittest.TestCase):
             self.obj._arguments_match(self._callback_dict, [test_instance]))
 
     def test_arguments_match_obj_no_attribute(self):
+
         class TestObj(object):
             qux = 'bar'
 
@@ -374,6 +370,7 @@ class CallbackTests(unittest.TestCase):
             self.obj._arguments_match(self._callback_dict, [test_instance]))
 
     def test_arguments_match_obj_argument_no_match(self):
+
         class TestObj(object):
             foo = 'baz'
 
@@ -382,6 +379,7 @@ class CallbackTests(unittest.TestCase):
             self.obj._arguments_match(self._callback_dict, [test_instance]))
 
     def test_arguments_match_obj_argument_with_method(self):
+
         class TestFrame(object):
             method = None
 
@@ -394,6 +392,7 @@ class CallbackTests(unittest.TestCase):
             self.obj._arguments_match(self._callback_dict, [test_instance]))
 
     def test_arguments_match_obj_argument_with_method_no_match(self):
+
         class TestFrame(object):
             method = None
 

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -14,6 +14,7 @@ from pika import channel, connection, exceptions, frame, spec
 # too-many-public-methods, too-many-lines
 # pylint: disable=W0212,C0111,C0103,R0904,C0302
 
+
 class ConnectionTemplate(connection.Connection):
     """Template for using as mock spec_set for the pika Connection class. It
     defines members accessed by the code under test that would be defined in
@@ -33,6 +34,7 @@ class ConnectionTemplate(connection.Connection):
 
 
 class ChannelTests(unittest.TestCase):
+
     @staticmethod
     @mock.patch('pika.connection.Connection', autospec=ConnectionTemplate)
     def _create_connection(connection_class_mock=None):
@@ -41,8 +43,7 @@ class ChannelTests(unittest.TestCase):
     def setUp(self):
         self.connection = self._create_connection()
         self._on_openok_callback = mock.Mock()
-        self.obj = channel.Channel(self.connection, 1,
-                                   self._on_openok_callback)
+        self.obj = channel.Channel(self.connection, 1, self._on_openok_callback)
         warnings.resetwarnings()
 
     def tearDown(self):
@@ -81,8 +82,7 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(self.obj._has_on_flow_callback, False)
 
     def test_init_on_openok_callback(self):
-        self.assertEqual(self.obj._on_openok_callback,
-                         self._on_openok_callback)
+        self.assertEqual(self.obj._on_openok_callback, self._on_openok_callback)
 
     def test_init_state(self):
         self.assertEqual(self.obj._state, channel.Channel.CLOSED)
@@ -107,8 +107,7 @@ class ChannelTests(unittest.TestCase):
 
     def test_add_callback_multiple_replies(self):
         mock_callback = mock.Mock()
-        self.obj.add_callback(mock_callback,
-                              [spec.Basic.Qos, spec.Basic.QosOk])
+        self.obj.add_callback(mock_callback, [spec.Basic.Qos, spec.Basic.QosOk])
         calls = [
             mock.call(self.obj.channel_number, spec.Basic.Qos, mock_callback,
                       True),
@@ -166,11 +165,10 @@ class ChannelTests(unittest.TestCase):
         consumer_tag = 'ctag0'
         callback_mock = mock.Mock()
         self.obj._consumers[consumer_tag] = callback_mock
-        self.assertRaises(
-            TypeError,
-            self.obj.basic_cancel,
-            consumer_tag,
-            callback='bad-callback')
+        self.assertRaises(TypeError,
+                          self.obj.basic_cancel,
+                          consumer_tag,
+                          callback='bad-callback')
 
     @mock.patch('pika.channel.Channel._raise_if_not_open')
     def test_basic_cancel_calls_raise_if_not_open(self, raise_if_not_open):
@@ -194,24 +192,21 @@ class ChannelTests(unittest.TestCase):
         # Verify consumer tag added to the cancelled list
         self.assertListEqual(list(self.obj._cancelled), [consumer_tag])
         # Verify user completion callback registered
-        self.obj.callbacks.add.assert_any_call(
-            self.obj.channel_number, spec.Basic.CancelOk, callback_mock)
+        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+                                               spec.Basic.CancelOk,
+                                               callback_mock)
         # Verify Channel._on_cancelok callback registered
         self.obj.callbacks.add.assert_any_call(
             self.obj.channel_number,
             spec.Basic.CancelOk,
             self.obj._on_cancelok,
-            arguments={
-                'consumer_tag': 'ctag0'
-            })
+            arguments={'consumer_tag': 'ctag0'})
         # Verify Channel._on_synchronous_complete callback registered
         self.obj.callbacks.add.assert_any_call(
             self.obj.channel_number,
             spec.Basic.CancelOk,
             self.obj._on_synchronous_complete,
-            arguments={
-                'consumer_tag': 'ctag0'
-            })
+            arguments={'consumer_tag': 'ctag0'})
 
     def test_basic_cancel_synch_no_user_callback_raises_value_error(self):
         self.obj._set_state(self.obj.OPEN)
@@ -249,8 +244,7 @@ class ChannelTests(unittest.TestCase):
         # the first parameter is updated
         self.obj._set_state(self.obj.OPEN)
         with self.assertRaises(TypeError):
-            self.obj.basic_consume('queue',
-                                   'whoops this should be a callback')
+            self.obj.basic_consume('queue', 'whoops this should be a callback')
 
     def test_basic_consume_legacy_parameter_callback(self):
         self.obj._set_state(self.obj.OPEN)
@@ -274,9 +268,7 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.queue_bind(callback_mock,
-                                'queue',
-                                'exchange')
+            self.obj.queue_bind(callback_mock, 'queue', 'exchange')
 
     def test_basic_cancel_legacy_parameter(self):
         self.obj._set_state(self.obj.OPEN)
@@ -317,29 +309,21 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.exchange_bind(callback_mock,
-                                   'destination',
-                                   'source',
-                                   'routing_key',
-                                   True)
+            self.obj.exchange_bind(callback_mock, 'destination', 'source',
+                                   'routing_key', True)
 
     def test_exchange_delete_legacy_parameter(self):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.exchange_delete(callback_mock,
-                                     'exchange',
-                                     True)
+            self.obj.exchange_delete(callback_mock, 'exchange', True)
 
     def test_exchange_unbind_legacy_parameter(self):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.exchange_unbind(callback_mock,
-                                     'destination',
-                                     'source',
-                                     'routing_key',
-                                     True)
+            self.obj.exchange_unbind(callback_mock, 'destination', 'source',
+                                     'routing_key', True)
 
     def test_flow_legacy_parameter(self):
         self.obj._set_state(self.obj.OPEN)
@@ -351,34 +335,28 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.queue_delete(callback_mock,
-                                  'queue',
-                                  True,
-                                  True)
+            self.obj.queue_delete(callback_mock, 'queue', True, True)
 
     def test_queue_unbind_legacy_parameter(self):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.queue_unbind(callback_mock,
-                                  'queue',
-                                  'exchange',
+            self.obj.queue_unbind(callback_mock, 'queue', 'exchange',
                                   'routing_key')
 
     def test_queue_purge_legacy_parameter(self):
         self.obj._set_state(self.obj.OPEN)
         callback_mock = mock.Mock()
         with self.assertRaises(TypeError):
-            self.obj.queue_purge(callback_mock,
-                                 'queue',
-                                 True)
+            self.obj.queue_purge(callback_mock, 'queue', True)
 
     def test_basic_consume_channel_closed(self):
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()
         self.assertRaises(exceptions.ChannelWrongStateError,
                           self.obj.basic_consume,
-                          'test-queue', mock_on_msg_callback,
+                          'test-queue',
+                          mock_on_msg_callback,
                           callback=mock_callback)
 
     @mock.patch('pika.channel.Channel._raise_if_not_open')
@@ -386,7 +364,9 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         mock_on_msg_callback = mock.Mock()
-        self.obj.basic_consume('test-queue', mock_on_msg_callback, callback=mock_callback)
+        self.obj.basic_consume('test-queue',
+                               mock_on_msg_callback,
+                               callback=mock_callback)
         raise_if_not_open.assert_called_once_with()
 
     def test_basic_consume_consumer_tag_no_completion_callback(self):
@@ -422,9 +402,10 @@ class ChannelTests(unittest.TestCase):
         consumer_tag = 'ctag1.0'
         mock_on_msg_callback = mock.Mock()
         mock_callback = mock.Mock()
-        self.obj.basic_consume(
-            'test-queue', mock_on_msg_callback,
-            consumer_tag=consumer_tag, callback=mock_callback)
+        self.obj.basic_consume('test-queue',
+                               mock_on_msg_callback,
+                               consumer_tag=consumer_tag,
+                               callback=mock_callback)
         self.assertIn(consumer_tag, self.obj._consumers)
 
     def test_basic_consume_duplicate_consumer_tag_raises(self):
@@ -435,31 +416,33 @@ class ChannelTests(unittest.TestCase):
         self.obj._consumers[consumer_tag] = logging.debug
         self.assertRaises(exceptions.DuplicateConsumerTag,
                           self.obj.basic_consume, 'test-queue',
-                          mock_on_msg_callback, False, False,
-                          consumer_tag, None, mock_callback)
+                          mock_on_msg_callback, False, False, consumer_tag,
+                          None, mock_callback)
 
     def test_basic_consume_consumers_callback_value(self):
         self.obj._set_state(self.obj.OPEN)
         consumer_tag = 'ctag1.0'
         mock_on_msg_callback = mock.Mock()
-        self.obj.basic_consume(
-            'test-queue', mock_on_msg_callback, consumer_tag=consumer_tag)
-        self.assertEqual(self.obj._consumers[consumer_tag], mock_on_msg_callback)
+        self.obj.basic_consume('test-queue',
+                               mock_on_msg_callback,
+                               consumer_tag=consumer_tag)
+        self.assertEqual(self.obj._consumers[consumer_tag],
+                         mock_on_msg_callback)
 
     @mock.patch('pika.spec.Basic.Consume')
     @mock.patch('pika.channel.Channel._rpc')
-    def test_basic_consume_consumers_rpc_with_no_completion_callback(self, rpc, _unused):
+    def test_basic_consume_consumers_rpc_with_no_completion_callback(
+            self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         consumer_tag = 'ctag1.0'
         mock_on_msg_callback = mock.Mock()
-        self.obj.basic_consume(
-            'test-queue', mock_on_msg_callback,
-            consumer_tag=consumer_tag)
-        expectation = spec.Basic.Consume(
-            queue='test-queue',
-            consumer_tag=consumer_tag,
-            no_ack=False,
-            exclusive=False)
+        self.obj.basic_consume('test-queue',
+                               mock_on_msg_callback,
+                               consumer_tag=consumer_tag)
+        expectation = spec.Basic.Consume(queue='test-queue',
+                                         consumer_tag=consumer_tag,
+                                         no_ack=False,
+                                         exclusive=False)
         rpc.assert_called_once_with(expectation, self.obj._on_eventok,
                                     [(spec.Basic.ConsumeOk, {
                                         'consumer_tag': consumer_tag
@@ -467,19 +450,20 @@ class ChannelTests(unittest.TestCase):
 
     @mock.patch('pika.spec.Basic.Consume')
     @mock.patch('pika.channel.Channel._rpc')
-    def test_basic_consume_consumers_rpc_with_completion_callback(self, rpc, _unused):
+    def test_basic_consume_consumers_rpc_with_completion_callback(
+            self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         consumer_tag = 'ctag1.0'
         mock_on_msg_callback = mock.Mock()
         mock_callback = mock.Mock()
-        self.obj.basic_consume(
-            'test-queue', mock_on_msg_callback,
-            consumer_tag=consumer_tag, callback=mock_callback)
-        expectation = spec.Basic.Consume(
-            queue='test-queue',
-            consumer_tag=consumer_tag,
-            no_ack=False,
-            exclusive=False)
+        self.obj.basic_consume('test-queue',
+                               mock_on_msg_callback,
+                               consumer_tag=consumer_tag,
+                               callback=mock_callback)
+        expectation = spec.Basic.Consume(queue='test-queue',
+                                         consumer_tag=consumer_tag,
+                                         no_ack=False,
+                                         exclusive=False)
         rpc.assert_called_once_with(expectation, mock_callback,
                                     [(spec.Basic.ConsumeOk, {
                                         'consumer_tag': consumer_tag
@@ -542,14 +526,13 @@ class ChannelTests(unittest.TestCase):
         self.obj.basic_publish(exchange, routing_key, body, properties,
                                mandatory)
         send_method.assert_called_once_with(
-            spec.Basic.Publish(
-                exchange=exchange,
-                routing_key=routing_key,
-                mandatory=mandatory), (properties, body))
+            spec.Basic.Publish(exchange=exchange,
+                               routing_key=routing_key,
+                               mandatory=mandatory), (properties, body))
 
     def test_basic_qos_raises_channel_wrong_state(self):
-        self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.basic_qos, 0, False, True)
+        self.assertRaises(exceptions.ChannelWrongStateError, self.obj.basic_qos,
+                          0, False, True)
 
     def test_basic_qos_invalid_prefetch_size_raises_error(self):
         self.obj._set_state(self.obj.OPEN)
@@ -577,8 +560,8 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.basic_qos(10, 20, False, callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Basic.Qos(10, 20, False), mock_callback, [spec.Basic.QosOk])
+        rpc.assert_called_once_with(spec.Basic.Qos(10, 20, False),
+                                    mock_callback, [spec.Basic.QosOk])
 
     def test_basic_reject_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
@@ -608,8 +591,8 @@ class ChannelTests(unittest.TestCase):
         # NOTE: we use `sys.maxsize` for compatibility with python 3, which
         # doesn't have `sys.maxint`
         self.obj.basic_reject(sys.maxsize, True)
-        send_method.assert_called_once_with(
-            spec.Basic.Reject(sys.maxsize, True))
+        send_method.assert_called_once_with(spec.Basic.Reject(
+            sys.maxsize, True))
 
     def test_basic_reject_spec_with_long_tag(self):
         # NOTE: we use `sys.maxsize` for compatibility with python 3, which
@@ -621,8 +604,8 @@ class ChannelTests(unittest.TestCase):
         self.assertIs(decoded.requeue, True)
 
     def test_basic_recover_raises_channel_wrong_state(self):
-        self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.basic_qos, 0, False, True)
+        self.assertRaises(exceptions.ChannelWrongStateError, self.obj.basic_qos,
+                          0, False, True)
 
     @mock.patch('pika.spec.Basic.Recover')
     @mock.patch('pika.channel.Channel._rpc')
@@ -630,8 +613,8 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.basic_recover(True, callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Basic.Recover(True), mock_callback, [spec.Basic.RecoverOk])
+        rpc.assert_called_once_with(spec.Basic.Recover(True), mock_callback,
+                                    [spec.Basic.RecoverOk])
 
     def test_close_in_closing_state_raises_channel_wrong_state(self):
         self.obj._set_state(self.obj.CLOSING)
@@ -675,8 +658,7 @@ class ChannelTests(unittest.TestCase):
 
         self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
-                                                   self.obj, self.obj,
-                                                   mock.ANY)
+                                                   self.obj, self.obj, mock.ANY)
 
         self.assertEqual(self.obj._cleanup.call_count, 1)
 
@@ -695,9 +677,7 @@ class ChannelTests(unittest.TestCase):
             basic_cancel.assert_called_once_with(consumer_tag='abc')
 
     def test_confirm_delivery_with_bad_callback_raises_value_error(self):
-        self.assertRaises(ValueError,
-                          self.obj.confirm_delivery,
-                          'bad-callback')
+        self.assertRaises(ValueError, self.obj.confirm_delivery, 'bad-callback')
 
     def test_confirm_delivery_raises_channel_wrong_state(self):
         cb = mock.Mock()
@@ -734,8 +714,7 @@ class ChannelTests(unittest.TestCase):
     def test_confirm_delivery_callback_without_nowait_selectok(self):
         self.obj._set_state(self.obj.OPEN)
         expectation = [
-            self.obj.channel_number,
-            spec.Confirm.SelectOk,
+            self.obj.channel_number, spec.Confirm.SelectOk,
             self.obj._on_selectok
         ]
         self.obj.confirm_delivery(ack_nack_callback=logging.debug,
@@ -762,41 +741,34 @@ class ChannelTests(unittest.TestCase):
         self.obj.confirm_delivery(ack_nack_callback=user_ack_nack_callback,
                                   callback=self.obj._on_selectok)
         expectation = [
-            mock.call(
-                *[
-                    self.obj.channel_number,
-                    spec.Basic.Ack,
-                    user_ack_nack_callback,
-                    False
-                ]),
-            mock.call(
-                *[
-                    self.obj.channel_number,
-                    spec.Basic.Nack,
-                    user_ack_nack_callback,
-                    False
-                ]),
-            mock.call(
-                *[
-                    self.obj.channel_number,
-                    spec.Confirm.SelectOk,
-                    self.obj._on_synchronous_complete
-                ],
-                arguments=None),
-            mock.call(
-                *[
-                    self.obj.channel_number,
-                    spec.Confirm.SelectOk,
-                    self.obj._on_selectok,
-                ],
-                arguments=None)
+            mock.call(*[
+                self.obj.channel_number, spec.Basic.Ack, user_ack_nack_callback,
+                False
+            ]),
+            mock.call(*[
+                self.obj.channel_number, spec.Basic.Nack,
+                user_ack_nack_callback, False
+            ]),
+            mock.call(*[
+                self.obj.channel_number, spec.Confirm.SelectOk,
+                self.obj._on_synchronous_complete
+            ],
+                      arguments=None),
+            mock.call(*[
+                self.obj.channel_number,
+                spec.Confirm.SelectOk,
+                self.obj._on_selectok,
+            ],
+                      arguments=None)
         ]
         self.assertEqual(self.obj.callbacks.add.call_args_list, expectation)
 
     def test_confirm_delivery_callback_yes_basic_ack_callback(self):
         self.obj._set_state(self.obj.OPEN)
         user_callback = mock.Mock()
-        expectation = [self.obj.channel_number, spec.Basic.Ack, user_callback, False]
+        expectation = [
+            self.obj.channel_number, spec.Basic.Ack, user_callback, False
+        ]
         expectation_item = mock.call(*expectation)
         self.obj.confirm_delivery(ack_nack_callback=user_callback)
         self.assertIn(expectation_item, self.obj.callbacks.add.call_args_list)
@@ -804,7 +776,9 @@ class ChannelTests(unittest.TestCase):
     def test_confirm_delivery_callback_yes_basic_nack_callback(self):
         self.obj._set_state(self.obj.OPEN)
         user_callback = mock.Mock()
-        expectation = [self.obj.channel_number, spec.Basic.Nack, user_callback, False]
+        expectation = [
+            self.obj.channel_number, spec.Basic.Nack, user_callback, False
+        ]
         expectation_item = mock.call(*expectation)
         self.obj.confirm_delivery(ack_nack_callback=user_callback)
         self.assertIn(expectation_item, self.obj.callbacks.add.call_args_list)
@@ -815,13 +789,13 @@ class ChannelTests(unittest.TestCase):
 
     def test_exchange_bind_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.exchange_bind,
-                          'foo', 'bar', 'baz', None, None)
+                          self.obj.exchange_bind, 'foo', 'bar', 'baz', None,
+                          None)
 
     def test_exchange_bind_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.exchange_bind,
-                          'foo', 'bar', 'baz', None, 'callback')
+        self.assertRaises(TypeError, self.obj.exchange_bind, 'foo', 'bar',
+                          'baz', None, 'callback')
 
     @mock.patch('pika.spec.Exchange.Bind')
     @mock.patch('pika.channel.Channel._rpc')
@@ -829,28 +803,28 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.exchange_bind('foo', 'bar', 'baz', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Exchange.Bind(0, 'foo', 'bar', 'baz'), mock_callback,
-            [spec.Exchange.BindOk])
+        rpc.assert_called_once_with(spec.Exchange.Bind(0, 'foo', 'bar', 'baz'),
+                                    mock_callback, [spec.Exchange.BindOk])
 
     @mock.patch('pika.spec.Exchange.Bind')
     @mock.patch('pika.channel.Channel._rpc')
     def test_exchange_bind_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.exchange_bind('foo', 'bar', 'baz', callback=None)
-        rpc.assert_called_once_with(
-            spec.Exchange.Bind(0, 'foo', 'bar', 'baz'), None, [])
+        rpc.assert_called_once_with(spec.Exchange.Bind(0, 'foo', 'bar', 'baz'),
+                                    None, [])
 
     def test_exchange_declare_raises_channel_wrong_state(self):
-        self.assertRaises(
-            exceptions.ChannelWrongStateError,
-            self.obj.exchange_declare,
-            exchange='foo')
+        self.assertRaises(exceptions.ChannelWrongStateError,
+                          self.obj.exchange_declare,
+                          exchange='foo')
 
     def test_exchange_declare_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.exchange_declare,
-                          'foo', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.exchange_declare,
+                          'foo',
+                          callback='callback')
 
     @mock.patch('pika.spec.Exchange.Declare')
     @mock.patch('pika.channel.Channel._rpc')
@@ -858,27 +832,27 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.exchange_declare('foo', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Exchange.Declare(0, 'foo'), mock_callback,
-            [spec.Exchange.DeclareOk])
+        rpc.assert_called_once_with(spec.Exchange.Declare(0, 'foo'),
+                                    mock_callback, [spec.Exchange.DeclareOk])
 
     @mock.patch('pika.spec.Exchange.Declare')
     @mock.patch('pika.channel.Channel._rpc')
     def test_exchange_declare_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.exchange_declare('foo', callback=None)
-        rpc.assert_called_once_with(
-            spec.Exchange.Declare(0, 'foo'), None, [])
+        rpc.assert_called_once_with(spec.Exchange.Declare(0, 'foo'), None, [])
 
     def test_exchange_delete_raises_channel_wrong_state(self):
-        self.assertRaises(
-            exceptions.ChannelWrongStateError,
-            self.obj.exchange_delete, exchange='foo')
+        self.assertRaises(exceptions.ChannelWrongStateError,
+                          self.obj.exchange_delete,
+                          exchange='foo')
 
     def test_exchange_delete_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.exchange_delete,
-                          'foo', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.exchange_delete,
+                          'foo',
+                          callback='callback')
 
     @mock.patch('pika.spec.Exchange.Delete')
     @mock.patch('pika.channel.Channel._rpc')
@@ -886,27 +860,28 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.exchange_delete('foo', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Exchange.Delete(0, 'foo'), mock_callback,
-            [spec.Exchange.DeleteOk])
+        rpc.assert_called_once_with(spec.Exchange.Delete(0, 'foo'),
+                                    mock_callback, [spec.Exchange.DeleteOk])
 
     @mock.patch('pika.spec.Exchange.Delete')
     @mock.patch('pika.channel.Channel._rpc')
     def test_exchange_delete_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.exchange_delete('foo', callback=None)
-        rpc.assert_called_once_with(
-            spec.Exchange.Delete(0, 'foo'), None, [])
+        rpc.assert_called_once_with(spec.Exchange.Delete(0, 'foo'), None, [])
 
     def test_exchange_unbind_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.exchange_unbind,
-                          None, 'foo', 'bar', 'baz')
+                          self.obj.exchange_unbind, None, 'foo', 'bar', 'baz')
 
     def test_exchange_unbind_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.exchange_unbind,
-                          'foo', 'bar', 'baz', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.exchange_unbind,
+                          'foo',
+                          'bar',
+                          'baz',
+                          callback='callback')
 
     @mock.patch('pika.spec.Exchange.Unbind')
     @mock.patch('pika.channel.Channel._rpc')
@@ -923,14 +898,17 @@ class ChannelTests(unittest.TestCase):
     def test_exchange_unbind_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
-        self.obj.exchange_unbind(
-            mock_callback, 'foo', 'bar', 'baz', callback=None)
+        self.obj.exchange_unbind(mock_callback,
+                                 'foo',
+                                 'bar',
+                                 'baz',
+                                 callback=None)
         rpc.assert_called_once_with(
             spec.Exchange.Unbind(0, 'foo', 'bar', 'baz'), None, [])
 
     def test_flow_raises_channel_wrong_state(self):
-        self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.flow, True, 'foo')
+        self.assertRaises(exceptions.ChannelWrongStateError, self.obj.flow,
+                          True, 'foo')
 
     def test_flow_raises_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
@@ -942,9 +920,8 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.flow(True, callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Channel.Flow(True), self.obj._on_flowok,
-            [spec.Channel.FlowOk])
+        rpc.assert_called_once_with(spec.Channel.Flow(True),
+                                    self.obj._on_flowok, [spec.Channel.FlowOk])
 
     @mock.patch('pika.spec.Channel.Flow')
     @mock.patch('pika.channel.Channel._rpc')
@@ -952,9 +929,8 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.flow(False, callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Channel.Flow(False), self.obj._on_flowok,
-            [spec.Channel.FlowOk])
+        rpc.assert_called_once_with(spec.Channel.Flow(False),
+                                    self.obj._on_flowok, [spec.Channel.FlowOk])
 
     @mock.patch('pika.channel.Channel._rpc')
     def test_flow_on_flowok_callback(self, _rpc):
@@ -987,13 +963,16 @@ class ChannelTests(unittest.TestCase):
 
     def test_queue_bind_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.queue_bind, '',
-                          'foo', 'bar', 'baz')
+                          self.obj.queue_bind, '', 'foo', 'bar', 'baz')
 
     def test_queue_bind_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.queue_bind,
-                          'foo', 'bar', 'baz', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.queue_bind,
+                          'foo',
+                          'bar',
+                          'baz',
+                          callback='callback')
 
     @mock.patch('pika.spec.Queue.Bind')
     @mock.patch('pika.channel.Channel._rpc')
@@ -1001,29 +980,29 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.queue_bind('foo', 'bar', 'baz', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Queue.Bind(0, 'foo', 'bar', 'baz'), mock_callback,
-            [spec.Queue.BindOk])
+        rpc.assert_called_once_with(spec.Queue.Bind(0, 'foo', 'bar', 'baz'),
+                                    mock_callback, [spec.Queue.BindOk])
 
     @mock.patch('pika.spec.Queue.Bind')
     @mock.patch('pika.channel.Channel._rpc')
     def test_queue_bind_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.queue_bind('foo', 'bar', 'baz', callback=None)
-        rpc.assert_called_once_with(
-            spec.Queue.Bind(0, 'foo', 'bar', 'baz'), None, [])
+        rpc.assert_called_once_with(spec.Queue.Bind(0, 'foo', 'bar', 'baz'),
+                                    None, [])
 
     def test_queue_declare_raises_channel_wrong_state(self):
-        self.assertRaises(
-            exceptions.ChannelWrongStateError,
-            self.obj.queue_declare,
-            queue='foo',
-            callback=None)
+        self.assertRaises(exceptions.ChannelWrongStateError,
+                          self.obj.queue_declare,
+                          queue='foo',
+                          callback=None)
 
     def test_queue_declare_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.queue_declare,
-                          'foo', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.queue_declare,
+                          'foo',
+                          callback='callback')
 
     @mock.patch('pika.spec.Queue.Declare')
     @mock.patch('pika.channel.Channel._rpc')
@@ -1031,29 +1010,29 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.queue_declare('foo', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Queue.Declare(0, 'foo'), mock_callback,
-            [(spec.Queue.DeclareOk, {
-                'queue': 'foo'
-            })])
+        rpc.assert_called_once_with(spec.Queue.Declare(0, 'foo'), mock_callback,
+                                    [(spec.Queue.DeclareOk, {
+                                        'queue': 'foo'
+                                    })])
 
     @mock.patch('pika.spec.Queue.Declare')
     @mock.patch('pika.channel.Channel._rpc')
     def test_queue_declare_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.queue_declare('foo', callback=None)
-        rpc.assert_called_once_with(
-            spec.Queue.Declare(0, 'foo'), None, [])
+        rpc.assert_called_once_with(spec.Queue.Declare(0, 'foo'), None, [])
 
     def test_queue_delete_raises_channel_wrong_state(self):
-        self.assertRaises(
-            exceptions.ChannelWrongStateError,
-            self.obj.queue_delete, queue='foo')
+        self.assertRaises(exceptions.ChannelWrongStateError,
+                          self.obj.queue_delete,
+                          queue='foo')
 
     def test_queue_delete_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.queue_delete,
-                          'foo', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.queue_delete,
+                          'foo',
+                          callback='callback')
 
     @mock.patch('pika.spec.Queue.Delete')
     @mock.patch('pika.channel.Channel._rpc')
@@ -1061,26 +1040,27 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.queue_delete('foo', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Queue.Delete(0, 'foo'), mock_callback, [spec.Queue.DeleteOk])
+        rpc.assert_called_once_with(spec.Queue.Delete(0, 'foo'), mock_callback,
+                                    [spec.Queue.DeleteOk])
 
     @mock.patch('pika.spec.Queue.Delete')
     @mock.patch('pika.channel.Channel._rpc')
     def test_queue_delete_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.queue_delete('foo', callback=None)
-        rpc.assert_called_once_with(
-            spec.Queue.Delete(0, 'foo'), None, [])
+        rpc.assert_called_once_with(spec.Queue.Delete(0, 'foo'), None, [])
 
     def test_queue_purge_raises_channel_wrong_state(self):
-        self.assertRaises(
-            exceptions.ChannelWrongStateError,
-            self.obj.queue_purge, queue='foo')
+        self.assertRaises(exceptions.ChannelWrongStateError,
+                          self.obj.queue_purge,
+                          queue='foo')
 
     def test_queue_purge_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.queue_purge,
-                          'foo', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.queue_purge,
+                          'foo',
+                          callback='callback')
 
     @mock.patch('pika.spec.Queue.Purge')
     @mock.patch('pika.channel.Channel._rpc')
@@ -1088,26 +1068,32 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.queue_purge('foo', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Queue.Purge(0, 'foo'), mock_callback, [spec.Queue.PurgeOk])
+        rpc.assert_called_once_with(spec.Queue.Purge(0, 'foo'), mock_callback,
+                                    [spec.Queue.PurgeOk])
 
     @mock.patch('pika.spec.Queue.Purge')
     @mock.patch('pika.channel.Channel._rpc')
     def test_queue_purge_rpc_request_nowait(self, rpc, _unused):
         self.obj._set_state(self.obj.OPEN)
         self.obj.queue_purge('foo', callback=None)
-        rpc.assert_called_once_with(
-            spec.Queue.Purge(0, 'foo'), None, [])
+        rpc.assert_called_once_with(spec.Queue.Purge(0, 'foo'), None, [])
 
     def test_queue_unbind_raises_channel_wrong_state(self):
         self.assertRaises(exceptions.ChannelWrongStateError,
                           self.obj.queue_unbind,
-                          'foo', 'bar', 'baz', callback=None)
+                          'foo',
+                          'bar',
+                          'baz',
+                          callback=None)
 
     def test_queue_unbind_raises_value_error_on_invalid_callback(self):
         self.obj._set_state(self.obj.OPEN)
-        self.assertRaises(TypeError, self.obj.queue_unbind, 'foo',
-                          'bar', 'baz', callback='callback')
+        self.assertRaises(TypeError,
+                          self.obj.queue_unbind,
+                          'foo',
+                          'bar',
+                          'baz',
+                          callback='callback')
 
     @mock.patch('pika.spec.Queue.Unbind')
     @mock.patch('pika.channel.Channel._rpc')
@@ -1115,13 +1101,12 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         mock_callback = mock.Mock()
         self.obj.queue_unbind('foo', 'bar', 'baz', callback=mock_callback)
-        rpc.assert_called_once_with(
-            spec.Queue.Unbind(0, 'foo', 'bar', 'baz'), mock_callback,
-            [spec.Queue.UnbindOk])
+        rpc.assert_called_once_with(spec.Queue.Unbind(0, 'foo', 'bar', 'baz'),
+                                    mock_callback, [spec.Queue.UnbindOk])
 
     def test_tx_commit_raises_channel_wrong_state(self):
-        self.assertRaises(exceptions.ChannelWrongStateError,
-                          self.obj.tx_commit, None)
+        self.assertRaises(exceptions.ChannelWrongStateError, self.obj.tx_commit,
+                          None)
 
     @mock.patch('pika.spec.Tx.Commit')
     @mock.patch('pika.channel.Channel._rpc')
@@ -1189,14 +1174,12 @@ class ChannelTests(unittest.TestCase):
     def test_handle_content_frame_sets_method_frame(self):
         frame_value = frame.Method(1, spec.Basic.Deliver('ctag0', 1))
         self.obj._handle_content_frame(frame_value)
-        self.assertEqual(self.obj._content_assembler._method_frame,
-                         frame_value)
+        self.assertEqual(self.obj._content_assembler._method_frame, frame_value)
 
     def test_handle_content_frame_sets_header_frame(self):
         frame_value = frame.Header(1, 10, spec.BasicProperties())
         self.obj._handle_content_frame(frame_value)
-        self.assertEqual(self.obj._content_assembler._header_frame,
-                         frame_value)
+        self.assertEqual(self.obj._content_assembler._header_frame, frame_value)
 
     def test_handle_content_frame_basic_deliver_called(self):
         method_value = frame.Method(1, spec.Basic.Deliver('ctag0', 1))
@@ -1221,10 +1204,10 @@ class ChannelTests(unittest.TestCase):
                                           b'0123456789')
 
     def test_handle_content_frame_basic_return_called(self):
-        method_value = frame.Method(1,
-                                    spec.Basic.Return(999, 'Reply Text',
-                                                      'exchange_value',
-                                                      'routing.key'))
+        method_value = frame.Method(
+            1,
+            spec.Basic.Return(999, 'Reply Text', 'exchange_value',
+                              'routing.key'))
         self.obj._handle_content_frame(method_value)
         header_value = frame.Header(1, 10, spec.BasicProperties())
         self.obj._handle_content_frame(header_value)
@@ -1271,19 +1254,17 @@ class ChannelTests(unittest.TestCase):
         self.obj._on_close_from_broker(method_frame)
 
         self.assertTrue(self.obj.is_closed,
-                        'Channel was not closed; state=%s' %
-                        (self.obj._state, ))
+                        'Channel was not closed; state=%s' % (self.obj._state,))
 
         self.obj._send_method.assert_called_once_with(spec.Channel.CloseOk())
 
-        self.obj.callbacks.process.assert_any_call(
-            self.obj.channel_number, '_on_channel_close', self.obj, self.obj,
-            mock.ANY)
+        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+                                                   '_on_channel_close',
+                                                   self.obj, self.obj, mock.ANY)
 
         reason = self.obj.callbacks.process.call_args_list[0][0][4]
         self.assertIsInstance(reason, exceptions.ChannelClosedByBroker)
-        self.assertEqual((reason.reply_code, reason.reply_text),
-                         (400, 'error'))
+        self.assertEqual((reason.reply_code, reason.reply_text), (400, 'error'))
 
         self.assertEqual(self.obj._cleanup.call_count, 1)
 
@@ -1297,8 +1278,7 @@ class ChannelTests(unittest.TestCase):
 
         # Verify didn't alter state (will wait for CloseOk)
         self.assertTrue(self.obj.is_closing,
-                        'Channel was not closed; state=%s' %
-                        (self.obj._state, ))
+                        'Channel was not closed; state=%s' % (self.obj._state,))
 
         self.assertIsInstance(self.obj._closing_reason,
                               exceptions.ChannelClosedByBroker)
@@ -1337,9 +1317,9 @@ class ChannelTests(unittest.TestCase):
 
         self.assertEqual(self.obj.callbacks.process.call_count, 2)
 
-        self.obj.callbacks.process.assert_any_call(
-            self.obj.channel_number, '_on_channel_close', self.obj, self.obj,
-            reason)
+        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+                                                   '_on_channel_close',
+                                                   self.obj, self.obj, reason)
 
         self.obj.callbacks.process.assert_any_call(
             self.obj.channel_number, self.obj._ON_CHANNEL_CLEANUP_CB_KEY,
@@ -1390,13 +1370,11 @@ class ChannelTests(unittest.TestCase):
             frame.Method(self.obj.channel_number, spec.Channel.CloseOk()))
 
         self.assertTrue(self.obj.is_closed,
-                        'Channel was not closed; state=%s' %
-                        (self.obj._state, ))
+                        'Channel was not closed; state=%s' % (self.obj._state,))
 
         self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
-                                                   self.obj, self.obj,
-                                                   mock.ANY)
+                                                   self.obj, self.obj, mock.ANY)
         reason = self.obj.callbacks.process.call_args_list[0][0][4]
         self.assertIsInstance(reason, exceptions.ChannelClosedByClient)
         self.assertEqual((reason.reply_code, reason.reply_text),
@@ -1417,15 +1395,13 @@ class ChannelTests(unittest.TestCase):
         # Close from broker before Channel.CloseOk
         self.obj._on_close_from_broker(
             frame.Method(self.obj.channel_number,
-                         spec.Channel.Close(400,
-                                            'broker is having a bad day')))
+                         spec.Channel.Close(400, 'broker is having a bad day')))
 
         self.assertIsInstance(self.obj._closing_reason,
                               exceptions.ChannelClosedByBroker)
-        self.assertEqual(
-            (self.obj._closing_reason.reply_code,
-             self.obj._closing_reason.reply_text),
-            (400, 'broker is having a bad day'))
+        self.assertEqual((self.obj._closing_reason.reply_code,
+                          self.obj._closing_reason.reply_text),
+                         (400, 'broker is having a bad day'))
         self.assertEqual(self.obj._state, self.obj.CLOSING)
 
         self.obj._on_closeok(
@@ -1433,14 +1409,13 @@ class ChannelTests(unittest.TestCase):
 
         # Verify this completes closing of the channel
         self.assertTrue(self.obj.is_closed,
-                        'Channel was not closed; state=%s' %
-                        (self.obj._state, ))
+                        'Channel was not closed; state=%s' % (self.obj._state,))
 
         self.assertEqual(self.obj.callbacks.process.call_count, 2)
 
-        self.obj.callbacks.process.assert_any_call(
-            self.obj.channel_number, '_on_channel_close', self.obj, self.obj,
-            mock.ANY)
+        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+                                                   '_on_channel_close',
+                                                   self.obj, self.obj, mock.ANY)
 
         self.assertEqual(self.obj._cleanup.call_count, 1)
 
@@ -1457,8 +1432,7 @@ class ChannelTests(unittest.TestCase):
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = b'0123456789'
         self.obj._on_getok(method_value, header_value, body_value)
-        error.assert_called_with(
-            'Basic.GetOk received with no active callback')
+        error.assert_called_with('Basic.GetOk received with no active callback')
 
     def test_on_getok_callback_called(self):
         mock_callback = mock.Mock()
@@ -1467,8 +1441,9 @@ class ChannelTests(unittest.TestCase):
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = b'0123456789'
         self.obj._on_getok(method_value, header_value, body_value)
-        mock_callback.assert_called_once_with(
-            self.obj, method_value.method, header_value.properties, body_value)
+        mock_callback.assert_called_once_with(self.obj, method_value.method,
+                                              header_value.properties,
+                                              body_value)
 
     def test_on_getok_callback_reset(self):
         mock_callback = mock.Mock()
@@ -1547,10 +1522,10 @@ class ChannelTests(unittest.TestCase):
         mock_callback.assert_called_once_with(self.obj)
 
     def test_onreturn(self):
-        method_value = frame.Method(1,
-                                    spec.Basic.Return(999, 'Reply Text',
-                                                      'exchange_value',
-                                                      'routing.key'))
+        method_value = frame.Method(
+            1,
+            spec.Basic.Return(999, 'Reply Text', 'exchange_value',
+                              'routing.key'))
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = frame.Body(1, b'0123456789')
         self.obj._on_return(method_value, header_value, body_value)
@@ -1585,8 +1560,7 @@ class ChannelTests(unittest.TestCase):
             'consumer_tag': 'tag_abc'
         })]
         expectation = [
-            spec.Basic.Cancel('tag_abc'), lambda *args: None,
-            acceptable_replies
+            spec.Basic.Cancel('tag_abc'), lambda *args: None, acceptable_replies
         ]
         self.obj._rpc(*expectation)
         self.assertIn(expectation, self.obj._blocked)
@@ -1630,17 +1604,16 @@ class ChannelTests(unittest.TestCase):
         method_frame = spec.Channel.Open()
         mock_callback = mock.Mock()
         self.obj._rpc(method_frame, mock_callback, [spec.Channel.OpenOk])
-        self.obj.callbacks.add.assert_called_with(
-            self.obj.channel_number,
-            spec.Channel.OpenOk,
-            mock_callback,
-            arguments=None)
+        self.obj.callbacks.add.assert_called_with(self.obj.channel_number,
+                                                  spec.Channel.OpenOk,
+                                                  mock_callback,
+                                                  arguments=None)
 
     def test_send_method(self):
         expectation = [2, 3]
         self.obj._send_method(*expectation)
         self.obj.connection._send_method.assert_called_once_with(
-                *[self.obj.channel_number] + expectation)
+            *[self.obj.channel_number] + expectation)
 
     def test_set_state(self):
         self.obj._state = channel.Channel.CLOSED
@@ -1657,7 +1630,8 @@ class ChannelTests(unittest.TestCase):
         self.assertIsNone(self.obj._blocking)
 
         with mock.patch.object(self.obj.callbacks, 'add') as cb_add_mock:
-            with mock.patch.object(self.obj, '_send_method',
+            with mock.patch.object(self.obj,
+                                   '_send_method',
                                    side_effect=TypeError) as send_method_mock:
                 with self.assertRaises(TypeError):
                     self.obj.queue_delete('', callback=lambda _frame: None)

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -4,9 +4,9 @@ from pika import compat
 
 
 class UtilsTests(unittest.TestCase):
+
     def test_get_linux_version_normal(self):
-        self.assertEqual(
-            compat.get_linux_version("4.11.0-2-amd64"), (4, 11, 0))
+        self.assertEqual(compat.get_linux_version("4.11.0-2-amd64"), (4, 11, 0))
 
     def test_get_linux_version_short(self):
         self.assertEqual(compat.get_linux_version("4.11.0"), (4, 11, 0))

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -32,8 +32,8 @@ class ChildParameters(connection.Parameters):
 
     def __eq__(self, other):
         if isinstance(other, ChildParameters):
-            return self.extra == other.extra and super(
-                ChildParameters, self).__eq__(other)
+            return self.extra == other.extra and super(ChildParameters,
+                                                       self).__eq__(other)
         return NotImplemented
 
 
@@ -52,43 +52,43 @@ class ParametersTestsBase(unittest.TestCase):
         kls = connection.Parameters
         defaults = {
             'blocked_connection_timeout':
-            kls.DEFAULT_BLOCKED_CONNECTION_TIMEOUT,
+                kls.DEFAULT_BLOCKED_CONNECTION_TIMEOUT,
             'channel_max':
-            kls.DEFAULT_CHANNEL_MAX,
+                kls.DEFAULT_CHANNEL_MAX,
             'client_properties':
-            kls.DEFAULT_CLIENT_PROPERTIES,
+                kls.DEFAULT_CLIENT_PROPERTIES,
             'connection_attempts':
-            kls.DEFAULT_CONNECTION_ATTEMPTS,
+                kls.DEFAULT_CONNECTION_ATTEMPTS,
             'credentials':
-            credentials.PlainCredentials(kls.DEFAULT_USERNAME,
-                                         kls.DEFAULT_PASSWORD),
+                credentials.PlainCredentials(kls.DEFAULT_USERNAME,
+                                             kls.DEFAULT_PASSWORD),
             'frame_max':
-            kls.DEFAULT_FRAME_MAX,
+                kls.DEFAULT_FRAME_MAX,
             'heartbeat':
-            kls.DEFAULT_HEARTBEAT_TIMEOUT,
+                kls.DEFAULT_HEARTBEAT_TIMEOUT,
             'host':
-            kls.DEFAULT_HOST,
+                kls.DEFAULT_HOST,
             'locale':
-            kls.DEFAULT_LOCALE,
+                kls.DEFAULT_LOCALE,
             'port':
-            kls.DEFAULT_PORT,
+                kls.DEFAULT_PORT,
             'retry_delay':
-            kls.DEFAULT_RETRY_DELAY,
+                kls.DEFAULT_RETRY_DELAY,
             'socket_timeout':
-            kls.DEFAULT_SOCKET_TIMEOUT,
+                kls.DEFAULT_SOCKET_TIMEOUT,
             'stack_timeout':
-            kls.DEFAULT_STACK_TIMEOUT,
+                kls.DEFAULT_STACK_TIMEOUT,
             'ssl_options':
-            kls.DEFAULT_SSL_OPTIONS,
+                kls.DEFAULT_SSL_OPTIONS,
             'virtual_host':
-            kls.DEFAULT_VIRTUAL_HOST,
+                kls.DEFAULT_VIRTUAL_HOST,
             'tcp_options':
-            kls.DEFAULT_TCP_OPTIONS
+                kls.DEFAULT_TCP_OPTIONS
         }
 
         # Make sure we didn't miss anything
-        self.assertSequenceEqual(
-            sorted(defaults), sorted(_ALL_PUBLIC_PARAMETERS_PROPERTIES))
+        self.assertSequenceEqual(sorted(defaults),
+                                 sorted(_ALL_PUBLIC_PARAMETERS_PROPERTIES))
 
         return defaults
 
@@ -101,11 +101,10 @@ class ParametersTestsBase(unittest.TestCase):
         """
         for name, expected_value in self.get_default_properties().items():
             value = getattr(params, name)
-            self.assertEqual(
-                value,
-                expected_value,
-                msg='Expected %s=%r, but got %r' % (name, expected_value,
-                                                    value))
+            self.assertEqual(value,
+                             expected_value,
+                             msg='Expected %s=%r, but got %r' %
+                             (name, expected_value, value))
 
 
 class ParametersTests(ParametersTestsBase):
@@ -325,6 +324,7 @@ class ParametersTests(ParametersTestsBase):
 
         def heartbeat_callback(_conn, _val):
             return 1
+
         params.heartbeat = heartbeat_callback
         self.assertTrue(callable(params.heartbeat))
         self.assertIs(params.heartbeat, heartbeat_callback)
@@ -447,11 +447,10 @@ class ParametersTests(ParametersTestsBase):
     def test_tcp_options(self):
         params = connection.Parameters()
 
-        opt = dict(
-            TCP_KEEPIDLE=60,
-            TCP_KEEPINTVL=2,
-            TCP_KEEPCNT=1,
-            TCP_USER_TIMEOUT=1000)
+        opt = dict(TCP_KEEPIDLE=60,
+                   TCP_KEEPINTVL=2,
+                   TCP_KEEPCNT=1,
+                   TCP_USER_TIMEOUT=1000)
         params.tcp_options = copy.deepcopy(opt)
         self.assertEqual(params.tcp_options, opt)
 
@@ -533,20 +532,21 @@ class ConnectionParametersTests(ParametersTestsBase):
         expected_values = copy.copy(kwargs)
 
         # Make sure we're testing all public properties
-        self.assertSequenceEqual(
-            sorted(expected_values), sorted(_ALL_PUBLIC_PARAMETERS_PROPERTIES))
+        self.assertSequenceEqual(sorted(expected_values),
+                                 sorted(_ALL_PUBLIC_PARAMETERS_PROPERTIES))
         # Check property values
         for t_param in expected_values:
             value = getattr(params, t_param)
-            self.assertEqual(
-                expected_values[t_param],
-                value,
-                msg='Expected %s=%r, but got %r' %
-                (t_param, expected_values[t_param], value))
+            self.assertEqual(expected_values[t_param],
+                             value,
+                             msg='Expected %s=%r, but got %r' %
+                             (t_param, expected_values[t_param], value))
 
     def test_callable_heartbeat(self):
+
         def heartbeat_callback(_connection, _broker_val):
             return 1
+
         parameters = pika.ConnectionParameters(heartbeat=heartbeat_callback)
         self.assertIs(parameters.heartbeat, heartbeat_callback)
 
@@ -563,22 +563,20 @@ class ConnectionParametersTests(ParametersTestsBase):
             'blocked_connection_timeout': 10.5
         }
         # Test Type Errors
-        for bad_field, bad_value in (
-                ('host', 15672),
-                ('port', '5672a'),
-                ('virtual_host', True),
-                ('channel_max', '4'),
-                ('frame_max', '5'),
-                ('credentials', 'bad'),
-                ('locale', 1),
-                ('heartbeat', '6'),
-                ('socket_timeout', '42'),
-                ('stack_timeout', '99'),
-                ('retry_delay', 'two'),
-                ('ssl', {'ssl': 'dict'}),
-                ('ssl_options', True),
-                ('connection_attempts', 'hello'),
-                ('blocked_connection_timeout', set())):
+        for bad_field, bad_value in (('host', 15672), ('port', '5672a'),
+                                     ('virtual_host', True), ('channel_max',
+                                                              '4'),
+                                     ('frame_max', '5'), ('credentials', 'bad'),
+                                     ('locale', 1), ('heartbeat', '6'),
+                                     ('socket_timeout',
+                                      '42'), ('stack_timeout',
+                                              '99'), ('retry_delay',
+                                                      'two'), ('ssl', {
+                                                          'ssl': 'dict'
+                                                      }), ('ssl_options', True),
+                                     ('connection_attempts',
+                                      'hello'), ('blocked_connection_timeout',
+                                                 set())):
 
             bkwargs = copy.deepcopy(kwargs)
 
@@ -692,11 +690,10 @@ class URLParametersTests(ParametersTestsBase):
             expected_value = query_args[t_param]
             actual_value = getattr(params, t_param)
 
-            self.assertEqual(
-                actual_value,
-                expected_value,
-                msg='Expected %s=%r, but got %r' %
-                (t_param, expected_value, actual_value))
+            self.assertEqual(actual_value,
+                             expected_value,
+                             msg='Expected %s=%r, but got %r' %
+                             (t_param, expected_value, actual_value))
 
         # check all values from base URL
         self.assertEqual(params.credentials.username, 'myuser')
@@ -749,12 +746,14 @@ class URLParametersTests(ParametersTestsBase):
         self.assertEqual(parameters.virtual_host,
                          pika.URLParameters.DEFAULT_VIRTUAL_HOST)
 
-    def test_uses_default_virtual_host_via_encoded_slash_upcase_ending_with_slash(self):
+    def test_uses_default_virtual_host_via_encoded_slash_upcase_ending_with_slash(
+            self):
         parameters = pika.URLParameters('amqp://myserver.mycompany.com/%2F/')
         self.assertEqual(parameters.virtual_host,
                          pika.URLParameters.DEFAULT_VIRTUAL_HOST)
 
-    def test_uses_default_virtual_host_via_encoded_slash_downcase_ending_with_slash(self):
+    def test_uses_default_virtual_host_via_encoded_slash_downcase_ending_with_slash(
+            self):
         parameters = pika.URLParameters('amqp://myserver.mycompany.com/%2f/')
         self.assertEqual(parameters.virtual_host,
                          pika.URLParameters.DEFAULT_VIRTUAL_HOST)

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -31,6 +31,7 @@ class ConstructibleConnection(connection.Connection):
     that we can instantiate and test it.
 
     """
+
     def _adapter_connect_stream(self):
         raise NotImplementedError
 
@@ -51,7 +52,9 @@ class ConstructibleConnection(connection.Connection):
 
 
 class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
+
     def setUp(self):
+
         class ChannelTemplate(channel.Channel):
             channel_number = None
 
@@ -117,19 +120,20 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
             self.assertEqual(self.connection.connection_state, closed_state)
 
     @mock.patch('pika.connection.Connection._rpc')
-    def test_update_secret_raises_wrong_state_when_not_open(
-            self, rpc):
-        connection_states = (self.connection.CONNECTION_CLOSED, self.connection.CONNECTION_CLOSING,
-                             self.connection.CONNECTION_INIT, self.connection.CONNECTION_START,
-                             self.connection.CONNECTION_PROTOCOL, self.connection.CONNECTION_TUNE)
+    def test_update_secret_raises_wrong_state_when_not_open(self, rpc):
+        connection_states = (self.connection.CONNECTION_CLOSED,
+                             self.connection.CONNECTION_CLOSING,
+                             self.connection.CONNECTION_INIT,
+                             self.connection.CONNECTION_START,
+                             self.connection.CONNECTION_PROTOCOL,
+                             self.connection.CONNECTION_TUNE)
         for connection_state in connection_states:
             self.connection.connection_state = connection_state
             with self.assertRaises(exceptions.ConnectionWrongStateError):
                 self.connection.update_secret(mock.Mock(), mock.Mock())
 
     @mock.patch('pika.connection.Connection._send_method')
-    def test_update_secret_sends_method(
-            self, send_method):
+    def test_update_secret_sends_method(self, send_method):
         """make sure it sends the update secret method"""
         new_secret = mock.Mock()
         reason = mock.Mock()
@@ -139,8 +143,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
             0, spec.Connection.UpdateSecret(new_secret, reason))
 
     @mock.patch('pika.connection.Connection._send_method')
-    def test_update_secret_adds_callback_on_update_secret_ok(
-            self, send_method):
+    def test_update_secret_adds_callback_on_update_secret_ok(self, send_method):
         """make sure the on update secret ok callback is added"""
         self.connection.connection_state = self.connection.CONNECTION_OPEN
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
@@ -260,12 +263,12 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
-            conn_exc = self.connection.callbacks.process.call_args_list[0][0][
-                4]
+            conn_exc = self.connection.callbacks.process.call_args_list[0][0][4]
             self.assertIs(type(conn_exc), exceptions.IncompatibleProtocolError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
 
-    def test_on_stream_terminated_invokes_auth_on_connection_error_and_closed(self):
+    def test_on_stream_terminated_invokes_auth_on_connection_error_and_closed(
+            self):
         """_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \
         `ProbableAuthenticationError` and `ON_CONNECTION_CLOSED` callbacks"""
         with mock.patch.object(self.connection.callbacks, 'process'):
@@ -285,10 +288,9 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
-            conn_exc = self.connection.callbacks.process.call_args_list[0][0][
-                4]
-            self.assertIs(
-                type(conn_exc), exceptions.ProbableAuthenticationError)
+            conn_exc = self.connection.callbacks.process.call_args_list[0][0][4]
+            self.assertIs(type(conn_exc),
+                          exceptions.ProbableAuthenticationError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
 
     def test_on_stream_terminated_invokes_access_denied_on_connection_error_and_closed(
@@ -312,8 +314,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
-            conn_exc = self.connection.callbacks.process.call_args_list[0][0][
-                4]
+            conn_exc = self.connection.callbacks.process.call_args_list[0][0][4]
             self.assertIs(type(conn_exc), exceptions.ProbableAccessDeniedError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
 
@@ -408,7 +409,8 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         with self.assertRaises(exceptions.ConnectionWrongStateError):
             self.connection.channel(on_open_callback=lambda *args: None)
 
-    def test_connect_no_adapter_connect_from_constructor_with_external_workflow(self):
+    def test_connect_no_adapter_connect_from_constructor_with_external_workflow(
+            self):
         """check that adapter connection is not happening in constructor with external connection workflow."""
         with mock.patch.object(
                 ConstructibleConnection,
@@ -477,12 +479,15 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         self.connection.connection_state = self.connection.CONNECTION_OPEN
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
 
-        opening_channel = mock.Mock(
-            is_open=False, is_closed=False, is_closing=False)
-        open_channel = mock.Mock(
-            is_open=True, is_closed=False, is_closing=False)
-        closing_channel = mock.Mock(
-            is_open=False, is_closed=False, is_closing=True)
+        opening_channel = mock.Mock(is_open=False,
+                                    is_closed=False,
+                                    is_closing=False)
+        open_channel = mock.Mock(is_open=True,
+                                 is_closed=False,
+                                 is_closing=False)
+        closing_channel = mock.Mock(is_open=False,
+                                    is_closed=False,
+                                    is_closing=True)
         self.connection._channels = {
             'openingc': opening_channel,
             'openc': open_channel,
@@ -546,13 +551,10 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
     @mock.patch('pika.heartbeat.HeartbeatChecker')
     @mock.patch('pika.frame.Method')
-    @mock.patch.object(
-        ConstructibleConnection,
-        '_adapter_emit_data',
-        spec_set=connection.Connection._adapter_emit_data)
-    def test_on_connection_tune(self,
-                                _adapter_emit_data,
-                                method,
+    @mock.patch.object(ConstructibleConnection,
+                       '_adapter_emit_data',
+                       spec_set=connection.Connection._adapter_emit_data)
+    def test_on_connection_tune(self, _adapter_emit_data, method,
                                 heartbeat_checker):
         """make sure _on_connection_tune tunes the connection params"""
         heartbeat_checker.return_value = 'hearbeat obj'
@@ -584,8 +586,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         self.assertEqual(9992, self.connection._body_max_length)
         heartbeat_checker.assert_called_once_with(self.connection, 20)
         self.assertEqual(
-            ['ab'],
-            [call[0][0] for call in _adapter_emit_data.call_args_list])
+            ['ab'], [call[0][0] for call in _adapter_emit_data.call_args_list])
         self.assertEqual('hearbeat obj', self.connection._heartbeat_checker)
 
         # Pika gives precendence to client heartbeat values if set
@@ -712,8 +713,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         # Simulate dispatch of blocked connection
         blocked_frame = pika.frame.Method(
-            0,
-            pika.spec.Connection.Blocked('reason'))
+            0, pika.spec.Connection.Blocked('reason'))
         self.connection._process_frame(blocked_frame)
 
         self.assertEqual(len(blocked_buffer), 1)
@@ -735,10 +735,9 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         self.assertIs(conn, self.connection)
         self.assertIs(frame, unblocked_frame)
 
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
     @mock.patch.object(connection.Connection,
                        'add_on_connection_blocked_callback')
     @mock.patch.object(connection.Connection,
@@ -761,12 +760,10 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
             conn._on_connection_unblocked)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_call_later')
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
-    def test_connection_blocked_sets_timer(self, connect_mock,
-                                           call_later_mock):
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
+    def test_connection_blocked_sets_timer(self, connect_mock, call_later_mock):
         with mock.patch.object(ConstructibleConnection,
                                '_adapter_connect_stream'):
             conn = ConstructibleConnection(
@@ -774,8 +771,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                     blocked_connection_timeout=60))
 
         conn._on_connection_blocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Blocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         # Check
         conn._adapter_call_later.assert_called_once_with(
@@ -784,10 +780,9 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         self.assertIsNotNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_call_later')
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
     def test_blocked_connection_multiple_blocked_in_a_row_sets_timer_once(
             self, connect_mock, call_later_mock):
 
@@ -799,8 +794,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         # Simulate Connection.Blocked trigger
         conn._on_connection_blocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Blocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         # Check
         conn._adapter_call_later.assert_called_once_with(
@@ -812,21 +806,18 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         # Simulate Connection.Blocked trigger again
         conn._on_connection_blocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Blocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         self.assertEqual(conn._adapter_call_later.call_count, 1)
         self.assertIs(conn._blocked_conn_timer, timer)
 
     @mock.patch.object(connection.Connection, '_on_stream_terminated')
-    @mock.patch.object(
-        ConstructibleConnection,
-        '_adapter_call_later',
-        spec_set=connection.Connection._adapter_call_later)
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
+    @mock.patch.object(ConstructibleConnection,
+                       '_adapter_call_later',
+                       spec_set=connection.Connection._adapter_call_later)
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
     def test_blocked_connection_timeout_terminates_connection(
             self, connect_mock, call_later_mock, on_terminate_mock):
 
@@ -838,8 +829,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                     blocked_connection_timeout=60))
 
             conn._on_connection_blocked(
-                conn,
-                mock.Mock(name='frame.Method(Connection.Blocked)'))
+                conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
             conn._on_blocked_connection_timeout()
 
@@ -854,16 +844,15 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
             self.assertIsNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_remove_timeout')
-    @mock.patch.object(
-        ConstructibleConnection,
-        '_adapter_call_later',
-        spec_set=connection.Connection._adapter_call_later)
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
-    def test_blocked_connection_unblocked_removes_timer(
-            self, connect_mock, call_later_mock, remove_timeout_mock):
+    @mock.patch.object(ConstructibleConnection,
+                       '_adapter_call_later',
+                       spec_set=connection.Connection._adapter_call_later)
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
+    def test_blocked_connection_unblocked_removes_timer(self, connect_mock,
+                                                        call_later_mock,
+                                                        remove_timeout_mock):
 
         with mock.patch.object(ConstructibleConnection,
                                '_adapter_connect_stream'):
@@ -872,30 +861,26 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                     blocked_connection_timeout=60))
 
         conn._on_connection_blocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Blocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         self.assertIsNotNone(conn._blocked_conn_timer)
 
         timer = conn._blocked_conn_timer
 
         conn._on_connection_unblocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Unblocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Unblocked)'))
 
         # Check
         conn._adapter_remove_timeout.assert_called_once_with(timer)
         self.assertIsNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_remove_timeout')
-    @mock.patch.object(
-        ConstructibleConnection,
-        '_adapter_call_later',
-        spec_set=connection.Connection._adapter_call_later)
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
+    @mock.patch.object(ConstructibleConnection,
+                       '_adapter_call_later',
+                       spec_set=connection.Connection._adapter_call_later)
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
     def test_blocked_connection_multiple_unblocked_in_a_row_removes_timer_once(
             self, connect_mock, call_later_mock, remove_timeout_mock):
 
@@ -907,8 +892,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         # Simulate Connection.Blocked
         conn._on_connection_blocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Blocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         self.assertIsNotNone(conn._blocked_conn_timer)
 
@@ -916,8 +900,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         # Simulate Connection.Unblocked
         conn._on_connection_unblocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Unblocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Unblocked)'))
 
         # Check
         conn._adapter_remove_timeout.assert_called_once_with(timer)
@@ -925,21 +908,18 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
 
         # Simulate Connection.Unblocked again
         conn._on_connection_unblocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Unblocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Unblocked)'))
 
         self.assertEqual(conn._adapter_remove_timeout.call_count, 1)
         self.assertIsNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_remove_timeout')
-    @mock.patch.object(
-        ConstructibleConnection,
-        '_adapter_call_later',
-        spec_set=connection.Connection._adapter_call_later)
-    @mock.patch.object(
-        connection.Connection,
-        '_adapter_connect_stream',
-        spec_set=connection.Connection._adapter_connect_stream)
+    @mock.patch.object(ConstructibleConnection,
+                       '_adapter_call_later',
+                       spec_set=connection.Connection._adapter_call_later)
+    @mock.patch.object(connection.Connection,
+                       '_adapter_connect_stream',
+                       spec_set=connection.Connection._adapter_connect_stream)
     @mock.patch.object(
         ConstructibleConnection,
         '_adapter_disconnect_stream',
@@ -956,8 +936,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
                 on_open_error_callback=lambda *args: None)
 
         conn._on_connection_blocked(
-            conn,
-            mock.Mock(name='frame.Method(Connection.Blocked)'))
+            conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         self.assertIsNotNone(conn._blocked_conn_timer)
 
@@ -969,23 +948,22 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         conn._adapter_remove_timeout.assert_called_once_with(timer)
         self.assertIsNone(conn._blocked_conn_timer)
 
-    @mock.patch.object(
-        ConstructibleConnection,
-        '_adapter_emit_data',
-        spec_set=connection.Connection._adapter_emit_data)
+    @mock.patch.object(ConstructibleConnection,
+                       '_adapter_emit_data',
+                       spec_set=connection.Connection._adapter_emit_data)
     def test_send_message_updates_frames_sent_and_bytes_sent(
-            self,
-            _adapter_emit_data):
+            self, _adapter_emit_data):
         self.connection._flush_outbound = mock.Mock()
         self.connection._body_max_length = 10000
-        method = spec.Basic.Publish(
-            exchange='my-exchange', routing_key='my-route')
+        method = spec.Basic.Publish(exchange='my-exchange',
+                                    routing_key='my-route')
 
         props = spec.BasicProperties()
         body = b'b' * 1000000
 
-        self.connection._send_method(
-            channel_number=1, method=method, content=(props, body))
+        self.connection._send_method(channel_number=1,
+                                     method=method,
+                                     content=(props, body))
 
         frames_sent = _adapter_emit_data.call_count
         bytes_sent = sum(
@@ -1005,7 +983,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         frame.Method(1, method).marshal()
         frame.Header(1, body_size=10, props=properties).marshal()
         # Create bogus body that should trigger an error during marshalling
-        body = [1,2,3,4]
+        body = [1, 2, 3, 4]
         # Verify that frame body can be created using the bogus body, but
         # that marshalling will fail
         frame.Body(1, body)
@@ -1015,8 +993,8 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         # Now, attempt to send the method with the bogus body
         with self.assertRaises(TypeError):
             self.connection._send_method(channel_number=1,
-                                    method=method,
-                                    content=(properties, body))
+                                         method=method,
+                                         content=(properties, body))
 
         # Now make sure that nothing is enqueued on frame buffer
         self.assertEqual(b'', self.connection._frame_buffer)

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -10,6 +10,7 @@ from pika import channel, exceptions, frame, spec
 
 
 class ContentFrameAssemblerTests(unittest.TestCase):
+
     def setUp(self):
         self.obj = channel.ContentFrameAssembler()
 

--- a/tests/unit/credentials_tests.py
+++ b/tests/unit/credentials_tests.py
@@ -7,8 +7,8 @@ from unittest import mock
 
 from pika import credentials, spec
 
-
 # pylint: disable=C0111,W0212,C0103
+
 
 class ChildPlainCredentials(credentials.PlainCredentials):
 
@@ -18,8 +18,8 @@ class ChildPlainCredentials(credentials.PlainCredentials):
 
     def __eq__(self, other):
         if isinstance(other, ChildPlainCredentials):
-            return self.extra == other.extra and super(
-                ChildPlainCredentials, self).__eq__(other)
+            return self.extra == other.extra and super(ChildPlainCredentials,
+                                                       self).__eq__(other)
         return NotImplemented
 
 
@@ -31,8 +31,8 @@ class ChildExternalCredentials(credentials.ExternalCredentials):
 
     def __eq__(self, other):
         if isinstance(other, ChildExternalCredentials):
-            return self.extra == other.extra and super(
-                ChildExternalCredentials, self).__eq__(other)
+            return self.extra == other.extra and super(ChildExternalCredentials,
+                                                       self).__eq__(other)
         return NotImplemented
 
 
@@ -41,25 +41,20 @@ class PlainCredentialsTests(unittest.TestCase):
     CREDENTIALS = 'guest', 'guest'
 
     def test_eq(self):
-        self.assertEqual(
-            credentials.PlainCredentials('u', 'p'),
-            credentials.PlainCredentials('u', 'p'))
+        self.assertEqual(credentials.PlainCredentials('u', 'p'),
+                         credentials.PlainCredentials('u', 'p'))
 
-        self.assertEqual(
-            credentials.PlainCredentials('u', 'p', True),
-            credentials.PlainCredentials('u', 'p', True))
+        self.assertEqual(credentials.PlainCredentials('u', 'p', True),
+                         credentials.PlainCredentials('u', 'p', True))
 
-        self.assertEqual(
-            credentials.PlainCredentials('u', 'p', False),
-            credentials.PlainCredentials('u', 'p', False))
+        self.assertEqual(credentials.PlainCredentials('u', 'p', False),
+                         credentials.PlainCredentials('u', 'p', False))
 
-        self.assertEqual(
-            credentials.PlainCredentials('u', 'p', False),
-            ChildPlainCredentials('u', 'p', False))
+        self.assertEqual(credentials.PlainCredentials('u', 'p', False),
+                         ChildPlainCredentials('u', 'p', False))
 
-        self.assertEqual(
-            ChildPlainCredentials('u', 'p', False),
-            credentials.PlainCredentials('u', 'p', False))
+        self.assertEqual(ChildPlainCredentials('u', 'p', False),
+                         credentials.PlainCredentials('u', 'p', False))
 
         class Foreign(object):
 
@@ -74,37 +69,29 @@ class PlainCredentialsTests(unittest.TestCase):
             'foobar')
 
     def test_ne(self):
-        self.assertNotEqual(
-            credentials.PlainCredentials('uu', 'p', False),
-            credentials.PlainCredentials('u', 'p', False))
+        self.assertNotEqual(credentials.PlainCredentials('uu', 'p', False),
+                            credentials.PlainCredentials('u', 'p', False))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('u', 'p', False),
-            credentials.PlainCredentials('uu', 'p', False))
+        self.assertNotEqual(credentials.PlainCredentials('u', 'p', False),
+                            credentials.PlainCredentials('uu', 'p', False))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('u', 'pp', False),
-            credentials.PlainCredentials('u', 'p', False))
+        self.assertNotEqual(credentials.PlainCredentials('u', 'pp', False),
+                            credentials.PlainCredentials('u', 'p', False))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('u', 'p', False),
-            credentials.PlainCredentials('u', 'pp', False))
+        self.assertNotEqual(credentials.PlainCredentials('u', 'p', False),
+                            credentials.PlainCredentials('u', 'pp', False))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('u', 'p', True),
-            credentials.PlainCredentials('u', 'p', False))
+        self.assertNotEqual(credentials.PlainCredentials('u', 'p', True),
+                            credentials.PlainCredentials('u', 'p', False))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('u', 'p', False),
-            credentials.PlainCredentials('u', 'p', True))
+        self.assertNotEqual(credentials.PlainCredentials('u', 'p', False),
+                            credentials.PlainCredentials('u', 'p', True))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('uu', 'p', False),
-            ChildPlainCredentials('u', 'p', False))
+        self.assertNotEqual(credentials.PlainCredentials('uu', 'p', False),
+                            ChildPlainCredentials('u', 'p', False))
 
-        self.assertNotEqual(
-            ChildPlainCredentials('u', 'pp', False),
-            credentials.PlainCredentials('u', 'p', False))
+        self.assertNotEqual(ChildPlainCredentials('u', 'pp', False),
+                            credentials.PlainCredentials('u', 'p', False))
 
         self.assertNotEqual(
             credentials.PlainCredentials('u', 'p', False),
@@ -129,8 +116,8 @@ class PlainCredentialsTests(unittest.TestCase):
     def test_response_for(self):
         cred = credentials.PlainCredentials(*self.CREDENTIALS)
         start = spec.Connection.Start()
-        self.assertEqual(
-            cred.response_for(start), ('PLAIN', b'\x00guest\x00guest'))
+        self.assertEqual(cred.response_for(start),
+                         ('PLAIN', b'\x00guest\x00guest'))
 
     def test_erase_response_for_no_mechanism_match(self):
         cred = credentials.PlainCredentials(*self.CREDENTIALS)
@@ -180,12 +167,10 @@ class ExternalCredentialsTest(unittest.TestCase):
             def __eq__(self, other):
                 return 'foobar'
 
-        self.assertEqual(
-            credentials.ExternalCredentials() == Foreign(),
-            'foobar')
-        self.assertEqual(
-            Foreign() == credentials.ExternalCredentials(),
-            'foobar')
+        self.assertEqual(credentials.ExternalCredentials() == Foreign(),
+                         'foobar')
+        self.assertEqual(Foreign() == credentials.ExternalCredentials(),
+                         'foobar')
 
     def test_ne(self):
         cred_1 = credentials.ExternalCredentials()
@@ -210,12 +195,10 @@ class ExternalCredentialsTest(unittest.TestCase):
             def __ne__(self, other):
                 return 'foobar'
 
-        self.assertEqual(
-            credentials.ExternalCredentials() != Foreign(),
-            'foobar')
-        self.assertEqual(
-            Foreign() != credentials.ExternalCredentials(),
-            'foobar')
+        self.assertEqual(credentials.ExternalCredentials() != Foreign(),
+                         'foobar')
+        self.assertEqual(Foreign() != credentials.ExternalCredentials(),
+                         'foobar')
 
     def test_response_for(self):
         cred = credentials.ExternalCredentials()

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -29,44 +29,47 @@ class DataTests(unittest.TestCase):
         b'\x04nullV'
         b'\x06strvalS\x00\x00\x00\x04Test'
         b'\x0ctimestampvalT\x00\x00\x00\x00Ec)\x92'
-        b'\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93'
-        )
+        b'\x07unicodeS\x00\x00\x00\x08utf8=\xe2\x9c\x93')
 
     FIELD_TBL_ENCODED += b'\x05bytesx\x00\x00\x00\x06foobar'
 
-    FIELD_TBL_VALUE = OrderedDict(
-        [
-            ('array', [1, 2, 3]),
-            ('boolval', True),
-            ('decimal', decimal.Decimal('3.14')),
-            ('decimal_too', decimal.Decimal('100')),
-            ('dictval', { 'foo': 'bar' }),
-            ('intval', 1),
-            ('bigint', 2592000000),
-            ('longval', long(912598613)),
-            ('neglong', long(-1)),
-            ('null', None),
-            ('strval', 'Test'),
-            ('timestampval', datetime.datetime(2006, 11, 21, 16, 30, 10, tzinfo=datetime.timezone.utc)),
-            ('unicode', u'utf8=✓'),
-            ('bytes', b'foobar'),
-        ])
+    FIELD_TBL_VALUE = OrderedDict([
+        ('array', [1, 2, 3]),
+        ('boolval', True),
+        ('decimal', decimal.Decimal('3.14')),
+        ('decimal_too', decimal.Decimal('100')),
+        ('dictval', {
+            'foo': 'bar'
+        }),
+        ('intval', 1),
+        ('bigint', 2592000000),
+        ('longval', long(912598613)),
+        ('neglong', long(-1)),
+        ('null', None),
+        ('strval', 'Test'),
+        ('timestampval',
+         datetime.datetime(2006,
+                           11,
+                           21,
+                           16,
+                           30,
+                           10,
+                           tzinfo=datetime.timezone.utc)),
+        ('unicode', u'utf8=✓'),
+        ('bytes', b'foobar'),
+    ])
 
     def test_decode_bytes(self):
-        input = (
-                b'\x00\x00\x00\x01'
-                b'\x05bytesx\x00\x00\x00\x06foobar'
-            )
+        input = (b'\x00\x00\x00\x01'
+                 b'\x05bytesx\x00\x00\x00\x06foobar')
         result = data.decode_table(input, 0)
         self.assertEqual(result, ({'bytes': b'foobar'}, 21))
 
     # b'\x08shortints\x04\xd2'
     # ('shortint', 1234),
     def test_decode_shortint(self):
-        input = (
-                b'\x00\x00\x00\x01'
-                b'\x08shortints\x04\xd2'
-            )
+        input = (b'\x00\x00\x00\x01'
+                 b'\x08shortints\x04\xd2')
         result = data.decode_table(input, 0)
         self.assertEqual(result, ({'shortint': 1234}, 16))
 
@@ -95,10 +98,8 @@ class DataTests(unittest.TestCase):
         with type tag 'l' and signed 64-bit representation.
         """
         # Table with x-delay = -30000 encoded as signed 64-bit 'l'
-        input = (
-            b'\x00\x00\x00\x10'
-            b'\x07x-delayl\xff\xff\xff\xff\xff\xff\x8a\xd0'
-        )
+        input = (b'\x00\x00\x00\x10'
+                 b'\x07x-delayl\xff\xff\xff\xff\xff\xff\x8a\xd0')
         result, _ = data.decode_table(input, 0)
         self.assertEqual(result, {'x-delay': long(-30000)})
 

--- a/tests/unit/diagnostic_utils_test.py
+++ b/tests/unit/diagnostic_utils_test.py
@@ -8,7 +8,6 @@ import logging
 
 from pika import diagnostic_utils
 
-
 # Suppress invalid-name, since our test names are descriptive and quite long
 # pylint: disable=C0103
 

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -6,7 +6,6 @@ import unittest
 
 from pika import exceptions
 
-
 # missing-docstring
 # pylint: disable=C0111
 
@@ -15,15 +14,14 @@ from pika import exceptions
 
 
 class ExceptionTests(unittest.TestCase):
+
     def test_amqp_connection_error_one_param_repr(self):
-        self.assertEqual(
-            repr(exceptions.AMQPConnectionError(10)),
-            'AMQPConnectionError: (10,)')
+        self.assertEqual(repr(exceptions.AMQPConnectionError(10)),
+                         'AMQPConnectionError: (10,)')
 
     def test_amqp_connection_error_two_params_repr(self):
-        self.assertEqual(
-            repr(exceptions.AMQPConnectionError(1, 'Test')),
-            'AMQPConnectionError: (1) Test')
+        self.assertEqual(repr(exceptions.AMQPConnectionError(1, 'Test')),
+                         'AMQPConnectionError: (1) Test')
 
     def test_authentication_error_repr(self):
         self.assertEqual(

--- a/tests/unit/exchange_type_test.py
+++ b/tests/unit/exchange_type_test.py
@@ -6,7 +6,6 @@ import unittest
 
 from pika.exchange_type import ExchangeType
 
-
 # missing-docstring
 # pylint: disable=C0111
 
@@ -15,6 +14,7 @@ from pika.exchange_type import ExchangeType
 
 
 class ExchangeTypeTests(unittest.TestCase):
+
     def test_exchange_type_direct(self):
         self.assertEqual(ExchangeType.direct.value, 'direct')
 

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -9,9 +9,8 @@ from pika import exceptions, frame, spec, DeliveryMode
 
 class FrameTests(unittest.TestCase):
 
-    BASIC_ACK = (
-        b'\x01\x00\x01\x00\x00\x00\r\x00<\x00P\x00\x00\x00\x00\x00\x00'
-        b'\x00d\x00\xce')
+    BASIC_ACK = (b'\x01\x00\x01\x00\x00\x00\r\x00<\x00P\x00\x00\x00\x00\x00\x00'
+                 b'\x00d\x00\xce')
     BODY_FRAME = b'\x03\x00\x01\x00\x00\x00\x14I like it that sound\xce'
     BODY_FRAME_VALUE = b'I like it that sound'
     CONTENT_HEADER = (b'\x02\x00\x01\x00\x00\x00\x0f\x00<\x00\x00\x00'
@@ -29,8 +28,7 @@ class FrameTests(unittest.TestCase):
 
     def headers_marshal_test(self):
         header = frame.Header(
-            1, 100,
-            spec.BasicProperties(delivery_mode=DeliveryMode.Persistent))
+            1, 100, spec.BasicProperties(delivery_mode=DeliveryMode.Persistent))
         self.assertEqual(header.marshal(), self.CONTENT_HEADER)
 
     def body_marshal_test(self):

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -8,7 +8,6 @@ from unittest import mock
 from pika import connection, frame, heartbeat
 import pika.exceptions
 
-
 # protected-access
 # pylint: disable=W0212
 
@@ -24,6 +23,7 @@ class ConstructableConnection(connection.Connection):
     that we can instantiate and test it.
 
     """
+
     def _adapter_connect_stream(self):
         pass
 
@@ -48,6 +48,7 @@ class ConstructableConnection(connection.Connection):
     def _adapter_remove_timeout(self, timeout_id):
         raise NotImplementedError
 
+
 class HeartbeatTests(unittest.TestCase):
 
     INTERVAL = 60
@@ -58,7 +59,8 @@ class HeartbeatTests(unittest.TestCase):
         self.mock_conn = mock.Mock(spec_set=ConstructableConnection())
         self.mock_conn.bytes_received = 100
         self.mock_conn.bytes_sent = 100
-        self.mock_conn._heartbeat_checker = mock.Mock(spec=heartbeat.HeartbeatChecker)
+        self.mock_conn._heartbeat_checker = mock.Mock(
+            spec=heartbeat.HeartbeatChecker)
         self.obj = heartbeat.HeartbeatChecker(self.mock_conn, self.INTERVAL)
 
     def tearDown(self):
@@ -83,8 +85,7 @@ class HeartbeatTests(unittest.TestCase):
         # Note: _bytes_received is initialized by calls
         # to _start_check_timer which calls _update_counters
         # which reads the initial values from the connection
-        self.assertEqual(self.obj._bytes_sent,
-                         self.mock_conn.bytes_sent)
+        self.assertEqual(self.obj._bytes_sent, self.mock_conn.bytes_sent)
 
     def test_constructor_initial_heartbeat_frames_received(self):
         self.assertEqual(self.obj._heartbeat_frames_received, 0)
@@ -183,8 +184,7 @@ class HeartbeatTests(unittest.TestCase):
         self.assertIsInstance(self.mock_conn._terminate_stream.call_args[0][0],
                               pika.exceptions.AMQPHeartbeatTimeout)
         self.assertEqual(
-            self.mock_conn._terminate_stream.call_args[0][0].args[0],
-            reason)
+            self.mock_conn._terminate_stream.call_args[0][0].args[0], reason)
 
     def test_has_received_data_false(self):
         self.obj._bytes_received = 100
@@ -210,8 +210,10 @@ class HeartbeatTests(unittest.TestCase):
         self.assertEqual(self.obj._heartbeat_frames_sent, 1)
 
     def test_start_send_timer_called(self):
-        want = [mock.call(self.SEND_INTERVAL, self.obj._send_heartbeat),
-                mock.call(self.CHECK_INTERVAL, self.obj._check_heartbeat)]
+        want = [
+            mock.call(self.SEND_INTERVAL, self.obj._send_heartbeat),
+            mock.call(self.CHECK_INTERVAL, self.obj._check_heartbeat)
+        ]
         got = self.mock_conn._adapter_call_later.call_args_list
         self.assertEqual(got, want)
 

--- a/tests/unit/select_connection_interrupt_tests.py
+++ b/tests/unit/select_connection_interrupt_tests.py
@@ -17,7 +17,6 @@ import unittest
 
 from pika.adapters import select_connection
 
-
 # protected-access
 # pylint: disable=W0212
 
@@ -33,8 +32,7 @@ class ReadInterruptHandlesEmptySocket(unittest.TestCase):
 
     def setUp(self):
         self._poller = select_connection.SelectPoller(
-            get_wait_seconds=lambda: 0,
-            process_timeouts=lambda: None)
+            get_wait_seconds=lambda: 0, process_timeouts=lambda: None)
 
     def tearDown(self):
         self._poller.close()

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -23,7 +23,6 @@ import pika
 from pika import compat
 from pika.adapters import select_connection
 
-
 # protected-access
 # pylint: disable=W0212
 
@@ -35,7 +34,6 @@ from pika.adapters import select_connection
 
 # attribute-defined-outside-init
 # pylint: disable=W0201
-
 
 LOGGER = logging.getLogger(__name__)
 
@@ -73,13 +71,8 @@ def _fd_events_to_str(events):
     if events & POLLPRI:
         str_events += "Pri."
 
-
-    remainig_events = events & ~(POLLIN |
-                                 POLLOUT |
-                                 POLLERR |
-                                 POLLHUP |
-                                 POLLNVAL |
-                                 POLLPRI)
+    remainig_events = events & ~(POLLIN | POLLOUT | POLLERR | POLLHUP |
+                                 POLLNVAL | POLLPRI)
     if remainig_events:
         str_events += '+{}'.format(bin(remainig_events))
 
@@ -91,8 +84,8 @@ class IOLoopBaseTest(unittest.TestCase):
     TIMEOUT = 1.5
 
     def setUp(self):
-        select_type_patch = mock.patch.multiple(
-            select_connection, SELECT_TYPE=self.SELECT_POLLER)
+        select_type_patch = mock.patch.multiple(select_connection,
+                                                SELECT_TYPE=self.SELECT_POLLER)
         select_type_patch.start()
         self.addCleanup(select_type_patch.stop)
 
@@ -156,7 +149,7 @@ class IOLoopCloseAfterStartReturnsTest(IOLoopBaseTest):
     SELECT_POLLER = 'select'
 
     def start_test(self):
-        self.ioloop.stop() # so start will terminate quickly
+        self.ioloop.stop()  # so start will terminate quickly
         self.start()
         self.ioloop.close()
         self.assertEqual(self.ioloop._callbacks, [])
@@ -211,11 +204,10 @@ class IOLoopThreadStopTestSelect(IOLoopBaseTest):
     def start_test(self):
         """Starts a thread that stops ioloop after a while and start polling"""
         timer = threading.Timer(
-            0.1,
-            lambda: self.ioloop.add_callback_threadsafe(self.ioloop.stop))
+            0.1, lambda: self.ioloop.add_callback_threadsafe(self.ioloop.stop))
         self.addCleanup(timer.cancel)
         timer.start()
-        self.start() # NOTE: Normal return from `start()` constitutes success
+        self.start()  # NOTE: Normal return from `start()` constitutes success
 
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
@@ -243,7 +235,7 @@ class IOLoopAddCallbackAfterCloseDoesNotRaiseTestSelect(IOLoopBaseTest):
     def start_test(self):
         # Simulate closing after start returns
         self.ioloop.stop()  # so that start() returns ASAP
-        self.start() # NOTE: Normal return from `start()` constitutes success
+        self.start()  # NOTE: Normal return from `start()` constitutes success
         self.ioloop.close()
 
         # Expect: add_callback_threadsafe() won't raise after ioloop.close()
@@ -251,7 +243,8 @@ class IOLoopAddCallbackAfterCloseDoesNotRaiseTestSelect(IOLoopBaseTest):
 
 
 # TODO FUTURE - fix this flaky test
-@unittest.skipIf(platform.python_implementation() == 'PyPy', 'test is flaky on PyPy')
+@unittest.skipIf(platform.python_implementation() == 'PyPy',
+                 'test is flaky on PyPy')
 class IOLoopTimerTestSelect(IOLoopBaseTest):
     """Set a bunch of very short timers to fire in reverse order and check
     that they fire in order of time, not
@@ -269,8 +262,8 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.timer_stack = list()
         for i in range(self.NUM_TIMERS, 0, -1):
             deadline = i * self.TIMER_INTERVAL
-            self.ioloop.call_later(
-                deadline, functools.partial(self.on_timer, i))
+            self.ioloop.call_later(deadline,
+                                   functools.partial(self.on_timer, i))
             self.timer_stack.append(i)
 
     def start_test(self):
@@ -300,8 +293,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         handle_holder = []
         self.timer_got_fired = False
         self.handle = self.ioloop.call_later(
-            0.1, functools.partial(
-                self._on_timer_delete_itself, handle_holder))
+            0.1, functools.partial(self._on_timer_delete_itself, handle_holder))
         handle_holder.append(self.handle)
         self.start()
         self.assertTrue(self.timer_got_called)
@@ -323,8 +315,9 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         """
         holder_for_target_timer = []
         self.ioloop.call_later(
-            0.01, functools.partial(
-                self._on_timer_delete_another, holder_for_target_timer))
+            0.01,
+            functools.partial(self._on_timer_delete_another,
+                              holder_for_target_timer))
         timer_2 = self.ioloop.call_later(0.02, self._on_timer_no_call)
         holder_for_target_timer.append(timer_2)
         time.sleep(0.03)  # so that timer_1 and timer_2 fires at the same time.
@@ -502,6 +495,7 @@ class IOLoopSimpleMessageTestCaseSelect(IOLoopSocketBaseSelect):
     end and reading from the other
 
     """
+
     def start(self):
         """Create a pair of sockets and poll"""
         self.create_write_socket(self.connected)
@@ -557,8 +551,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         """Read from within poll loop that gets receives eintr error."""
         self.assertEqual(events, self.ioloop.READ)
 
-        sock = socket.fromfd(
-            os.dup(fileno), socket.AF_INET, socket.SOCK_STREAM)
+        sock = socket.fromfd(os.dup(fileno), socket.AF_INET, socket.SOCK_STREAM)
         self.addCleanup(sock.close)
 
         mesg = sock.recv(256)
@@ -606,8 +599,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         tmr_k = threading.Timer(0.1,
                                 lambda: os.kill(os.getpid(), signal.SIGUSR1))
         self.addCleanup(tmr_k.cancel)
-        tmr_w = threading.Timer(0.2,
-                                lambda: sockpair[1].send(self.MSG_CONTENT))
+        tmr_w = threading.Timer(0.2, lambda: sockpair[1].send(self.MSG_CONTENT))
         self.addCleanup(tmr_w.cancel)
         tmr_k.start()
         tmr_w.start()
@@ -635,6 +627,7 @@ class IOLoopEintrTestCaseKqueue(IOLoopEintrTestCaseSelect):
 
 
 class SelectPollerTestPollWithoutSockets(unittest.TestCase):
+
     def start_test(self):
         timer = select_connection._Timer()
         poller = select_connection.SelectPoller(
@@ -668,16 +661,15 @@ class PollerTestCaseSelect(unittest.TestCase):
     SELECT_POLLER = 'select'
 
     def setUp(self):
-        select_type_patch = mock.patch.multiple(
-            select_connection, SELECT_TYPE=self.SELECT_POLLER)
+        select_type_patch = mock.patch.multiple(select_connection,
+                                                SELECT_TYPE=self.SELECT_POLLER)
         select_type_patch.start()
         self.addCleanup(select_type_patch.stop)
 
         timer = select_connection._Timer()
         self.addCleanup(timer.close)
         self.poller = select_connection.IOLoop._get_poller(
-            timer.get_remaining_interval,
-            timer.process_timeouts)
+            timer.get_remaining_interval, timer.process_timeouts)
         self.addCleanup(self.poller.close)
 
     def test_poller_close(self):
@@ -737,7 +729,6 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
         return ioloop
 
-
     def create_nonblocking_tcp_socket(self):
         """Create a TCP stream socket and schedule cleanup to close it
 
@@ -781,7 +772,10 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
             sock.connect(addr_pair)
         except pika.compat.SOCKET_ERROR as error:
             # EINPROGRESS for posix and EWOULDBLOCK for windows
-            if error.errno not in (errno.EINPROGRESS, errno.EWOULDBLOCK,):
+            if error.errno not in (
+                    errno.EINPROGRESS,
+                    errno.EWOULDBLOCK,
+            ):
                 raise
 
     def get_dead_socket_address(self):
@@ -795,8 +789,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         self.addCleanup(s1.close)
         return s1.getsockname()  # pylint: disable=E1101
 
-    def which_events_are_set_with_varying_eventmasks(self,
-                                                     sock,
+    def which_events_are_set_with_varying_eventmasks(self, sock,
                                                      requested_eventmasks,
                                                      msg_prefix):
         """Common logic for which_events_are_set_* tests. Runs the event loop
@@ -814,15 +807,12 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         def handle_socket_events(_fd, in_events):
             socket_error = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
             socket_error = 0 if socket_error == 0 else '{} ({})'.format(
-                socket_error,
-                os.strerror(socket_error))
+                socket_error, os.strerror(socket_error))
 
             _trace_stderr('[%s] %s: watching=%s; indicated=%s; sockerr=%s',
-                          ioloop._poller.__class__.__name__,
-                          msg_prefix,
+                          ioloop._poller.__class__.__name__, msg_prefix,
                           _fd_events_to_str(requested_eventmasks[0]),
-                          _fd_events_to_str(in_events),
-                          socket_error)
+                          _fd_events_to_str(in_events), socket_error)
 
             # NOTE ERROR may be added automatically by some pollers
             #      without being requested.
@@ -839,11 +829,9 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
             else:
                 ioloop.stop()
 
-        ioloop.add_handler(sock.fileno(),
-                           handle_socket_events,
+        ioloop.add_handler(sock.fileno(), handle_socket_events,
                            requested_eventmasks[0])
         ioloop.start()
-
 
     def test_which_events_are_set_when_failed_to_connect(self):
 
@@ -854,10 +842,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         self.safe_connect_nonblocking_socket(sock,
                                              self.get_dead_socket_address())
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE | self.ERROR
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE | self.ERROR
         ]
 
         # NOTE: on OS X, we just get POLLHUP when requesting WRITE in this case
@@ -889,10 +875,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s2.close()
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE
         ]
 
         self.which_events_are_set_with_varying_eventmasks(
@@ -900,7 +884,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
             requested_eventmasks=requested_eventmasks,
             msg_prefix='@ Remote closed')
 
-    def test_which_events_are_set_after_remote_end_closes_with_pending_data(self):
+    def test_which_events_are_set_after_remote_end_closes_with_pending_data(
+            self):
 
         s1, s2 = self.create_blocking_socketpair()
 
@@ -908,10 +893,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s2.close()
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE
         ]
 
         self.which_events_are_set_with_varying_eventmasks(
@@ -925,10 +908,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
         s2.shutdown(socket.SHUT_RD)
 
-        requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.WRITE
-        ]
+        requested_eventmasks = [self.READ | self.WRITE | self.ERROR, self.WRITE]
 
         self.which_events_are_set_with_varying_eventmasks(
             sock=s1,
@@ -941,12 +921,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
         s2.shutdown(socket.SHUT_WR)
 
-        requested_eventmasks = [
-            (self.READ | self.WRITE | self.ERROR),
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE
-        ]
+        requested_eventmasks = [(self.READ | self.WRITE | self.ERROR),
+                                self.READ | self.WRITE, self.READ, self.WRITE]
 
         self.which_events_are_set_with_varying_eventmasks(
             sock=s1,
@@ -961,10 +937,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s2.shutdown(socket.SHUT_WR)
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE
         ]
 
         self.which_events_are_set_with_varying_eventmasks(
@@ -979,10 +953,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s2.shutdown(socket.SHUT_RDWR)
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE
         ]
 
         self.which_events_are_set_with_varying_eventmasks(
@@ -999,10 +971,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s1.shutdown(socket.SHUT_RD)  # pylint: disable=E1101
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE
         ]
 
         # NOTE: Unlike POSIX, Windows select doesn't indicate as readable socket
@@ -1026,8 +996,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s1.shutdown(socket.SHUT_WR)  # pylint: disable=E1101
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.WRITE | self.ERROR
+            self.READ | self.WRITE | self.ERROR, self.WRITE | self.ERROR
         ]
 
         # NOTE: on OS X, we just get POLLHUP when requesting WRITE in this case
@@ -1050,10 +1019,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         s1.shutdown(socket.SHUT_RDWR)  # pylint: disable=E1101
 
         requested_eventmasks = [
-            self.READ | self.WRITE | self.ERROR,
-            self.READ | self.WRITE,
-            self.READ,
-            self.WRITE | self.ERROR
+            self.READ | self.WRITE | self.ERROR, self.READ | self.WRITE,
+            self.READ, self.WRITE | self.ERROR
         ]
         # NOTE: on OS X, we just get POLLHUP when requesting WRITE in this case
         # with PollPoller. It's documented in `man poll` on OS X as mutually

--- a/tests/unit/select_connection_timer_tests.py
+++ b/tests/unit/select_connection_timer_tests.py
@@ -11,7 +11,6 @@ from unittest import mock
 import pika.compat
 from pika.adapters import select_connection
 
-
 # Suppress protected-access
 # pylint: disable=W0212
 
@@ -40,8 +39,8 @@ class ChildTimeout(select_connection._Timeout):
 
     def __eq__(self, other):
         if isinstance(other, ChildTimeout):
-            return self.extra == other.extra and super(
-                ChildTimeout, self).__eq__(other)
+            return self.extra == other.extra and super(ChildTimeout,
+                                                       self).__eq__(other)
         return NotImplemented
 
 
@@ -50,8 +49,10 @@ class TimeoutClassTests(unittest.TestCase):
 
     def test_properties(self):
         now = _now()
+
         def cb():
             pass
+
         timeout = select_connection._Timeout(now + 5.3, cb)
         self.assertIs(timeout.callback, cb)
         self.assertEqual(timeout.deadline, now + 5.3)
@@ -81,19 +82,15 @@ class TimeoutClassTests(unittest.TestCase):
 
     def test_eq(self):
         # Comparison should be by deadline only
-        self.assertEqual(
-            select_connection._Timeout(5, lambda: None),
-            select_connection._Timeout(5, lambda: 5))
-        self.assertEqual(
-            select_connection._Timeout(5, lambda: 5),
-            select_connection._Timeout(5, lambda: None))
+        self.assertEqual(select_connection._Timeout(5, lambda: None),
+                         select_connection._Timeout(5, lambda: 5))
+        self.assertEqual(select_connection._Timeout(5, lambda: 5),
+                         select_connection._Timeout(5, lambda: None))
 
-        self.assertEqual(
-            select_connection._Timeout(5, lambda: None),
-            ChildTimeout(5, lambda: 5))
-        self.assertEqual(
-            ChildTimeout(5, lambda: 5),
-            select_connection._Timeout(5, lambda: None))
+        self.assertEqual(select_connection._Timeout(5, lambda: None),
+                         ChildTimeout(5, lambda: 5))
+        self.assertEqual(ChildTimeout(5, lambda: 5),
+                         select_connection._Timeout(5, lambda: None))
 
         class Foreign(object):
 
@@ -101,34 +98,26 @@ class TimeoutClassTests(unittest.TestCase):
                 return 'foobar'
 
         self.assertEqual(
-            select_connection._Timeout(5, lambda: None) == Foreign(),
-            'foobar')
+            select_connection._Timeout(5, lambda: None) == Foreign(), 'foobar')
         self.assertEqual(
-            Foreign() == select_connection._Timeout(5, lambda: None),
-            'foobar')
+            Foreign() == select_connection._Timeout(5, lambda: None), 'foobar')
 
     def test_ne(self):
         # Comparison should be by deadline only
-        self.assertNotEqual(
-            select_connection._Timeout(5, lambda: None),
-            select_connection._Timeout(10, lambda: None))
-        self.assertNotEqual(
-            select_connection._Timeout(10, lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertNotEqual(select_connection._Timeout(5, lambda: None),
+                            select_connection._Timeout(10, lambda: None))
+        self.assertNotEqual(select_connection._Timeout(10, lambda: None),
+                            select_connection._Timeout(5, lambda: None))
 
-        self.assertNotEqual(
-            select_connection._Timeout(5, lambda: None),
-            ChildTimeout(10, lambda: None))
-        self.assertNotEqual(
-            ChildTimeout(10, lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertNotEqual(select_connection._Timeout(5, lambda: None),
+                            ChildTimeout(10, lambda: None))
+        self.assertNotEqual(ChildTimeout(10, lambda: None),
+                            select_connection._Timeout(5, lambda: None))
 
-        self.assertNotEqual(
-            select_connection._Timeout(5, lambda: None),
-            dict(deadline=5, callback=lambda: None))
-        self.assertNotEqual(
-            dict(deadline=5, callback=lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertNotEqual(select_connection._Timeout(5, lambda: None),
+                            dict(deadline=5, callback=lambda: None))
+        self.assertNotEqual(dict(deadline=5, callback=lambda: None),
+                            select_connection._Timeout(5, lambda: None))
 
         class Foreign(object):
 
@@ -136,21 +125,17 @@ class TimeoutClassTests(unittest.TestCase):
                 return 'foobar'
 
         self.assertEqual(
-            select_connection._Timeout(5, lambda: None) != Foreign(),
-            'foobar')
+            select_connection._Timeout(5, lambda: None) != Foreign(), 'foobar')
         self.assertEqual(
-            Foreign() != select_connection._Timeout(5, lambda: None),
-            'foobar')
+            Foreign() != select_connection._Timeout(5, lambda: None), 'foobar')
 
     def test_lt(self):
         # Comparison should be by deadline only
-        self.assertLess(
-            select_connection._Timeout(5, lambda: None),
-            select_connection._Timeout(10, lambda: None))
+        self.assertLess(select_connection._Timeout(5, lambda: None),
+                        select_connection._Timeout(10, lambda: None))
 
-        self.assertLess(
-            select_connection._Timeout(5, lambda: None),
-            ChildTimeout(10, lambda: None))
+        self.assertLess(select_connection._Timeout(5, lambda: None),
+                        ChildTimeout(10, lambda: None))
 
         class Foreign(object):
 
@@ -158,26 +143,23 @@ class TimeoutClassTests(unittest.TestCase):
                 return 'foobar'
 
         self.assertEqual(
-            select_connection._Timeout(5, lambda: None) < Foreign(),
-            'foobar')
+            select_connection._Timeout(5, lambda: None) < Foreign(), 'foobar')
 
         self.assertFalse(
-            select_connection._Timeout(5, lambda: None)
-            < select_connection._Timeout(5, lambda: None))
+            select_connection._Timeout(5, lambda: None) <
+            select_connection._Timeout(5, lambda: None))
 
         self.assertFalse(
-            select_connection._Timeout(5, lambda: None)
-            < select_connection._Timeout(1, lambda: None))
+            select_connection._Timeout(5, lambda: None) <
+            select_connection._Timeout(1, lambda: None))
 
     def test_gt(self):
         # Comparison should be by deadline only
-        self.assertGreater(
-            select_connection._Timeout(10, lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertGreater(select_connection._Timeout(10, lambda: None),
+                           select_connection._Timeout(5, lambda: None))
 
-        self.assertGreater(
-            select_connection._Timeout(10, lambda: None),
-            ChildTimeout(5, lambda: None))
+        self.assertGreater(select_connection._Timeout(10, lambda: None),
+                           ChildTimeout(5, lambda: None))
 
         class Foreign(object):
 
@@ -185,34 +167,29 @@ class TimeoutClassTests(unittest.TestCase):
                 return 'foobar'
 
         self.assertEqual(
-            select_connection._Timeout(5, lambda: None) > Foreign(),
-            'foobar')
+            select_connection._Timeout(5, lambda: None) > Foreign(), 'foobar')
 
         self.assertFalse(
-            select_connection._Timeout(5, lambda: None)
-            > select_connection._Timeout(5, lambda: None))
+            select_connection._Timeout(5, lambda: None) >
+            select_connection._Timeout(5, lambda: None))
 
         self.assertFalse(
-            select_connection._Timeout(1, lambda: None)
-            > select_connection._Timeout(5, lambda: None))
+            select_connection._Timeout(1, lambda: None) >
+            select_connection._Timeout(5, lambda: None))
 
     def test_le(self):
         # Comparison should be by deadline only
-        self.assertLessEqual(
-            select_connection._Timeout(5, lambda: None),
-            select_connection._Timeout(10, lambda: None))
+        self.assertLessEqual(select_connection._Timeout(5, lambda: None),
+                             select_connection._Timeout(10, lambda: None))
 
-        self.assertLessEqual(
-            select_connection._Timeout(5, lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertLessEqual(select_connection._Timeout(5, lambda: None),
+                             select_connection._Timeout(5, lambda: None))
 
-        self.assertLessEqual(
-            select_connection._Timeout(5, lambda: None),
-            ChildTimeout(10, lambda: None))
+        self.assertLessEqual(select_connection._Timeout(5, lambda: None),
+                             ChildTimeout(10, lambda: None))
 
-        self.assertLessEqual(
-            select_connection._Timeout(5, lambda: None),
-            ChildTimeout(5, lambda: None))
+        self.assertLessEqual(select_connection._Timeout(5, lambda: None),
+                             ChildTimeout(5, lambda: None))
 
         class Foreign(object):
 
@@ -220,30 +197,25 @@ class TimeoutClassTests(unittest.TestCase):
                 return 'foobar'
 
         self.assertEqual(
-            select_connection._Timeout(5, lambda: None) <= Foreign(),
-            'foobar')
+            select_connection._Timeout(5, lambda: None) <= Foreign(), 'foobar')
 
         self.assertFalse(
-            select_connection._Timeout(5, lambda: None)
-            <= select_connection._Timeout(1, lambda: None))
+            select_connection._Timeout(5, lambda: None) <=
+            select_connection._Timeout(1, lambda: None))
 
     def test_ge(self):
         # Comparison should be by deadline only
-        self.assertGreaterEqual(
-            select_connection._Timeout(10, lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertGreaterEqual(select_connection._Timeout(10, lambda: None),
+                                select_connection._Timeout(5, lambda: None))
 
-        self.assertGreaterEqual(
-            select_connection._Timeout(5, lambda: None),
-            select_connection._Timeout(5, lambda: None))
+        self.assertGreaterEqual(select_connection._Timeout(5, lambda: None),
+                                select_connection._Timeout(5, lambda: None))
 
-        self.assertGreaterEqual(
-            select_connection._Timeout(10, lambda: None),
-            ChildTimeout(5, lambda: None))
+        self.assertGreaterEqual(select_connection._Timeout(10, lambda: None),
+                                ChildTimeout(5, lambda: None))
 
-        self.assertGreaterEqual(
-            select_connection._Timeout(5, lambda: None),
-            ChildTimeout(5, lambda: None))
+        self.assertGreaterEqual(select_connection._Timeout(5, lambda: None),
+                                ChildTimeout(5, lambda: None))
 
         class Foreign(object):
 
@@ -251,12 +223,11 @@ class TimeoutClassTests(unittest.TestCase):
                 return 'foobar'
 
         self.assertEqual(
-            select_connection._Timeout(5, lambda: None) >= Foreign(),
-            'foobar')
+            select_connection._Timeout(5, lambda: None) >= Foreign(), 'foobar')
 
         self.assertFalse(
-            select_connection._Timeout(1, lambda: None)
-            >= select_connection._Timeout(5, lambda: None))
+            select_connection._Timeout(1, lambda: None) >=
+            select_connection._Timeout(5, lambda: None))
 
 
 class TimerClassTests(unittest.TestCase):
@@ -365,7 +336,7 @@ class TimerClassTests(unittest.TestCase):
         timer = select_connection._Timer()
 
         with mock.patch('pika.compat.time_now', return_value=now):
-            timer.call_later(10, lambda: bucket.append(3)) # t3
+            timer.call_later(10, lambda: bucket.append(3))  # t3
             t2 = timer.call_later(6, lambda: bucket.append(2))
             t1 = timer.call_later(5, lambda: bucket.append(1))
 
@@ -447,8 +418,7 @@ class TimerClassTests(unittest.TestCase):
 
         with mock.patch('pika.compat.time_now', return_value=now):
             t1 = timer.call_later(
-                5,
-                lambda: bucket.append(
+                5, lambda: bucket.append(
                     timer.call_later(0, lambda: bucket.append(2))))
 
         # Advance time by 10 seconds and verify that t1 fires and creates t2,
@@ -498,7 +468,6 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(len(timer._timeout_heap), 0)
             self.assertEqual(timer._num_cancellations, 0)
 
-
     def test_cancel_expired_timeout_from_another_timeout(self):
         now = _now()
         bucket = []
@@ -507,9 +476,8 @@ class TimerClassTests(unittest.TestCase):
         with mock.patch('pika.compat.time_now', return_value=now):
             t2 = timer.call_later(10, lambda: bucket.append(2))
             t1 = timer.call_later(
-                5,
-                lambda: (self.assertEqual(timer._num_cancellations, 0),
-                         timer.remove_timeout(t2)))
+                5, lambda: (self.assertEqual(timer._num_cancellations, 0),
+                            timer.remove_timeout(t2)))
 
             self.assertIs(t1, timer._timeout_heap[0])
 

--- a/tests/unit/spec_tests.py
+++ b/tests/unit/spec_tests.py
@@ -10,6 +10,7 @@ from pika.compat import long
 
 
 class BasicPropertiesTests(unittest.TestCase):
+
     def test_equality(self):
         a = spec.BasicProperties(content_type='text/plain')
         self.assertEqual(a, a)
@@ -29,6 +30,6 @@ class BasicPropertiesTests(unittest.TestCase):
     def test_headers_repr(self):
         hdr = 'timestamp_in_ms'
         v = long(912598613)
-        h = { hdr : v }
+        h = {hdr: v}
         p = spec.BasicProperties(content_type='text/plain', headers=h)
         self.assertEqual(repr(p.headers[hdr]), '912598613L')

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -11,7 +11,8 @@ import unittest
 from unittest import mock
 
 from tests.wrappers import threaded_test_wrapper
-from tests.wrappers.threaded_test_wrapper import (_ThreadedTestWrapper, run_in_thread_with_timeout)
+from tests.wrappers.threaded_test_wrapper import (_ThreadedTestWrapper,
+                                                  run_in_thread_with_timeout)
 
 # Suppress invalid-name, since our test names are descriptive and quite long
 # pylint: disable=C0103
@@ -34,6 +35,7 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
         raise NotImplementedError
 
     def test_propagation_of_failure_from_test_execution_thread(self):
+
         class SelfCheckExceptionHandling(Exception):
             pass
 
@@ -86,8 +88,7 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
             # Patch DEFAULT_TEST_TIMEOUT to much smaller value than sleep in
             # my_start()
             with mock.patch.object(threaded_test_wrapper,
-                                   'DEFAULT_TEST_TIMEOUT',
-                                   0.01):
+                                   'DEFAULT_TEST_TIMEOUT', 0.01):
                 # Redirect start() call from thread to our own my_start()
                 with self.assertRaises(AssertionError) as exc_ctx:
                     my_sleeper()
@@ -124,7 +125,6 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
         self.assertEqual(len(kwargs_ut), 1, repr(kwargs_ut))
         self.assertIn('kwarg0', kwargs_ut, repr(kwargs_ut))
         self.assertIs(kwargs_ut['kwarg0'], kwarg0)
-
 
     def test_skip_test_is_passed_through(self):
 

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -8,7 +8,6 @@ from unittest import mock
 from pika.adapters import tornado_connection
 from pika.adapters.utils import selector_ioloop_adapter
 
-
 # missing-docstring
 # pylint: disable=C0111
 
@@ -17,6 +16,7 @@ from pika.adapters.utils import selector_ioloop_adapter
 
 
 class TornadoConnectionTests(unittest.TestCase):
+
     @mock.patch('pika.adapters.base_connection.BaseConnection.__init__')
     def test_tornado_connection_call_parent(self, mock_init):
         _SelectorIOServicesAdapter = (
@@ -28,13 +28,16 @@ class TornadoConnectionTests(unittest.TestCase):
             bucket.append(adapter)
             return adapter
 
-        with mock.patch('pika.adapters.utils.selector_ioloop_adapter.SelectorIOServicesAdapter',
-                        side_effect=construct_io_services_adapter):
+        with mock.patch(
+                'pika.adapters.utils.selector_ioloop_adapter.SelectorIOServicesAdapter',
+                side_effect=construct_io_services_adapter):
             tornado_connection.TornadoConnection()
-        mock_init.assert_called_once_with(
-            None, None, None, None,
-            bucket[0],
-            internal_connection_workflow=True)
+        mock_init.assert_called_once_with(None,
+                                          None,
+                                          None,
+                                          None,
+                                          bucket[0],
+                                          internal_connection_workflow=True)
 
         self.assertIs(bucket[0].get_native_ioloop(),
                       tornado_connection.ioloop.IOLoop.instance())

--- a/tests/wrappers/threaded_test_wrapper.py
+++ b/tests/wrappers/threaded_test_wrapper.py
@@ -11,7 +11,6 @@ import threading
 import traceback
 import unittest
 
-
 MODULE_PID = os.getpid()
 
 DEFAULT_TEST_TIMEOUT = 15
@@ -52,8 +51,7 @@ def create_run_in_thread_decorator(test_timeout=None):
                 times out
             """
             runner = _ThreadedTestWrapper(
-                functools.partial(fun, *args, **kwargs),
-                test_timeout)
+                functools.partial(fun, *args, **kwargs), test_timeout)
             return runner.kick_off()
 
         return run_in_thread_with_timeout_wrapper
@@ -145,12 +143,10 @@ class _ThreadedTestWrapper(object):
             self._exc_info = sys.exc_info()
             del self._fun_result  # to force exception on inadvertent access
             if not isinstance(self._exc_info[1], unittest.SkipTest):
-                print(
-                    'ERROR start() of test {} failed:\n{}'.format(
-                        self,
-                        self._exc_info_to_str(self._exc_info)),
-                    end='',
-                    file=self._stderr)
+                print('ERROR start() of test {} failed:\n{}'.format(
+                    self, self._exc_info_to_str(self._exc_info)),
+                      end='',
+                      file=self._stderr)
 
     @staticmethod
     def _exc_info_to_str(exc_info):

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -74,7 +74,8 @@ def camel(s):
     return normalize_separators(s).title().replace('_', '')
 
 
-amqp_codegen.AmqpMethod.structName = lambda m: camel(m.klass.name) + '.' + camel(m.name)
+amqp_codegen.AmqpMethod.structName = lambda m: camel(m.klass.name
+                                                    ) + '.' + camel(m.name)
 amqp_codegen.AmqpClass.structName = lambda c: camel(c.name) + "Properties"
 
 
@@ -215,8 +216,8 @@ def generate(specPath):
         print("            flagword_index += 1")
         for f in c.fields:
             if spec.resolveDomain(f.domain) == 'bit':
-                print("        self.%s = (flags & %s) != 0" % (pyize(f.name),
-                                                               flagName(c, f)))
+                print("        self.%s = (flags & %s) != 0" %
+                      (pyize(f.name), flagName(c, f)))
             else:
                 print("        if flags & %s:" % (flagName(c, f),))
                 genSingleDecode("            ", "self.%s" % (pyize(f.name),),
@@ -262,8 +263,8 @@ def generate(specPath):
         print("        flags = 0")
         for f in c.fields:
             if spec.resolveDomain(f.domain) == 'bit':
-                print("        if self.%s: flags = flags | %s" % (pyize(
-                    f.name), flagName(c, f)))
+                print("        if self.%s: flags = flags | %s" %
+                      (pyize(f.name), flagName(c, f)))
             else:
                 print("        if self.%s is not None:" % (pyize(f.name),))
                 print("            flags = flags | %s" % (flagName(c, f),))
@@ -318,8 +319,8 @@ from pika.compat import str_or_bytes, unicode_type
 str = bytes
 """)
 
-    print("PROTOCOL_VERSION = (%d, %d, %d)" % (spec.major, spec.minor,
-                                               spec.revision))
+    print("PROTOCOL_VERSION = (%d, %d, %d)" %
+          (spec.major, spec.minor, spec.revision))
     print("PORT = %d" % spec.port)
     print('')
 
@@ -354,8 +355,8 @@ str = bytes
                   (methodid, m.klass.index, m.index, methodid))
             print("        NAME = %s" % (fieldvalue(m.structName(),)))
             print('')
-            print(
-                "        def __init__(self%s):" % (fieldDeclList(m.arguments),))
+            print("        def __init__(self%s):" %
+                  (fieldDeclList(m.arguments),))
             print(fieldInitList('            ', m.arguments))
             print("        @property")
             print("        def synchronous(self):")


### PR DESCRIPTION
## Summary

Adds a [Hatch](https://hatch.pypa.io/) development environment and scripts to `pyproject.toml`, replacing raw command invocations scattered across `AGENTS.md` and `CONTRIBUTING.md` with a single source of truth. Credit to @alonfaraj for the suggestion in #1577.

`hatch run <script>` creates the virtual environment and installs all dependencies automatically, so contributors do not need to run `pip install -r test-requirements.txt` separately.

## Scripts added

| Script | Purpose |
|---|---|
| `hatch run fmt` | Format `pika/` in-place with yapf |
| `hatch run fmt-check` | Check formatting without modifying files (mirrors CI) |
| `hatch run lint` | Run ruff across all source directories |
| `hatch run typecheck` | Run mypy |
| `hatch run unit` | Run unit tests only (no RabbitMQ needed) |
| `hatch run test` | Run full test suite (requires RabbitMQ on localhost) |
| `hatch run rabbitmq` | Start RabbitMQ via Docker (`--name pika-rabbitmq`) |

## Testing

- `hatch run lint` -- passes
- `hatch run fmt-check` -- passes
- `hatch run typecheck` -- passes
- `hatch run unit` -- 593 passed, 18 skipped
- `hatch run test` -- 1141 passed, 58 skipped

## Related

Closes #1578
See #1577
