### PR TITLE
fix: examples with rabbitmq 4.3 need durable queues

### DIFF
--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -204,7 +204,7 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
-        self._channel.queue_declare(queue=queue_name, callback=cb)
+        self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -204,7 +204,7 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
-        self._channel.queue_declare(queue=queue_name, exclusive=True, callback=cb)
+        self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -204,7 +204,7 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
-        self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
+        self._channel.queue_declare(queue=queue_name, exclusive=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -190,7 +190,7 @@ class ExamplePublisher(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         self._channel.queue_declare(queue=queue_name,
-                                    durable=True,
+                                    exclusive=True,
                                     callback=self.on_queue_declareok)
 
     def on_queue_declareok(self, _unused_frame):

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -190,7 +190,7 @@ class ExamplePublisher(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         self._channel.queue_declare(queue=queue_name,
-                                    exclusive=True,
+                                    durable=True,
                                     callback=self.on_queue_declareok)
 
     def on_queue_declareok(self, _unused_frame):

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -190,6 +190,7 @@ class ExamplePublisher(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         self._channel.queue_declare(queue=queue_name,
+                                    durable=True,
                                     callback=self.on_queue_declareok)
 
     def on_queue_declareok(self, _unused_frame):

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -208,7 +208,7 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
-        self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
+        self._channel.queue_declare(queue=queue_name, exclusive=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -208,7 +208,7 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
-        self._channel.queue_declare(queue=queue_name, callback=cb)
+        self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -208,7 +208,7 @@ class ExampleConsumer(object):
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
-        self._channel.queue_declare(queue=queue_name, exclusive=True, callback=cb)
+        self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
         """Method invoked by pika when the Queue.Declare RPC call made in

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -59,7 +59,7 @@ channel.exchange_declare(exchange="test_exchange",
                          passive=False,
                          durable=True,
                          auto_delete=False)
-channel.queue_declare(queue="standard", exclusive=True, auto_delete=True)
+channel.queue_declare(queue="standard", exclusive=True)
 channel.queue_bind(queue="standard",
                    exchange="test_exchange",
                    routing_key="standard_key")

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -59,7 +59,7 @@ channel.exchange_declare(exchange="test_exchange",
                          passive=False,
                          durable=True,
                          auto_delete=False)
-channel.queue_declare(queue="standard", auto_delete=True)
+channel.queue_declare(queue="standard", durable=True, auto_delete=True)
 channel.queue_bind(queue="standard",
                    exchange="test_exchange",
                    routing_key="standard_key")

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -59,7 +59,7 @@ channel.exchange_declare(exchange="test_exchange",
                          passive=False,
                          durable=True,
                          auto_delete=False)
-channel.queue_declare(queue="standard", durable=True, auto_delete=True)
+channel.queue_declare(queue="standard", exclusive=True, auto_delete=True)
 channel.queue_bind(queue="standard",
                    exchange="test_exchange",
                    routing_key="standard_key")

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -58,7 +58,7 @@ while True:
                                  passive=False,
                                  durable=True,
                                  auto_delete=False)
-        channel.queue_declare(queue='standard', exclusive=True, auto_delete=True)
+        channel.queue_declare(queue='standard', durable=True, auto_delete=True)
         channel.queue_bind(queue='standard',
                            exchange='test_exchange',
                            routing_key='standard_key')

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -58,7 +58,7 @@ while True:
                                  passive=False,
                                  durable=True,
                                  auto_delete=False)
-        channel.queue_declare(queue='standard', auto_delete=True)
+        channel.queue_declare(queue='standard', durable=True, auto_delete=True)
         channel.queue_bind(queue='standard',
                            exchange='test_exchange',
                            routing_key='standard_key')

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -58,7 +58,7 @@ while True:
                                  passive=False,
                                  durable=True,
                                  auto_delete=False)
-        channel.queue_declare(queue='standard', durable=True, auto_delete=True)
+        channel.queue_declare(queue='standard', exclusive=True, auto_delete=True)
         channel.queue_bind(queue='standard',
                            exchange='test_exchange',
                            routing_key='standard_key')

--- a/examples/consume.py
+++ b/examples/consume.py
@@ -31,7 +31,7 @@ def main():
                              passive=False,
                              durable=True,
                              auto_delete=False)
-    channel.queue_declare(queue='standard', exclusive=True, auto_delete=True)
+    channel.queue_declare(queue='standard', exclusive=True)
     channel.queue_bind(queue='standard',
                        exchange='test_exchange',
                        routing_key='standard_key')

--- a/examples/consume.py
+++ b/examples/consume.py
@@ -31,7 +31,7 @@ def main():
                              passive=False,
                              durable=True,
                              auto_delete=False)
-    channel.queue_declare(queue='standard', durable=True, auto_delete=True)
+    channel.queue_declare(queue='standard', exclusive=True, auto_delete=True)
     channel.queue_bind(queue='standard',
                        exchange='test_exchange',
                        routing_key='standard_key')

--- a/examples/consume.py
+++ b/examples/consume.py
@@ -31,7 +31,7 @@ def main():
                              passive=False,
                              durable=True,
                              auto_delete=False)
-    channel.queue_declare(queue='standard', auto_delete=True)
+    channel.queue_declare(queue='standard', durable=True, auto_delete=True)
     channel.queue_bind(queue='standard',
                        exchange='test_exchange',
                        routing_key='standard_key')

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -19,9 +19,7 @@ class Publisher(threading.Thread):
         parameters = ConnectionParameters("localhost", credentials=credentials)
         self.connection = BlockingConnection(parameters)
         self.channel = self.connection.channel()
-        self.channel.queue_declare(queue=self.queue,
-                                   exclusive=True,
-                                   auto_delete=True)
+        self.channel.queue_declare(queue=self.queue, exclusive=True)
 
     def run(self):
         while self.is_running:

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -19,7 +19,7 @@ class Publisher(threading.Thread):
         parameters = ConnectionParameters("localhost", credentials=credentials)
         self.connection = BlockingConnection(parameters)
         self.channel = self.connection.channel()
-        self.channel.queue_declare(queue=self.queue, auto_delete=True)
+        self.channel.queue_declare(queue=self.queue, durable=True, auto_delete=True)
 
     def run(self):
         while self.is_running:

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -19,7 +19,9 @@ class Publisher(threading.Thread):
         parameters = ConnectionParameters("localhost", credentials=credentials)
         self.connection = BlockingConnection(parameters)
         self.channel = self.connection.channel()
-        self.channel.queue_declare(queue=self.queue, durable=True, auto_delete=True)
+        self.channel.queue_declare(queue=self.queue,
+                                   durable=True,
+                                   auto_delete=True)
 
     def run(self):
         while self.is_running:

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -20,7 +20,7 @@ class Publisher(threading.Thread):
         self.connection = BlockingConnection(parameters)
         self.channel = self.connection.channel()
         self.channel.queue_declare(queue=self.queue,
-                                   durable=True,
+                                   exclusive=True,
                                    auto_delete=True)
 
     def run(self):

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1148,8 +1148,9 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
 
         """
         check_callback_arg(callback, 'callback')
-        return _TimerHandle(self._reactor.callLater(
-            delay, callback))  # pyright: ignore[reportAttributeAccessIssue]
+        return _TimerHandle(
+            self._reactor.callLater(delay, callback)
+        )  # type: ignore[arg-type] # pyright: ignore[reportAttributeAccessIssue]
 
     def _adapter_remove_timeout(self, timeout_id: Any) -> None:
         """Implement

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1148,9 +1148,9 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
 
         """
         check_callback_arg(callback, 'callback')
-        return _TimerHandle(
-            self._reactor.callLater(delay, callback)
-        )  # type: ignore[arg-type] # pyright: ignore[reportAttributeAccessIssue]
+        reactor: Any = self._reactor
+        call_id = reactor.callLater(delay, callback)
+        return _TimerHandle(call_id)
 
     def _adapter_remove_timeout(self, timeout_id: Any) -> None:
         """Implement


### PR DESCRIPTION
## Proposed Changes

Starting from version 4.3 of RabbitMQ, Transient (non-durable) non-exclusive classic queues are [deprecated](https://www.rabbitmq.com/release-information/deprecated-features-list) and cannot be declared by default (https://www.rabbitmq.com/docs/queues#durability)

This fixes the various examples to work with version 4.3, setting the `durable=True` when creating the queues

## Types of Changes

What types of changes does your code introduce to this project?

- [x] Bugfix (non-breaking change which fixes issue #1580)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further Comments

@lukebakken I don't think changing the default value in the library code is a good idea, do you think we should document this? Any other action we should take?

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://lu.ma/open-source-saturday-torino)