### PR TITLE
fix: handle channel closure in BlockingConnection.process_data_events

### DIFF
--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -371,6 +371,9 @@ class BlockingConnection:
         # Receives on_close_callback args from Connection
         self._closed_result = _CallbackResult(self._OnClosedArgs)
 
+        # Store exceptions for server-initiated channel closures
+        self._server_channel_closures: deque[Exception] = deque()
+
         # Perform connection workflow
         self._impl: select_connection.SelectConnection = None  # type: ignore  # so that attribute is created in case below raises
         self._impl = self._create_connection(parameters, _impl_class)
@@ -899,13 +902,10 @@ class BlockingConnection:
         if self._channels_pending_dispatch:
             self._dispatch_channel_events()
 
-        for impl_channel in self._impl._channels.values():
-            channel = impl_channel._get_cookie()
-            if channel.is_closed and isinstance(
-                    channel._closing_reason, exceptions.ChannelClosedByBroker):
-                LOGGER.debug('Channel %d closed by broker: %r',
-                             channel.channel_number, channel._closing_reason)
-                raise channel._closing_reason
+        if self._server_channel_closures:
+            exc = self._server_channel_closures.popleft()
+            LOGGER.debug('Channel closed by broker: %r', exc)
+            raise exc
 
     def sleep(self, duration: float) -> None:
         """A safer way to sleep than calling time.sleep() directly that would
@@ -1492,6 +1492,7 @@ class BlockingChannel:
         self._closing_reason = reason
 
         if isinstance(reason, exceptions.ChannelClosedByBroker):
+            self.connection._server_channel_closures.append(reason)
             self._cleanup()
 
             # Request urgent termination of `process_data_events()`, in case

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -899,6 +899,14 @@ class BlockingConnection:
         if self._channels_pending_dispatch:
             self._dispatch_channel_events()
 
+        for impl_channel in self._impl._channels.values():
+            channel = impl_channel._get_cookie()
+            if channel.is_closed and isinstance(
+                    channel._closing_reason, exceptions.ChannelClosedByBroker):
+                LOGGER.debug('Channel %d closed by broker: %r',
+                             channel.channel_number, channel._closing_reason)
+                raise channel._closing_reason
+
     def sleep(self, duration: float) -> None:
         """A safer way to sleep than calling time.sleep() directly that would
         keep the adapter from ignoring frames sent from the broker. The

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -358,7 +358,7 @@ class BlockingConnectionTests(unittest.TestCase):
         self.assertIs(unblocked_buffer[0], frame)
 
     @patch.object(blocking_connection.select_connection,
-                  'SelectConnection',
+                  "SelectConnection",
                   spec_set=SelectConnectionTemplate)
     def test_process_data_events_raises_on_channel_closed_by_broker(
             self, select_connection_class_mock):
@@ -366,21 +366,57 @@ class BlockingConnectionTests(unittest.TestCase):
         impl_mock.is_closed = False
 
         with mock.patch.object(blocking_connection.BlockingConnection,
-                               '_create_connection',
+                               "_create_connection",
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection("params")
 
-        exc = pika.exceptions.ChannelClosedByBroker(406, 'consumer_timeout')
-        channel_mock = mock.Mock(is_closed=True,
-                                 _closing_reason=exc,
-                                 channel_number=1)
-        impl_channel_mock = mock.Mock(_get_cookie=mock.Mock(
-            return_value=channel_mock))
-        impl_mock._channels = {1: impl_channel_mock}
+        exc = pika.exceptions.ChannelClosedByBroker(406, "consumer_timeout")
 
-        with mock.patch.object(connection, '_flush_output'):
+        impl_channel_mock = mock.Mock()
+        impl_channel_mock.channel_number = 1
+        channel = blocking_connection.BlockingChannel(impl_channel_mock,
+                                                      connection)
+
+        with mock.patch.object(channel, "_cleanup"):
+            channel._on_channel_closed(impl_channel_mock, exc)
+
+        with mock.patch.object(connection, "_flush_output"):
             with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
                 connection.process_data_events(time_limit=0)
 
             self.assertEqual(cm.exception.reply_code, 406)
-            self.assertEqual(cm.exception.reply_text, 'consumer_timeout')
+            self.assertEqual(cm.exception.reply_text, "consumer_timeout")
+
+    @patch.object(blocking_connection.select_connection,
+                  "SelectConnection",
+                  spec_set=SelectConnectionTemplate)
+    def test_process_data_events_raises_after_full_channel_cleanup(
+            self, select_connection_class_mock):
+        impl_mock = select_connection_class_mock.return_value
+        impl_mock.is_closed = False
+        impl_mock._channels = {}
+
+        with mock.patch.object(blocking_connection.BlockingConnection,
+                               "_create_connection",
+                               return_value=impl_mock):
+            connection = blocking_connection.BlockingConnection("params")
+
+        exc = pika.exceptions.ChannelClosedByBroker(406, "consumer_timeout")
+
+        impl_channel_mock = mock.Mock()
+        impl_channel_mock.channel_number = 1
+        channel = blocking_connection.BlockingChannel(impl_channel_mock,
+                                                      connection)
+
+        with mock.patch.object(channel, "_cleanup"):
+            channel._on_channel_closed(impl_channel_mock, exc)
+
+        impl_mock._channels.pop(1, None)
+        impl_channel_mock._cookie = None
+
+        with mock.patch.object(connection, "_flush_output"):
+            with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
+                connection.process_data_events(time_limit=0)
+
+            self.assertEqual(cm.exception.reply_code, 406)
+            self.assertEqual(cm.exception.reply_text, "consumer_timeout")

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -356,3 +356,31 @@ class BlockingConnectionTests(unittest.TestCase):
         evt.dispatch()
         self.assertEqual(len(unblocked_buffer), 1)
         self.assertIs(unblocked_buffer[0], frame)
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_process_data_events_raises_on_channel_closed_by_broker(
+            self, select_connection_class_mock):
+        impl_mock = select_connection_class_mock.return_value
+        impl_mock.is_closed = False
+
+        with mock.patch.object(blocking_connection.BlockingConnection,
+                               '_create_connection',
+                               return_value=impl_mock):
+            connection = blocking_connection.BlockingConnection('params')
+
+        exc = pika.exceptions.ChannelClosedByBroker(406, 'consumer_timeout')
+        channel_mock = mock.Mock(is_closed=True,
+                                 _closing_reason=exc,
+                                 channel_number=1)
+        impl_channel_mock = mock.Mock(_get_cookie=mock.Mock(
+            return_value=channel_mock))
+        impl_mock._channels = {1: impl_channel_mock}
+
+        with mock.patch.object(connection, '_flush_output'):
+            with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
+                connection.process_data_events(time_limit=0)
+
+            self.assertEqual(cm.exception.reply_code, 406)
+            self.assertEqual(cm.exception.reply_text, 'consumer_timeout')


### PR DESCRIPTION
## Proposed Changes

When using `BlockingConnection.process_data_events()` in long-running publisher applications (per `examples/long_running_publisher.py`), if RabbitMQ closes a channel due to consumer timeout or other broker-initiated reasons, the exception was silently swallowed. The connection remained open but the application had no way of knowing the channel was closed

This PR implement the existing behavior in https://github.com/pika/pika/blob/305fbe60088790a2648580078b4808f138e325d7/pika/adapters/blocking_connection.py#L2128 in `BlockingConnection.process_data_events`

The error was caused by `BlockingConnection.process_data_events()` not checking after dispatching channel events whether any channel had been closed by the broker. The channel closure detection logic only existed in the channel-level method. The fix is to, after dispatching channel events, to iterate over all channels and raise `ChannelClosedByBroker` if a channel is closed with that reason.

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes issue #1472 )
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation (correction or otherwise)
- [ ] Cosmetics (whitespace, appearance)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

[![Open Source Saturday](https://img.shields.io/badge/%E2%9D%A4%EF%B8%8F-open%20source%20saturday-F64060.svg)](https://lu.ma/open-source-saturday-torino)