### PR TITLE
Enable expanded Ruff rules

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -19,4 +19,4 @@ jobs:
           python-version: '3.10'
       - run: |
           python -m pip install --upgrade pip hatch
-          hatch run lint
+          hatch run lint-check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,8 +65,8 @@ If you would like to run TLS/SSL tests, use the following procedure:
 
 ## Code Formatting and Linting
 
-Please format your code using [yapf](https://pypi.org/project/yapf/) with ``google`` style prior to issuing your pull request. 
-*Note: only format those lines that you have changed in your pull request. 
+Please format your code using [yapf](https://pypi.org/project/yapf/) with ``google`` style prior to issuing your pull request.
+*Note: only format those lines that you have changed in your pull request.
 If you format an entire file and change code outside of the scope of your PR, it will likely be rejected.*
 
     hatch run fmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,10 +65,9 @@ If you would like to run TLS/SSL tests, use the following procedure:
 
 ## Code Formatting and Linting
 
-Please format your code using [yapf](https://pypi.org/project/yapf/)
-with ``google`` style prior to issuing your pull request. *Note: only format those
-lines that you have changed in your pull request. If you format an entire file and
-change code outside of the scope of your PR, it will likely be rejected.*
+Please format your code using [yapf](https://pypi.org/project/yapf/) with ``google`` style prior to issuing your pull request. 
+*Note: only format those lines that you have changed in your pull request. 
+If you format an entire file and change code outside of the scope of your PR, it will likely be rejected.*
 
     hatch run fmt
 
@@ -76,8 +75,12 @@ To verify formatting without modifying files (mirrors CI), use
 
     hatch run fmt-check
 
-Please also ensure your code passes [ruff](https://docs.astral.sh/ruff/) linting:
+Please also lint your code using [ruff](https://docs.astral.sh/ruff/):
 
     hatch run lint
+
+To verify linting without modifying files (mirrors CI), use
+
+    hatch run lint-check
 
 Both checks run in CI on every push and pull request.

--- a/examples/async_as_callback.py
+++ b/examples/async_as_callback.py
@@ -4,8 +4,7 @@ import logging
 import ssl
 import time
 from enum import Enum
-from typing import Dict
-from typing import Optional
+from typing import Dict, Optional
 
 import msgpack
 from pydantic import BaseModel, validator

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -3,6 +3,7 @@
 import functools
 import logging
 import time
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -1,8 +1,9 @@
 # pylint: disable=C0111,C0103,R0205
 
 import functools
-import logging
 import json
+import logging
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -3,8 +3,8 @@
 import functools
 import logging
 import time
-import pika
 
+import pika
 from pika.adapters.asyncio_connection import AsyncioConnection
 from pika.exchange_type import ExchangeType
 

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import threading
 import time
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/basic_publisher_threaded.py
+++ b/examples/basic_publisher_threaded.py
@@ -2,10 +2,11 @@
 
 import functools
 import logging
-import threading
-import pika
-import queue
 import pprint
+import queue
+import threading
+
+import pika
 
 LOG_FORMAT = ("%(levelname) -10s %(asctime)s %(name) -30s %(funcName) "
               "-35s %(lineno) -5d: %(message)s")

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -2,8 +2,10 @@
 
 import functools
 import random
+
 import pika
 from pika.exchange_type import ExchangeType
+
 """
 This module implements a client that connects to multiple RabbitMQ brokers
 distributed across different ports (5672, 5673, 5674) and consumes messages

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -1,11 +1,4 @@
 # pylint: disable=C0111,C0103,R0205
-
-import functools
-import random
-
-import pika
-from pika.exchange_type import ExchangeType
-
 """
 This module implements a client that connects to multiple RabbitMQ brokers
 distributed across different ports (5672, 5673, 5674) and consumes messages
@@ -28,6 +21,12 @@ The name of the module, `blocking_consume_recover_multiple_hosts.py`, reflects i
 - "recover": The module is designed to recover from connection errors by attempting to reconnect.
 - "multiple_hosts": It connects to multiple RabbitMQ brokers distributed across different ports to ensure availability and redundancy.
 """
+
+import functools
+import random
+
+import pika
+from pika.exchange_type import ExchangeType
 
 
 def on_message(ch, method_frame, _header_frame, body, userdata=None):

--- a/examples/confirmation.py
+++ b/examples/confirmation.py
@@ -1,8 +1,9 @@
 # pylint: disable=C0111,C0103,R0205,W0603
 
 import logging
+
 import pika
-from pika import spec, DeliveryMode
+from pika import DeliveryMode, spec
 
 ITERATIONS = 100
 

--- a/examples/consume.py
+++ b/examples/consume.py
@@ -1,6 +1,7 @@
 """Basic message consumer example"""
 import functools
 import logging
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/consumer_queued.py
+++ b/examples/consumer_queued.py
@@ -9,7 +9,7 @@ from pika.exchange_type import ExchangeType
 body_buffer = []
 lock = threading.Lock()
 
-print('pika version: %s' % pika.__version__)
+print(f'pika version: {pika.__version__}')
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))
@@ -45,11 +45,11 @@ def process_buffer():
             if not ticker:
                 continue
 
-            print('got ticker %s, gonna bind it...' % ticker)
+            print(f'got ticker {ticker}, gonna bind it...')
             bind_channel.queue_bind(exchange='com.micex.lasttrades',
                                     queue=queue_tickers,
                                     routing_key=str(ticker))
-            print('ticker %s binded ok' % ticker)
+            print(f'ticker {ticker} binded ok')
     finally:
         lock.release()
 

--- a/examples/consumer_queued.py
+++ b/examples/consumer_queued.py
@@ -2,6 +2,7 @@
 
 import json
 import threading
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/consumer_simple.py
+++ b/examples/consumer_simple.py
@@ -6,7 +6,7 @@ import logging
 import pika
 from pika.exchange_type import ExchangeType
 
-print('pika version: %s' % pika.__version__)
+print(f'pika version: {pika.__version__}')
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))
@@ -44,11 +44,11 @@ def callback(_ch, _method, _properties, body):
     if not ticker:
         return
 
-    print('got ticker %s, gonna bind it...' % ticker)
+    print(f'got ticker {ticker}, gonna bind it...')
     bind_channel.queue_bind(exchange='com.micex.lasttrades',
                             queue=queue_tickers,
                             routing_key=str(ticker))
-    print('ticker %s binded ok' % ticker)
+    print(f'ticker {ticker} binded ok')
 
 
 logging.basicConfig(level=logging.INFO)

--- a/examples/consumer_simple.py
+++ b/examples/consumer_simple.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/direct_reply_to.py
+++ b/examples/direct_reply_to.py
@@ -54,7 +54,7 @@ def main():
 
 
 def on_server_rx_rpc_request(ch, method_frame, properties, body):
-    print('RPC Server got request: %s' % body)
+    print(f'RPC Server got request: {body}')
 
     ch.basic_publish('', routing_key=properties.reply_to, body='Polo')
 
@@ -64,7 +64,7 @@ def on_server_rx_rpc_request(ch, method_frame, properties, body):
 
 
 def on_client_rx_reply_from_server(ch, _method_frame, _properties, body):
-    print('RPC Client got reply: %s' % body)
+    print(f'RPC Client got reply: {body}')
 
     # NOTE A real client might want to make additional RPC requests, but in this
     # simple example we're closing the channel after getting our first reply

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -2,7 +2,8 @@
 
 import threading
 from time import sleep
-from pika import ConnectionParameters, BlockingConnection, PlainCredentials
+
+from pika import BlockingConnection, ConnectionParameters, PlainCredentials
 
 
 class Publisher(threading.Thread):

--- a/examples/producer.py
+++ b/examples/producer.py
@@ -6,7 +6,7 @@ import random
 import pika
 from pika.exchange_type import ExchangeType
 
-print('pika version: %s' % pika.__version__)
+print(f'pika version: {pika.__version__}')
 
 connection = pika.BlockingConnection(
     pika.ConnectionParameters(host='localhost'))
@@ -51,6 +51,6 @@ for i in range(0, _COUNT_):
         routing_key='order.stop.create',
         body=json.dumps(msg),
         properties=pika.BasicProperties(content_type='application/json'))
-    print('send ticker %s' % ticker)
+    print(f'send ticker {ticker}')
 
 connection.close()

--- a/examples/producer.py
+++ b/examples/producer.py
@@ -2,6 +2,7 @@
 
 import json
 import random
+
 import pika
 from pika.exchange_type import ExchangeType
 

--- a/examples/publish.py
+++ b/examples/publish.py
@@ -1,6 +1,7 @@
 # pylint: disable=C0111,C0103,R0205
 
 import logging
+
 import pika
 from pika import DeliveryMode
 from pika.exchange_type import ExchangeType

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -66,9 +66,8 @@ class PikaService(service.MultiService):
                 factory=f)
         serv.factory = f
         f.service = serv  # pylint: disable=W0201
-        name = '%s%s:%d' % ('ssl:' if self.parameters.ssl_options else '',
-                            self.parameters.host, self.parameters.port)
-        serv.__repr__ = lambda: '<AMQP Connection to %s>' % name
+        name = f'{("ssl:" if self.parameters.ssl_options else "")}{self.parameters.host}:{self.parameters.port}'
+        serv.__repr__ = lambda: f'<AMQP Connection to {name}>'
         serv.setName(name)
         serv.setServiceParent(self)
 
@@ -139,8 +138,7 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
             msg,
         ) = item
 
-        log.msg('%s (%s): %s' %
-                (deliver.exchange, deliver.routing_key, repr(msg)),
+        log.msg(f'{deliver.exchange} ({deliver.routing_key}): {repr(msg)}',
                 system='Pika:<=')
         d = defer.maybeDeferred(callback, item)
         d.addCallbacks(lambda _: channel.basic_ack(deliver.delivery_tag),
@@ -176,7 +174,7 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
                                               body=msg,
                                               properties=prop)
         except Exception as error:  # pylint: disable=W0703
-            log.msg('Error while sending message: %s' % error, system=self.name)
+            log.msg(f'Error while sending message: {error}', system=self.name)
 
 
 class PikaFactory(protocol.ReconnectingClientFactory):
@@ -198,13 +196,12 @@ class PikaFactory(protocol.ReconnectingClientFactory):
         return self.client
 
     def clientConnectionLost(self, connector, reason):  # pylint: disable=W0221
-        log.msg('Lost connection.  Reason: %s' % reason.value, system=self.name)
+        log.msg(f'Lost connection.  Reason: {reason.value}', system=self.name)
         protocol.ReconnectingClientFactory.clientConnectionLost(
             self, connector, reason)
 
     def clientConnectionFailed(self, connector, reason):
-        log.msg('Connection failed. Reason: %s' % reason.value,
-                system=self.name)
+        log.msg(f'Connection failed. Reason: {reason.value}', system=self.name)
         protocol.ReconnectingClientFactory.clientConnectionFailed(
             self, connector, reason)
 

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -23,16 +23,13 @@ as defined by PREFETCH_COUNT
 import logging
 import sys
 
-from twisted.internet import protocol
-from twisted.application import internet
-from twisted.application import service
+from twisted.application import internet, service
+from twisted.internet import defer, protocol, reactor, ssl, task
 from twisted.internet.defer import inlineCallbacks
-from twisted.internet import ssl, defer, task
 from twisted.python import log
-from twisted.internet import reactor
 
 import pika
-from pika import spec, DeliveryMode
+from pika import DeliveryMode, spec
 from pika.adapters import twisted_connection
 from pika.exchange_type import ExchangeType
 

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -8,19 +8,13 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 # pylint: disable=C0413
 # ruff: noqa: E402
 
-from pika.connection import ConnectionParameters
-from pika.connection import URLParameters
-from pika.connection import SSLOptions
-from pika.credentials import PlainCredentials
-from pika.spec import BasicProperties
-from pika.delivery_mode import DeliveryMode
-
 from pika import adapters
-from pika.adapters import BaseConnection
-from pika.adapters import BlockingConnection
-from pika.adapters import SelectConnection
-
+from pika.adapters import BaseConnection, BlockingConnection, SelectConnection
 from pika.adapters.utils.connection_workflow import AMQPConnectionWorkflow
+from pika.connection import ConnectionParameters, SSLOptions, URLParameters
+from pika.credentials import PlainCredentials
+from pika.delivery_mode import DeliveryMode
+from pika.spec import BasicProperties
 
 __all__ = [
     'adapters',

--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -1,6 +1,7 @@
 """Internal utility helpers for platform and socket compatibility."""
 # pylint: disable=C0103
 from __future__ import annotations
+
 import abc
 import os
 import re

--- a/pika/adapters/__init__.py
+++ b/pika/adapters/__init__.py
@@ -20,8 +20,7 @@ Pika provides multiple adapters to connect to RabbitMQ:
 from pika.adapters.asyncio_connection import AsyncioConnection
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.blocking_connection import BlockingConnection
-from pika.adapters.select_connection import SelectConnection
-from pika.adapters.select_connection import IOLoop
+from pika.adapters.select_connection import IOLoop, SelectConnection
 
 __all__ = [
     'AsyncioConnection',

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import asyncio
 import logging
 import sys
-from typing import Any, Awaitable, Callable, TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Sequence
 
 from pika.adapters import base_connection
-from pika.adapters.utils import connection_workflow, nbio_interface, io_services_utils
+from pika.adapters.utils import connection_workflow, io_services_utils, nbio_interface
 
 if TYPE_CHECKING:
     from pika import connection

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -110,9 +110,9 @@ class BaseConnection(connection.Connection):
         #
         #     return '%s->%s' % (sockname, peername)
         # TODO need helpful __repr__ in transports
-        return ('<{} {} transport={} params={}>'.format(
-            self.__class__.__name__, self._STATE_NAMES[self.connection_state],
-            self._transport, self.params))
+        return (
+            f'<{self.__class__.__name__} {self._STATE_NAMES[self.connection_state]} transport={self._transport} params={self.params}>'
+        )
 
     @classmethod
     @abc.abstractmethod
@@ -365,8 +365,7 @@ class BaseConnection(connection.Connection):
             # NOTE: On success, the stack will be up already, so there is no
             #       corresponding callback.
             assert conn_or_exc is self, \
-                'Expected self conn={!r} from workflow, but got {!r}.'.format(
-                    self, conn_or_exc)
+                f'Expected self conn={self!r} from workflow, but got {conn_or_exc!r}.'
 
     def _handle_connection_workflow_failure(self,
                                             error: Exception | None) -> None:

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -11,9 +11,8 @@ import logging
 from typing import Any, Callable, Sequence
 
 import pika.exceptions
-
-from pika.adapters.utils import connection_workflow, nbio_interface
 from pika import connection
+from pika.adapters.utils import connection_workflow, nbio_interface
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -131,7 +131,7 @@ class _CallbackResult:
         """Append an element to values"""
         assert not self._ready or isinstance(self._values, list), (
             '_CallbackResult state is incompatible with append_element: '
-            'ready=%r; values=%r' % (self._ready, self._values))
+            f'ready={self._ready!r}; values={self._values!r}')
 
         try:
             value = self._value_class(*args, **kwargs)  # type: ignore
@@ -158,8 +158,8 @@ class _CallbackResult:
         """
         assert self._ready, '_CallbackResult was not set'
         assert isinstance(self._values, tuple) and len(self._values) == 1, (
-            '_CallbackResult value is incompatible with set_value_once: %r' %
-            (self._values,))
+            f'_CallbackResult value is incompatible with set_value_once: {self._values!r}'
+        )
 
         return self._values[0]
 
@@ -174,8 +174,8 @@ class _CallbackResult:
         """
         assert self._ready, '_CallbackResult was not set'
         assert isinstance(self._values, list) and self._values, (
-            '_CallbackResult value is incompatible with append_element: %r' %
-            (self._values,))
+            f'_CallbackResult value is incompatible with append_element: {self._values!r}'
+        )
 
         return self._values
 
@@ -232,9 +232,7 @@ class _TimerEvt:
         self.timer_id: object | None = None
 
     def __repr__(self) -> str:
-        return '<{} timer_id={} callback={}>'.format(self.__class__.__name__,
-                                                     self.timer_id,
-                                                     self._callback)
+        return f'<{self.__class__.__name__} timer_id={self.timer_id} callback={self._callback}>'
 
     def dispatch(self) -> None:
         """Dispatch the user's callback method"""
@@ -259,9 +257,7 @@ class _ConnectionBlockedUnblockedEvtBase(Generic[T]):
         self._method_frame = method_frame
 
     def __repr__(self) -> str:
-        return '<{} callback={}, frame={}>'.format(self.__class__.__name__,
-                                                   self._callback,
-                                                   self._method_frame)
+        return f'<{self.__class__.__name__} callback={self._callback}, frame={self._method_frame}>'
 
     def dispatch(self) -> None:
         """Dispatch the user's callback method"""
@@ -447,7 +443,7 @@ class BlockingConnection:
 
         if not configs:
             raise ValueError('Expected a non-empty sequence of connection '
-                             'parameters, but got {!r}.'.format(configs))
+                             f'parameters, but got {configs!r}.')
 
         # Connection workflow completion args
         #   `result` may be an instance of connection on success or exception on
@@ -846,8 +842,7 @@ class BlockingConnection:
             connection (NEW in v1.0.0)
         """
         if not self.is_open:
-            msg = '{}.close({}, {!r}) called on closed connection.'.format(
-                self.__class__.__name__, reply_code, reply_text)
+            msg = f'{self.__class__.__name__}.close({reply_code}, {reply_text!r}) called on closed connection.'
             LOGGER.error(msg)
             raise exceptions.ConnectionWrongStateError(msg)
 
@@ -1058,8 +1053,7 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):
         self.method_frame = method_frame
 
     def __repr__(self) -> str:
-        return '<{} method_frame={!r}>'.format(self.__class__.__name__,
-                                               self.method_frame)
+        return f'<{self.__class__.__name__} method_frame={self.method_frame!r}>'
 
     @property
     def method(self):
@@ -1096,10 +1090,7 @@ class _ReturnedMessageEvt(_ChannelPendingEvt):
         self.body = body
 
     def __repr__(self) -> str:
-        return ('<%s callback=%r channel=%r method=%r properties=%r '
-                'body=%.300r>') % (self.__class__.__name__, self.callback,
-                                   self.channel, self.method, self.properties,
-                                   self.body)
+        return f'<{self.__class__.__name__} callback={self.callback!r} channel={self.channel!r} method={self.method!r} properties={self.properties!r} body={self.body[:300]!r}>'
 
     def dispatch(self) -> None:
         """Dispatch user's callback"""
@@ -1215,8 +1206,7 @@ class _QueueConsumerGeneratorInfo:
         self.pending_events: deque[Any] = deque()
 
     def __repr__(self) -> str:
-        return '<{} params={!r} consumer_tag={!r}>'.format(
-            self.__class__.__name__, self.params, self.consumer_tag)
+        return f'<{self.__class__.__name__} params={self.params!r} consumer_tag={self.consumer_tag!r}>'
 
 
 class BlockingChannel:
@@ -2049,9 +2039,8 @@ class BlockingChannel:
             if params != self._queue_consumer_generator.params:
                 raise ValueError(
                     'Consume with different params not allowed on existing '
-                    'queue consumer generator; previous params: %r; '
-                    'new params: %r' % (self._queue_consumer_generator.params,
-                                        (queue, auto_ack, exclusive)))
+                    f'queue consumer generator; previous params: {self._queue_consumer_generator.params!r}; '
+                    f'new params: {(queue, auto_ack, exclusive)!r}')
         else:
             LOGGER.debug('Creating new queue consumer generator; params: %r',
                          params)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1090,7 +1090,10 @@ class _ReturnedMessageEvt(_ChannelPendingEvt):
         self.body = body
 
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} callback={self.callback!r} channel={self.channel!r} method={self.method!r} properties={self.properties!r} body={self.body[:300]!r}>'
+        return (
+            f'<{self.__class__.__name__} callback={self.callback!r} channel={self.channel!r}'
+            f' method={self.method!r} properties={self.properties!r}'
+            f' body={self.body!r:.300}>')
 
     def dispatch(self) -> None:
         """Dispatch user's callback"""

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1271,7 +1271,7 @@ class BlockingChannel:
         self._connection = connection
 
         # A mapping of consumer tags to _ConsumerInfo for active consumers
-        self._consumer_infos: dict[Any, Any] = dict()
+        self._consumer_infos: dict[Any, Any] = {}
 
         # Queue consumer generator generator info of type
         # _QueueConsumerGeneratorInfo created by BlockingChannel.consume
@@ -1346,7 +1346,7 @@ class BlockingChannel:
         """Clean up members that might inhibit garbage collection"""
         self._message_confirmation_result.reset()
         self._pending_events = deque()
-        self._consumer_infos = dict()
+        self._consumer_infos = {}
         self._queue_consumer_generator = None
 
     @property

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -19,28 +19,29 @@ classes.
 
 from __future__ import annotations
 
-from collections import namedtuple, deque
 import contextlib
 import functools
 import logging
 import threading
-from typing import Any, Callable, Generator, Generic, Sequence, TypeVar, TYPE_CHECKING
+from collections import deque, namedtuple
+from typing import TYPE_CHECKING, Any, Callable, Generator, Generic, Sequence, TypeVar
 
-import pika.channel
 import pika._utils
+import pika.channel
 import pika.connection
 import pika.exceptions as exceptions
 import pika.spec
 import pika.validators as validators
-from pika.adapters.utils import connection_workflow
 
 # NOTE: import SelectConnection after others to avoid circular depenency
 from pika.adapters import select_connection
+from pika.adapters.utils import connection_workflow
 from pika.exchange_type import ExchangeType
 
 if TYPE_CHECKING:
     from traceback import TracebackException
     from types import TracebackType
+
     import pika.frame
 
 T = TypeVar(

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -4,14 +4,12 @@ from __future__ import annotations
 import functools
 import logging
 import os
-import threading
-from typing import Any, Callable, Sequence, TYPE_CHECKING
-
-import gevent._interfaces  # type: ignore[import-untyped]
-
 import queue
+import threading
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import gevent
+import gevent._interfaces  # type: ignore[import-untyped]
 import gevent.hub  # type: ignore[import-untyped]
 import gevent.socket  # type: ignore[import-untyped]
 

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -8,7 +8,7 @@ import queue
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
-import gevent # type: ignore[import-untyped]
+import gevent  # type: ignore[import-untyped]
 import gevent._interfaces  # type: ignore[import-untyped]
 import gevent.hub  # type: ignore[import-untyped]
 import gevent.socket  # type: ignore[import-untyped]

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -8,7 +8,7 @@ import queue
 import threading
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
-import gevent
+import gevent # type: ignore[import-untyped]
 import gevent._interfaces  # type: ignore[import-untyped]
 import gevent.hub  # type: ignore[import-untyped]
 import gevent.socket  # type: ignore[import-untyped]

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -644,7 +644,7 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore  # pylint: disable=
         self._waking_mutex = threading.Lock()
 
         # fd-to-handler function mappings
-        self._fd_handlers: dict[int, Callable[..., None]] = dict()
+        self._fd_handlers: dict[int, Callable[..., None]] = {}
 
         # event-to-fdset mappings
         self._fd_events: dict[int, set[int]] = {
@@ -1161,7 +1161,7 @@ class KQueuePoller(_PollerBase):
         if self._kqueue is None:
             return
 
-        kevents = list()
+        kevents = []
 
         if events_to_clear & PollEvents.READ:
             kevents.append(

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -10,22 +10,25 @@ import errno
 import heapq
 import logging
 import select
-import time
 import threading
-from typing import Any, Callable, Sequence, Union, TYPE_CHECKING
+import time
+from typing import TYPE_CHECKING, Any, Callable, Sequence, Union
 
 import pika._utils
-
-from pika.adapters.utils import nbio_interface
 from pika.adapters.base_connection import BaseConnection
+from pika.adapters.utils import nbio_interface
 from pika.adapters.utils.selector_ioloop_adapter import (
-    SelectorIOServicesAdapter, AbstractSelectorIOLoop)
+    AbstractSelectorIOLoop,
+    SelectorIOServicesAdapter,
+)
 
 if TYPE_CHECKING:
+    import socket
+
     from typing_extensions import TypedDict
+
     from pika import connection
     from pika.adapters.utils import connection_workflow
-    import socket
 
     SELECT_ERROR_T = Union[OSError, IOError, InterruptedError, select.error]
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -191,8 +191,8 @@ class _Timeout:
 
         if deadline < 0:
             raise ValueError(
-                'deadline must be non-negative epoch number, but got %r' %
-                (deadline,))
+                f'deadline must be non-negative epoch number, but got {deadline!r}'
+            )
 
         if not callable(callback):
             raise TypeError(
@@ -283,8 +283,7 @@ class _Timer:
 
         if delay < 0:
             raise ValueError(
-                'call_later: delay must be non-negative, but got {!r}'.format(
-                    delay))
+                f'call_later: delay must be non-negative, but got {delay!r}')
 
         now = pika._utils.time_now()
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -4,12 +4,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Callable, Sequence, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from tornado import ioloop
 
-from pika.adapters.utils import nbio_interface, selector_ioloop_adapter
 from pika.adapters import base_connection
+from pika.adapters.utils import nbio_interface, selector_ioloop_adapter
 
 if TYPE_CHECKING:
     from pika import connection

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -142,8 +142,7 @@ class TwistedChannel:
             self._on_consumer_cancelled_by_broker)
 
     def __repr__(self) -> str:
-        return '<{cls} channel={chan!r}>'.format(cls=self.__class__.__name__,
-                                                 chan=self._channel)
+        return f'<{self.__class__.__name__} channel={self._channel!r}>'
 
     def _on_channel_closed(self, _channel: channel.Channel,
                            reason: Exception | None) -> None:
@@ -1033,8 +1032,8 @@ class TwistedChannel:
             for consumer_tag in list(
                     self._queue_name_to_consumer_tags.get(queue_name, set())):
                 self._consumers[consumer_tag].close(
-                    exceptions.ConsumerCancelled("Queue %s was deleted." %
-                                                 queue_name))
+                    exceptions.ConsumerCancelled(
+                        f"Queue {queue_name} was deleted."))
                 del self._consumers[consumer_tag]
                 self._queue_name_to_consumer_tags[queue_name].remove(
                     consumer_tag)

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -14,26 +14,27 @@ from __future__ import annotations
 import functools
 import logging
 from collections import namedtuple
-from typing import Any, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
-from twisted.internet import (defer, error as twisted_error, reactor, protocol)
 import twisted.internet.base
 import twisted.python
-from twisted.python.failure import Failure
 import twisted.python.failure
+from twisted.internet import defer, protocol, reactor
+from twisted.internet import error as twisted_error
+from twisted.python.failure import Failure
 
 import pika.connection
+import pika.frame
+import pika.spec
 from pika import exceptions, spec
 from pika.adapters.utils import nbio_interface
 from pika.adapters.utils.io_services_utils import check_callback_arg
 from pika.exchange_type import ExchangeType
-import pika.frame
-import pika.spec
 
 if TYPE_CHECKING:
-    from pika import channel
-    from pika import amqp_object
     import twisted.internet.interfaces
+
+    from pika import amqp_object, channel
 
 # Twistisms
 # pylint: disable=C0111,C0103

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import functools
 import logging
 import socket
-from typing import Any, Callable, Iterator, Sequence, TYPE_CHECKING, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Sequence, Tuple, Union
 
 import pika._utils
 import pika.connection

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -106,11 +106,10 @@ class AMQPConnectionWorkflowFailed(AMQPConnectorException):
         self.exceptions = tuple(exceptions)
 
     def __repr__(self) -> str:
-        return ('{}: {} exceptions in all; last exception - {!r}; first '
-                'exception - {!r}').format(
-                    self.__class__.__name__, len(self.exceptions),
-                    self.exceptions[-1],
-                    self.exceptions[0] if len(self.exceptions) > 1 else None)
+        return (
+            f'{self.__class__.__name__}: {len(self.exceptions)} exceptions in all; last exception - {self.exceptions[-1]!r}; first '
+            f'exception - {self.exceptions[0] if len(self.exceptions) > 1 else None!r}'
+        )
 
 
 class AMQPConnector:
@@ -259,8 +258,8 @@ class AMQPConnector:
                 _LOG.debug('AMQPConnector.abort(): closing of Connection was '
                            'already initiated.')
                 assert self._state == self._STATE_TIMEOUT, \
-                    ('Connection is closing, but not in TIMEOUT state; state={}'
-                     .format(self._state))
+                    (f'Connection is closing, but not in TIMEOUT state; state={self._state}'
+                     )
 
     def _close(self) -> None:
         """Cancel asynchronous tasks and clean up to assist garbage collection.
@@ -289,8 +288,7 @@ class AMQPConnector:
         # synchronous closing. We special-case it elsewhere in the code where
         # needed.
         assert self._amqp_conn is None, \
-            '_deactivate called with self._amqp_conn not None; state={}'.format(
-                self._state)
+            f'_deactivate called with self._amqp_conn not None; state={self._state}'
 
         if self._tcp_timeout_ref is not None:
             self._tcp_timeout_ref.cancel()
@@ -330,8 +328,9 @@ class AMQPConnector:
         self._tcp_timeout_ref = None
 
         error = AMQPConnectorSocketConnectError(
-            socket.timeout('TCP connection attempt timed out: {!r}/{}'.format(
-                self._conn_params.host, self._addr_record)))
+            socket.timeout(
+                f'TCP connection attempt timed out: {self._conn_params.host!r}/{self._addr_record}'
+            ))
         self._report_completion_and_cleanup(error)
 
     def _on_overall_timeout(self) -> None:
@@ -352,9 +351,9 @@ class AMQPConnector:
         self._state = self._STATE_TIMEOUT
 
         if prev_state == self._STATE_AMQP:
-            msg = ('Timeout while setting up AMQP to {!r}/{}; ssl={}'.format(
-                self._conn_params.host, self._addr_record,
-                bool(self._conn_params.ssl_options)))
+            msg = (
+                f'Timeout while setting up AMQP to {self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
+            )
             _LOG.error(msg)
             # Initiate close of AMQP connection and wait for asynchronous
             # callback from the Connection instance before reporting completion
@@ -367,15 +366,14 @@ class AMQPConnector:
         if prev_state == self._STATE_TCP:
             error: Exception = AMQPConnectorSocketConnectError(
                 AMQPConnectorStackTimeout(
-                    'Timeout while connecting socket to {!r}/{}'.format(
-                        self._conn_params.host, self._addr_record)))
+                    f'Timeout while connecting socket to {self._conn_params.host!r}/{self._addr_record}'
+                ))
         else:
             assert prev_state == self._STATE_TRANSPORT
             error = AMQPConnectorTransportSetupError(
                 AMQPConnectorStackTimeout(
-                    'Timeout while setting up transport to {!r}/{}; ssl={}'.
-                    format(self._conn_params.host, self._addr_record,
-                           bool(self._conn_params.ssl_options))))
+                    f'Timeout while setting up transport to {self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
+                ))
 
         self._report_completion_and_cleanup(error)
 
@@ -495,9 +493,8 @@ class AMQPConnector:
         elif self._state == self._STATE_TIMEOUT:
             result = AMQPConnectorAMQPHandshakeError(
                 AMQPConnectorStackTimeout(
-                    'Timeout during AMQP handshake{!r}/{}; ssl={}'.format(
-                        self._conn_params.host, self._addr_record,
-                        bool(self._conn_params.ssl_options))))
+                    f'Timeout during AMQP handshake{self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
+                ))
         elif self._state == self._STATE_AMQP:
             if error is None:
                 _LOG.debug(
@@ -687,8 +684,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
             iter(connection_configs)
         except Exception as error:
             raise TypeError(
-                'connection_configs does not support iteration: {!r}'.format(
-                    error))
+                f'connection_configs does not support iteration: {error!r}')
         if not connection_configs:
             raise ValueError(
                 f'connection_configs is empty: {connection_configs!r}.')

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -14,16 +14,15 @@ import socket
 import ssl
 import sys
 import traceback
-from typing import Any, Callable, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable
 
-from pika.adapters.utils.nbio_interface import (AbstractIOReference,
-                                                AbstractStreamTransport)
 import pika._utils
 import pika.diagnostic_utils
+from pika.adapters.utils.nbio_interface import AbstractIOReference, AbstractStreamTransport
 
 if TYPE_CHECKING:
-    from pika.adapters.utils import nbio_interface
     import pika.connection
+    from pika.adapters.utils import nbio_interface
 
 # "Try again" error codes for non-blocking socket I/O - send()/recv().
 # NOTE: POSIX.1 allows either error to be returned for this case and doesn't require

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -55,8 +55,7 @@ def check_callback_arg(callback: Any, name: str) -> None:
 
     """
     if not callable(callback):
-        raise TypeError('{} must be callable, but got {!r}'.format(
-            name, callback))
+        raise TypeError(f'{name} must be callable, but got {callback!r}')
 
 
 def check_fd_arg(fd: int) -> None:
@@ -220,8 +219,7 @@ class _AsyncSocketConnector:
                     'Unable to check resolved address: no socket.inet_pton().')
             else:
                 msg = ('Invalid or unresolved IP address '
-                       '{!r} for socket {}: {!r}').format(
-                           resolved_addr, sock, error)
+                       f'{resolved_addr!r} for socket {sock}: {error!r}')
                 _LOGGER.error(msg)
                 raise ValueError(msg)
 
@@ -414,7 +412,7 @@ class _AsyncStreamConnector:
 
         if not isinstance(ssl_context, (type(None), ssl.SSLContext)):
             raise ValueError('Expected ssl_context=None | ssl.SSLContext, but '
-                             'got {!r}'.format(ssl_context))
+                             f'got {ssl_context!r}')
 
         if server_hostname is not None and ssl_context is None:
             raise ValueError('Non-None server_hostname must not be passed '
@@ -428,7 +426,7 @@ class _AsyncStreamConnector:
         except Exception as error:
             raise ValueError(
                 'Expected connected socket, but getpeername() failed: '
-                'error={!r}; {}; '.format(error, sock))
+                f'error={error!r}; {sock}; ')
 
         self._nbio: None | (
             nbio_interface.AbstractIOServices |

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -14,13 +14,13 @@ testing and lessening the maintenance burden.
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING, Callable, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import pika._utils
 
 if TYPE_CHECKING:
-    import ssl
     import socket
+    import ssl
 
 
 class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -175,7 +175,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         self._loop = native_loop
 
         # Active watchers: maps file descriptors to `_FileDescriptorCallbacks`
-        self._watchers: dict[int, _FileDescriptorCallbacks] = dict()
+        self._watchers: dict[int, _FileDescriptorCallbacks] = {}
 
         # Native loop-specific event masks of interest
         self._readable_mask = self._loop.READ

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -12,9 +12,8 @@ import socket
 import threading
 from typing import Any, Callable
 
-from pika.adapters.utils import nbio_interface, io_services_utils
-from pika.adapters.utils.io_services_utils import (check_callback_arg,
-                                                   check_fd_arg)
+from pika.adapters.utils import io_services_utils, nbio_interface
+from pika.adapters.utils.io_services_utils import check_callback_arg, check_fd_arg
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -15,7 +15,7 @@ class AMQPObject:
     INDEX: int | None = None
 
     def __repr__(self) -> str:
-        items = list()
+        items = []
         for key, value in self.__dict__.items():
             if getattr(self.__class__, key, None) != value:
                 items.append(f'{key}={value}')

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -20,7 +20,7 @@ class AMQPObject:
             if getattr(self.__class__, key, None) != value:
                 items.append(f'{key}={value}')
         if not items:
-            return "<%s>" % self.NAME
+            return f"<{self.NAME}>"
         return f"<{self.NAME}({sorted(items)})>"
 
     def __eq__(self, other: object) -> bool:

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -118,8 +118,7 @@ class CallbackManager:
 
     def __init__(self) -> None:
         """Create an instance of the CallbackManager"""
-        self._stack: dict[_Prefix, dict[AMQPValue, list[dict[str,
-                                                             Any]]]] = dict()
+        self._stack: dict[_Prefix, dict[AMQPValue, list[dict[str, Any]]]] = {}
 
     @sanitize_prefix
     def add(self,
@@ -149,10 +148,10 @@ class CallbackManager:
         """
         # Prep the stack
         if prefix not in self._stack:
-            self._stack[prefix] = dict()
+            self._stack[prefix] = {}
 
         if key not in self._stack[prefix]:
-            self._stack[prefix][key] = list()
+            self._stack[prefix][key] = []
 
         # Check for a duplicate
         for callback_dict in self._stack[prefix][key]:
@@ -176,7 +175,7 @@ class CallbackManager:
 
     def clear(self) -> None:
         """Clear all the callbacks if there are any defined."""
-        self._stack = dict()
+        self._stack = {}
         LOGGER.debug('Callbacks cleared')
 
     @sanitize_prefix
@@ -228,7 +227,7 @@ class CallbackManager:
         if prefix not in self._stack or key not in self._stack[prefix]:
             return False
 
-        callbacks = list()
+        callbacks = []
         # Check each callback, append it to the list if it should be called
         for callback_dict in list(self._stack[prefix][key]):
             if self._should_process_callback(callback_dict, caller, list(args)):
@@ -266,7 +265,7 @@ class CallbackManager:
 
         """
         if callback_value:
-            offsets_to_remove = list()
+            offsets_to_remove = []
             for offset in range(len(self._stack[prefix][key]), 0, -1):
                 callback_dict = self._stack[prefix][key][offset - 1]
 

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -6,10 +6,9 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import Any, Callable, Union, Type, cast
+from typing import Any, Callable, Type, Union, cast
 
-from pika import frame
-from pika import amqp_object
+from pika import amqp_object, frame
 
 _Prefix = Union[str, int]
 _Caller = object

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -7,23 +7,23 @@ implementing the methods and behaviors for an AMQP Channel.
 
 from __future__ import annotations
 
+import logging
+import uuid
 from collections import deque
 from collections.abc import Sequence
-import logging
-from typing import Any, Callable, TYPE_CHECKING, Union
-import uuid
 from enum import Enum
+from typing import TYPE_CHECKING, Any, Callable, Union
 
-import pika.frame as frame
 import pika.exceptions as exceptions
+import pika.frame as frame
 import pika.spec as spec
 import pika.validators as validators
 from pika._utils import as_bytes
 from pika.exchange_type import ExchangeType
 
 if TYPE_CHECKING:
-    from pika.connection import Connection
     from pika import amqp_object
+    from pika.connection import Connection
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -114,11 +114,11 @@ class Channel:
 
         self._content_assembler = ContentFrameAssembler()
 
-        self._blocked: deque = deque(list())
+        self._blocked: deque = deque([])
         self._blocking: Any | None = None
         self._has_on_flow_callback: bool = False
         self._cancelled: set = set()
-        self._consumers: dict = dict()
+        self._consumers: dict = {}
         self._consumers_with_noack: set = set()
         self._on_flowok_callback: Callable[..., Any] | None = None
         self._on_getok_callback: Callable[..., Any] | None = None
@@ -374,7 +374,7 @@ class Channel:
                                consumer_tag=consumer_tag,
                                no_ack=auto_ack,
                                exclusive=exclusive,
-                               arguments=arguments or dict()), rpc_callback,
+                               arguments=arguments or {}), rpc_callback,
             [(spec.Basic.ConsumeOk, {
                 'consumer_tag': consumer_tag
             })])
@@ -688,7 +688,7 @@ class Channel:
         nowait = validators.rpc_completion_callback(callback)
         return self._rpc(
             spec.Exchange.Bind(0, destination, source, routing_key, nowait,
-                               arguments or dict()), callback,
+                               arguments or {}), callback,
             [spec.Exchange.BindOk] if not nowait else [])
 
     def exchange_declare(
@@ -741,7 +741,7 @@ class Channel:
                 auto_delete,
                 internal,
                 nowait,
-                arguments or dict()),
+                arguments or {}),
             callback,
             [spec.Exchange.DeclareOk] if not nowait else [])
 
@@ -884,7 +884,7 @@ class Channel:
             routing_key = queue
         return self._rpc(
             spec.Queue.Bind(0, queue, exchange, routing_key, nowait,
-                            arguments or dict()), callback,
+                            arguments or {}), callback,
             [spec.Queue.BindOk] if not nowait else [])
 
     def queue_declare(self,
@@ -929,8 +929,8 @@ class Channel:
 
         return self._rpc(
             spec.Queue.Declare(0, queue, passive, durable, exclusive,
-                               auto_delete, nowait, arguments or dict()),
-            callback, replies)
+                               auto_delete, nowait, arguments or {}), callback,
+            replies)
 
     def queue_delete(self,
                      queue: str,
@@ -1000,8 +1000,8 @@ class Channel:
         if routing_key is None:
             routing_key = queue
         return self._rpc(
-            spec.Queue.Unbind(0, queue, exchange, routing_key, arguments or
-                              dict()), callback, [spec.Queue.UnbindOk])
+            spec.Queue.Unbind(0, queue, exchange, routing_key, arguments or {}),
+            callback, [spec.Queue.UnbindOk])
 
     def tx_commit(self, callback: _OnTxCommitCallback | None = None) -> None:
         """Commit a transaction
@@ -1088,7 +1088,7 @@ class Channel:
         """Remove all consumers and any callbacks for the channel."""
         self.callbacks.process(self.channel_number,
                                self._ON_CHANNEL_CLEANUP_CB_KEY, self, self)
-        self._consumers = dict()
+        self._consumers = {}
         self.callbacks.cleanup(str(self.channel_number))
         self._cookie = None
 
@@ -1581,7 +1581,7 @@ class ContentFrameAssembler:
         self._method_frame: frame.Method | None = None
         self._header_frame: frame.Header | None = None
         self._seen_so_far = 0
-        self._body_fragments: list[bytes] = list()
+        self._body_fragments: list[bytes] = []
 
     def process(
         self, frame_value: frame.Frame
@@ -1644,4 +1644,4 @@ class ContentFrameAssembler:
         self._method_frame = None
         self._header_frame = None
         self._seen_so_far = 0
-        self._body_fragments = list()
+        self._body_fragments = []

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -145,9 +145,7 @@ class Channel:
         return self.channel_number
 
     def __repr__(self) -> str:
-        return '<{} number={} {} conn={!r}>'.format(
-            self.__class__.__name__, self.channel_number,
-            self._STATE_NAMES[self._state], self.connection)\
+        return f'<{self.__class__.__name__} number={self.channel_number} {self._STATE_NAMES[self._state]} conn={self.connection!r}>'\
 
     def add_callback(self,
                      callback: Callable[..., Any],
@@ -392,7 +390,7 @@ class Channel:
         :rtype: str
 
         """
-        return 'ctag%i.%s' % (self.channel_number, uuid.uuid4().hex)
+        return f'ctag{self.channel_number}.{uuid.uuid4().hex}'
 
     def basic_get(self,
                   queue: str,
@@ -1447,8 +1445,8 @@ class Channel:
 
         """
         assert method.synchronous, (
-            'Only synchronous-capable methods may be used with _rpc: %r' %
-            (method,))
+            f'Only synchronous-capable methods may be used with _rpc: {method!r}'
+        )
 
         # Validate we got None or a list of acceptable_replies
         if not isinstance(acceptable_replies, (type(None), list)):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -145,7 +145,7 @@ class Channel:
         return self.channel_number
 
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} number={self.channel_number} {self._STATE_NAMES[self._state]} conn={self.connection!r}>'\
+        return f'<{self.__class__.__name__} number={self.channel_number} {self._STATE_NAMES[self._state]} conn={self.connection!r}>'
 
     def add_callback(self,
                      callback: Callable[..., Any],

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1126,7 +1126,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
         self._frame_buffer = b''
 
         # Dict of open channels
-        self._channels = dict()
+        self._channels = {}
 
         # Data used for Heartbeat checking and back-pressure detection
         self.bytes_sent = 0
@@ -2386,7 +2386,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
         """
         self.server_properties = method_frame.method.server_properties  # pyright: ignore[reportAttributeAccessIssue]
         self.server_capabilities = self.server_properties.get(  # pyright: ignore[reportOptionalMemberAccess]
-            'capabilities', dict())
+            'capabilities', {})
         if hasattr(self.server_properties, 'capabilities'):
             del self.server_properties[
                 'capabilities']  # pyright: ignore[reportOptionalSubscript]

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -147,9 +147,9 @@ class Parameters:  # pylint: disable=R0902
         :rtype: str
 
         """
-        return ('<%s host=%s port=%s virtual_host=%s ssl=%s>' %
-                (self.__class__.__name__, self.host, self.port,
-                 self.virtual_host, bool(self.ssl_options)))
+        return (
+            f'<{self.__class__.__name__} host={self.host} port={self.port} virtual_host={self.virtual_host} ssl={bool(self.ssl_options)}>'
+        )
 
     def __eq__(self, other) -> bool:
         if isinstance(other, Parameters):
@@ -184,10 +184,10 @@ class Parameters:  # pylint: disable=R0902
         if value is not None:
             if not isinstance(value, numbers.Real):
                 raise TypeError('blocked_connection_timeout must be a Real '
-                                'number, but got %r' % (value,))
+                                f'number, but got {value!r}')
             if value < 0:
                 raise ValueError('blocked_connection_timeout must be >= 0, but '
-                                 'got %r' % (value,))
+                                 f'got {value!r}')
         self._blocked_connection_timeout = value
 
     @property
@@ -210,8 +210,9 @@ class Parameters:  # pylint: disable=R0902
         if not isinstance(value, numbers.Integral):
             raise TypeError(f'channel_max must be an int, but got {value!r}')
         if value < 1 or value > pika.channel.MAX_CHANNELS:
-            raise ValueError('channel_max must be <= %i and > 0, but got %r' %
-                             (pika.channel.MAX_CHANNELS, value))
+            raise ValueError(
+                f'channel_max must be <= {pika.channel.MAX_CHANNELS} and > 0, but got {value!r}'
+            )
         self._channel_max = value
 
     @property
@@ -237,7 +238,7 @@ class Parameters:  # pylint: disable=R0902
                 type(None),
         )):
             raise TypeError('client_properties must be dict or None, '
-                            'but got %r' % (value,))
+                            f'but got {value!r}')
         # Copy the mutable object to avoid accidental side-effects
         self._client_properties = copy.deepcopy(value)
 
@@ -288,8 +289,9 @@ class Parameters:  # pylint: disable=R0902
 
         """
         if not isinstance(value, tuple(pika.credentials.VALID_TYPES)):
-            raise TypeError('credentials must be an object of type: %r, but '
-                            'got %r' % (pika.credentials.VALID_TYPES, value))
+            raise TypeError(
+                f'credentials must be an object of type: {pika.credentials.VALID_TYPES!r}, but '
+                f'got {value!r}')
         # Copy the mutable object to avoid accidental side-effects
         self._credentials = copy.deepcopy(value)
 
@@ -313,15 +315,13 @@ class Parameters:  # pylint: disable=R0902
         if not isinstance(value, numbers.Integral):
             raise TypeError(f'frame_max must be an int, but got {value!r}')
         if value < spec.FRAME_MIN_SIZE:
-            raise ValueError('Min AMQP 0.9.1 Frame Size is %i, but got %r' % (
-                spec.FRAME_MIN_SIZE,
-                value,
-            ))
+            raise ValueError(
+                f'Min AMQP 0.9.1 Frame Size is {spec.FRAME_MIN_SIZE}, but got {value!r}'
+            )
         elif value > spec.FRAME_MAX_SIZE:
-            raise ValueError('Max AMQP 0.9.1 Frame Size is %i, but got %r' % (
-                spec.FRAME_MAX_SIZE,
-                value,
-            ))
+            raise ValueError(
+                f'Max AMQP 0.9.1 Frame Size is {spec.FRAME_MAX_SIZE}, but got {value!r}'
+            )
         self._frame_max = value
 
     @property
@@ -351,8 +351,8 @@ class Parameters:  # pylint: disable=R0902
         if value is not None:
             if not isinstance(value, numbers.Integral) and not callable(value):
                 raise TypeError(
-                    'heartbeat must be an int or a callable function, but got %r'
-                    % (value,))
+                    f'heartbeat must be an int or a callable function, but got {value!r}'
+                )
             if not callable(value) and value < 0:
                 raise ValueError(f'heartbeat must >= 0, but got {value!r}')
         self._heartbeat = value  # pyright: ignore[reportAttributeAccessIssue]
@@ -434,8 +434,7 @@ class Parameters:  # pylint: disable=R0902
         """
         if not isinstance(value, numbers.Real):
             raise TypeError(
-                'retry_delay must be a float or int, but got {!r}'.format(
-                    value))
+                f'retry_delay must be a float or int, but got {value!r}')
         self._retry_delay = value
 
     @property
@@ -458,7 +457,7 @@ class Parameters:  # pylint: disable=R0902
         if value is not None:
             if not isinstance(value, numbers.Real):
                 raise TypeError('socket_timeout must be a float or int, '
-                                'but got %r' % (value,))
+                                f'but got {value!r}')
             if value <= 0:
                 raise ValueError(
                     f'socket_timeout must be > 0, but got {value!r}')
@@ -489,7 +488,7 @@ class Parameters:  # pylint: disable=R0902
         if value is not None:
             if not isinstance(value, numbers.Real):
                 raise TypeError('stack_timeout must be a float or int, '
-                                'but got %r' % (value,))
+                                f'but got {value!r}')
             if value <= 0:
                 raise ValueError(
                     f'stack_timeout must be > 0, but got {value!r}')
@@ -514,8 +513,7 @@ class Parameters:  # pylint: disable=R0902
         """
         if not isinstance(value, (SSLOptions, type(None))):
             raise TypeError(
-                'ssl_options must be None or SSLOptions but got {!r}'.format(
-                    value))
+                f'ssl_options must be None or SSLOptions but got {value!r}')
         self._ssl_options = value
 
     @property
@@ -554,8 +552,7 @@ class Parameters:  # pylint: disable=R0902
         """
         if not isinstance(value, (dict, type(None))):
             raise TypeError(
-                'tcp_options must be a dict or None, but got {!r}'.format(
-                    value))
+                f'tcp_options must be a dict or None, but got {value!r}')
         self._tcp_options = value
 
 
@@ -779,8 +776,9 @@ class URLParameters(Parameters):
         elif parts.scheme == 'http':
             self.ssl_options = None
         elif parts.scheme:
-            raise ValueError('Unexpected URL scheme %r; supported scheme '
-                             'values: amqp, amqps' % (parts.scheme,))
+            raise ValueError(
+                f'Unexpected URL scheme {parts.scheme!r}; supported scheme '
+                'values: amqp, amqps')
 
         if parts.hostname is not None:
             self.host = parts.hostname
@@ -813,9 +811,9 @@ class URLParameters(Parameters):
             try:
                 (value,) = value  # type: ignore[assignment]
             except ValueError:
-                raise ValueError('Expected exactly one value for URL parameter '
-                                 '%s, but got %i values: %s' %
-                                 (name, len(value), value))
+                raise ValueError(
+                    f'Expected exactly one value for URL parameter '
+                    f'{name}, but got {len(value)} values: {value}')
 
             set_value(value)
 
@@ -825,10 +823,7 @@ class URLParameters(Parameters):
             blocked_connection_timeout = float(value)
         except ValueError as exc:
             raise ValueError(
-                'Invalid blocked_connection_timeout value {!r}: {!r}'.format(
-                    value,
-                    exc,
-                ))
+                f'Invalid blocked_connection_timeout value {value!r}: {exc!r}')
         self.blocked_connection_timeout = blocked_connection_timeout
 
     def _set_url_channel_max(self, value: int) -> None:
@@ -836,10 +831,7 @@ class URLParameters(Parameters):
         try:
             channel_max = int(value)
         except ValueError as exc:
-            raise ValueError('Invalid channel_max value {!r}: {!r}'.format(
-                value,
-                exc,
-            ))
+            raise ValueError(f'Invalid channel_max value {value!r}: {exc!r}')
         self.channel_max = channel_max
 
     def _set_url_client_properties(self, value: str) -> None:
@@ -852,10 +844,7 @@ class URLParameters(Parameters):
             connection_attempts = int(value)
         except ValueError as exc:
             raise ValueError(
-                'Invalid connection_attempts value {!r}: {!r}'.format(
-                    value,
-                    exc,
-                ))
+                f'Invalid connection_attempts value {value!r}: {exc!r}')
         self.connection_attempts = connection_attempts
 
     def _set_url_frame_max(self, value: int) -> None:
@@ -863,10 +852,7 @@ class URLParameters(Parameters):
         try:
             frame_max = int(value)
         except ValueError as exc:
-            raise ValueError('Invalid frame_max value {!r}: {!r}'.format(
-                value,
-                exc,
-            ))
+            raise ValueError(f'Invalid frame_max value {value!r}: {exc!r}')
         self.frame_max = frame_max
 
     def _set_url_heartbeat(self, value: int) -> None:
@@ -874,10 +860,7 @@ class URLParameters(Parameters):
         try:
             heartbeat_timeout = int(value)
         except ValueError as exc:
-            raise ValueError('Invalid heartbeat value {!r}: {!r}'.format(
-                value,
-                exc,
-            ))
+            raise ValueError(f'Invalid heartbeat value {value!r}: {exc!r}')
         self.heartbeat = heartbeat_timeout
 
     def _set_url_locale(self, value: str) -> None:
@@ -889,10 +872,7 @@ class URLParameters(Parameters):
         try:
             retry_delay = float(value)
         except ValueError as exc:
-            raise ValueError('Invalid retry_delay value {!r}: {!r}'.format(
-                value,
-                exc,
-            ))
+            raise ValueError(f'Invalid retry_delay value {value!r}: {exc!r}')
         self.retry_delay = retry_delay
 
     def _set_url_socket_timeout(self, value: float) -> None:
@@ -900,10 +880,7 @@ class URLParameters(Parameters):
         try:
             socket_timeout = float(value)
         except ValueError as exc:
-            raise ValueError('Invalid socket_timeout value {!r}: {!r}'.format(
-                value,
-                exc,
-            ))
+            raise ValueError(f'Invalid socket_timeout value {value!r}: {exc!r}')
         self.socket_timeout = socket_timeout
 
     def _set_url_stack_timeout(self, value: float) -> None:
@@ -911,10 +888,7 @@ class URLParameters(Parameters):
         try:
             stack_timeout = float(value)
         except ValueError as exc:
-            raise ValueError('Invalid stack_timeout value {!r}: {!r}'.format(
-                value,
-                exc,
-            ))
+            raise ValueError(f'Invalid stack_timeout value {value!r}: {exc!r}')
         self.stack_timeout = stack_timeout
 
     def _set_url_ssl_options(self, value: str) -> None:
@@ -989,8 +963,7 @@ class SSLOptions:
         """
         if not isinstance(context, ssl.SSLContext):
             raise TypeError(
-                'context must be of ssl.SSLContext type, but got {!r}'.format(
-                    context))
+                f'context must be of ssl.SSLContext type, but got {context!r}')
 
         self.context = context
         self.server_hostname = server_hostname
@@ -1302,7 +1275,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
         """
         if not self.is_open:
             raise exceptions.ConnectionWrongStateError(
-                'Channel allocation requires an open connection: %s' % self)
+                f'Channel allocation requires an open connection: {self}')
 
         validators.rpc_completion_callback(on_open_callback)
 
@@ -1338,7 +1311,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
         """
         if not self.is_open:
             raise exceptions.ConnectionWrongStateError(
-                'Secret update requires an open connection: %s' % self)
+                f'Secret update requires an open connection: {self}')
 
         validators.rpc_completion_callback(callback)
         self._rpc(0, spec.Connection.UpdateSecret(new_secret, reason), callback,
@@ -1359,10 +1332,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
             closed or closing.
         """
         if self.is_closing or self.is_closed:
-            msg = ('Illegal close({}, {!r}) request on {} because it '
-                   'was called while connection state={}.'.format(
-                       reply_code, reply_text, self,
-                       self._STATE_NAMES[self.connection_state]))
+            msg = (
+                f'Illegal close({reply_code}, {reply_text!r}) request on {self} because it '
+                f'was called while connection state={self._STATE_NAMES[self.connection_state]}.'
+            )
             LOGGER.error(msg)
             raise exceptions.ConnectionWrongStateError(msg)
 
@@ -1387,8 +1360,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
 
             error = exceptions.ConnectionOpenAborted(
                 'Connection.close() called before connection '
-                'finished opening: prev_state={} ({}): {!r}'.format(
-                    self._STATE_NAMES[prev_state], reply_code, reply_text))
+                f'finished opening: prev_state={self._STATE_NAMES[prev_state]} ({reply_code}): {reply_text!r}'
+            )
             self._terminate_stream(error)
 
         else:
@@ -1600,7 +1573,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
         """
         properties = {
             'product': PRODUCT,
-            'platform': 'Python %s' % platform.python_version(),
+            'platform': f'Python {platform.python_version()}',
             'capabilities': {
                 'authentication_failure_close': True,
                 'basic.nack': True,
@@ -2023,7 +1996,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
             if ret_heartbeat is None or callable(ret_heartbeat):
                 # Enforce callback-specific restrictions on callback's return value
                 raise TypeError('heartbeat callback must not return None '
-                                'or callable, but got %r' % (ret_heartbeat,))
+                                f'or callable, but got {ret_heartbeat!r}')
 
             # Leave it to hearbeat setter deal with the rest of the validation
             self.params.heartbeat = ret_heartbeat
@@ -2074,8 +2047,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
 
         """
         assert isinstance(error, (type(None), Exception)), \
-            'error arg is neither None nor instance of Exception: {!r}.'.format(
-                error)
+            f'error arg is neither None nor instance of Exception: {error!r}.'
 
         if error is not None:
             # Save the exception for user callback once the stream closes

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -13,12 +13,25 @@ import math
 import numbers
 import platform
 import ssl
-from typing import Any, Dict, Optional, Sequence, Type, TypeVar, Union, Callable, cast, TYPE_CHECKING
-from urllib.parse import unquote as url_unquote, parse_qs as url_parse_qs, urlparse
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+)
+from urllib.parse import parse_qs as url_parse_qs
+from urllib.parse import unquote as url_unquote
+from urllib.parse import urlparse
 
+import pika._utils
 import pika.callback
 import pika.channel
-import pika._utils
 import pika.credentials
 import pika.exceptions as exceptions
 import pika.frame as frame
@@ -27,8 +40,8 @@ import pika.spec as spec
 import pika.validators as validators
 
 if TYPE_CHECKING:
-    from pika.channel import Channel
     from pika import amqp_object
+    from pika.channel import Channel
 
 PRODUCT = "Pika Python Client Library"
 

--- a/pika/data.py
+++ b/pika/data.py
@@ -1,8 +1,9 @@
 """AMQP Table Encoding/Decoding"""
 from __future__ import annotations
-import struct
-import decimal
+
 import calendar
+import decimal
+import struct
 from datetime import datetime, timezone
 from typing import Any
 

--- a/pika/diagnostic_utils.py
+++ b/pika/diagnostic_utils.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import functools
 import sys
 import traceback
-from typing import Any, Callable, TypeVar, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Callable, TypeVar, cast
 
 if TYPE_CHECKING:
     import logging  # pragma: no cover

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -331,7 +331,7 @@ class ShortStringTooLong(AMQPError):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}: AMQP Short String can contain up to 255 bytes: '
-            f'{self.args[0]:.300}')
+            f'{self.args[0]!s:.300}')
 
 
 class DuplicateGetOkCallback(ChannelError):

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -12,16 +12,14 @@ if TYPE_CHECKING:
 class AMQPError(Exception):
 
     def __repr__(self) -> str:
-        return '{}: An unspecified AMQP error has occurred; {}'.format(
-            self.__class__.__name__, self.args)
+        return f'{self.__class__.__name__}: An unspecified AMQP error has occurred; {self.args}'
 
 
 class AMQPConnectionError(AMQPError):
 
     def __repr__(self) -> str:
         if len(self.args) == 2:
-            return '{}: ({}) {}'.format(self.__class__.__name__, self.args[0],
-                                        self.args[1])
+            return f'{self.__class__.__name__}: ({self.args[0]}) {self.args[1]}'
         else:
             return f'{self.__class__.__name__}: {self.args}'
 
@@ -37,48 +35,40 @@ class StreamLostError(AMQPConnectionError):
 class IncompatibleProtocolError(AMQPConnectionError):
 
     def __repr__(self) -> str:
-        return ('{}: The protocol returned by the server is not supported: {}'.
-                format(
-                    self.__class__.__name__,
-                    self.args,
-                ))
+        return (
+            f'{self.__class__.__name__}: The protocol returned by the server is not supported: {self.args}'
+        )
 
 
 class AuthenticationError(AMQPConnectionError):
 
     def __repr__(self) -> str:
-        return ('%s: Server and client could not negotiate use of the %s '
-                'authentication mechanism' %
-                (self.__class__.__name__, self.args[0]))
+        return (
+            f'{self.__class__.__name__}: Server and client could not negotiate use of the {self.args[0]} '
+            'authentication mechanism')
 
 
 class ProbableAuthenticationError(AMQPConnectionError):
 
     def __repr__(self) -> str:
         return (
-            '%s: Client was disconnected at a connection stage indicating a '
-            'probable authentication error: %s' % (
-                self.__class__.__name__,
-                self.args,
-            ))
+            f'{self.__class__.__name__}: Client was disconnected at a connection stage indicating a '
+            f'probable authentication error: {self.args}')
 
 
 class ProbableAccessDeniedError(AMQPConnectionError):
 
     def __repr__(self) -> str:
         return (
-            '%s: Client was disconnected at a connection stage indicating a '
-            'probable denial of access to the specified virtual host: %s' % (
-                self.__class__.__name__,
-                self.args,
-            ))
+            f'{self.__class__.__name__}: Client was disconnected at a connection stage indicating a '
+            f'probable denial of access to the specified virtual host: {self.args}'
+        )
 
 
 class NoFreeChannels(AMQPConnectionError):
 
     def __repr__(self) -> str:
-        return '%s: The connection has run out of free channels' % (
-            self.__class__.__name__)
+        return f'{self.__class__.__name__}: The connection has run out of free channels'
 
 
 class ConnectionWrongStateError(AMQPConnectionError):
@@ -88,8 +78,9 @@ class ConnectionWrongStateError(AMQPConnectionError):
         if self.args:
             return super().__repr__()
         else:
-            return ('%s: The connection is in wrong state for the requested '
-                    'operation.' % self.__class__.__name__)
+            return (
+                f'{self.__class__.__name__}: The connection is in wrong state for the requested '
+                'operation.')
 
 
 class ConnectionClosed(AMQPConnectionError):
@@ -106,8 +97,7 @@ class ConnectionClosed(AMQPConnectionError):
         super().__init__(int(reply_code), str(reply_text))
 
     def __repr__(self) -> str:
-        return '{}: ({}) {!r}'.format(self.__class__.__name__, self.reply_code,
-                                      self.reply_text)
+        return f'{self.__class__.__name__}: ({self.reply_code}) {self.reply_text!r}'
 
     @property
     def reply_code(self) -> int:
@@ -172,8 +162,7 @@ class ChannelClosed(AMQPChannelError):
         super().__init__(int(reply_code), str(reply_text))
 
     def __repr__(self) -> str:
-        return '{}: ({}) {!r}'.format(self.__class__.__name__, self.reply_code,
-                                      self.reply_text)
+        return f'{self.__class__.__name__}: ({self.reply_code}) {self.reply_text!r}'
 
     @property
     def reply_code(self):
@@ -213,14 +202,15 @@ class ChannelClosedByClient(ChannelClosed):
 class DuplicateConsumerTag(AMQPChannelError):
 
     def __repr__(self) -> str:
-        return ('%s: The consumer tag specified already exists for this '
-                'channel: %s' % (self.__class__.__name__, self.args[0]))
+        return (
+            f'{self.__class__.__name__}: The consumer tag specified already exists for this '
+            f'channel: {self.args[0]}')
 
 
 class ConsumerCancelled(AMQPChannelError):
 
     def __repr__(self) -> str:
-        return '%s: Server cancelled consumer' % self.__class__.__name__
+        return f'{self.__class__.__name__}: Server cancelled consumer'
 
 
 class UnroutableError(AMQPChannelError):
@@ -239,13 +229,12 @@ class UnroutableError(AMQPChannelError):
         :param sequence(blocking_connection.ReturnedMessage) messages: Sequence
             of returned unroutable messages
         """
-        super().__init__("%s unroutable message(s) returned" % (len(messages)))
+        super().__init__(f"{len(messages)} unroutable message(s) returned")
 
         self.messages = messages
 
     def __repr__(self) -> str:
-        return '%s: %i unroutable messages returned by broker' % (
-            self.__class__.__name__, len(self.messages))
+        return f'{self.__class__.__name__}: {len(self.messages)} unroutable messages returned by broker'
 
 
 class NackError(AMQPChannelError):
@@ -260,70 +249,62 @@ class NackError(AMQPChannelError):
         :param sequence(blocking_connection.ReturnedMessage) messages: Sequence
             of returned unroutable messages
         """
-        super().__init__("%s message(s) NACKed" % (len(messages)))
+        super().__init__(f"{len(messages)} message(s) NACKed")
 
         self.messages = messages
 
     def __repr__(self) -> str:
-        return '%s: %i unroutable messages returned by broker' % (
-            self.__class__.__name__, len(self.messages))
+        return f'{self.__class__.__name__}: {len(self.messages)} unroutable messages returned by broker'
 
 
 class InvalidChannelNumber(AMQPError):
 
     def __repr__(self) -> str:
-        return '{}: An invalid channel number has been specified: {}'.format(
-            self.__class__.__name__, self.args[0])
+        return f'{self.__class__.__name__}: An invalid channel number has been specified: {self.args[0]}'
 
 
 class ProtocolSyntaxError(AMQPError):
 
     def __repr__(self) -> str:
-        return '%s: An unspecified protocol syntax error occurred' % (
-            self.__class__.__name__)
+        return f'{self.__class__.__name__}: An unspecified protocol syntax error occurred'
 
 
 class UnexpectedFrameError(ProtocolSyntaxError):
 
     def __repr__(self) -> str:
-        return '{}: Received a frame out of sequence: {!r}'.format(
-            self.__class__.__name__, self.args[0])
+        return f'{self.__class__.__name__}: Received a frame out of sequence: {self.args[0]!r}'
 
 
 class ProtocolVersionMismatch(ProtocolSyntaxError):
 
     def __repr__(self) -> str:
-        return '{}: Protocol versions did not match: {!r} vs {!r}'.format(
-            self.__class__.__name__, self.args[0], self.args[1])
+        return f'{self.__class__.__name__}: Protocol versions did not match: {self.args[0]!r} vs {self.args[1]!r}'
 
 
 class BodyTooLongError(ProtocolSyntaxError):
 
     def __repr__(self) -> str:
-        return ('%s: Received too many bytes for a message delivery: '
-                'Received %i, expected %i' %
-                (self.__class__.__name__, self.args[0], self.args[1]))
+        return (
+            f'{self.__class__.__name__}: Received too many bytes for a message delivery: '
+            f'Received {self.args[0]}, expected {self.args[1]}')
 
 
 class InvalidFrameError(ProtocolSyntaxError):
 
     def __repr__(self) -> str:
-        return '{}: Invalid frame received: {!r}'.format(
-            self.__class__.__name__, self.args[0])
+        return f'{self.__class__.__name__}: Invalid frame received: {self.args[0]!r}'
 
 
 class InvalidFieldTypeException(ProtocolSyntaxError):
 
     def __repr__(self) -> str:
-        return '{}: Unsupported field kind {}'.format(self.__class__.__name__,
-                                                      self.args[0])
+        return f'{self.__class__.__name__}: Unsupported field kind {self.args[0]}'
 
 
 class UnsupportedAMQPFieldException(ProtocolSyntaxError):
 
     def __repr__(self) -> str:
-        return '{}: Unsupported field kind {}'.format(self.__class__.__name__,
-                                                      type(self.args[1]))
+        return f'{self.__class__.__name__}: Unsupported field kind {type(self.args[1])}'
 
 
 class MethodNotImplemented(AMQPError):
@@ -333,8 +314,7 @@ class MethodNotImplemented(AMQPError):
 class ChannelError(Exception):
 
     def __repr__(self) -> str:
-        return '%s: An unspecified error occurred with the Channel' % (
-            self.__class__.__name__)
+        return f'{self.__class__.__name__}: An unspecified error occurred with the Channel'
 
 
 class ReentrancyError(Exception):
@@ -349,12 +329,14 @@ class ReentrancyError(Exception):
 class ShortStringTooLong(AMQPError):
 
     def __repr__(self) -> str:
-        return ('%s: AMQP Short String can contain up to 255 bytes: '
-                '%.300s' % (self.__class__.__name__, self.args[0]))
+        return (
+            f'{self.__class__.__name__}: AMQP Short String can contain up to 255 bytes: '
+            f'{self.args[0]:.300}')
 
 
 class DuplicateGetOkCallback(ChannelError):
 
     def __repr__(self) -> str:
-        return ('%s: basic_get can only be called again after the callback for '
-                'the previous basic_get is executed' % self.__class__.__name__)
+        return (
+            f'{self.__class__.__name__}: basic_get can only be called again after the callback for '
+            'the previous basic_get is executed')

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -1,12 +1,11 @@
 """Frame objects that do the frame demarshaling and marshaling."""
 from __future__ import annotations
+
 import logging
 import struct
 from typing import Generic, TypeVar
 
-from pika import amqp_object
-from pika import exceptions
-from pika import spec
+from pika import amqp_object, exceptions, spec
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -153,7 +153,7 @@ class Heartbeat(Frame):
         :rtype: bytes
 
         """
-        return self._marshal(list())
+        return self._marshal([])
 
 
 class ProtocolHeader(amqp_object.AMQPObject):

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -267,4 +267,4 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:  
         # Return the amount of data and a Heartbeat frame
         return frame_end, Heartbeat()
 
-    raise exceptions.InvalidFrameError("Unknown frame type: %i" % frame_type)
+    raise exceptions.InvalidFrameError(f"Unknown frame type: {frame_type}")

--- a/pika/tcp_socket_opts.py
+++ b/pika/tcp_socket_opts.py
@@ -2,9 +2,9 @@
 
 import logging
 import socket
-import pika._utils
-
 from typing import Dict, Optional
+
+import pika._utils
 
 LOGGER = logging.getLogger(__name__)
 

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -11,10 +11,8 @@ def require_string(value: Any, value_name: str) -> None:
 
     """
     if not isinstance(value, str):
-        raise TypeError('{} must be a str or unicode str, but got {!r}'.format(
-            value_name,
-            value,
-        ))
+        raise TypeError(
+            f'{value_name} must be a str or unicode str, but got {value!r}')
 
 
 def require_callback(callback: Callable[..., Any],
@@ -25,10 +23,8 @@ def require_callback(callback: Callable[..., Any],
 
     """
     if not callable(callback):
-        raise TypeError('callback {} must be callable, but got {!r}'.format(
-            callback_name,
-            callback,
-        ))
+        raise TypeError(
+            f'callback {callback_name} must be callable, but got {callback!r}')
 
 
 def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,8 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
 fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
-lint = "ruff check pika/ tests/ examples/ utils/"
+lint = "ruff check pika/ tests/ examples/ utils/ --fix"
+lint-check = "ruff check pika/ tests/ examples/ utils/"
 typecheck = "python -m mypy"
 unit = "pytest tests/unit/"
 test = "pytest"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
 fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
-lint = "ruff check pika/ tests/ examples/ utils/ --fix --unsafe-fixes"
+lint = "ruff check pika/ tests/ examples/ utils/ --fix"
 lint-check = "ruff check pika/ tests/ examples/ utils/"
 typecheck = "python -m mypy"
 unit = "pytest tests/unit/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ extend-exclude = [
 quote-style = "single"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "C"]
+select = ["E", "W", "F", "I", "UP", "C", "PTH"]
 ignore = ["E501", "C901"]
 
 [tool.yapf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,10 @@ extend-exclude = [
     "utils/codegen.py",   # code generation helper script
 ]
 
+[tool.ruff.lint]
+select = ["E4", "E7", "E9", "F"]
+ignore = []
+
 [tool.yapf]
 based_on_style = "google"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F"]
+select = ["E4", "E7", "E9", "F", "I"]
 ignore = []
 
 [tool.yapf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ extend-exclude = [
 ]
 
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "F", "I"]
+select = ["E4", "E7", "E9", "W", "F", "I"]
 ignore = []
 
 [tool.yapf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,8 @@ extend-exclude = [
 quote-style = "single"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP"]
-ignore = ["E501"]
+select = ["E", "W", "F", "I", "UP", "C"]
+ignore = ["E501", "C901"]
 
 [tool.yapf]
 based_on_style = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,12 @@ extend-exclude = [
     "utils/codegen.py",   # code generation helper script
 ]
 
+[tool.ruff.format]
+quote-style = "single"
+
 [tool.ruff.lint]
-select = ["E4", "E7", "E9", "W", "F", "I"]
-ignore = []
+select = ["E", "W", "F", "I", "UP"]
+ignore = ["E501"]
 
 [tool.yapf]
 based_on_style = "google"
@@ -94,7 +97,7 @@ dependencies = [
 [tool.hatch.envs.default.scripts]
 fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
 fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
-lint = "ruff check pika/ tests/ examples/ utils/ --fix"
+lint = "ruff check pika/ tests/ examples/ utils/ --fix --unsafe-fixes"
 lint-check = "ruff check pika/ tests/ examples/ utils/"
 typecheck = "python -m mypy"
 unit = "pytest tests/unit/"

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -51,7 +51,7 @@ class TestConstructAndImmediatelyCloseConnection(AsyncTestCase, AsyncAdapters):
         @async_test_base.make_stop_on_error_with_self(self)
         def on_opened(connection):
             self.fail('Connection should have aborted, but got '
-                      'on_opened({!r})'.format(connection))
+                      f'on_opened({connection!r})')
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_open_error(connection, error):
@@ -89,7 +89,7 @@ class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
         @async_test_base.make_stop_on_error_with_self(self)
         def on_opened(connection):
             self.fail('Connection should have aborted, but got '
-                      'on_opened({!r})'.format(connection))
+                      f'on_opened({connection!r})')
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_open_error(connection, error):
@@ -119,7 +119,7 @@ class TestSocketConnectTimeoutWithTinySocketTimeout(AsyncTestCase,
         @async_test_base.make_stop_on_error_with_self(self)
         def on_opened(connection):
             self.fail('Socket connection should have timed out, but got '
-                      'on_opened({!r})'.format(connection))
+                      f'on_opened({connection!r})')
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_open_error(connection, error):
@@ -148,14 +148,13 @@ class TestStackConnectionTimeoutWithTinyStackTimeout(AsyncTestCase,
         @async_test_base.make_stop_on_error_with_self(self)
         def on_opened(connection):
             self.fail('Stack connection should have timed out, but got '
-                      'on_opened({!r})'.format(connection))
+                      f'on_opened({connection!r})')
 
         def on_open_error(connection, exception):
             error = None
             if not isinstance(exception, pika.exceptions.AMQPConnectionError):
                 error = AssertionError(
-                    'Expected AMQPConnectionError, but got {!r}'.format(
-                        exception))
+                    f'Expected AMQPConnectionError, but got {exception!r}')
             self.stop(error)
 
         connection_class(params,
@@ -836,7 +835,7 @@ class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):  # pylint: dis
 
     def on_ready(self, frame):
         self.ctag = self.channel.basic_consume(self.queue, self.on_message)
-        self.msg_body = "%s: %i" % (self.__class__.__name__, time_now())
+        self.msg_body = f"{self.__class__.__name__}: {time_now()}"
         self.channel.basic_publish(self.exchange, self.routing_key,
                                    self.msg_body)
 
@@ -856,7 +855,7 @@ class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):  # pylint: 
 
     @staticmethod
     def _get_msg_body():
-        return '\n'.join(["%s" % i for i in range(0, 2097152)])
+        return '\n'.join([f"{i}" for i in range(0, 2097152)])
 
     def on_ready(self, frame):
         self.ctag = self.channel.basic_consume(self.queue, self.on_message)
@@ -879,7 +878,7 @@ class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):  # pylint: disable
     DESCRIPTION = "Publish a message and get it"
 
     def on_ready(self, frame):
-        self.msg_body = "%s: %i" % (self.__class__.__name__, time_now())
+        self.msg_body = f"{self.__class__.__name__}: {time_now()}"
         self.channel.basic_publish(self.exchange, self.routing_key,
                                    self.msg_body)
         self.channel.basic_get(self.queue, self.on_get)

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -22,16 +22,14 @@ import threading
 import uuid
 
 import pika
-from pika.adapters.utils import connection_workflow
+import pika.exceptions
+import pika.frame
 from pika import spec
 from pika._utils import as_bytes, time_now
-import pika.exceptions
+from pika.adapters.utils import connection_workflow
 from pika.exchange_type import ExchangeType
-import pika.frame
-
 from tests.base import async_test_base
-from tests.base.async_test_base import (AsyncTestCase, BoundQueueTestCase,
-                                        AsyncAdapters)
+from tests.base.async_test_base import AsyncAdapters, AsyncTestCase, BoundQueueTestCase
 
 
 class TestA_Connect(AsyncTestCase, AsyncAdapters):  # pylint: disable=C0103

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -95,7 +95,7 @@ class BlockingTestCaseBase(unittest.TestCase):
                 return real_poll(*args, **kwargs)
             except BaseException as exc:
                 self.fail('Unwanted exception leaked into asynchronous layer '
-                          'via ioloop.poll(): {!r}'.format(exc))
+                          f'via ioloop.poll(): {exc!r}')
 
         connection._impl.ioloop.poll = my_poll
         self.addCleanup(setattr, connection._impl.ioloop, 'poll', real_poll)
@@ -111,7 +111,7 @@ class BlockingTestCaseBase(unittest.TestCase):
                 raise
             except BaseException as exc:
                 self.fail('Unwanted exception leaked into asynchronous layer '
-                          'via ioloop.process_timeouts(): {!r}'.format(exc))
+                          f'via ioloop.process_timeouts(): {exc!r}')
 
         connection._impl.ioloop.process_timeouts = my_process_timeouts
         self.addCleanup(setattr, connection._impl.ioloop, 'process_timeouts',
@@ -2968,7 +2968,7 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
             if num_messages == 2:
                 break
         else:
-            self.fail('expected 2 messages, but consumed %i' % (num_messages,))
+            self.fail(f'expected 2 messages, but consumed {num_messages}')
 
         # Verify no more ready messages in queue
         frame = ch.queue_declare(q_name, passive=True)

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1,18 +1,17 @@
 """blocking adapter test"""
-from datetime import datetime, timezone
 import functools
 import logging
 import socket
 import threading
 import unittest
 import uuid
+from datetime import datetime, timezone
 
 import pika
-from pika.adapters import blocking_connection
-from pika._utils import as_bytes, time_now
 import pika.exceptions
+from pika._utils import as_bytes, time_now
+from pika.adapters import blocking_connection
 from pika.exchange_type import ExchangeType
-
 from tests.misc.forward_server import ForwardServer
 from tests.misc.test_utils import retry_assertion
 

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1510,8 +1510,9 @@ class TestPublishAndBasicPublishWithPubacksUnroutable(BlockingTestCaseBase):
         self.addCleanup(connection.channel().exchange_delete, exg_name)
 
         # Verify unroutable message handling using basic_publish
-        msg2_headers = dict(
-            test_name='TestPublishAndBasicPublishWithPubacksUnroutable')
+        msg2_headers = {
+            'test_name': 'TestPublishAndBasicPublishWithPubacksUnroutable'
+        }
         msg2_properties = pika.spec.BasicProperties(headers=msg2_headers)
         with self.assertRaises(pika.exceptions.UnroutableError) as cm:
             ch.basic_publish(exg_name,
@@ -1835,8 +1836,9 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
         ch.queue_bind(q_name, exchange=exg_name, routing_key=routing_key)
 
         # Deposit a message in the queue
-        msg1_headers = dict(
-            test_name='TestPublishAndConsumeWithPubacksAndQosOfOne')
+        msg1_headers = {
+            'test_name': 'TestPublishAndConsumeWithPubacksAndQosOfOne'
+        }
         msg1_properties = pika.spec.BasicProperties(headers=msg1_headers)
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
@@ -2298,7 +2300,7 @@ class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
         ch.queue_bind(q_name, exchange=exg_name, routing_key=routing_key)
 
         # Deposit a message in the queue with mandatory=True
-        msg1_headers = dict(test_name='TestBasicPublishWithoutPubacks')
+        msg1_headers = {'test_name': 'TestBasicPublishWithoutPubacks'}
         msg1_properties = pika.spec.BasicProperties(headers=msg1_headers)
         ch.basic_publish(exg_name,
                          routing_key=routing_key,

--- a/tests/acceptance/enforce_one_basicget_test.py
+++ b/tests/acceptance/enforce_one_basicget_test.py
@@ -1,10 +1,10 @@
 import unittest
-
 from unittest.mock import MagicMock
-from pika.frame import Method, Header
-from pika.exceptions import DuplicateGetOkCallback
+
 from pika.channel import Channel
 from pika.connection import Connection
+from pika.exceptions import DuplicateGetOkCallback
+from pika.frame import Header, Method
 
 
 class OnlyOneBasicGetTestCase(unittest.TestCase):

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -274,13 +274,13 @@ class SocketWatcherTestBase(AsyncServicesTestBase):
 
         if readable != expected.readable:
             raise AssertionError(
-                'Expected readable={!r}, but got {!r} (writable={!r})'.format(
-                    expected.readable, readable, writable))
+                f'Expected readable={expected.readable!r}, but got {readable!r} (writable={writable!r})'
+            )
 
         if writable != expected.writable:
             raise AssertionError(
-                'Expected writable={!r}, but got {!r} (readable={!r})'.format(
-                    expected.writable, writable, readable))
+                f'Expected writable={expected.writable!r}, but got {writable!r} (readable={readable!r})'
+            )
 
 
 class TestSocketWatchersUponConnectionAndNoIncomingData(SocketWatcherTestBase,

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -11,7 +11,6 @@ import socket
 import unittest
 
 import pika._utils
-
 from pika.adapters.utils import nbio_interface
 from tests.misc.forward_server import ForwardServer
 from tests.stubs.io_services_test_stubs import IOServicesTestStubs

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -60,8 +60,8 @@ class TestCase(unittest.TestCase):
             if failure.check(*expectedFailures):
                 return failure.value
             else:
-                output = ('\nExpected: %r\nGot:\n%s' %
-                          (expectedFailures, str(failure)))
+                output = (
+                    f'\nExpected: {expectedFailures!r}\nGot:\n{str(failure)}')
                 raise self.failureException(output)
 
         return d.addCallbacks(_cb, _eb)

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -12,21 +12,29 @@
 """twisted adapter test"""
 import functools
 import unittest
-
 from unittest import mock
+
 import pytest
-from twisted.internet import defer, error as twisted_error, reactor
+from twisted.internet import defer, reactor
+from twisted.internet import error as twisted_error
 from twisted.python.failure import Failure
 
-from pika.adapters.twisted_connection import (ClosableDeferredQueue,
-                                              TwistedChannel,
-                                              _TwistedConnectionAdapter,
-                                              TwistedProtocolConnection,
-                                              _TimerHandle)
 from pika import spec
-from pika.exceptions import (AMQPConnectionError, ConsumerCancelled,
-                             DuplicateGetOkCallback, NackError, UnroutableError,
-                             ChannelClosedByBroker)
+from pika.adapters.twisted_connection import (
+    ClosableDeferredQueue,
+    TwistedChannel,
+    TwistedProtocolConnection,
+    _TimerHandle,
+    _TwistedConnectionAdapter,
+)
+from pika.exceptions import (
+    AMQPConnectionError,
+    ChannelClosedByBroker,
+    ConsumerCancelled,
+    DuplicateGetOkCallback,
+    NackError,
+    UnroutableError,
+)
 from pika.frame import Method
 
 

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -450,14 +450,13 @@ class TwistedChannelTestCase(TestCase):
         args = [object()]
         kwargs = {"routing_key": object(), "body": object()}
         d = self.channel.basic_publish(*args, **kwargs)
-        kwargs.update(
-            dict(
-                # Args are converted to kwargs
-                exchange=args[0],
-                # Defaults
-                mandatory=False,
-                properties=None,
-            ))
+        kwargs.update({
+            # Args are converted to kwargs
+            "exchange": args[0],
+            # Defaults
+            "mandatory": False,
+            "properties": None,
+        })
         self.pika_channel.basic_publish.assert_called_once_with(**kwargs)
         assert d.called
 
@@ -489,7 +488,7 @@ class TwistedChannelTestCase(TestCase):
         kwargs = {"prefetch_size": 2}
         d = self.channel.basic_qos(**kwargs)
         # Defaults
-        kwargs.update(dict(prefetch_count=0, global_qos=False))
+        kwargs.update({"prefetch_count": 0, "global_qos": False})
         self._test_wrapped_func(self.pika_channel.basic_qos, kwargs, True)
         assert d.called
 

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -58,7 +58,7 @@ def make_stop_on_error_with_self(the_self=None):
                 this = args[0]
             if not isinstance(this, AsyncTestCase):
                 raise AssertionError('Decorated method is not an AsyncTestCase '
-                                     'instance method: {!r}'.format(fun))
+                                     f'instance method: {fun!r}')
             try:
                 return fun(*args, **kwargs)
             except Exception as error:  # pylint: disable=W0703
@@ -161,7 +161,7 @@ class AsyncTestCase(unittest.TestCase):
             self.assertTrue(
                 self._public_stop_requested,
                 'Unexpected end of test; connection close reason: '
-                '{!r}'.format(self._conn_closed_reason))
+                f'{self._conn_closed_reason!r}')
             if self._public_stop_error_in is not None:
                 raise self._public_stop_error_in  # pylint: disable=E0702
         finally:

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -1,21 +1,20 @@
 """Base test classes for async_adapter_tests.py
 
 """
-from datetime import datetime, timezone
 import functools
+import logging
 import select
 import sys
-import logging
 import unittest
-from unittest import mock
 import uuid
+from datetime import datetime, timezone
+from unittest import mock
 
 import pika
 import pika._utils
 from pika import adapters
 from pika.adapters import select_connection
 from pika.exchange_type import ExchangeType
-
 from tests.wrappers.threaded_test_wrapper import create_run_in_thread_decorator
 
 # invalid-name
@@ -351,8 +350,8 @@ class AsyncAdapters:
     def test_with_gevent(self):
         """GeventConnection"""
         import gevent
-        from pika.adapters.gevent_connection import GeventConnection
-        from pika.adapters.gevent_connection import _GeventSelectorIOLoop
+
+        from pika.adapters.gevent_connection import GeventConnection, _GeventSelectorIOLoop
 
         def ioloop_factory():
             return _GeventSelectorIOLoop(gevent.get_hub())
@@ -363,6 +362,7 @@ class AsyncAdapters:
     def test_with_tornado(self):
         """TornadoConnection"""
         import tornado.ioloop
+
         from pika.adapters.tornado_connection import TornadoConnection
         ioloop_factory = tornado.ioloop.IOLoop
         self.start(TornadoConnection, ioloop_factory)
@@ -371,6 +371,7 @@ class AsyncAdapters:
     def test_with_asyncio(self):
         """AsyncioConnection"""
         import asyncio
+
         from pika.adapters.asyncio_connection import AsyncioConnection
         ioloop_factory = asyncio.new_event_loop
         self.start(AsyncioConnection, ioloop_factory)

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -1,18 +1,18 @@
 """TCP/IP forwarding/echo service for testing."""
 
 import array
-from datetime import datetime, timezone
 import errno
-from functools import partial
 import logging
 import multiprocessing
 import os
 import socket
-import struct
 import socketserver
+import struct
 import sys
 import threading
 import traceback
+from datetime import datetime, timezone
+from functools import partial
 
 import pika._utils
 

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -176,14 +176,16 @@ class ForwardServer:  # pylint: disable=R0902
 
         self._subproc = mp_ctx.Process(
             target=_run_server,
-            kwargs=dict(local_addr=self._server_addr,
-                        local_addr_family=self._server_addr_family,
-                        local_socket_type=self._server_socket_type,
-                        local_linger_args=self._local_linger_args,
-                        remote_addr=self._remote_addr,
-                        remote_addr_family=self._remote_addr_family,
-                        remote_socket_type=self._remote_socket_type,
-                        queue=queue))
+            kwargs={
+                "local_addr": self._server_addr,
+                "local_addr_family": self._server_addr_family,
+                "local_socket_type": self._server_socket_type,
+                "local_linger_args": self._local_linger_args,
+                "remote_addr": self._remote_addr,
+                "remote_addr_family": self._remote_addr_family,
+                "remote_socket_type": self._remote_socket_type,
+                "queue": queue
+            })
         self._subproc.daemon = True
         self._subproc.start()
 

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import time
 import traceback
+
 import pika._utils
 
 

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -87,8 +87,7 @@ class IOServicesTestStubs:
         # implementation.
 
         from pika.adapters.select_connection import IOLoop
-        from pika.adapters.utils.selector_ioloop_adapter import (
-            SelectorIOServicesAdapter)
+        from pika.adapters.utils.selector_ioloop_adapter import SelectorIOServicesAdapter
         native_loop = IOLoop()
         self._run_start(
             nbio_factory=lambda: SelectorIOServicesAdapter(native_loop),
@@ -100,8 +99,8 @@ class IOServicesTestStubs:
         # implementation.
 
         from tornado.ioloop import IOLoop
-        from pika.adapters.utils.selector_ioloop_adapter import (
-            SelectorIOServicesAdapter)
+
+        from pika.adapters.utils.selector_ioloop_adapter import SelectorIOServicesAdapter
 
         native_loop = IOLoop()
         self._run_start(
@@ -114,7 +113,8 @@ class IOServicesTestStubs:
         # implementation.
 
         import asyncio
-        from pika.adapters.asyncio_connection import (_AsyncioIOServicesAdapter)
+
+        from pika.adapters.asyncio_connection import _AsyncioIOServicesAdapter
 
         native_loop = asyncio.new_event_loop()
         self._run_start(

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -57,7 +57,7 @@ class BaseConnectionTests(unittest.TestCase):
 
     def test_tcp_options_with_dict_tcp_options(self):
 
-        tcp_options = dict(TCP_KEEPIDLE=60)
+        tcp_options = {'TCP_KEEPIDLE': 60}
         params = pika.ConnectionParameters(tcp_options=tcp_options)
         self.assertEqual(params.tcp_options, tcp_options)
 
@@ -74,7 +74,7 @@ class BaseConnectionTests(unittest.TestCase):
 
     def test_tcp_options_with_invalid_tcp_options(self):
 
-        tcp_options = dict(TCP_EVIL_OPTION=1234)
+        tcp_options = {'TCP_EVIL_OPTION': 1234}
         params = pika.ConnectionParameters(tcp_options=tcp_options)
         self.assertEqual(params.tcp_options, tcp_options)
 

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -2,12 +2,12 @@
 Tests for pika.adapters.blocking_connection.BlockingChannel
 
 """
-from collections import deque
 import unittest
+from collections import deque
 from unittest import mock
 
-from pika.adapters import blocking_connection
 from pika import channel
+from pika.adapters import blocking_connection
 
 BLOCKING_CHANNEL = 'pika.adapters.blocking_connection.BlockingChannel'
 BLOCKING_CONNECTION = 'pika.adapters.blocking_connection.BlockingConnection'

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -8,10 +8,10 @@ from unittest import mock
 from unittest.mock import patch
 
 import pika
-from pika.adapters import blocking_connection
-from pika.adapters.utils import nbio_interface
 import pika.channel
 import pika.exceptions
+from pika.adapters import blocking_connection
+from pika.adapters.utils import nbio_interface
 
 # Disable protected-access
 # pylint: disable=W0212

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -149,7 +149,7 @@ class CallbackTests(unittest.TestCase):
     def test_clear(self):
         self.obj.add(self.PREFIX, self.KEY, None)
         self.obj.clear()
-        self.assertDictEqual(self.obj._stack, dict())
+        self.assertDictEqual(self.obj._stack, {})
 
     def test_cleanup_removes_prefix(self):
         other_prefix = 'Foo'
@@ -185,7 +185,7 @@ class CallbackTests(unittest.TestCase):
         self.assertEqual(self.obj.pending(self.PREFIX_CLASS, self.KEY), 2)
 
     def test_process_callback_false(self):
-        self.obj._stack = dict()
+        self.obj._stack = {}
         self.assertFalse(
             self.obj.process('FAIL', 'False', 'Empty', self.mock_caller, []))
 
@@ -263,7 +263,7 @@ class CallbackTests(unittest.TestCase):
         self.obj.remove(prefix=self.PREFIX,
                         key=self.KEY,
                         callback_value=self.callback_mock)
-        self.assertDictEqual(self.obj._stack, dict())
+        self.assertDictEqual(self.obj._stack, {})
 
     def test_remove_with_callback_true_non_empty_stack(self):
         self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -391,7 +391,7 @@ class ChannelTests(unittest.TestCase):
         self.obj._set_state(self.obj.OPEN)
         expectation = 'ctag1.'
         mock_on_msg_callback = mock.Mock()
-        for ctag in ['ctag1.%i' % ii for ii in range(11)]:
+        for ctag in [f'ctag1.{ii}' for ii in range(11)]:
             self.obj._cancelled.add(ctag)
         self.assertEqual(
             self.obj.basic_consume('test-queue', mock_on_msg_callback)[:6],

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -91,7 +91,7 @@ class ChannelTests(unittest.TestCase):
         self.assertIsInstance(self.obj._cancelled, set)
 
     def test_init_consumers(self):
-        self.assertEqual(self.obj._consumers, dict())
+        self.assertEqual(self.obj._consumers, {})
 
     def test_init_flow(self):
         self.assertEqual(self.obj.flow_active, True)

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -101,10 +101,10 @@ class ParametersTestsBase(unittest.TestCase):
         """
         for name, expected_value in self.get_default_properties().items():
             value = getattr(params, name)
-            self.assertEqual(value,
-                             expected_value,
-                             msg='Expected %s=%r, but got %r' %
-                             (name, expected_value, value))
+            self.assertEqual(
+                value,
+                expected_value,
+                msg=f'Expected {name}={expected_value!r}, but got {value!r}')
 
 
 class ParametersTests(ParametersTestsBase):
@@ -537,10 +537,12 @@ class ConnectionParametersTests(ParametersTestsBase):
         # Check property values
         for t_param in expected_values:
             value = getattr(params, t_param)
-            self.assertEqual(expected_values[t_param],
-                             value,
-                             msg='Expected %s=%r, but got %r' %
-                             (t_param, expected_values[t_param], value))
+            self.assertEqual(
+                expected_values[t_param],
+                value,
+                msg=
+                f'Expected {t_param}={expected_values[t_param]!r}, but got {value!r}'
+            )
 
     def test_callable_heartbeat(self):
 
@@ -690,10 +692,12 @@ class URLParametersTests(ParametersTestsBase):
             expected_value = query_args[t_param]
             actual_value = getattr(params, t_param)
 
-            self.assertEqual(actual_value,
-                             expected_value,
-                             msg='Expected %s=%r, but got %r' %
-                             (t_param, expected_value, actual_value))
+            self.assertEqual(
+                actual_value,
+                expected_value,
+                msg=
+                f'Expected {t_param}={expected_value!r}, but got {actual_value!r}'
+            )
 
         # check all values from base URL
         self.assertEqual(params.credentials.username, 'myuser')

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -180,8 +180,8 @@ class ParametersTests(ParametersTestsBase):
         self.assertNotEqual(params_1, params_3)
         self.assertNotEqual(params_3, params_1)
 
-        self.assertNotEqual(params_1, dict(host='localhost', port=5672))
-        self.assertNotEqual(dict(host='localhost', port=5672), params_1)
+        self.assertNotEqual(params_1, {'host': 'localhost', 'port': 5672})
+        self.assertNotEqual({'host': 'localhost', 'port': 5672}, params_1)
 
         class Foreign:
 
@@ -427,7 +427,7 @@ class ParametersTests(ParametersTestsBase):
         self.assertIsNone(params.ssl_options)
 
         with self.assertRaises(TypeError):
-            params.ssl_options = dict()
+            params.ssl_options = {}
 
     def test_virtual_host(self):
         params = connection.Parameters()
@@ -447,10 +447,12 @@ class ParametersTests(ParametersTestsBase):
     def test_tcp_options(self):
         params = connection.Parameters()
 
-        opt = dict(TCP_KEEPIDLE=60,
-                   TCP_KEEPINTVL=2,
-                   TCP_KEEPCNT=1,
-                   TCP_USER_TIMEOUT=1000)
+        opt = {
+            'TCP_KEEPIDLE': 60,
+            'TCP_KEEPINTVL': 2,
+            'TCP_KEEPCNT': 1,
+            'TCP_USER_TIMEOUT': 1000
+        }
         params.tcp_options = copy.deepcopy(opt)
         self.assertEqual(params.tcp_options, opt)
 

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -7,7 +7,8 @@ import copy
 import ssl
 import unittest
 import warnings
-from urllib.parse import quote as url_quote, urlencode
+from urllib.parse import quote as url_quote
+from urllib.parse import urlencode
 
 import pika
 from pika import channel, connection, credentials, spec

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -12,13 +12,13 @@ Tests for pika.connection.Connection
 # Suppress pylint messages concerning invalid method name
 # pylint: disable=C0103
 
-import random
 import platform
+import random
 import unittest
 from unittest import mock
 
-from pika import connection, channel, credentials, exceptions, frame, spec
 import pika
+from pika import channel, connection, credentials, exceptions, frame, spec
 
 
 def dummy_callback():

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -79,7 +79,7 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
     @mock.patch('pika.connection.Connection._on_close_ready')
     def test_close_calls_on_close_ready_when_no_channels(
             self, on_close_ready_mock):
-        self.connection._channels = dict()
+        self.connection._channels = {}
         self.connection.close()
         self.assertTrue(on_close_ready_mock.called,
                         'on_close_ready_mock should have been called')

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -428,12 +428,12 @@ class ConnectionTests(unittest.TestCase):  # pylint: disable=R0904
         for required_key in ('product', 'platform', 'capabilities',
                              'information', 'version'):
             self.assertTrue(required_key in client_props,
-                            '%s missing' % required_key)
+                            f'{required_key} missing')
 
     def test_client_properties_default(self):
         expectation = {
             'product': connection.PRODUCT,
-            'platform': 'Python %s' % platform.python_version(),
+            'platform': f'Python {platform.python_version()}',
             'capabilities': {
                 'authentication_failure_close': True,
                 'basic.nack': True,

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -23,7 +23,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         self.assertEqual(self.obj._seen_so_far, 0)
 
     def test_init_body_fragments(self):
-        self.assertEqual(self.obj._body_fragments, list())
+        self.assertEqual(self.obj._body_fragments, [])
 
     def test_process_with_basic_deliver(self):
         value = frame.Method(1, spec.Basic.Deliver())
@@ -114,7 +114,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         body_frame = frame.Body(1, b'abc123')
         self.obj.process(body_frame)
         self.obj._reset()
-        self.assertEqual(self.obj._body_fragments, list())
+        self.assertEqual(self.obj._body_fragments, [])
 
     def test_ascii_bytes_body_instance(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())

--- a/tests/unit/credentials_tests.py
+++ b/tests/unit/credentials_tests.py
@@ -91,13 +91,18 @@ class PlainCredentialsTests(unittest.TestCase):
         self.assertNotEqual(ChildPlainCredentials('u', 'pp', False),
                             credentials.PlainCredentials('u', 'p', False))
 
-        self.assertNotEqual(
-            credentials.PlainCredentials('u', 'p', False),
-            dict(username='u', password='p', erase_on_connect=False))
+        self.assertNotEqual(credentials.PlainCredentials('u', 'p', False), {
+            'username': 'u',
+            'password': 'p',
+            'erase_on_connect': False
+        })
 
         self.assertNotEqual(
-            dict(username='u', password='p', erase_on_connect=False),
-            credentials.PlainCredentials('u', 'p', False))
+            {
+                'username': 'u',
+                'password': 'p',
+                'erase_on_connect': False
+            }, credentials.PlainCredentials('u', 'p', False))
 
         class Foreign:
 
@@ -185,8 +190,8 @@ class ExternalCredentialsTest(unittest.TestCase):
         self.assertNotEqual(cred_1, cred_3)
         self.assertNotEqual(cred_3, cred_1)
 
-        self.assertNotEqual(cred_1, dict(erase_on_connect=False))
-        self.assertNotEqual(dict(erase_on_connect=False), cred_1)
+        self.assertNotEqual(cred_1, {'erase_on_connect': False})
+        self.assertNotEqual({'erase_on_connect': False}, cred_1)
 
         class Foreign:
 

--- a/tests/unit/diagnostic_utils_test.py
+++ b/tests/unit/diagnostic_utils_test.py
@@ -33,7 +33,11 @@ class DiagnosticUtilsTest(unittest.TestCase):
 
         # Test with args and kwargs
         expected_args = ('a', 2, 'B', Exception('oh-oh'))
-        expected_kwargs = dict(hello='world', bye='hello', error=RuntimeError())
+        expected_kwargs = {
+            'hello': 'world',
+            'bye': 'hello',
+            'error': RuntimeError()
+        }
 
         result = my_func(*expected_args, **expected_kwargs)
 
@@ -48,8 +52,8 @@ class DiagnosticUtilsTest(unittest.TestCase):
             self.assertIs(bucket[0][1][key], expected_kwargs[key])
 
         # Now, repeat without any args/kwargs
-        expected_args = tuple()
-        expected_kwargs = dict()
+        expected_args = ()
+        expected_kwargs = {}
         bucket.clear()
 
         result = my_func()

--- a/tests/unit/diagnostic_utils_test.py
+++ b/tests/unit/diagnostic_utils_test.py
@@ -2,9 +2,8 @@
 Test of `pika.diagnostic_utils`
 """
 
-import unittest
-
 import logging
+import unittest
 
 from pika import diagnostic_utils
 

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -4,7 +4,7 @@ Tests for pika.frame
 """
 import unittest
 
-from pika import exceptions, frame, spec, DeliveryMode
+from pika import DeliveryMode, exceptions, frame, spec
 
 
 class FrameTests(unittest.TestCase):

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -5,8 +5,8 @@ Tests for pika.heartbeat
 import unittest
 from unittest import mock
 
-from pika import connection, frame, heartbeat
 import pika.exceptions
+from pika import connection, frame, heartbeat
 
 # protected-access
 # pylint: disable=W0212

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -68,10 +68,9 @@ class TestStartCalledFromOtherThreadAndWithVaryingNativeLoops(
         # IOServicesTestStubs
         if cls._native_loop_classes != _SUPPORTED_LOOP_CLASSES:
             raise AssertionError(
-                'Expected these {} native I/O loop classes from '
-                'IOServicesTestStubs: {!r}, but got these {}: {!r}'.format(
-                    len(_SUPPORTED_LOOP_CLASSES), _SUPPORTED_LOOP_CLASSES,
-                    len(cls._native_loop_classes), cls._native_loop_classes))
+                f'Expected these {len(_SUPPORTED_LOOP_CLASSES)} native I/O loop classes from '
+                f'IOServicesTestStubs: {_SUPPORTED_LOOP_CLASSES!r}, but got these {len(cls._native_loop_classes)}: {cls._native_loop_classes!r}'
+            )
 
     def setUp(self):
         self._runner_thread_id = threading.current_thread().ident

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -15,7 +15,6 @@ import unittest
 import tornado.ioloop
 
 from pika.adapters import select_connection
-
 from tests.stubs.io_services_test_stubs import IOServicesTestStubs
 
 # Suppress invalid-name, since our test names are descriptive and quite long

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -805,8 +805,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
         def handle_socket_events(_fd, in_events):
             socket_error = sock.getsockopt(socket.SOL_SOCKET, socket.SO_ERROR)
-            socket_error = 0 if socket_error == 0 else '{} ({})'.format(
-                socket_error, os.strerror(socket_error))
+            socket_error = 0 if socket_error == 0 else f'{socket_error} ({os.strerror(socket_error)})'
 
             _trace_stderr('[%s] %s: watching=%s; indicated=%s; sockerr=%s',
                           ioloop._poller.__class__.__name__, msg_prefix,
@@ -817,9 +816,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
             #      without being requested.
             self.assertTrue(
                 in_events & (requested_eventmasks[0] | self.ERROR),
-                'watching={}; indicated={}'.format(
-                    _fd_events_to_str(requested_eventmasks[0]),
-                    _fd_events_to_str(in_events)))
+                f'watching={_fd_events_to_str(requested_eventmasks[0])}; indicated={_fd_events_to_str(in_events)}'
+            )
 
             requested_eventmasks.pop(0)
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -258,7 +258,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         interval.
 
         """
-        self.timer_stack = list()
+        self.timer_stack = []
         for i in range(self.NUM_TIMERS, 0, -1):
             deadline = i * self.TIMER_INTERVAL
             self.ioloop.call_later(deadline,
@@ -288,7 +288,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         corresponding handler generates no exceptions.
 
         """
-        self.timer_stack = list()
+        self.timer_stack = []
         handle_holder = []
         self.timer_got_fired = False
         self.handle = self.ioloop.call_later(
@@ -410,7 +410,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
 
     def setUp(self):
         super().setUp()
-        self.sock_map = dict()
+        self.sock_map = {}
         self.create_accept_socket()
 
     def tearDown(self):

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -4,7 +4,6 @@ Tests for SelectConnection IOLoops
 """
 
 import errno
-from datetime import datetime, timezone
 import functools
 import logging
 import os
@@ -13,9 +12,10 @@ import select
 import signal
 import socket
 import sys
-import time
 import threading
+import time
 import unittest
+from datetime import datetime, timezone
 from unittest import mock
 
 import pika

--- a/tests/unit/select_connection_timer_tests.py
+++ b/tests/unit/select_connection_timer_tests.py
@@ -73,7 +73,7 @@ class TimeoutClassTests(unittest.TestCase):
                       cm.exception.args[0])
 
         with self.assertRaises(TypeError) as cm:
-            select_connection._Timeout(5, dict())
+            select_connection._Timeout(5, {})
 
         self.assertIn('callback must be a callable, but got',
                       cm.exception.args[0])
@@ -112,10 +112,14 @@ class TimeoutClassTests(unittest.TestCase):
         self.assertNotEqual(ChildTimeout(10, lambda: None),
                             select_connection._Timeout(5, lambda: None))
 
-        self.assertNotEqual(select_connection._Timeout(5, lambda: None),
-                            dict(deadline=5, callback=lambda: None))
-        self.assertNotEqual(dict(deadline=5, callback=lambda: None),
-                            select_connection._Timeout(5, lambda: None))
+        self.assertNotEqual(select_connection._Timeout(5, lambda: None), {
+            'deadline': 5,
+            'callback': lambda: None
+        })
+        self.assertNotEqual({
+            'deadline': 5,
+            'callback': lambda: None
+        }, select_connection._Timeout(5, lambda: None))
 
         class Foreign:
 

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -3,16 +3,15 @@ Tests for threaded_test_wrapper.py
 
 """
 
-from io import StringIO
 import sys
 import threading
 import time
 import unittest
+from io import StringIO
 from unittest import mock
 
 from tests.wrappers import threaded_test_wrapper
-from tests.wrappers.threaded_test_wrapper import (_ThreadedTestWrapper,
-                                                  run_in_thread_with_timeout)
+from tests.wrappers.threaded_test_wrapper import _ThreadedTestWrapper, run_in_thread_with_timeout
 
 # Suppress invalid-name, since our test names are descriptive and quite long
 # pylint: disable=C0103

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -98,7 +98,7 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
     def test_integrity_of_args_and_return_value(self):
         args_bucket = []
         kwargs_bucket = []
-        value_to_return = dict()
+        value_to_return = {}
 
         @run_in_thread_with_timeout
         def my_guinea_pig(*args, **kwargs):
@@ -106,10 +106,10 @@ class ThreadedTestWrapperSelfChecks(unittest.TestCase):
             kwargs_bucket.append(kwargs)
             return value_to_return
 
-        arg0 = dict()
-        arg1 = tuple()
+        arg0 = {}
+        arg1 = ()
 
-        kwarg0 = list()
+        kwarg0 = []
 
         result = my_guinea_pig(arg0, arg1, kwarg0=kwarg0)
 

--- a/tests/wrappers/threaded_test_wrapper.py
+++ b/tests/wrappers/threaded_test_wrapper.py
@@ -143,10 +143,10 @@ class _ThreadedTestWrapper:
             self._exc_info = sys.exc_info()
             del self._fun_result  # to force exception on inadvertent access
             if not isinstance(self._exc_info[1], unittest.SkipTest):
-                print('ERROR start() of test {} failed:\n{}'.format(
-                    self, self._exc_info_to_str(self._exc_info)),
-                      end='',
-                      file=self._stderr)
+                print(
+                    f'ERROR start() of test {self} failed:\n{self._exc_info_to_str(self._exc_info)}',
+                    end='',
+                    file=self._stderr)
 
     @staticmethod
     def _exc_info_to_str(exc_info):


### PR DESCRIPTION
## Proposed Changes

This PR formalizes and tightens linting by introducing an explicit Ruff configuration in `pyproject.toml`, aligning the contributor documentation and CI behavior with that configuration, and applying the resulting mechanical cleanups across the repository. The changes include import sorting, warning cleanup, pyupgrade-driven modernizations, pathlib adoption, and other style-related fixes, all applied in a single pass to keep CI green under the expanded rule set.

## Current Ruff configuration

Under `[tool.ruff.lint]`:

* **Enabled rule groups:** `E`, `W`, `F`, `I`, `UP`, `C`, `PTH`

  * **E / W:** pycodestyle errors and warnings.
  * **F:** Pyflakes checks.
  * **I:** isort-compatible import ordering.
  * **UP:** pyupgrade rules (while targeting `py37`).
  * **C:** McCabe complexity checks (`C901` is globally ignored; see below).
  * **PTH:** flake8-use-pathlib rules encouraging `pathlib` usage over selected `os` APIs.

* **Ignored rules:**

  * `E501`: line-length enforcement remains delegated to `yapf`, which is still the active formatter.
  * `C901`: complexity violations are reported but not enforced as hard failures.

Under `[tool.ruff.format]`, Ruff formatting is configured to use **single quotes**.

The Hatch `lint` script runs `ruff check ... --fix` without enabling `--unsafe-fixes`, while `lint-check` performs a non-mutating CI-style validation run.


## Other notable changes

- **CONTRIBUTING** and **`.github/workflows/lint.yaml`** updated so expectations match the new Ruff workflow.
- **Docstrings / module layout:** module descriptions adjusted to sit at the top of files where needed (PEP 257-style consistency with the new lint pass).
- **`gevent_connection`:** import line adjusted for untyped `gevent` imports under the stricter toolchain.

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] Documentation <!-- correction or otherwise -->
- [x] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

<!-- Link related issues using GitHub keywords:
- Fixes #123
- Closes #456
- Resolves owner/repo#789
-->

- Fixes #

## Further Comments

`E501` is ignored because `yapf` does not enforce line-length limits for docstrings, unlike some other formatters hence it can't be fixes.
Ruff also reports these cases, but since it cannot automatically fix them, we ignore the rule for now.
