### PR TITLE
Expands Ruff lint coverage

### DIFF
--- a/examples/async_as_callback.py
+++ b/examples/async_as_callback.py
@@ -134,8 +134,7 @@ class BasicMessageSender(BasicPikaClient):
     def encode_message(self, body: Dict, encoding_type: str = "bytes"):
         if encoding_type == "bytes":
             return msgpack.packb(body)
-        else:
-            raise NotImplementedError
+        raise NotImplementedError
 
     def send_message(
         self,
@@ -169,8 +168,7 @@ class BasicMessageReceiver(BasicPikaClient):
     def decode_message(self, body):
         if isinstance(body, bytes):
             return msgpack.unpackb(body)
-        else:
-            raise NotImplementedError
+        raise NotImplementedError
 
     def get_message(self, queue_name: str, auto_ack: bool = False):
         method_frame, header_frame, body = self.channel.basic_get(
@@ -178,9 +176,8 @@ class BasicMessageReceiver(BasicPikaClient):
         if method_frame:
             logger.debug(f"{method_frame}, {header_frame}, {body}")
             return method_frame, header_frame, body
-        else:
-            logger.debug("No message returned")
-            return None
+        logger.debug("No message returned")
+        return None
 
     def consume_messages(self, queue, callback):
         self.check_connection()

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -93,12 +93,12 @@ class ExampleConsumer:
         LOGGER.error('Connection open failed: %s', err)
         self.reconnect()
 
-    def on_connection_closed(self, _unused_connection, reason):
+    def on_connection_closed(self, _connection, reason):
         """This method is invoked by pika when the connection to RabbitMQ is
         closed unexpectedly. Since it is unexpected, we will reconnect to
         RabbitMQ if it disconnects.
 
-        :param pika.connection.Connection connection: The closed connection obj
+        :param pika.connection.Connection _connection: The closed connection obj
         :param Exception reason: exception representing reason for loss of
             connection.
 
@@ -181,11 +181,11 @@ class ExampleConsumer:
                                        exchange_type=self.EXCHANGE_TYPE,
                                        callback=cb)
 
-    def on_exchange_declareok(self, _unused_frame, userdata):
+    def on_exchange_declareok(self, _frame, userdata):
         """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
         command.
 
-        :param pika.Frame.Method unused_frame: Exchange.DeclareOk response frame
+        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame
         :param str|unicode userdata: Extra user data (exchange name)
 
         """

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -84,12 +84,12 @@ class ExamplePublisher:
         LOGGER.error('Connection open failed, reopening in 5 seconds: %s', err)
         self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
 
-    def on_connection_closed(self, _unused_connection, reason):
+    def on_connection_closed(self, _connection, reason):
         """This method is invoked by pika when the connection to RabbitMQ is
         closed unexpectedly. Since it is unexpected, we will reconnect to
         RabbitMQ if it disconnects.
 
-        :param pika.connection.Connection connection: The closed connection obj
+        :param pika.connection.Connection _connection: The closed connection obj
         :param Exception reason: exception representing reason for loss of
             connection.
 
@@ -167,11 +167,11 @@ class ExamplePublisher:
                                        exchange_type=self.EXCHANGE_TYPE,
                                        callback=cb)
 
-    def on_exchange_declareok(self, _unused_frame, userdata):
+    def on_exchange_declareok(self, _frame, userdata):
         """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
         command.
 
-        :param pika.Frame.Method unused_frame: Exchange.DeclareOk response frame
+        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame
         :param str|unicode userdata: Extra user data (exchange name)
 
         """
@@ -191,14 +191,14 @@ class ExamplePublisher:
                                     durable=True,
                                     callback=self.on_queue_declareok)
 
-    def on_queue_declareok(self, _unused_frame):
+    def on_queue_declareok(self, _frame):
         """Method invoked by pika when the Queue.Declare RPC call made in
         setup_queue has completed. In this method we will bind the queue
         and exchange together with the routing key by issuing the Queue.Bind
         RPC command. When this command is complete, the on_bindok method will
         be invoked by pika.
 
-        :param pika.frame.Method method_frame: The Queue.DeclareOk frame
+        :param pika.frame.Method _frame: The Queue.DeclareOk frame
 
         """
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, self.QUEUE,

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -96,12 +96,12 @@ class ExampleConsumer:
         LOGGER.error('Connection open failed: %s', err)
         self.reconnect()
 
-    def on_connection_closed(self, _unused_connection, reason):
+    def on_connection_closed(self, _connection, reason):
         """This method is invoked by pika when the connection to RabbitMQ is
         closed unexpectedly. Since it is unexpected, we will reconnect to
         RabbitMQ if it disconnects.
 
-        :param pika.connection.Connection connection: The closed connection obj
+        :param pika.connection.Connection _connection: The closed connection obj
         :param Exception reason: exception representing reason for loss of
             connection.
 
@@ -184,11 +184,11 @@ class ExampleConsumer:
                                        exchange_type=self.EXCHANGE_TYPE,
                                        callback=cb)
 
-    def on_exchange_declareok(self, _unused_frame, userdata):
+    def on_exchange_declareok(self, _frame, userdata):
         """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
         command.
 
-        :param pika.Frame.Method unused_frame: Exchange.DeclareOk response frame
+        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame
         :param str|unicode userdata: Extra user data (exchange name)
 
         """

--- a/examples/confirmation.py
+++ b/examples/confirmation.py
@@ -19,7 +19,7 @@ def on_open(conn):
 def on_channel_open(channel):
     global published
     channel.confirm_delivery(ack_nack_callback=on_delivery_confirmation)
-    for _iteration in range(0, ITERATIONS):
+    for _iteration in range(ITERATIONS):
         channel.basic_publish(
             'test', 'test.confirm', 'message body value',
             pika.BasicProperties(content_type='text/plain',

--- a/examples/producer.py
+++ b/examples/producer.py
@@ -31,7 +31,7 @@ def getticker():
 
 _COUNT_ = 10
 
-for i in range(0, _COUNT_):
+for i in range(_COUNT_):
     ticker = getticker()
     msg = {
         'order.stop.create': {

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -135,7 +135,7 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
             msg,
         ) = item
 
-        log.msg(f'{deliver.exchange} ({deliver.routing_key}): {repr(msg)}',
+        log.msg(f'{deliver.exchange} ({deliver.routing_key}): {msg!r}',
                 system='Pika:<=')
         d = defer.maybeDeferred(callback, item)
         d.addCallbacks(lambda _: channel.basic_ack(deliver.delivery_tag),
@@ -159,7 +159,7 @@ class PikaProtocol(twisted_connection.TwistedProtocolConnection):
     @inlineCallbacks
     def send_message(self, exchange, routing_key, msg):
         """Send a single message."""
-        log.msg(f'{exchange} ({routing_key}): {repr(msg)}', system='Pika:=>')
+        log.msg(f'{exchange} ({routing_key}): {msg!r}', system='Pika:=>')
         yield self._channel.exchange_declare(exchange=exchange,
                                              exchange_type=ExchangeType.topic,
                                              durable=True,

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -16,7 +16,6 @@ from pika.delivery_mode import DeliveryMode
 from pika.spec import BasicProperties
 
 __all__ = [
-    'adapters',
     'AMQPConnectionWorkflow',
     'BaseConnection',
     'BasicProperties',
@@ -24,7 +23,8 @@ __all__ = [
     'ConnectionParameters',
     'DeliveryMode',
     'PlainCredentials',
-    'SelectConnection',
     'SSLOptions',
+    'SelectConnection',
     'URLParameters',
+    'adapters',
 ]

--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -67,7 +67,7 @@ def get_linux_version(release_str: str) -> tuple[int, ...]:
     :param release_str: kernel release string
     :rtype: tuple[int, ...]
     """
-    ver_str = release_str.split('-')[0]
+    ver_str = release_str.split('-', 1)[0]
     return tuple(map(to_digit, ver_str.split('.', 3)[:3]))
 
 

--- a/pika/adapters/__init__.py
+++ b/pika/adapters/__init__.py
@@ -26,6 +26,6 @@ __all__ = [
     'AsyncioConnection',
     'BaseConnection',
     'BlockingConnection',
-    'SelectConnection',
     'IOLoop',
+    'SelectConnection',
 ]

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1208,7 +1208,7 @@ class _QueueConsumerGeneratorInfo:
         """
         self.params = params
         self.consumer_tag = consumer_tag
-        #self.messages = deque()
+        # self.messages = deque()
 
         # Holds pending events of types _ConsumerDeliveryEvt and
         # _ConsumerCancellationEvt

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -52,7 +52,7 @@ class _CallbackResult:
     """ CallbackResult is a non-thread-safe implementation for receiving
     callback results; INTERNAL USE ONLY!
     """
-    __slots__ = ('_value_class', '_ready', '_values')
+    __slots__ = ('_ready', '_value_class', '_values')
 
     def __init__(self, value_class: Callable[..., Any] | None = None):
         """
@@ -217,7 +217,7 @@ class _IoloopTimerContext:
 
 class _TimerEvt:
     """Represents a timer created via `BlockingConnection.call_later`"""
-    __slots__ = ('timer_id', '_callback')
+    __slots__ = ('_callback', 'timer_id')
 
     def __init__(self, callback: Callable[..., None]):
         """
@@ -1023,7 +1023,7 @@ class _ConsumerDeliveryEvt(_ChannelPendingEvt):
     contains method, properties, and body of the delivered message.
     """
 
-    __slots__ = ('method', 'properties', 'body')
+    __slots__ = ('body', 'method', 'properties')
 
     def __init__(self, method: pika.spec.Basic.Deliver,
                  properties: pika.spec.BasicProperties, body: bytes) -> None:
@@ -1068,7 +1068,7 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):
 class _ReturnedMessageEvt(_ChannelPendingEvt):
     """This event represents a message returned by broker via `Basic.Return`"""
 
-    __slots__ = ('callback', 'channel', 'method', 'properties', 'body')
+    __slots__ = ('body', 'callback', 'channel', 'method', 'properties')
 
     def __init__(self, callback: Callable[[
         BlockingChannel, pika.spec.Basic.Return, pika.spec.
@@ -1109,7 +1109,7 @@ class ReturnedMessage:
     mode
     """
 
-    __slots__ = ('method', 'properties', 'body')
+    __slots__ = ('body', 'method', 'properties')
 
     def __init__(self, method: pika.spec.Basic.Return,
                  properties: pika.spec.BasicProperties, body: bytes) -> None:
@@ -1126,8 +1126,13 @@ class ReturnedMessage:
 class _ConsumerInfo:
     """Information about an active consumer"""
 
-    __slots__ = ('consumer_tag', 'auto_ack', 'on_message_callback',
-                 'alternate_event_sink', 'state')
+    __slots__ = (
+        'alternate_event_sink',
+        'auto_ack',
+        'consumer_tag',
+        'on_message_callback',
+        'state',
+    )
 
     # Consumer states
     SETTING_UP = 1
@@ -1195,7 +1200,7 @@ class _ConsumerInfo:
 
 class _QueueConsumerGeneratorInfo:
     """Container for information about the active queue consumer generator """
-    __slots__ = ('params', 'consumer_tag', 'pending_events')
+    __slots__ = ('consumer_tag', 'params', 'pending_events')
 
     def __init__(self, params: tuple[str, bool, bool],
                  consumer_tag: str) -> None:

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -472,10 +472,9 @@ class BlockingConnection:
                 error = on_cw_done_result.value.result
                 LOGGER.error('Connection workflow failed: %r', error)
                 raise self._reap_last_connection_workflow_error(error)
-            else:
-                LOGGER.info('Connection workflow succeeded: %r',
-                            on_cw_done_result.value.result)
-                return on_cw_done_result.value.result
+            LOGGER.info('Connection workflow succeeded: %r',
+                        on_cw_done_result.value.result)
+            return on_cw_done_result.value.result
         except Exception:
             LOGGER.exception('Error in _create_connection().')
             ioloop.close()
@@ -545,9 +544,8 @@ class BlockingConnection:
                     LOGGER.error('Unexpected connection close detected: %r',
                                  self._closed_result.value.error)
                     raise self._closed_result.value.error
-                else:
-                    LOGGER.info('User-initiated close: result=%r',
-                                self._closed_result.value)
+                LOGGER.info('User-initiated close: result=%r',
+                            self._closed_result.value)
             finally:
                 self._cleanup()
 
@@ -1904,13 +1902,12 @@ class BlockingChannel:
                 return [(evt.method, evt.properties, evt.body)
                         for evt in self._remove_pending_deliveries(consumer_tag)
                        ]
-            else:
-                # impl takes care of rejecting any incoming deliveries during
-                # cancellation
-                messages = self._remove_pending_deliveries(consumer_tag)
-                assert not messages, messages
+            # impl takes care of rejecting any incoming deliveries during
+            # cancellation
+            messages = self._remove_pending_deliveries(consumer_tag)
+            assert not messages, messages
 
-                return []
+            return []
         finally:
             # NOTE: The entry could be purged if channel or connection closes
             if consumer_tag in self._consumer_infos:
@@ -2284,10 +2281,9 @@ class BlockingChannel:
                 if get_ok_result:
                     evt = get_ok_result.value
                     return evt.method, evt.properties, evt.body
-                else:
-                    assert self._basic_getempty_result, (
-                        "wait completed without GetOk and GetEmpty")
-                    return None, None, None
+                assert self._basic_getempty_result, (
+                    "wait completed without GetOk and GetEmpty")
+                return None, None, None
 
     def basic_publish(self,
                       exchange: str,
@@ -2352,15 +2348,14 @@ class BlockingChannel:
                         returned_messages = []
                     raise exceptions.NackError(returned_messages)
 
-                else:
-                    assert isinstance(conf_method,
-                                      pika.spec.Basic.Ack), (conf_method)
+                assert isinstance(conf_method,
+                                  pika.spec.Basic.Ack), (conf_method)
 
-                    if self._puback_return is not None:
-                        # Unroutable message was returned
-                        messages = [self._puback_return]
-                        self._puback_return = None
-                        raise exceptions.UnroutableError(messages)
+                if self._puback_return is not None:
+                    # Unroutable message was returned
+                    messages = [self._puback_return]
+                    self._puback_return = None
+                    raise exceptions.UnroutableError(messages)
         else:
             # In non-publisher-acknowledgments mode
             self._impl.basic_publish(exchange=exchange,

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -384,16 +384,17 @@ class _GeventAddressResolver:
     See: https://www.gevent.org/dns.html
     """
     __slots__ = (
-        '_loop',
-        '_on_done',
-        '_greenlet',
+        '_ga_family',
+        '_ga_flags',
         # getaddrinfo(..) args:
         '_ga_host',
         '_ga_port',
-        '_ga_family',
-        '_ga_socktype',
         '_ga_proto',
-        '_ga_flags')
+        '_ga_socktype',
+        '_greenlet',
+        '_loop',
+        '_on_done',
+    )
 
     def __init__(self, native_loop: AbstractSelectorIOLoop, host: str,
                  port: int, family: int, socktype: int, proto: int, flags: int,

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -178,8 +178,8 @@ class _Timeout:
     """Represents a timeout"""
 
     __slots__ = (
-        'deadline',
         'callback',
+        'deadline',
     )
 
     def __init__(self, deadline: float, callback: Callable[[], None]):

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -78,8 +78,7 @@ def _is_resumable(exc: SELECT_ERROR_T) -> bool:
     checker = _SELECT_ERROR_CHECKERS.get(exc.__class__, None)
     if checker is not None:
         return checker(exc)
-    else:
-        return False
+    return False
 
 
 class SelectConnection(BaseConnection):
@@ -1005,8 +1004,7 @@ class SelectPoller(_PollerBase):
             except _SELECT_ERRORS as error:
                 if _is_resumable(error):
                     continue
-                else:
-                    raise
+                raise
 
         # Build an event bit mask for each fileno we've received an event for
         fd_event_map: dict[int, int] = collections.defaultdict(int)
@@ -1114,8 +1112,7 @@ class KQueuePoller(_PollerBase):
             except _SELECT_ERRORS as error:
                 if _is_resumable(error):
                     continue
-                else:
-                    raise
+                raise
 
         fd_event_map: dict[int, int] = collections.defaultdict(int)
         for event in kevents:
@@ -1248,8 +1245,7 @@ class PollPoller(_PollerBase):
             except _SELECT_ERRORS as error:
                 if _is_resumable(error):
                     continue
-                else:
-                    raise
+                raise
 
         fd_event_map: dict[int, int] = collections.defaultdict(int)
         for fileno, event in events:

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -17,7 +17,6 @@ from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Callable
 
 import twisted.internet.base
-import twisted.python
 import twisted.python.failure
 from twisted.internet import defer, protocol, reactor
 from twisted.internet import error as twisted_error
@@ -1204,7 +1203,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
 
-        :param Failure: A Twisted Failure instance wrapping an exception.
+        :param Failure error: A Twisted Failure instance wrapping an exception.
 
         """
         self._transport = None

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -603,11 +603,10 @@ class TwistedChannel:
             mandatory=mandatory)
         if not self._delivery_confirmation:
             return defer.succeed(result)
-        else:
-            # See https://www.rabbitmq.com/confirms.html#publisher-confirms
-            self._delivery_message_id += 1
-            self._deliveries[self._delivery_message_id] = defer.Deferred()
-            return self._deliveries[self._delivery_message_id]
+        # See https://www.rabbitmq.com/confirms.html#publisher-confirms
+        self._delivery_message_id += 1
+        self._deliveries[self._delivery_message_id] = defer.Deferred()
+        return self._deliveries[self._delivery_message_id]
 
     def basic_qos(self,
                   prefetch_size: int = 0,

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -707,7 +707,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         """
         if self._state == self._STATE_INIT:
             raise AMQPConnectorWrongState('Cannot abort before starting.')
-        elif self._state == self._STATE_DONE:
+        if self._state == self._STATE_DONE:
             raise AMQPConnectorWrongState(
                 'Cannot abort after completion was reported')
 

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -84,8 +84,7 @@ def _retry_on_sigint(func):
             except pika._utils.SOCKET_ERROR as error:
                 if error.errno == errno.EINTR:
                     continue
-                else:
-                    raise
+                raise
 
     return retry_sigint_wrap
 

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -21,7 +21,6 @@ import pika.diagnostic_utils
 from pika.adapters.utils.nbio_interface import AbstractIOReference, AbstractStreamTransport
 
 if TYPE_CHECKING:
-    import pika.connection
     from pika.adapters.utils import nbio_interface
 
 # "Try again" error codes for non-blocking socket I/O - send()/recv().

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -559,11 +559,10 @@ class _AddressResolver:
                 self._cleanup()
 
                 return True
-            else:
-                LOGGER.debug(
-                    'Ignoring _AddressResolver cancel request when not ACTIVE; '
-                    '(%s:%s); state=%s', self._host, self._port, self._state)
-                return False
+            LOGGER.debug(
+                'Ignoring _AddressResolver cancel request when not ACTIVE; '
+                '(%s:%s); state=%s', self._host, self._port, self._state)
+            return False
 
     def _resolve(self) -> None:
         """Call `socket.getaddrinfo()` and return result via user's callback

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -26,8 +26,7 @@ class AMQPObject:
     def __eq__(self, other: object) -> bool:
         if other is not None:
             return self.__dict__ == other.__dict__
-        else:
-            return False
+        return False
 
 
 class Class(AMQPObject):

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -370,8 +370,8 @@ class CallbackManager:
 
         """
         LOGGER.debug('Comparing %r to %r', value, expectation)
-        for key in expectation:
-            if value.get(key) != expectation[key]:
+        for key, expected in expectation.items():
+            if value.get(key) != expected:
                 LOGGER.debug('Values in dict do not match for %s', key)
                 return False
         return True
@@ -387,12 +387,12 @@ class CallbackManager:
         :rtype: bool
 
         """
-        for key in expectation:
+        for key, expected in expectation.items():
             if not hasattr(value, key):
                 LOGGER.debug('%r does not have required attribute: %s',
                              type(value), key)
                 return False
-            if getattr(value, key) != expectation[key]:
+            if getattr(value, key) != expected:
                 LOGGER.debug('Values in %s do not match for %s', type(value),
                              key)
                 return False

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -10,7 +10,7 @@ import uuid
 from collections import deque
 from collections.abc import Sequence
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Union
 
 import pika.exceptions as exceptions
 import pika.frame as frame
@@ -75,7 +75,7 @@ class Channel:
     OPEN = 2
     CLOSING = 3  # client-initiated close in progress
 
-    _STATE_NAMES: dict[int, str] = {
+    _STATE_NAMES: ClassVar[dict[int, str]] = {
         CLOSED: 'CLOSED',
         OPENING: 'OPENING',
         OPEN: 'OPEN',
@@ -109,7 +109,7 @@ class Channel:
 
         self._content_assembler = ContentFrameAssembler()
 
-        self._blocked: deque = deque([])
+        self._blocked: deque = deque()
         self._blocking: Any | None = None
         self._has_on_flow_callback: bool = False
         self._cancelled: set = set()

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1591,16 +1591,14 @@ class ContentFrameAssembler:
                 spec.has_content(frame_value.method.INDEX)):
             self._method_frame = frame_value
             return None
-        elif isinstance(frame_value, frame.Header):
+        if isinstance(frame_value, frame.Header):
             self._header_frame = frame_value
             if frame_value.body_size == 0:
                 return self._finish()
-            else:
-                return None
-        elif isinstance(frame_value, frame.Body):
+            return None
+        if isinstance(frame_value, frame.Body):
             return self._handle_body_frame(frame_value)
-        else:
-            raise exceptions.UnexpectedFrameError(frame_value)
+        raise exceptions.UnexpectedFrameError(frame_value)
 
     def _finish(self) -> tuple[frame.Method, frame.Header, bytes]:
         """Invoked when all of the message has been received
@@ -1628,7 +1626,7 @@ class ContentFrameAssembler:
         self._body_fragments.append(body_frame.fragment)
         if self._seen_so_far == self._header_frame.body_size:  # type: ignore
             return self._finish()
-        elif self._seen_so_far > self._header_frame.body_size:  # type: ignore
+        if self._seen_so_far > self._header_frame.body_size:  # type: ignore
             raise exceptions.BodyTooLongError(
                 self._seen_so_far, self._header_frame.body_size)  # type: ignore
         return None

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -316,7 +316,7 @@ class Parameters:
             raise ValueError(
                 f'Min AMQP 0.9.1 Frame Size is {spec.FRAME_MIN_SIZE}, but got {value!r}'
             )
-        elif value > spec.FRAME_MAX_SIZE:
+        if value > spec.FRAME_MAX_SIZE:
             raise ValueError(
                 f'Max AMQP 0.9.1 Frame Size is {spec.FRAME_MAX_SIZE}, but got {value!r}'
             )
@@ -2348,7 +2348,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
 
         if content[1]:
             chunks = int(math.ceil(float(length) / self._body_max_length))
-            for chunk in range(0, chunks):
+            for chunk in range(chunks):
                 start = chunk * self._body_max_length
                 end = start + self._body_max_length
                 if end > length:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -15,6 +15,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    ClassVar,
     Dict,
     Optional,
     Sequence,
@@ -53,11 +54,24 @@ class Parameters:
 
     # Declare slots to protect against accidental assignment of an invalid
     # attribute
-    __slots__ = ('_blocked_connection_timeout', '_channel_max',
-                 '_client_properties', '_connection_attempts', '_credentials',
-                 '_frame_max', '_heartbeat', '_host', '_locale', '_port',
-                 '_retry_delay', '_socket_timeout', '_stack_timeout',
-                 '_ssl_options', '_virtual_host', '_tcp_options')
+    __slots__ = (
+        '_blocked_connection_timeout',
+        '_channel_max',
+        '_client_properties',
+        '_connection_attempts',
+        '_credentials',
+        '_frame_max',
+        '_heartbeat',
+        '_host',
+        '_locale',
+        '_port',
+        '_retry_delay',
+        '_socket_timeout',
+        '_ssl_options',
+        '_stack_timeout',
+        '_tcp_options',
+        '_virtual_host',
+    )
 
     DEFAULT_USERNAME = 'guest'
     DEFAULT_PASSWORD = 'guest'
@@ -985,7 +999,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
     CONNECTION_OPEN = 5
     CONNECTION_CLOSING = 6  # client-initiated close in progress
 
-    _STATE_NAMES = {
+    _STATE_NAMES: ClassVar[dict[int, str]] = {
         CONNECTION_CLOSED: 'CLOSED',
         CONNECTION_INIT: 'INIT',
         CONNECTION_PROTOCOL: 'PROTOCOL',
@@ -2347,7 +2361,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore
         marshaled_body_frames.append(frame_header.marshal())
 
         if content[1]:
-            chunks = int(math.ceil(float(length) / self._body_max_length))
+            chunks = math.ceil(float(length) / self._body_max_length)
             for chunk in range(chunks):
                 start = chunk * self._body_max_length
                 end = start + self._body_max_length

--- a/pika/data.py
+++ b/pika/data.py
@@ -98,14 +98,14 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
         pieces.append(struct.pack('>cI', b'S', len(value)))
         pieces.append(value)
         return 5 + len(value)
-    elif isinstance(value, bytes):
+    if isinstance(value, bytes):
         pieces.append(struct.pack('>cI', b'x', len(value)))
         pieces.append(value)
         return 5 + len(value)
-    elif isinstance(value, bool):
+    if isinstance(value, bool):
         pieces.append(struct.pack('>cB', b't', int(value)))
         return 2
-    elif isinstance(value, int):
+    if isinstance(value, int):
         try:
             packed = struct.pack('>ci', b'I', value)
             pieces.append(packed)

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -19,8 +19,7 @@ class AMQPConnectionError(AMQPError):
     def __repr__(self) -> str:
         if len(self.args) == 2:
             return f'{self.__class__.__name__}: ({self.args[0]}) {self.args[1]}'
-        else:
-            return f'{self.__class__.__name__}: {self.args}'
+        return f'{self.__class__.__name__}: {self.args}'
 
 
 class ConnectionOpenAborted(AMQPConnectionError):
@@ -76,10 +75,9 @@ class ConnectionWrongStateError(AMQPConnectionError):
     def __repr__(self) -> str:
         if self.args:
             return super().__repr__()
-        else:
-            return (
-                f'{self.__class__.__name__}: The connection is in wrong state for the requested '
-                'operation.')
+        return (
+            f'{self.__class__.__name__}: The connection is in wrong state for the requested '
+            'operation.')
 
 
 class ConnectionClosed(AMQPConnectionError):

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -242,10 +242,10 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
         # Return the amount of data consumed and the Method object
         return frame_end, Method(channel_number, method)
 
-    elif frame_type == spec.FRAME_HEADER:
+    if frame_type == spec.FRAME_HEADER:
 
         # Return the header class and body size
-        class_id, weight, body_size = struct.unpack_from('>HHQ', frame_data)
+        class_id, _weight, body_size = struct.unpack_from('>HHQ', frame_data)
 
         # Get the Properties type
         properties = spec.props[class_id]()
@@ -256,12 +256,12 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
         # Return a Header frame
         return frame_end, Header(channel_number, body_size, properties)
 
-    elif frame_type == spec.FRAME_BODY:
+    if frame_type == spec.FRAME_BODY:
 
         # Return the amount of data consumed and the Body frame w/ data
         return frame_end, Body(channel_number, frame_data)
 
-    elif frame_type == spec.FRAME_HEARTBEAT:
+    if frame_type == spec.FRAME_HEARTBEAT:
 
         # Return the amount of data and a Heartbeat frame
         return frame_end, Heartbeat()

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -119,10 +119,8 @@ class Body(Frame):
 
     def __init__(self, channel_number: int, fragment: bytes) -> None:
         """
-        Parameters:
-
-        - channel_number: int
-        - fragment: bytes
+        :param int channel_number: The channel number for the frame
+        :param bytes fragment: The fragment of the body
         """
         Frame.__init__(self, spec.FRAME_BODY, channel_number)
         self.fragment = fragment

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -42,8 +42,7 @@ def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
     if callable(callback):
         # nowait=False
         return False
-    else:
-        raise TypeError('completion callback must be callable if not None')
+    raise TypeError('completion callback must be callable if not None')
 
 
 def zero_or_greater(name: str, value: int) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,8 +65,27 @@ extend-exclude = [
 quote-style = "single"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "C", "PTH", "D417", "RET", "PIE"]
-ignore = ["E501", "C901"]
+select = [
+    "E",    # pycodestyle errors
+    "F",    # Pyflakes checks, including unused imports and unused variables
+    "W",    # pycodestyle warnings
+    "I",    # isort import sorting
+    "UP",   # modern Python syntax suggestions
+    "C",    # complexity and comprehension-related checks
+    "PTH",  # prefer pathlib over os.path
+    "D417", # missing documented parameters in docstrings
+    "RET",  # return statement cleanup and consistency
+    "PIE",  # miscellaneous code improvements
+    #"PERF", # performance anti-patterns
+    "PLE",  # Pylint error rules
+    "PLC",  # Pylint convention rules
+]
+
+ignore = [
+    "E501",    # line too long
+    "C901",    # function is too complex
+    "PLC0415", # import should be at the top level of a file
+]
 
 [tool.yapf]
 based_on_style = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ extend-exclude = [
 quote-style = "single"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "C", "PTH", "D417"]
+select = ["E", "W", "F", "I", "UP", "C", "PTH", "D417", "RET", "PIE"]
 ignore = ["E501", "C901"]
 
 [tool.yapf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ extend-exclude = [
 quote-style = "single"
 
 [tool.ruff.lint]
-select = ["E", "W", "F", "I", "UP", "C", "PTH"]
+select = ["E", "W", "F", "I", "UP", "C", "PTH", "D417"]
 ignore = ["E501", "C901"]
 
 [tool.yapf]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,11 +75,12 @@ select = [
     "PTH",  # prefer pathlib over os.path
     "D417", # missing documented parameters in docstrings
     "RET",  # return statement cleanup and consistency
-    "PIE",  # miscellaneous code improvements
+    "PIE",  # flake8 pie
     "PERF", # performance anti-patterns
     "PLE",  # Pylint error rules
     "PLC",  # Pylint convention rules
-    "RUF"   # Ruff-specific rules
+    "RUF",  # Ruff-specific rules
+    "FURB", # refurb  
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ select = [
     "PLE",  # Pylint error rules
     "PLC",  # Pylint convention rules
     "RUF",  # Ruff-specific rules
-    "FURB", # refurb  
+    "FURB", # refurbishing and modernizing codebase
 ]
 
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,15 +76,17 @@ select = [
     "D417", # missing documented parameters in docstrings
     "RET",  # return statement cleanup and consistency
     "PIE",  # miscellaneous code improvements
-    #"PERF", # performance anti-patterns
+    "PERF", # performance anti-patterns
     "PLE",  # Pylint error rules
     "PLC",  # Pylint convention rules
+    "RUF"   # Ruff-specific rules
 ]
 
 ignore = [
     "E501",    # line too long
     "C901",    # function is too complex
     "PLC0415", # import should be at the top level of a file
+    "PERF203", # `try`-`except` within a loop incurs performance overhead
 ]
 
 [tool.yapf]

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -510,7 +510,7 @@ class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
                               callback=self.on_queue_declared)
 
     def on_queue_declared(self, frame):
-        for i in range(0, 100):
+        for i in range(100):
             msg_body = f'{self.__class__.__name__}:{i}:{time_now()}'
             self.channel.basic_publish('', self.queue_name, msg_body)
         self.ctag = self.channel.basic_consume(self.queue_name,
@@ -602,7 +602,7 @@ class TestNoDeadlockWhenClosingChannelWithPendingBlockedRequestsAndConcurrentCha
     def begin(self, channel):
         base_exch_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.channel.add_on_close_callback(self.on_channel_closed)
-        for i in range(0, 99):
+        for i in range(99):
             # Passively declare a non-existent exchange to force Channel.Close
             # from broker
             exch_name = base_exch_name + ':' + str(i)
@@ -837,7 +837,7 @@ class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
 
     @staticmethod
     def _get_msg_body():
-        return '\n'.join([f"{i}" for i in range(0, 2097152)])
+        return '\n'.join([f"{i}" for i in range(2097152)])
 
     def on_ready(self, frame):
         self.ctag = self.channel.basic_consume(self.queue, self.on_message)

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -48,8 +48,7 @@ class TestCase(unittest.TestCase):
         def _eb(failure):
             if failure.check(*expectedFailures):
                 return failure.value
-            output = (
-                f'\nExpected: {expectedFailures!r}\nGot:\n{str(failure)}')
+            output = (f'\nExpected: {expectedFailures!r}\nGot:\n{str(failure)}')
             raise self.failureException(output)
 
         return d.addCallbacks(_cb, _eb)

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -48,7 +48,7 @@ class TestCase(unittest.TestCase):
         def _eb(failure):
             if failure.check(*expectedFailures):
                 return failure.value
-            output = (f'\nExpected: {expectedFailures!r}\nGot:\n{str(failure)}')
+            output = (f'\nExpected: {expectedFailures!r}\nGot:\n{failure!s}')
             raise self.failureException(output)
 
         return d.addCallbacks(_cb, _eb)
@@ -236,7 +236,7 @@ class TwistedChannelTestCase(TestCase):
         d.addCallback(check)
         # Simulate a server response
         self.assertEqual(len(self.channel._calls), 1)
-        list(self.channel._calls)[0].callback(None)
+        next(iter(self.channel._calls)).callback(None)
         assert d.called
 
     @pytest.mark.timeout(5)

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -48,10 +48,9 @@ class TestCase(unittest.TestCase):
         def _eb(failure):
             if failure.check(*expectedFailures):
                 return failure.value
-            else:
-                output = (
-                    f'\nExpected: {expectedFailures!r}\nGot:\n{str(failure)}')
-                raise self.failureException(output)
+            output = (
+                f'\nExpected: {expectedFailures!r}\nGot:\n{str(failure)}')
+            raise self.failureException(output)
 
         return d.addCallbacks(_cb, _eb)
 

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -94,8 +94,7 @@ class AsyncTestCase(unittest.TestCase):
         """
         if enable_tls():
             return self._new_tls_connection_params()
-        else:
-            return self._new_plaintext_connection_params()
+        return self._new_plaintext_connection_params()
 
     def _new_tls_connection_params(self):
         """
@@ -122,8 +121,7 @@ class AsyncTestCase(unittest.TestCase):
         method_desc = super().shortDescription()
         if self.DESCRIPTION:
             return f"{self.DESCRIPTION} ({method_desc})"
-        else:
-            return method_desc
+        return method_desc
 
     def begin(self, channel):
         """Extend to start the actual tests on the channel"""

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -103,8 +103,7 @@ class AsyncTestCase(unittest.TestCase):
         """
         self.logger.info('testing using TLS/SSL connection to port 5671')
         url = 'amqps://localhost:5671/%2F?ssl_options=%7B%27ca_certs%27%3A%27testdata%2Fcerts%2Fca_certificate.pem%27%2C%27keyfile%27%3A%27testdata%2Fcerts%2Fclient_key.pem%27%2C%27certfile%27%3A%27testdata%2Fcerts%2Fclient_certificate.pem%27%7D'
-        params = pika.URLParameters(url)
-        return params
+        return pika.URLParameters(url)
 
     @staticmethod
     def _new_plaintext_connection_params():

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -411,16 +411,15 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                 except pika._utils.SOCKET_ERROR as exc:
                     if exc.errno == errno.EINTR:
                         continue
-                    elif exc.errno == errno.ECONNRESET:
+                    if exc.errno == errno.ECONNRESET:
                         # Source peer forcibly closed connection
                         _trace("%s errno.ECONNRESET from %s",
                                datetime.now(timezone.utc), src_peername)
                         break
-                    else:
-                        _trace("%s Unexpected errno=%s from %s\n%s",
-                               datetime.now(timezone.utc), exc.errno,
-                               src_peername, "".join(traceback.format_stack()))
-                        raise
+                    _trace("%s Unexpected errno=%s from %s\n%s",
+                           datetime.now(timezone.utc), exc.errno,
+                           src_peername, "".join(traceback.format_stack()))
+                    raise
 
                 if not nbytes:
                     # Source input EOF
@@ -438,19 +437,18 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                             "the connection: errno.EPIPE",
                             datetime.now(timezone.utc), dest_sock.getpeername())
                         break
-                    elif exc.errno == errno.ECONNRESET:
+                    if exc.errno == errno.ECONNRESET:
                         # Destination peer forcibly closed connection
                         _trace(
                             "%s Destination peer %s forcibly closed "
                             "connection: errno.ECONNRESET",
                             datetime.now(timezone.utc), dest_sock.getpeername())
                         break
-                    else:
-                        _trace("%s Unexpected errno=%s in sendall to %s\n%s",
-                               datetime.now(timezone.utc), exc.errno,
-                               dest_sock.getpeername(),
-                               "".join(traceback.format_stack()))
-                        raise
+                    _trace("%s Unexpected errno=%s in sendall to %s\n%s",
+                           datetime.now(timezone.utc), exc.errno,
+                           dest_sock.getpeername(),
+                           "".join(traceback.format_stack()))
+                    raise
         except Exception:
             _trace("forward failed\n%s", "".join(traceback.format_exc()))
             raise
@@ -493,8 +491,7 @@ def echo(port=0):
             except pika._utils.SOCKET_ERROR as exc:
                 if exc.errno == errno.EINTR:
                     continue
-                else:
-                    raise
+                raise
 
             if not data:
                 break

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -417,8 +417,8 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                                datetime.now(timezone.utc), src_peername)
                         break
                     _trace("%s Unexpected errno=%s from %s\n%s",
-                           datetime.now(timezone.utc), exc.errno,
-                           src_peername, "".join(traceback.format_stack()))
+                           datetime.now(timezone.utc), exc.errno, src_peername,
+                           "".join(traceback.format_stack()))
                     raise
 
                 if not nbytes:

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -4,6 +4,7 @@ Tests for pika.callback
 """
 import logging
 import unittest
+from typing import ClassVar
 from unittest import mock
 
 from pika import callback, frame, spec
@@ -19,7 +20,7 @@ class CallbackTests(unittest.TestCase):
     ONLY_CALLER = callback.CallbackManager.ONLY_CALLER
     PREFIX_CLASS = spec.Basic.Consume
     PREFIX = 'Basic.Consume'
-    ARGUMENTS_VALUE = {'foo': 'bar'}
+    ARGUMENTS_VALUE: ClassVar[dict[str, str]] = {'foo': 'bar'}
 
     @property
     def _callback_dict(self):

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -2,6 +2,8 @@
 Tests for pika.callback
 
 """
+from __future__ import annotations
+
 import logging
 import unittest
 from typing import ClassVar

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1607,7 +1607,7 @@ class ChannelTests(unittest.TestCase):
         expectation = [2, 3]
         self.obj._send_method(*expectation)
         self.obj.connection._send_method.assert_called_once_with(
-            *[self.obj.channel_number] + expectation)
+            self.obj.channel_number, *expectation)
 
     def test_set_state(self):
         self.obj._state = channel.Channel.CLOSED

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -684,8 +684,7 @@ class URLParametersTests(ParametersTestsBase):
 
         # check all value from query string
 
-        for t_param in query_args:
-            expected_value = query_args[t_param]
+        for t_param, expected_value in query_args.items():
             actual_value = getattr(params, t_param)
 
             self.assertEqual(

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -14,7 +14,6 @@ from pika import channel, connection, credentials, exceptions, frame, spec
 
 def dummy_callback():
     """Callback method to use in tests"""
-    pass
 
 
 class ConstructibleConnection(connection.Connection):

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -349,7 +349,7 @@ class ConnectionTests(unittest.TestCase):
     def test_add_on_open_error_callback(self):
         """make sure the add on open error callback is added"""
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
-        #Test with remove default first (also checks default is True)
+        # Test with remove default first (also checks default is True)
         self.connection.add_on_open_error_callback(dummy_callback)
         self.connection.callbacks.remove.assert_called_once_with(
             0, self.connection.ON_CONNECTION_ERROR,
@@ -522,8 +522,8 @@ class ConnectionTests(unittest.TestCase):
         method_frame.method.mechanisms = str(credentials.PlainCredentials.TYPE)
         method_frame.method.version_major = 0
         method_frame.method.version_minor = 9
-        #This may be incorrectly mocked, or the code is wrong
-        #TODO: Code does hasattr check, should this be a has_key/in check?
+        # This may be incorrectly mocked, or the code is wrong
+        # TODO: Code does hasattr check, should this be a has_key/in check?
         method_frame.method.server_properties = {
             'capabilities': {
                 'basic.nack': True,
@@ -531,7 +531,7 @@ class ConnectionTests(unittest.TestCase):
                 'exchange_exchange_bindings': False
             }
         }
-        #This will be called, but should not be implmented here, just mock it
+        # This will be called, but should not be implmented here, just mock it
         self.connection._flush_outbound = mock.Mock()
         self.connection._adapter_emit_data = mock.Mock()
         self.connection._on_connection_start(method_frame)
@@ -552,7 +552,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection._flush_outbound = mock.Mock()
         marshal = mock.Mock(return_value='ab')
         method.return_value = mock.Mock(marshal=marshal)
-        #may be good to test this here, but i don't want to test too much
+        # may be good to test this here, but i don't want to test too much
         self.connection._rpc = mock.Mock()
 
         method_frame = mock.Mock()
@@ -565,10 +565,10 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.frame_max = 20000
         self.connection.params.heartbeat = 20
 
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
 
-        #verfy
+        # verfy
         self.assertEqual(self.connection.CONNECTION_TUNE,
                          self.connection.connection_state)
         self.assertEqual(20, self.connection.params.channel_max)
@@ -586,49 +586,49 @@ class ConnectionTests(unittest.TestCase):
         # Both client and server values set. Pick client value
         method_frame.method.heartbeat = 60
         self.connection.params.heartbeat = 20
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(20, self.connection.params.heartbeat)
 
         # Client value is None, use the server's
         method_frame.method.heartbeat = 500
         self.connection.params.heartbeat = None
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(500, self.connection.params.heartbeat)
 
         # Client value is 0, use it
         method_frame.method.heartbeat = 60
         self.connection.params.heartbeat = 0
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(0, self.connection.params.heartbeat)
 
         # Server value is 0, client value is None
         method_frame.method.heartbeat = 0
         self.connection.params.heartbeat = None
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(0, self.connection.params.heartbeat)
 
         # Both client and server values are 0
         method_frame.method.heartbeat = 0
         self.connection.params.heartbeat = 0
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(0, self.connection.params.heartbeat)
 
         # Server value is 0, use the client's
         method_frame.method.heartbeat = 0
         self.connection.params.heartbeat = 60
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(60, self.connection.params.heartbeat)
 
         # Server value is 10, client passes a heartbeat function that
@@ -640,9 +640,9 @@ class ConnectionTests(unittest.TestCase):
 
         method_frame.method.heartbeat = 10
         self.connection.params.heartbeat = choose_max
-        #Test
+        # Test
         self.connection._on_connection_tune(method_frame)
-        #verfy
+        # verfy
         self.assertEqual(60, self.connection.params.heartbeat)
 
     def test_on_connection_close_from_broker_passes_correct_exception(self):
@@ -654,7 +654,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection._terminate_stream = mock.Mock()
         self.connection._on_connection_close_from_broker(method_frame)
 
-        #Check
+        # Check
         self.connection._terminate_stream.assert_called_once_with(mock.ANY)
 
         exc = self.connection._terminate_stream.call_args[0][0]
@@ -671,7 +671,7 @@ class ConnectionTests(unittest.TestCase):
 
         self.connection._on_connection_close_ok(method_frame)
 
-        #Check
+        # Check
         self.connection._terminate_stream.assert_called_once_with(None)
 
     @mock.patch('pika.frame.decode_frame')
@@ -689,7 +689,7 @@ class ConnectionTests(unittest.TestCase):
             self.connection.frames_received = 0
             decode_frame.return_value = (2, frame_value)
             self.connection._on_data_available(data_in)
-            #test value
+            # test value
             self.assertListEqual([], self.connection._frame_buffer)
             self.assertEqual(2, self.connection.bytes_received)
             self.assertEqual(1, self.connection.frames_received)

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -6,6 +6,7 @@ import datetime
 import decimal
 import unittest
 from collections import OrderedDict
+from typing import ClassVar
 
 from pika import data, exceptions
 
@@ -31,7 +32,7 @@ class DataTests(unittest.TestCase):
 
     FIELD_TBL_ENCODED += b'\x05bytesx\x00\x00\x00\x06foobar'
 
-    FIELD_TBL_VALUE = OrderedDict([
+    FIELD_TBL_VALUE: ClassVar[OrderedDict] = OrderedDict([
         ('array', [1, 2, 3]),
         ('boolval', True),
         ('decimal', decimal.Decimal('3.14')),

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -36,7 +36,7 @@ class DataTests(unittest.TestCase):
         ('array', [1, 2, 3]),
         ('boolval', True),
         ('decimal', decimal.Decimal('3.14')),
-        ('decimal_too', decimal.Decimal('100')),
+        ('decimal_too', decimal.Decimal(100)),
         ('dictval', {
             'foo': 'bar'
         }),

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -82,11 +82,11 @@ class DataTests(unittest.TestCase):
         self.assertEqual(byte_count, 233)
 
     def test_decode_table(self):
-        value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
+        value, _byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
         self.assertDictEqual(value, self.FIELD_TBL_VALUE)
 
     def test_decode_table_bytes(self):
-        value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
+        _value, byte_count = data.decode_table(self.FIELD_TBL_ENCODED, 0)
         self.assertEqual(byte_count, 233)
 
     def test_decode_signed_long_negative(self):

--- a/tests/unit/diagnostic_utils_test.py
+++ b/tests/unit/diagnostic_utils_test.py
@@ -41,8 +41,8 @@ class DiagnosticUtilsTest(unittest.TestCase):
         for i in range(len(expected_args)):
             self.assertIs(bucket[0][0][i], expected_args[i])
 
-        for key in expected_kwargs.keys():
-            self.assertIs(bucket[0][1][key], expected_kwargs[key])
+        for key, expected_value in expected_kwargs.items():
+            self.assertIs(bucket[0][1][key], expected_value)
 
         # Now, repeat without any args/kwargs
         expected_args = ()

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -11,6 +11,7 @@ except ImportError:
 
 import threading
 import unittest
+from typing import ClassVar
 
 import tornado.ioloop
 
@@ -45,7 +46,7 @@ if asyncio is not None:
 class TestStartCalledFromOtherThreadAndWithVaryingNativeLoops(
         unittest.TestCase, IOServicesTestStubs):
 
-    _native_loop_classes = set()
+    _native_loop_classes: ClassVar[set[type]] = set()
 
     @classmethod
     def setUpClass(cls):

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -1,6 +1,7 @@
 """
 Test for io_services_test_stubs.py
 """
+from __future__ import annotations
 
 import pika._utils
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -532,7 +532,6 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
     def signal_handler(signum, interrupted_stack):
         """A signal handler that gets called in response to
            os.kill(signal.SIGUSR1)."""
-        pass
 
     def _eintr_read_handler(self, fileno, events):
         """Read from within poll loop that gets receives eintr error."""
@@ -1032,25 +1031,21 @@ class SelectPollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
     """Runs `DefaultPollerSocketEventsTestCase` tests with forced use of
     SelectPoller
     """
-    pass
 
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 @mock.patch.multiple(select_connection, SELECT_TYPE='poll')
 class PollPollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
     """Same as DefaultPollerSocketEventsTestCase but uses poll syscall"""
-    pass
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 @mock.patch.multiple(select_connection, SELECT_TYPE='epoll')
 class EpollPollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
     """Same as DefaultPollerSocketEventsTestCase but uses epoll syscall"""
-    pass
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 @mock.patch.multiple(select_connection, SELECT_TYPE='kqueue')
 class KqueuePollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
     """Same as DefaultPollerSocketEventsTestCase but uses kqueue syscall"""
-    pass

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -782,8 +782,7 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         """Common logic for which_events_are_set_* tests. Runs the event loop
         while varying eventmasks at each socket event callback
 
-        :param ioloop:
-        :param sock:
+        :param sock: socket to watch for events
         :param requested_eventmasks: a mutable list of eventmasks to apply after
                                      each socket event callback
         :param msg_prefix: Message prefix to apply when printing watched vs.


### PR DESCRIPTION
## Summary

Expands Ruff lint coverage in CI and applies fixes across the library, examples, and tests. The goal is stronger static checks without changing runtime behavior.

### Ruff rules added

New rule groups in `[tool.ruff.lint] select`:

| Rule set | Purpose |
|----------|---------|
| **D417** | Docstrings document all parameters |
| **RET** | Cleaner, more consistent `return` usage |
| **PIE** | Miscellaneous improvements (e.g. unnecessary pass, duplicate literals) |
| **PERF** | Performance anti-patterns (see ignore below) |
| **PLE** | Pylint errors |
| **PLC** | Pylint conventions (e.g. dict iteration via `.items()`) |
| **RUF** | Ruff-specific rules (`__all__` / `__slots__` sorting, f-string `!r`, `ClassVar` for mutable class attrs, etc.) |
| **FURB** | Refurb modernization suggestions |

New ignores:

- **PLC0415** - A few tests in `tests/stubs/io_services_test_stubs.py` using lazy import so ignore it for now
- **PERF203** - `try`/`except` in a loop (kept for the intentional EINTR-retry decorator in `io_services_utils.py`; other sites refactored where practical)

### Main code changes

- **Lint-driven cleanups** across `pika/`, `examples/`, and `tests/`: dict loops use `.items()`, f-strings use `{x!r}` instead of `repr(x)`, `__all__` / `__slots__` sorted, `ClassVar` on shared mutable class attributes (`_STATE_NAMES`, test fixtures, etc.).
- **Performance / style**: `set.discard()` instead of `remove` + `KeyError` in Twisted consumer cleanup; bounds-checked callback removal in `callback.py`; `split('-', 1)` in `_utils.get_linux_version()`.
- **Docstrings**: parameter names aligned with signatures (D417).
- **Returns / control flow**: unnecessary `else` after `return` removed where RET flagged them (RET).
- **Examples & tests**: small fixes for new rules (e.g. `twisted_service.py`, connection/channel unit tests, `Decimal` construction in tests).

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [x] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

<!-- Link related issues using GitHub keywords:
- Fixes #123
- Closes #456
- Resolves owner/repo#789
-->

- Fixes #

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion
by explaining why you chose the solution you did and what alternatives
you considered, etc. -->
