### PR TITLE
Fix `Channel.close()` for channels with multiple consumers

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -594,7 +594,7 @@ class Channel:
         self._closing_reason = exceptions.ChannelClosedByClient(
             reply_code, reply_text)
 
-        for consumer_tag in self._consumers.keys():
+        for consumer_tag in list(self._consumers.keys()):
             if consumer_tag not in self._cancelled:
                 self.basic_cancel(consumer_tag=consumer_tag)
 

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -670,6 +670,16 @@ class ChannelTests(unittest.TestCase):
             # every consumer before closing the channel
             basic_cancel.assert_called_once_with(consumer_tag='abc')
 
+    def test_close_basic_cancel_called_for_all_consumers(self):
+        self.obj._set_state(self.obj.OPEN)
+        self.obj._consumers['abc'] = None
+        self.obj._consumers['def'] = None
+        with mock.patch.object(self.obj, 'basic_cancel') as basic_cancel:
+            self.obj.close()
+            assert basic_cancel.call_count == 2
+            basic_cancel.assert_any_call(consumer_tag='abc')
+            basic_cancel.assert_any_call(consumer_tag='def')
+
     def test_confirm_delivery_with_bad_callback_raises_value_error(self):
         self.assertRaises(ValueError, self.obj.confirm_delivery, 'bad-callback')
 


### PR DESCRIPTION
Commit a611288d8ac34cb594f7fe0dd2eb9256c57eea9d introduced a bug causing `Channel.close()` to fail for channels with more than one consumer.  This pull fixes that.

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [X] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [X] I have read the `CONTRIBUTING.md` document
- [X] All tests pass locally with my changes
- [X] I have added tests that prove my fix is effective or that my feature works
