### PR TITLE
Fix `DeliveryMode` to inherit from `IntEnum`

### DIFF
--- a/pika/delivery_mode.py
+++ b/pika/delivery_mode.py
@@ -1,8 +1,12 @@
-from enum import Enum
+from enum import IntEnum
 
 
-class DeliveryMode(Enum):
+class DeliveryMode(IntEnum):
     """Enum for specifying the message delivery mode.
+
+    Inherits from :class:`enum.IntEnum` so members are usable wherever an
+    integer is expected, including the wire encoder for
+    :class:`pika.spec.BasicProperties.delivery_mode`.
 
     Attributes:
         Transient: The message is not written to disk and may be lost if the

--- a/tests/unit/delivery_mode_test.py
+++ b/tests/unit/delivery_mode_test.py
@@ -1,16 +1,95 @@
 """
 Tests for pika.delivery_mode
-
 """
+import struct
 import unittest
 
 from pika.delivery_mode import DeliveryMode
+from pika.spec import BasicProperties
 
 
 class DeliveryModeTests(unittest.TestCase):
 
-    def test_delivery_mode_transient(self):
+    def test_delivery_mode_transient_value(self):
         self.assertEqual(DeliveryMode.Transient.value, 1)
 
-    def test_delivery_mode_persistent(self):
+    def test_delivery_mode_persistent_value(self):
         self.assertEqual(DeliveryMode.Persistent.value, 2)
+
+    def test_delivery_mode_is_int(self):
+        """DeliveryMode members must be usable as integers.
+
+        Required for compatibility with the wire encoder, which calls
+        ``struct.pack('B', delivery_mode)``.  ``struct.pack`` requires
+        ``__index__()`` on its argument; a plain ``Enum`` does not satisfy
+        this and a publish would raise ``struct.error: required argument
+        is not an integer``.
+        """
+        self.assertEqual(int(DeliveryMode.Transient), 1)
+        self.assertEqual(int(DeliveryMode.Persistent), 2)
+        # __index__ is what struct.pack calls.
+        self.assertEqual(DeliveryMode.Transient.__index__(), 1)
+        self.assertEqual(DeliveryMode.Persistent.__index__(), 2)
+        # Direct equality with int.
+        self.assertEqual(DeliveryMode.Transient, 1)
+        self.assertEqual(DeliveryMode.Persistent, 2)
+
+    def test_struct_pack_accepts_delivery_mode(self):
+        """``struct.pack('B', delivery_mode)`` must succeed - this is the
+        exact call BasicProperties.encode() makes for the delivery_mode
+        field.  A plain ``Enum`` would raise here.
+        """
+        self.assertEqual(struct.pack('B', DeliveryMode.Transient), b'\x01')
+        self.assertEqual(struct.pack('B', DeliveryMode.Persistent), b'\x02')
+
+    def test_basic_properties_encode_with_enum(self):
+        """A ``BasicProperties`` constructed with a ``DeliveryMode`` enum
+        member must encode without error.  This exercises the real
+        publish path that broke when ``DeliveryMode`` was a plain enum.
+        """
+        props = BasicProperties(delivery_mode=DeliveryMode.Persistent)
+        encoded = b''.join(props.encode())
+        self.assertIsInstance(encoded, bytes)
+        self.assertGreater(len(encoded), 0)
+
+    def test_basic_properties_encode_with_integer(self):
+        """A ``BasicProperties`` constructed with an integer delivery_mode
+        must continue to encode without error - backward compatibility for
+        callers that have not migrated to the enum.
+        """
+        props = BasicProperties(delivery_mode=2)
+        encoded = b''.join(props.encode())
+        self.assertIsInstance(encoded, bytes)
+        self.assertGreater(len(encoded), 0)
+
+    def test_basic_properties_round_trip_with_enum(self):
+        """Encoding a ``BasicProperties`` with a ``DeliveryMode`` enum
+        member and decoding it must recover the integer value.
+        """
+        original = BasicProperties(delivery_mode=DeliveryMode.Persistent)
+        encoded = b''.join(original.encode())
+        decoded = BasicProperties()
+        decoded.decode(encoded)
+        # Decode reads via struct.unpack_from which returns a raw int.
+        self.assertEqual(decoded.delivery_mode, 2)
+        # The raw int must compare equal to the enum member.
+        self.assertEqual(decoded.delivery_mode, DeliveryMode.Persistent)
+
+    def test_basic_properties_round_trip_with_integer(self):
+        """Encoding with an integer literal and decoding must recover the
+        same integer.
+        """
+        original = BasicProperties(delivery_mode=1)
+        encoded = b''.join(original.encode())
+        decoded = BasicProperties()
+        decoded.decode(encoded)
+        self.assertEqual(decoded.delivery_mode, 1)
+
+    def test_basic_properties_encode_rejects_non_integer(self):
+        """A ``BasicProperties`` constructed with a non-integer
+        delivery_mode (e.g. a string) must raise at encode time so callers
+        passing the wrong type get a useful diagnostic.
+        """
+        props = BasicProperties(delivery_mode='persistent')  # type: ignore
+        with self.assertRaises((struct.error, TypeError)):
+            b''.join(props.encode())


### PR DESCRIPTION
## Summary

`pika.DeliveryMode` was a plain `Enum`, but the wire encoder calls `struct.pack('B', delivery_mode)` which requires an integer.  Passing `DeliveryMode.Transient` or `DeliveryMode.Persistent` directly to `BasicProperties` raised `struct.error: required argument is not an integer` on every publish, on every supported Python version (3.7 through 3.14), since the enum was introduced in 2021.

`examples/publish.py`, `examples/confirmation.py`, `examples/basic_publisher_threaded.py`, and `docs/examples/comparing_publishing_sync_async.rst` all use the enum the way the documentation suggests, and all reproduce the failure.

## Changes

- `pika/delivery_mode.py`: change base class from `Enum` to `IntEnum`.  Members are now integers, satisfy `__index__()`, and work as `delivery_mode` values directly.  Existing callers passing integer literals (`delivery_mode=1`) or `DeliveryMode.Persistent.value` continue to work unchanged.
- `tests/unit/delivery_mode_test.py`: replace the two value-attribute tests with nine behavioral tests that exercise the actual usage path:
  - Integer compatibility (`int()`, `__index__()`, equality with `int`).
  - `struct.pack('B', ...)` — the exact call that broke.
  - `BasicProperties.encode()` with both the enum and an integer literal.
  - Encode/decode round-trip with both forms.
  - Negative test asserting that a non-integer `delivery_mode` (string) raises a clear error at encode time.

The previous tests only checked `DeliveryMode.Persistent.value == 2`, which is a tautology of the enum literal — they never reached the wire encoder, which is why the bug went undetected for years.

## Verification

Tested on every Python version pika supports.  All nine tests pass on each:

```
=== Python 3.7.17 ===  Ran 9 tests in 0.000s  OK
=== Python 3.8.20 ===  Ran 9 tests in 0.000s  OK
=== Python 3.9.25 ===  Ran 9 tests in 0.000s  OK
=== Python 3.10.20 === Ran 9 tests in 0.001s  OK
=== Python 3.11.15 === Ran 9 tests in 0.000s  OK
=== Python 3.12.13 === Ran 9 tests in 0.000s  OK
=== Python 3.13.13 === Ran 9 tests in 0.000s  OK
=== Python 3.14.5  === Ran 9 tests in 0.000s  OK
```

`examples/publish.py` runs cleanly with this change applied (no `struct.error`).

Full unit-test suite: 674 passed, 20 skipped (skips are pre-existing `tornado` collection issues unrelated to this change).

`hatch run typecheck`: clean.
`hatch run fmt`: no changes.

## Types of Changes

- [x] Bugfix (closes #1603)
- [ ] New feature
- [ ] Breaking change
- [x] Documentation (docstring updated to call out `IntEnum` choice)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
