### PR TITLE
Add codecov.yml to fix premature coverage reporting

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  notify:
+    wait_for_ci: true
+
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+    project:
+      default:
+        target: auto
+        threshold: 1%


### PR DESCRIPTION
## Proposed Changes

Add `codecov.yml` so Codecov waits for all CI matrix legs to complete before posting coverage results. Without this, Codecov reports as soon as the first upload arrives, producing inaccurate coverage deltas and `?` flags for jobs still in progress.

Settings added:

- `wait_for_ci: true` — holds off reporting until all CI statuses finish
- `patch.target: 100%` — new/modified lines must be fully covered
- `project.target: auto, threshold: 1%` — allows up to 1% overall coverage drop per PR

## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1611

## Further Comments
Can be added if needed 
- `carryforward: true` — reuses previous flag data if a matrix leg fails to upload
