### PR TITLE
Deprecate Tornado, Twisted, Blocking, and Gevent connection adapters

### DIFF
--- a/docs/modules/adapters/blocking.md
+++ b/docs/modules/adapters/blocking.md
@@ -1,5 +1,12 @@
 # Blocking Connection Adapter
 
+> [!WARNING]
+> `BlockingConnection` is deprecated and will be removed in Pika 2.0. Because
+> the calling thread *is* the IOLoop, any blocking user code stalls heartbeats
+> unless `process_data_events()` is called periodically, and the adapter is not
+> thread-safe. Use [`ThreadSafeConnection`](thread_safe.md) instead, which runs
+> its own IOLoop on a background thread and provides a thread-safe blocking API.
+
 ::: pika.adapters.blocking_connection
 
 Be sure to check out examples in [examples](../../examples.md).

--- a/docs/modules/adapters/gevent.md
+++ b/docs/modules/adapters/gevent.md
@@ -1,5 +1,10 @@
 # Gevent Connection Adapter
 
+> [!WARNING]
+> `GeventConnection` is deprecated and will be removed in Pika 2.0. Use
+> [`ThreadSafeConnection`](thread_safe.md) instead, which runs its own IOLoop
+> on a background thread and works with any framework, including Gevent.
+
 ::: pika.adapters.gevent_connection
 
 Be sure to check out the [asynchronous examples](../../examples.md).

--- a/docs/modules/adapters/index.md
+++ b/docs/modules/adapters/index.md
@@ -4,12 +4,23 @@ Pika uses connection adapters to provide a flexible method for adapting pika's c
 ## Adapters
 
 - [ThreadSafeConnection](thread_safe.md)
-- [BlockingConnection](blocking.md)
+- [BlockingConnection](blocking.md) *(deprecated, removed in Pika 2.0)*
 - [SelectConnection](select.md)
 - [AsyncioConnection](asyncio.md)
-- [TornadoConnection](tornado.md)
-- [TwistedProtocolConnection](twisted.md)
-- [GeventConnection](gevent.md)
+- [TornadoConnection](tornado.md) *(deprecated, removed in Pika 2.0)*
+- [TwistedProtocolConnection](twisted.md) *(deprecated, removed in Pika 2.0)*
+- [GeventConnection](gevent.md) *(deprecated, removed in Pika 2.0)*
+
+> [!WARNING]
+> `BlockingConnection`, `TornadoConnection`, `TwistedProtocolConnection`, and
+> `GeventConnection` are deprecated and will be removed in Pika 2.0. The async
+> adapters exist to integrate Pika into a framework's event loop — a constraint
+> that no longer applies — and `BlockingConnection` runs the IOLoop on the
+> calling thread, which makes heartbeats fragile and the adapter non-thread-safe.
+> [`ThreadSafeConnection`](thread_safe.md) runs its own IOLoop on a background
+> thread and works with any framework (asyncio, Tornado, Twisted, Gevent,
+> Django, Flask, or plain synchronous code) without adapter-specific
+> integration.
 
 ## Threading
 

--- a/docs/modules/adapters/tornado.md
+++ b/docs/modules/adapters/tornado.md
@@ -1,5 +1,10 @@
 # Tornado Connection Adapter
 
+> [!WARNING]
+> `TornadoConnection` is deprecated and will be removed in Pika 2.0. Use
+> [`ThreadSafeConnection`](thread_safe.md) instead, which runs its own IOLoop
+> on a background thread and works with any framework, including Tornado.
+
 ::: pika.adapters.tornado_connection
 
 Be sure to check out the [asynchronous examples](../../examples.md) including the Tornado specific [consumer](../../examples/tornado_consumer.md) example.

--- a/docs/modules/adapters/twisted.md
+++ b/docs/modules/adapters/twisted.md
@@ -1,5 +1,11 @@
 # Twisted Connection Adapter
 
+> [!WARNING]
+> `TwistedProtocolConnection` is deprecated and will be removed in Pika 2.0.
+> Use [`ThreadSafeConnection`](thread_safe.md) instead, which runs its own
+> IOLoop on a background thread and works with any framework, including
+> Twisted.
+
 ::: pika.adapters.twisted_connection
 
 ## Class Reference

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -21,6 +21,7 @@ import contextlib
 import functools
 import logging
 import threading
+import warnings
 from collections import deque, namedtuple
 from typing import TYPE_CHECKING, Any, Callable, Generator, Generic, Sequence, TypeVar
 
@@ -348,6 +349,15 @@ class BlockingConnection:
         :raises RuntimeError:
 
         """
+        warnings.warn(
+            "BlockingConnection is deprecated and will be removed in Pika 2.0. "
+            "Use ThreadSafeConnection instead, which runs its own IOLoop on a "
+            "background thread and provides a thread-safe blocking API that "
+            "does not stall heartbeats on slow message processing. See "
+            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         # Used for mutual exclusion to avoid race condition between
         # BlockingConnection._cleanup() and another thread calling
         # BlockingConnection.add_callback_threadsafe() against a closed

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -6,6 +6,7 @@ import logging
 import os
 import queue
 import threading
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import gevent  # type: ignore[import-untyped]
@@ -74,6 +75,14 @@ class GeventConnection(BaseConnection):
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory
         """
+        warnings.warn(
+            "GeventConnection is deprecated and will be removed in Pika 2.0. "
+            "Use ThreadSafeConnection instead, which works with any framework "
+            "including Gevent. See "
+            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if pika._utils.ON_WINDOWS:
             raise RuntimeError('GeventConnection is not supported on Windows.')
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 from tornado import ioloop
@@ -58,6 +59,14 @@ class TornadoConnection(base_connection.BaseConnection):
             connection workflow via the `create_connection()` factory
 
         """
+        warnings.warn(
+            "TornadoConnection is deprecated and will be removed in Pika 2.0. "
+            "Use ThreadSafeConnection instead, which works with any framework "
+            "including Tornado. See "
+            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if isinstance(custom_ioloop, nbio_interface.AbstractIOServices):
             nbio = custom_ioloop
         else:

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import functools
 import logging
+import warnings
 from collections import namedtuple
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -1247,6 +1248,14 @@ class TwistedProtocolConnection(protocol.Protocol):
     def __init__(self,
                  parameters: pika.connection.ConnectionParameters | None = None,
                  custom_reactor: Any = None):
+        warnings.warn(
+            "TwistedProtocolConnection is deprecated and will be removed in "
+            "Pika 2.0. Use ThreadSafeConnection instead, which works with any "
+            "framework including Twisted. See "
+            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.ready: defer.Deferred[Any] | None = defer.Deferred()
         self.ready.addCallback(lambda _: self.connectionReady())
         self.closed: defer.Deferred[Any] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,3 +170,6 @@ addopts = [
     "--strict-config",
     "--tb=short",
 ]
+filterwarnings = [
+    "ignore:.*will be removed in Pika 2\\.0:DeprecationWarning",
+]

--- a/tests/unit/deprecation_tests.py
+++ b/tests/unit/deprecation_tests.py
@@ -10,6 +10,24 @@ from unittest import mock
 
 from pika.adapters import blocking_connection
 
+try:
+    import tornado  # noqa: F401
+    HAS_TORNADO = True
+except ImportError:
+    HAS_TORNADO = False
+
+try:
+    import gevent  # noqa: F401
+    HAS_GEVENT = True
+except ImportError:
+    HAS_GEVENT = False
+
+try:
+    import twisted  # noqa: F401
+    HAS_TWISTED = True
+except ImportError:
+    HAS_TWISTED = False
+
 
 class DeprecationTestCase(unittest.TestCase):
     """Base class with a helper to instantiate an adapter and assert that it
@@ -44,6 +62,7 @@ class BlockingConnectionDeprecationTests(DeprecationTestCase):
                 lambda: blocking_connection.BlockingConnection('params'))
 
 
+@unittest.skipUnless(HAS_TORNADO, 'tornado not installed')
 class TornadoConnectionDeprecationTests(DeprecationTestCase):
 
     def test_init_emits_deprecation_warning(self):
@@ -54,6 +73,7 @@ class TornadoConnectionDeprecationTests(DeprecationTestCase):
                                    tornado_connection.TornadoConnection)
 
 
+@unittest.skipUnless(HAS_GEVENT, 'gevent not installed')
 @unittest.skipIf(sys.platform == 'win32',
                  'GeventConnection is not supported on Windows')
 class GeventConnectionDeprecationTests(DeprecationTestCase):
@@ -66,6 +86,7 @@ class GeventConnectionDeprecationTests(DeprecationTestCase):
                                    gevent_connection.GeventConnection)
 
 
+@unittest.skipUnless(HAS_TWISTED, 'twisted not installed')
 class TwistedProtocolConnectionDeprecationTests(DeprecationTestCase):
 
     def test_init_emits_deprecation_warning(self):

--- a/tests/unit/deprecation_tests.py
+++ b/tests/unit/deprecation_tests.py
@@ -1,0 +1,78 @@
+"""
+Tests that adapters slated for removal in Pika 2.0 emit a DeprecationWarning
+on instantiation. See https://github.com/pika/pika/issues/1608.
+
+"""
+import sys
+import unittest
+import warnings
+from unittest import mock
+
+from pika.adapters import blocking_connection
+
+
+class DeprecationTestCase(unittest.TestCase):
+    """Base class with a helper to instantiate an adapter and assert that it
+    emits a single, well-formed DeprecationWarning.
+    """
+
+    def assert_deprecated(self, adapter_name, factory):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            factory()
+
+        deprecations = [
+            w for w in caught if issubclass(w.category, DeprecationWarning)
+        ]
+        self.assertEqual(
+            len(deprecations), 1,
+            f'{adapter_name} should emit exactly one DeprecationWarning')
+
+        message = str(deprecations[0].message)
+        self.assertIn(adapter_name, message)
+        self.assertIn('Pika 2.0', message)
+        self.assertIn('ThreadSafeConnection', message)
+
+
+class BlockingConnectionDeprecationTests(DeprecationTestCase):
+
+    def test_init_emits_deprecation_warning(self):
+        with mock.patch.object(blocking_connection.BlockingConnection,
+                               '_create_connection'):
+            self.assert_deprecated(
+                'BlockingConnection',
+                lambda: blocking_connection.BlockingConnection('params'))
+
+
+class TornadoConnectionDeprecationTests(DeprecationTestCase):
+
+    def test_init_emits_deprecation_warning(self):
+        from pika.adapters import tornado_connection
+        with mock.patch('pika.adapters.base_connection.BaseConnection.__init__',
+                        return_value=None):
+            self.assert_deprecated('TornadoConnection',
+                                   tornado_connection.TornadoConnection)
+
+
+@unittest.skipIf(sys.platform == 'win32',
+                 'GeventConnection is not supported on Windows')
+class GeventConnectionDeprecationTests(DeprecationTestCase):
+
+    def test_init_emits_deprecation_warning(self):
+        from pika.adapters import gevent_connection
+        with mock.patch('pika.adapters.base_connection.BaseConnection.__init__',
+                        return_value=None):
+            self.assert_deprecated('GeventConnection',
+                                   gevent_connection.GeventConnection)
+
+
+class TwistedProtocolConnectionDeprecationTests(DeprecationTestCase):
+
+    def test_init_emits_deprecation_warning(self):
+        from pika.adapters import twisted_connection
+        self.assert_deprecated('TwistedProtocolConnection',
+                               twisted_connection.TwistedProtocolConnection)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Proposed Changes

- Emit a `DeprecationWarning` on instantiation of the three event-loop-integration connection adapters that are slated for removal in Pika 2.0:
    - `TornadoConnection`
    - `TwistedProtocolConnection`
    - `GeventConnection`
    - `BlockingConnection`

- Each warning names the replacement (`ThreadSafeConnection`), states the removal version (`Pika 2.0`), links the docs, and uses `stacklevel=2` so it points at the caller's line, not pika internals.

- **Added `tests/unit/deprecation_tests.py`** — one test per adapter (`TornadoConnection`, `TwistedProtocolConnection`, `GeventConnection`, `BlockingConnection`) asserting that instantiation emits exactly one `DeprecationWarning` whose message names `ThreadSafeConnection` and the `Pika 2.0` removal version; the Gevent case is skipped on Windows (where the adapter is unsupported).
## Types of Changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1608

## Further Comments

**End users generally will NOT see these warnings — this is expected.** Python silences `DeprecationWarning` by default *except* when it's triggered from `__main__`. So a developer who writes `TornadoConnection()` directly in their entry-point script sees it; an app that creates the connection inside an imported module (the common case) sees **nothing** unless run with `-W default` / `-Wd` / `PYTHONWARNINGS=default`; and test suites see it (pytest re-enables `DeprecationWarning` by default). This is the idiomatic, intended behavior - deprecations target *developers*.
