### PR TITLE
Fix flaky test_concurrent_publishes_all_scheduled

### DIFF
--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -496,6 +496,20 @@ class ThreadSafeChannelTests(unittest.TestCase):
         """All publishes from N threads must each schedule exactly one callback."""
         ch, _raw_ch, wrapper = self._make_channel()
         n = 20
+
+        # Count scheduled callbacks via a lock-guarded list rather than
+        # ``Mock.call_count``: the mock's internal bookkeeping is not
+        # thread-safe, so concurrent calls can lose an increment and make
+        # this assertion spuriously fail.
+        scheduled = []
+        scheduled_lock = threading.Lock()
+
+        def record(cb):
+            with scheduled_lock:
+                scheduled.append(cb)
+
+        wrapper.add_callback_threadsafe.side_effect = record
+
         barrier = threading.Barrier(n)
 
         def publish():
@@ -508,7 +522,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         for t in threads:
             t.join()
 
-        self.assertEqual(wrapper.add_callback_threadsafe.call_count, n)
+        self.assertEqual(len(scheduled), n)
 
 
 class ConsumerWorkPoolTests(unittest.TestCase):


### PR DESCRIPTION
## Proposed Changes

`test_concurrent_publishes_all_scheduled` is flaky in CI (e.g. `AssertionError: 19 != 20` on the Python 3.7 xdist workers) like [here](https://github.com/pika/pika/actions/runs/27132143418/job/80075478390?pr=1615#step:6:2902).
The test releases 20 threads simultaneously through a `threading.Barrier`, each calling `basic_publish`, then asserts on `wrapper.add_callback_threadsafe.call_count`.

The flakiness is in the test's measurement, not the code under test. `wrapper` is a `MagicMock`, and `Mock.__call__` updates `call_count` via a non-atomic read-modify-write (plus appends to several internal bookkeeping lists). When the barrier releases all threads at once, two calls into the same shared mock interleave and one increment is lost which cause the intermittent `19 != 20`. 
The production path (`ThreadSafeChannel.basic_publish`) already schedules exactly one callback per call, so nothing is actually dropped at runtime.

This counts scheduled callbacks through a lock-guarded list driven by the mock's `side_effect` instead of trusting `Mock.call_count`.

## Types of Changes

- [x] Bugfix <!-- flaky test; non-breaking -->
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works <!-- existing test made deterministic; ran 50x without failure -->
- [ ] I have added necessary documentation (if appropriate) <!-- n/a, test-only change -->