### PR TITLE
Fix: Wide typehints and docstrings

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - chore/types-and-docstrings
   pull_request:
     branches:
       - main

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - chore/types-and-docstrings
   pull_request:
     branches:
       - main

--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -41,7 +41,7 @@ def time_now() -> float:
 def as_bytes(value: str | bytes) -> bytes:
     """Returns value as bytes.
 
-    :param value: string or bytes value to convert
+    :param value: value to convert
     :rtype: bytes
     """
     if not isinstance(value, bytes):

--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -86,9 +86,9 @@ def nonblocking_socketpair(
     Returns a pair of sockets in the manner of socketpair with the additional
     feature that they will be non-blocking.
 
-    :param int family: socket family (default AF_INET)
-    :param int socket_type: socket type (default SOCK_STREAM)
-    :param int proto: socket protocol (default 0)
+    :param family: socket family (default AF_INET)
+    :param socket_type: socket type (default SOCK_STREAM)
+    :param proto: socket protocol (default 0)
     :returns: a pair of connected non-blocking sockets
     :rtype: tuple[socket.socket, socket.socket]
     """

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -97,6 +97,7 @@ class AsyncioConnection(base_connection.BaseConnection):
 
         def connection_factory(params) -> AsyncioConnection:
             """Connection factory.
+            :param params: Connection parameters
             :rtype: Self
             """
             if params is None:

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -87,10 +87,10 @@ class AsyncioConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param connection_configs: One or more connection parameter objects
-        :param on_done: Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom event loop to use for the connection workflow
-        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
+        :param asyncio.AbstractEventLoop | None custom_ioloop: Optional custom event loop to use for the connection workflow
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
@@ -130,7 +130,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
     def __init__(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
         """
-        :param loop: If None, uses the
+        :param asyncio.AbstractEventLoop | None loop: If None, uses the
             running event loop via asyncio.get_running_loop(), or creates
             a new one via asyncio.new_event_loop() when no loop is running
             (e.g. when called from a non-async thread).
@@ -174,7 +174,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.add_callback_threadsafe()`.
 
-        :param callback: The callback to call from the thread
+        :param Callable[[], None] callback: The callback to call from the thread
         """
         self._loop.call_soon_threadsafe(callback)
 
@@ -184,7 +184,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractIOServices.call_later()`.
 
         :param float delay: Delay in seconds
-        :param callback: The callback to call after the delay
+        :param Callable[[], None] callback: The callback to call after the delay
         :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback))
@@ -202,7 +202,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         :param str host: Hostname or IP address
         :param int port: TCP port number
-        :param on_done: The callback to call with the result of getaddrinfo
+        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
         :param int family: Socket address family (e.g. ``socket.AF_INET``)
         :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param int proto: Protocol number (0 for default)
@@ -222,7 +222,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
         :param int fd: File descriptor
-        :param on_readable: The callback to call when the file descriptor is readable
+        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
         """
         self._loop.add_reader(fd, on_readable)
         LOGGER.debug('set_reader(%s, _)', fd)
@@ -242,7 +242,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
         :param int fd: File descriptor
-        :param on_writable: The callback to call when the file descriptor is writable
+        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
         """
         self._loop.add_writer(fd, on_writable)
         LOGGER.debug('set_writer(%s, _)', fd)

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -91,14 +91,12 @@ class AsyncioConnection(base_connection.BaseConnection):
         :param on_done: Callback to report when connection workflow is done
         :param custom_ioloop: Optional custom event loop to use for the connection workflow
         :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
-        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
 
         def connection_factory(params) -> AsyncioConnection:
             """Connection factory.
             :param params: Connection parameters
-            :rtype: Self
             """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
@@ -148,7 +146,6 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.get_native_ioloop()`.
 
-        :rtype: asyncio.AbstractEventLoop
         """
         return self._loop
 
@@ -186,7 +183,6 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         :param delay: Delay in seconds
         :param callback: The callback to call after the delay
-        :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback))
 
@@ -208,7 +204,6 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param proto: Protocol number (0 for default)
         :param flags: :func:`socket.getaddrinfo` flags
-        :rtype: nbio_interface.AbstractIOReference
         """
         return self._schedule_and_wrap_in_io_ref(
             self._loop.getaddrinfo(host,
@@ -233,7 +228,6 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.remove_reader()`.
 
         :param fd: File descriptor
-        :rtype: bool
         """
         LOGGER.debug('remove_reader(%s)', fd)
         return self._loop.remove_reader(fd)
@@ -253,7 +247,6 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.remove_writer()`.
 
         :param fd: File descriptor
-        :rtype: bool
         """
         LOGGER.debug('remove_writer(%s)', fd)
         return self._loop.remove_writer(fd)

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -38,8 +38,8 @@ class AsyncioConnection(base_connection.BaseConnection):
         """ Create a new instance of the AsyncioConnection class, connecting
         to RabbitMQ automatically
 
-        :param pika.connection.Parameters parameters: Connection parameters
-        :param callable on_open_callback: The method to call when the connection
+        :param parameters: Connection parameters
+        :param on_open_callback: The method to call when the connection
             is open
         :param on_open_error_callback: Callback (or None) with signature
             ``(Connection, BaseException) -> None``; called if the connection
@@ -56,7 +56,7 @@ class AsyncioConnection(base_connection.BaseConnection):
             (``asyncio.AbstractEventLoop`` or
             ``nbio_interface.AbstractIOServices``). Defaults to the running event loop, or a new event
             loop when none is running.
-        :param bool internal_connection_workflow: True for autonomous connection
+        :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
 
@@ -87,10 +87,10 @@ class AsyncioConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done: Callback to report when connection workflow is done
-        :param asyncio.AbstractEventLoop|None custom_ioloop: Optional custom event loop to use for the connection workflow
-        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param connection_configs: One or more connection parameter objects
+        :param on_done: Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom event loop to use for the connection workflow
+        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
@@ -130,7 +130,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
     def __init__(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
         """
-        :param asyncio.AbstractEventLoop | None loop: If None, uses the
+        :param loop: If None, uses the
             running event loop via asyncio.get_running_loop(), or creates
             a new one via asyncio.new_event_loop() when no loop is running
             (e.g. when called from a non-async thread).
@@ -174,7 +174,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.add_callback_threadsafe()`.
 
-        :param Callable[[], None] callback: The callback to call from the thread
+        :param callback: The callback to call from the thread
         """
         self._loop.call_soon_threadsafe(callback)
 
@@ -183,8 +183,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.call_later()`.
 
-        :param float delay: Delay in seconds
-        :param Callable[[], None] callback: The callback to call after the delay
+        :param delay: Delay in seconds
+        :param callback: The callback to call after the delay
         :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback))
@@ -200,13 +200,13 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.getaddrinfo()`.
 
-        :param str host: Hostname or IP address
-        :param int port: TCP port number
-        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
-        :param int family: Socket address family (e.g. ``socket.AF_INET``)
-        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
-        :param int proto: Protocol number (0 for default)
-        :param int flags: :func:`socket.getaddrinfo` flags
+        :param host: Hostname or IP address
+        :param port: TCP port number
+        :param on_done: The callback to call with the result of getaddrinfo
+        :param family: Socket address family (e.g. ``socket.AF_INET``)
+        :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param proto: Protocol number (0 for default)
+        :param flags: :func:`socket.getaddrinfo` flags
         :rtype: nbio_interface.AbstractIOReference
         """
         return self._schedule_and_wrap_in_io_ref(
@@ -221,8 +221,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
-        :param int fd: File descriptor
-        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
+        :param fd: File descriptor
+        :param on_readable: The callback to call when the file descriptor is readable
         """
         self._loop.add_reader(fd, on_readable)
         LOGGER.debug('set_reader(%s, _)', fd)
@@ -231,7 +231,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.remove_reader()`.
 
-        :param int fd: File descriptor
+        :param fd: File descriptor
         :rtype: bool
         """
         LOGGER.debug('remove_reader(%s)', fd)
@@ -241,8 +241,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
-        :param int fd: File descriptor
-        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
+        :param fd: File descriptor
+        :param on_writable: The callback to call when the file descriptor is writable
         """
         self._loop.add_writer(fd, on_writable)
         LOGGER.debug('set_writer(%s, _)', fd)
@@ -251,7 +251,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.remove_writer()`.
 
-        :param int fd: File descriptor
+        :param fd: File descriptor
         :rtype: bool
         """
         LOGGER.debug('remove_writer(%s)', fd)
@@ -288,7 +288,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
     def __init__(self, handle: asyncio.Handle) -> None:
         """
 
-        :param asyncio.Handle handle:
+        :param handle:
         """
         self._handle: asyncio.Handle | None = handle
 
@@ -313,8 +313,8 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
                           None]
     ) -> None:
         """
-        :param asyncio.Future future:
-        :param callable on_done: user callback that takes the completion result
+        :param future:
+        :param on_done: user callback that takes the completion result
             or exception as its only arg. It will not be called if the operation
             was cancelled.
 
@@ -327,7 +327,7 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
 
         def on_done_adapter(future: asyncio.Future) -> None:
             """Handle completion callback from the future instance
-            :param asyncio.Future future: The future that completed
+            :param future: The future that completed
             """
 
             # NOTE: Asyncio schedules callback for cancelled futures, but pika

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -87,10 +87,10 @@ class AsyncioConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
-        :param asyncio.AbstractEventLoop | None custom_ioloop: Optional custom event loop to use for the connection workflow
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param connection_configs: One or more connection parameter objects
+        :param on_done: Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom event loop to use for the connection workflow
+        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
@@ -130,7 +130,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
     def __init__(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
         """
-        :param asyncio.AbstractEventLoop | None loop: If None, uses the
+        :param loop: If None, uses the
             running event loop via asyncio.get_running_loop(), or creates
             a new one via asyncio.new_event_loop() when no loop is running
             (e.g. when called from a non-async thread).
@@ -174,7 +174,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.add_callback_threadsafe()`.
 
-        :param Callable[[], None] callback: The callback to call from the thread
+        :param callback: The callback to call from the thread
         """
         self._loop.call_soon_threadsafe(callback)
 
@@ -184,7 +184,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractIOServices.call_later()`.
 
         :param float delay: Delay in seconds
-        :param Callable[[], None] callback: The callback to call after the delay
+        :param callback: The callback to call after the delay
         :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback))
@@ -202,7 +202,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         :param str host: Hostname or IP address
         :param int port: TCP port number
-        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
+        :param on_done: The callback to call with the result of getaddrinfo
         :param int family: Socket address family (e.g. ``socket.AF_INET``)
         :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param int proto: Protocol number (0 for default)
@@ -222,7 +222,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
         :param int fd: File descriptor
-        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
+        :param on_readable: The callback to call when the file descriptor is readable
         """
         self._loop.add_reader(fd, on_readable)
         LOGGER.debug('set_reader(%s, _)', fd)
@@ -242,7 +242,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
         :param int fd: File descriptor
-        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
+        :param on_writable: The callback to call when the file descriptor is writable
         """
         self._loop.add_writer(fd, on_writable)
         LOGGER.debug('set_writer(%s, _)', fd)

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -87,11 +87,18 @@ class AsyncioConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
+        :param asyncio.AbstractEventLoop | None custom_ioloop: Optional custom event loop to use for the connection workflow
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
 
-        def connection_factory(params):
-            """Connection factory."""
+        def connection_factory(params) -> AsyncioConnection:
+            """Connection factory.
+            :rtype: Self
+            """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
                                  'instance, but got None in params arg.')
@@ -121,7 +128,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
     """
 
-    def __init__(self, loop: asyncio.AbstractEventLoop | None = None):
+    def __init__(self, loop: asyncio.AbstractEventLoop | None = None) -> None:
         """
         :param asyncio.AbstractEventLoop | None loop: If None, uses the
             running event loop via asyncio.get_running_loop(), or creates
@@ -140,6 +147,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.get_native_ioloop()`.
 
+        :rtype: asyncio.AbstractEventLoop
         """
         return self._loop
 
@@ -166,6 +174,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.add_callback_threadsafe()`.
 
+        :param Callable[[], None] callback: The callback to call from the thread
         """
         self._loop.call_soon_threadsafe(callback)
 
@@ -174,6 +183,9 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.call_later()`.
 
+        :param float delay: Delay in seconds
+        :param Callable[[], None] callback: The callback to call after the delay
+        :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback))
 
@@ -188,6 +200,14 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractIOServices.getaddrinfo()`.
 
+        :param str host: Hostname or IP address
+        :param int port: TCP port number
+        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
+        :param int family: Socket address family (e.g. ``socket.AF_INET``)
+        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param int proto: Protocol number (0 for default)
+        :param int flags: :func:`socket.getaddrinfo` flags
+        :rtype: nbio_interface.AbstractIOReference
         """
         return self._schedule_and_wrap_in_io_ref(
             self._loop.getaddrinfo(host,
@@ -201,6 +221,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
+        :param int fd: File descriptor
+        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
         """
         self._loop.add_reader(fd, on_readable)
         LOGGER.debug('set_reader(%s, _)', fd)
@@ -209,6 +231,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.remove_reader()`.
 
+        :param int fd: File descriptor
+        :rtype: bool
         """
         LOGGER.debug('remove_reader(%s)', fd)
         return self._loop.remove_reader(fd)
@@ -217,6 +241,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
+        :param int fd: File descriptor
+        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
         """
         self._loop.add_writer(fd, on_writable)
         LOGGER.debug('set_writer(%s, _)', fd)
@@ -225,6 +251,8 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.utils.nbio_interface.AbstractFileDescriptorServices.remove_writer()`.
 
+        :param int fd: File descriptor
+        :rtype: bool
         """
         LOGGER.debug('remove_writer(%s)', fd)
         return self._loop.remove_writer(fd)
@@ -298,7 +326,9 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
         self._future = future
 
         def on_done_adapter(future: asyncio.Future) -> None:
-            """Handle completion callback from the future instance"""
+            """Handle completion callback from the future instance
+            :param asyncio.Future future: The future that completed
+            """
 
             # NOTE: Asyncio schedules callback for cancelled futures, but pika
             # doesn't want that

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -88,9 +88,9 @@ class AsyncioConnection(base_connection.BaseConnection):
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
         :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
-        :param asyncio.AbstractEventLoop | None custom_ioloop: Optional custom event loop to use for the connection workflow
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done: Callback to report when connection workflow is done
+        :param asyncio.AbstractEventLoop|None custom_ioloop: Optional custom event loop to use for the connection workflow
+        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -90,7 +90,8 @@ class AsyncioConnection(base_connection.BaseConnection):
         :param connection_configs: One or more connection parameter objects
         :param on_done: Callback to report when connection workflow is done
         :param custom_ioloop: Optional custom event loop to use for the connection workflow
-        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param workflow: Optional connection workflow instance to use; if None,
+            a default workflow will be created
         """
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -132,7 +132,7 @@ class BaseConnection(connection.Connection):
 
         See also `_start_connection_workflow()`.
 
-        :param sequence connection_configs: A sequence of one or more
+        :param connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects.
         :param on_done: as defined in
             `connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
@@ -163,7 +163,7 @@ class BaseConnection(connection.Connection):
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """Helper function for custom implementations of `create_connection()`.
 
-        :param sequence connection_configs: A sequence of one or more
+        :param connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects.
         :param connection_factory: A function that takes
             `pika.connection.Parameters` as its only arg and returns a brand new

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -193,7 +193,6 @@ class BaseConnection(connection.Connection):
 
         def create_connector() -> connection_workflow.AMQPConnector:
             """`AMQPConnector` factory.
-            :rtype: connection_workflow.AMQPConnector
             """
             return connection_workflow.AMQPConnector(
                 lambda params: _StreamingProtocolShim(connection_factory(params)
@@ -267,7 +266,6 @@ class BaseConnection(connection.Connection):
 
         def create_connector() -> connection_workflow.AMQPConnector:
             """`AMQPConnector` factory
-            :rtype: connection_workflow.AMQPConnector
             """
             return connection_workflow.AMQPConnector(
                 lambda _params: _StreamingProtocolShim(self), self._nbio)

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -192,7 +192,9 @@ class BaseConnection(connection.Connection):
             workflow.set_io_services(nbio)
 
         def create_connector() -> connection_workflow.AMQPConnector:
-            """`AMQPConnector` factory."""
+            """`AMQPConnector` factory.
+            :rtype: connection_workflow.AMQPConnector
+            """
             return connection_workflow.AMQPConnector(
                 lambda params: _StreamingProtocolShim(connection_factory(params)
                                                      ), nbio)
@@ -264,7 +266,9 @@ class BaseConnection(connection.Connection):
         self._connection_workflow.set_io_services(self._nbio)
 
         def create_connector() -> connection_workflow.AMQPConnector:
-            """`AMQPConnector` factory"""
+            """`AMQPConnector` factory
+            :rtype: connection_workflow.AMQPConnector
+            """
             return connection_workflow.AMQPConnector(
                 lambda _params: _StreamingProtocolShim(self), self._nbio)
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -36,20 +36,20 @@ class BaseConnection(connection.Connection):
                  internal_connection_workflow: bool = True) -> None:
         """Create a new instance of the Connection object.
 
-        :param None|pika.connection.Parameters parameters: Connection parameters
-        :param None|method on_open_callback: Method to call on connection open
-        :param None | method on_open_error_callback: Called if the connection
+        :param parameters: Connection parameters
+        :param on_open_callback: Method to call on connection open
+        :param on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`: on_open_error_callback(Connection, exception).
-        :param None | method on_close_callback: Called when a previously fully
+        :param on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the cause
             of connection failure.
-        :param pika.adapters.utils.nbio_interface.AbstractIOServices nbio:
+        :param nbio:
             asynchronous services
-        :param bool internal_connection_workflow: True for autonomous connection
+        :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
         :raises: RuntimeError
@@ -134,9 +134,9 @@ class BaseConnection(connection.Connection):
 
         :param sequence connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects.
-        :param callable on_done: as defined in
+        :param on_done: as defined in
             `connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
-        :param object | None custom_ioloop: Provide a custom I/O loop that is
+        :param custom_ioloop: Provide a custom I/O loop that is
             native to the specific adapter implementation; if None, the adapter
             will use a default loop instance, which is typically a singleton.
         :param workflow:
@@ -165,19 +165,19 @@ class BaseConnection(connection.Connection):
 
         :param sequence connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects.
-        :param callable connection_factory: A function that takes
+        :param connection_factory: A function that takes
             `pika.connection.Parameters` as its only arg and returns a brand new
             `pika.connection.Connection`-based adapter instance each time it is
             called. The factory must instantiate the connection with
             `internal_connection_workflow=False`.
-        :param pika.adapters.utils.nbio_interface.AbstractIOServices nbio:
+        :param nbio:
         :param workflow:
             Pass an instance of an implementation of the
             `connection_workflow.AbstractAMQPConnectionWorkflow` interface;
             defaults to a `connection_workflow.AMQPConnectionWorkflow` instance
             with default values for optional args. Type:
             `connection_workflow.AbstractAMQPConnectionWorkflow | None`.
-        :param callable on_done: as defined in
+        :param on_done: as defined in
             :py:meth:`connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
         :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
@@ -286,7 +286,7 @@ class BaseConnection(connection.Connection):
             shim_or_exc: _StreamingProtocolShim | Exception) -> None:
         """
 
-        :param callable user_on_done: user's `on_done` callback as defined in
+        :param user_on_done: user's `on_done` callback as defined in
             :py:meth:`connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
         :param shim_or_exc: `_StreamingProtocolShim | Exception`
         """
@@ -419,7 +419,7 @@ class BaseConnection(connection.Connection):
         """Take ownership of data and send it to AMQP server as soon as
         possible.
 
-        :param bytes data:
+        :param data:
 
         """
         assert self._transport is not None
@@ -431,7 +431,7 @@ class BaseConnection(connection.Connection):
 
         :py:class:`.utils.nbio_interface.AbstractStreamProtocol` implementation.
 
-        :param nbio_interface.AbstractStreamTransport transport:
+        :param transport:
         :raises Exception: Exception-based exception on error
 
         """
@@ -523,7 +523,7 @@ class _StreamingProtocolShim(nbio_interface.AbstractStreamProtocol):
 
     def __init__(self, conn: BaseConnection) -> None:
         """
-        :param BaseConnection conn:
+        :param conn:
         """
         self.conn = conn
 

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -36,12 +36,12 @@ class BaseConnection(connection.Connection):
                  internal_connection_workflow: bool = True) -> None:
         """Create a new instance of the Connection object.
 
-        :param parameters: Connection parameters
-        :param on_open_callback: Method to call on connection open
-        :param on_open_error_callback: Called if the connection
+        :param None|pika.connection.Parameters parameters: Connection parameters
+        :param None|method on_open_callback: Method to call on connection open
+        :param None | method on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`: on_open_error_callback(Connection, exception).
-        :param on_close_callback: Called when a previously fully
+        :param None | method on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
@@ -136,7 +136,7 @@ class BaseConnection(connection.Connection):
             `pika.connection.Parameters`-based objects.
         :param callable on_done: as defined in
             `connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
-        :param custom_ioloop: Provide a custom I/O loop that is
+        :param object | None custom_ioloop: Provide a custom I/O loop that is
             native to the specific adapter implementation; if None, the adapter
             will use a default loop instance, which is typically a singleton.
         :param workflow:

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -36,12 +36,12 @@ class BaseConnection(connection.Connection):
                  internal_connection_workflow: bool = True) -> None:
         """Create a new instance of the Connection object.
 
-        :param None|pika.connection.Parameters parameters: Connection parameters
-        :param None|method on_open_callback: Method to call on connection open
-        :param None | method on_open_error_callback: Called if the connection
+        :param parameters: Connection parameters
+        :param on_open_callback: Method to call on connection open
+        :param on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`: on_open_error_callback(Connection, exception).
-        :param None | method on_close_callback: Called when a previously fully
+        :param on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
@@ -136,7 +136,7 @@ class BaseConnection(connection.Connection):
             `pika.connection.Parameters`-based objects.
         :param callable on_done: as defined in
             `connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
-        :param object | None custom_ioloop: Provide a custom I/O loop that is
+        :param custom_ioloop: Provide a custom I/O loop that is
             native to the specific adapter implementation; if None, the adapter
             will use a default loop instance, which is typically a singleton.
         :param workflow:

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -963,7 +963,7 @@ class BlockingConnection:
         numbers.
 
         :rtype: pika.adapters.blocking_connection.BlockingChannel
-        :param int | None channel_number: optional channel number to use
+        :param int|None channel_number: optional channel number to use
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -1815,9 +1815,9 @@ class BlockingChannel:
         :param str queue: Queue name
         :param bool auto_ack: If True, the broker acknowledges messages automatically
         :param bool exclusive: If True, restrict access to the current connection
-        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
-        :param dict[str, Any] | None arguments: Custom key/value pair arguments for the consumer
-        :param None | Callable[[BlockingChannel, pika.spec.Basic.Deliver, pika.spec.BasicProperties, bytes], None] on_message_callback: Callback for delivered messages
+        :param str|None consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param dict[str,Any]|None arguments: Custom key/value pair arguments for the consumer
+        :param None|Callable[[BlockingChannel,pika.spec.Basic.Deliver,pika.spec.BasicProperties,bytes],None] on_message_callback: Callback for delivered messages
         :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
@@ -2034,7 +2034,7 @@ class BlockingChannel:
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
 
-        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param str|None consumer_tag: if specified, only the consumer with the given tag will be cancelled
         """
         if consumer_tag:
             self.basic_cancel(consumer_tag)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -620,7 +620,7 @@ class BlockingConnection:
         """Handle expiry of a timer that was registered via
         `_adapter_call_later()`
 
-        :param _TimerEvt evt:
+        :param evt:
 
         """
         self._ready_events.append(evt)
@@ -847,8 +847,8 @@ class BlockingConnection:
         """RabbitMQ AMQP extension - This method updates the secret used to authenticate this connection.
         It is used when secrets have an expiration date and need to be renewed, like OAuth 2 tokens.
 
-        :param string new_secret: The new secret
-        :param string reason: The reason for the secret update
+        :param new_secret: The new secret
+        :param reason: The reason for the secret update
 
         :raises pika.exceptions.ConnectionWrongStateError: if connection is
             not open.
@@ -1498,7 +1498,7 @@ class BlockingChannel:
         dispatch to user and signal our connection that this channel is ready
         for event dispatch
 
-        :param _ChannelPendingEvt evt: an event derived from _ChannelPendingEvt
+        :param evt: an event derived from _ChannelPendingEvt
         """
         self._pending_events.append(evt)
         self.connection._request_channel_dispatch(self.channel_number)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -46,6 +46,7 @@ import pika.validators as validators
 from pika.adapters import select_connection
 from pika.adapters.utils import connection_workflow
 from pika.exchange_type import ExchangeType
+from pika.spec import Basic
 
 if TYPE_CHECKING:
     from traceback import TracebackException
@@ -65,7 +66,7 @@ class _CallbackResult:
     """
     __slots__ = ('_ready', '_value_class', '_values')
 
-    def __init__(self, value_class: Callable[..., Any] | None = None):
+    def __init__(self, value_class: Callable[..., Any] | None = None) -> None:
         """
         :param callable value_class: only needed if the CallbackResult
                                      instance will be used with
@@ -109,7 +110,9 @@ class _CallbackResult:
 
     @property
     def ready(self) -> bool:
-        """True if the object is in a signaled state"""
+        """True if the object is in a signaled state
+        :rtype: bool
+        """
         return self._ready
 
     def signal_once(self, *_args: Any, **_kwargs: Any) -> None:
@@ -232,7 +235,7 @@ class _TimerEvt:
     """Represents a timer created via `BlockingConnection.call_later`"""
     __slots__ = ('_callback', 'timer_id')
 
-    def __init__(self, callback: Callable[..., None]):
+    def __init__(self, callback: Callable[..., None]) -> None:
         """
         :param callback: see callback in `BlockingConnection.call_later`
         """
@@ -433,6 +436,7 @@ class BlockingConnection:
         dispatcher and False if caller higher up in the call stack already owns
         it. Only managed code that gets ownership (got True) is permitted to
         dispatch
+        :rtype: Generator[bool, Any, None]
         """
         try:
             # __enter__ part
@@ -551,7 +555,7 @@ class BlockingConnection:
         #   empty outbound buffer and no waiters
         #         OR
         #   empty outbound buffer and any waiter is ready
-        def is_done():
+        def is_done() -> bool:
             return (self._closed_result.ready or
                     ((not self._impl._transport or
                       self._impl._get_write_buffer_size() == 0) and
@@ -910,7 +914,7 @@ class BlockingConnection:
         """
         with self._acquire_event_dispatch() as dispatch_acquired:
             # Check if we can actually process pending events
-            def common_terminator():
+            def common_terminator() -> bool:
                 return bool(
                     dispatch_acquired and
                     (self._channels_pending_dispatch or self._ready_events))
@@ -959,6 +963,7 @@ class BlockingConnection:
         numbers.
 
         :rtype: pika.adapters.blocking_connection.BlockingChannel
+        :param int | None channel_number: optional channel number to use
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -984,6 +989,7 @@ class BlockingConnection:
     def is_closed(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
+        :rtype: bool
         """
         return self._impl.is_closed
 
@@ -991,6 +997,7 @@ class BlockingConnection:
     def is_open(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
+        :rtype: bool
         """
         return self._impl.is_open
 
@@ -1089,8 +1096,10 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):
         return f'<{self.__class__.__name__} method_frame={self.method_frame!r}>'
 
     @property
-    def method(self):
-        """method of type spec.Basic.Cancel"""
+    def method(self) -> Basic.Cancel:
+        """method of type spec.Basic.Cancel
+        :rtype: Basic.Cancel
+        """
         return self.method_frame.method
 
 
@@ -1169,15 +1178,17 @@ class _ConsumerInfo:
     TEARING_DOWN = 3
     CANCELLED_BY_BROKER = 4
 
-    def __init__(self,
-                 consumer_tag: str,
-                 auto_ack: bool,
-                 on_message_callback: None | (Callable[[
-                     BlockingChannel, pika.spec.Basic.Deliver, pika.spec.
-                     BasicProperties, bytes
-                 ], None]) = None,
-                 alternate_event_sink: None |
-                 (Callable[[_ChannelPendingEvt], None]) = None):
+    def __init__(
+        self,
+        consumer_tag: str,
+        auto_ack: bool,
+        on_message_callback: None | (Callable[[
+            BlockingChannel, pika.spec.Basic.Deliver, pika.spec.
+            BasicProperties, bytes
+        ], None]) = None,
+        alternate_event_sink: None |
+        (Callable[[_ChannelPendingEvt], None]) = None
+    ) -> None:
         """
         NOTE: exactly one of callback/alternate_event_sink musts be non-None.
 
@@ -1208,22 +1219,30 @@ class _ConsumerInfo:
 
     @property
     def setting_up(self) -> bool:
-        """True if in SETTING_UP state"""
+        """True if in SETTING_UP state
+        :rtype: bool
+        """
         return self.state == self.SETTING_UP
 
     @property
     def active(self) -> bool:
-        """True if in ACTIVE state"""
+        """True if in ACTIVE state
+        :rtype: bool
+        """
         return self.state == self.ACTIVE
 
     @property
     def tearing_down(self) -> bool:
-        """True if in TEARING_DOWN state"""
+        """True if in TEARING_DOWN state
+        :rtype: bool
+        """
         return self.state == self.TEARING_DOWN
 
     @property
     def cancelled_by_broker(self) -> bool:
-        """True if in CANCELLED_BY_BROKER state"""
+        """True if in CANCELLED_BY_BROKER state
+        :rtype: bool
+        """
         return self.state == self.CANCELLED_BY_BROKER
 
 
@@ -1288,7 +1307,7 @@ class BlockingChannel:
     _CONSUMER_CANCELLED_CB_KEY = 'blocking_channel_consumer_cancelled'
 
     def __init__(self, channel_impl: pika.channel.Channel,
-                 connection: BlockingConnection):
+                 connection: BlockingConnection) -> None:
         """Create a new instance of the Channel
 
         :param pika.channel.Channel channel_impl: Channel implementation object
@@ -1380,12 +1399,16 @@ class BlockingChannel:
 
     @property
     def channel_number(self) -> int:
-        """Channel number"""
+        """Channel number
+        :rtype: int
+        """
         return self._impl.channel_number
 
     @property
     def connection(self) -> BlockingConnection:
-        """The channel's BlockingConnection instance"""
+        """The channel's BlockingConnection instance
+        :rtype: BlockingConnection
+        """
         return self._connection
 
     @property
@@ -1418,7 +1441,7 @@ class BlockingChannel:
 
     _ALWAYS_READY_WAITERS = ((lambda: True),)
 
-    def _flush_output(self, *waiters: Callable[[], bool]):
+    def _flush_output(self, *waiters: Callable[[], bool]) -> None:
         """ Flush output and process input while waiting for any of the given
         callbacks to return true. The wait is aborted upon channel-close or
         connection-close.
@@ -1471,7 +1494,7 @@ class BlockingChannel:
 
         self._puback_return = ReturnedMessage(method, properties, body)
 
-    def _add_pending_event(self, evt: _ChannelPendingEvt):
+    def _add_pending_event(self, evt: _ChannelPendingEvt) -> None:
         """Append an event to the channel's list of events that are ready for
         dispatch to user and signal our connection that this channel is ready
         for event dispatch
@@ -1546,7 +1569,7 @@ class BlockingChannel:
     def _on_consumer_message_delivery(self, _channel: pika.channel.Channel,
                                       method: pika.spec.Basic.Deliver,
                                       properties: pika.spec.BasicProperties,
-                                      body: bytes):
+                                      body: bytes) -> None:
         """Called by impl when a message is delivered for a consumer
 
         :param Channel _channel: The implementation channel object
@@ -1712,7 +1735,7 @@ class BlockingChannel:
                       auto_ack: bool = False,
                       exclusive: bool = False,
                       consumer_tag: str | None = None,
-                      arguments: dict[str, Any] | None = None):
+                      arguments: dict[str, Any] | None = None) -> str:
         """Sends the AMQP command Basic.Consume to the broker and binds messages
         for the consumer_tag to the consumer callback. If you do not pass in
         a consumer_tag, one will be automatically generated for you. Returns
@@ -1757,18 +1780,20 @@ class BlockingChannel:
                                         consumer_tag=consumer_tag,
                                         arguments=arguments)
 
-    def _basic_consume_impl(self,
-                            queue: str,
-                            auto_ack: bool,
-                            exclusive: bool,
-                            consumer_tag: str | None,
-                            arguments: dict[str, Any] | None = None,
-                            on_message_callback: None | (Callable[[
-                                BlockingChannel, pika.spec.Basic.Deliver, pika.
-                                spec.BasicProperties, bytes
-                            ], None]) = None,
-                            alternate_event_sink: None |
-                            (Callable[[_ChannelPendingEvt], None]) = None):
+    def _basic_consume_impl(
+        self,
+        queue: str,
+        auto_ack: bool,
+        exclusive: bool,
+        consumer_tag: str | None,
+        arguments: dict[str, Any] | None = None,
+        on_message_callback: None | (Callable[[
+            BlockingChannel, pika.spec.Basic.Deliver, pika.spec.
+            BasicProperties, bytes
+        ], None]) = None,
+        alternate_event_sink: None |
+        (Callable[[_ChannelPendingEvt], None]) = None
+    ) -> str:
         """The low-level implementation used by `basic_consume` and `consume`.
         See `basic_consume` docstring for more info.
 
@@ -1787,6 +1812,13 @@ class BlockingChannel:
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
             consumer_tag is already present.
 
+        :param str queue: Queue name
+        :param bool auto_ack: If True, the broker acknowledges messages automatically
+        :param bool exclusive: If True, restrict access to the current connection
+        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param dict[str, Any] | None arguments: Custom key/value pair arguments for the consumer
+        :param None | Callable[[BlockingChannel, pika.spec.Basic.Deliver, pika.spec.BasicProperties, bytes], None] on_message_callback: Callback for delivered messages
+        :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
             raise ValueError(
@@ -2002,6 +2034,7 @@ class BlockingChannel:
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
 
+        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
         """
         if consumer_tag:
             self.basic_cancel(consumer_tag)
@@ -2059,6 +2092,7 @@ class BlockingChannel:
             NEW in pika 0.10.0
         :raises ChannelClosed: when this channel is closed by broker.
 
+        :rtype: Generator[tuple[pika.spec.Basic.Deliver | None, pika.spec.BasicProperties | None, bytes | None]]
         """
         self._impl._raise_if_not_open()
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1802,17 +1802,17 @@ class BlockingChannel:
         This method has one additional parameter alternate_event_sink over the
         args described in `basic_consume`.
 
-        :param alternate_event_sink: if specified, _ConsumerDeliveryEvt
-            and _ConsumerCancellationEvt objects will be diverted to this
-            callback instead of being deposited in the channel's
-            `_pending_events` container. Signature:
-            alternate_event_sink(evt)
         :param queue: Queue name
         :param auto_ack: If True, the broker acknowledges messages automatically
         :param exclusive: If True, restrict access to the current connection
         :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
         :param arguments: Custom key/value pair arguments for the consumer
         :param on_message_callback: Callback for delivered messages
+        :param alternate_event_sink: if specified, _ConsumerDeliveryEvt
+            and _ConsumerCancellationEvt objects will be diverted to this
+            callback instead of being deposited in the channel's
+            `_pending_events` container. Signature:
+            alternate_event_sink(evt)
 
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
             consumer_tag is already present.

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -961,8 +961,8 @@ class BlockingConnection:
         specify but it is recommended that you let Pika manage the channel
         numbers.
 
-        :rtype: pika.adapters.blocking_connection.BlockingChannel
         :param channel_number: optional channel number to use
+        :rtype: pika.adapters.blocking_connection.BlockingChannel
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -1807,16 +1807,15 @@ class BlockingChannel:
             callback instead of being deposited in the channel's
             `_pending_events` container. Signature:
             alternate_event_sink(evt)
-
-        :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
-            consumer_tag is already present.
-
         :param queue: Queue name
         :param auto_ack: If True, the broker acknowledges messages automatically
         :param exclusive: If True, restrict access to the current connection
         :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
         :param arguments: Custom key/value pair arguments for the consumer
         :param on_message_callback: Callback for delivered messages
+
+        :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
+            consumer_tag is already present.
         :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -110,9 +110,7 @@ class _CallbackResult:
 
     @property
     def ready(self) -> bool:
-        """True if the object is in a signaled state
-        :rtype: bool
-        """
+        """True if the object is in a signaled state"""
         return self._ready
 
     def signal_once(self, *_args: Any, **_kwargs: Any) -> None:
@@ -436,7 +434,6 @@ class BlockingConnection:
         dispatcher and False if caller higher up in the call stack already owns
         it. Only managed code that gets ownership (got True) is permitted to
         dispatch
-        :rtype: Generator[bool, Any, None]
         """
         try:
             # __enter__ part
@@ -988,7 +985,6 @@ class BlockingConnection:
     def is_closed(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
-        :rtype: bool
         """
         return self._impl.is_closed
 
@@ -996,7 +992,6 @@ class BlockingConnection:
     def is_open(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
-        :rtype: bool
         """
         return self._impl.is_open
 
@@ -1097,7 +1092,6 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):
     @property
     def method(self) -> Basic.Cancel:
         """method of type spec.Basic.Cancel
-        :rtype: Basic.Cancel
         """
         return self.method_frame.method
 
@@ -1218,30 +1212,22 @@ class _ConsumerInfo:
 
     @property
     def setting_up(self) -> bool:
-        """True if in SETTING_UP state
-        :rtype: bool
-        """
+        """True if in SETTING_UP state"""
         return self.state == self.SETTING_UP
 
     @property
     def active(self) -> bool:
-        """True if in ACTIVE state
-        :rtype: bool
-        """
+        """True if in ACTIVE state"""
         return self.state == self.ACTIVE
 
     @property
     def tearing_down(self) -> bool:
-        """True if in TEARING_DOWN state
-        :rtype: bool
-        """
+        """True if in TEARING_DOWN state"""
         return self.state == self.TEARING_DOWN
 
     @property
     def cancelled_by_broker(self) -> bool:
-        """True if in CANCELLED_BY_BROKER state
-        :rtype: bool
-        """
+        """True if in CANCELLED_BY_BROKER state"""
         return self.state == self.CANCELLED_BY_BROKER
 
 
@@ -1398,15 +1384,12 @@ class BlockingChannel:
 
     @property
     def channel_number(self) -> int:
-        """Channel number
-        :rtype: int
-        """
+        """Channel number"""
         return self._impl.channel_number
 
     @property
     def connection(self) -> BlockingConnection:
         """The channel's BlockingConnection instance
-        :rtype: BlockingConnection
         """
         return self._connection
 
@@ -1816,7 +1799,6 @@ class BlockingChannel:
 
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
             consumer_tag is already present.
-        :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
             raise ValueError(
@@ -2090,7 +2072,6 @@ class BlockingChannel:
             NEW in pika 0.10.0
         :raises ChannelClosed: when this channel is closed by broker.
 
-        :rtype: Generator[tuple[pika.spec.Basic.Deliver | None, pika.spec.BasicProperties | None, bytes | None]]
         """
         self._impl._raise_if_not_open()
 

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -68,7 +68,7 @@ class _CallbackResult:
 
     def __init__(self, value_class: Callable[..., Any] | None = None) -> None:
         """
-        :param callable value_class: only needed if the CallbackResult
+        :param value_class: only needed if the CallbackResult
                                      instance will be used with
                                      `set_value_once` and `append_element`.
                                      *args and **kwargs of the value setter
@@ -202,8 +202,8 @@ class _IoloopTimerContext:
     def __init__(self, duration: float,
                  connection: select_connection.SelectConnection) -> None:
         """
-        :param float duration: non-negative timer duration in seconds
-        :param select_connection.SelectConnection connection:
+        :param duration: non-negative timer duration in seconds
+        :param connection:
         """
         assert hasattr(connection, '_adapter_call_later'), connection
         self._duration = duration
@@ -264,7 +264,7 @@ class _ConnectionBlockedUnblockedEvtBase(Generic[T]):
         :param callback: see callback parameter in
           `BlockingConnection.add_on_connection_blocked_callback` and
           `BlockingConnection.add_on_connection_unblocked_callback`
-        :param pika.frame.Method method_frame: with method_frame.method of type
+        :param method_frame: with method_frame.method of type
           `pika.spec.Connection.Blocked` or `pika.spec.Connection.Unblocked`
         """
         self._callback = callback
@@ -458,7 +458,6 @@ class BlockingConnection:
             parameters instance or non-empty sequence of them.
             Type: `None | pika.connection.Parameters | sequence`.
         :param impl_class: for tests/debugging only; implementation class.
-            Type: `None | SelectConnection`.
 
         :rtype: impl_class
 
@@ -515,7 +514,7 @@ class BlockingConnection:
             error: BaseException) -> BaseException:
         """Extract exception value from the last connection attempt
 
-        :param Exception error: error passed by the `AMQPConnectionWorkflow`
+        :param error: error passed by the `AMQPConnectionWorkflow`
             completion callback.
 
         :returns: Exception value from the last connection attempt
@@ -583,7 +582,7 @@ class BlockingConnection:
         _dispatch_events method or to terminate `process_data_events`;
         BlockingConnection will honor these requests from a safe context.
 
-        :param int channel_number: positive channel number to request a call
+        :param channel_number: positive channel number to request a call
             to the channel's `_dispatch_events`; a negative channel number to
             request termination of `process_data_events`
         """
@@ -647,10 +646,10 @@ class BlockingConnection:
     ) -> None:
         """Handle Connection.Blocked notification from RabbitMQ broker
 
-        :param callable user_callback: callback passed to
+        :param user_callback: callback passed to
            `add_on_connection_blocked_callback`
-        :param select_connection.SelectConnection _impl:
-        :param pika.frame.Method method_frame: method frame having `method`
+        :param _impl:
+        :param method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
         """
         self._ready_events.append(
@@ -664,10 +663,10 @@ class BlockingConnection:
     ) -> None:
         """Handle Connection.Unblocked notification from RabbitMQ broker
 
-        :param callable user_callback: callback passed to
+        :param user_callback: callback passed to
            `add_on_connection_unblocked_callback`
-        :param select_connection.SelectConnection _impl:
-        :param pika.frame.Method method_frame: method frame having `method`
+        :param _impl:
+        :param method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
         """
         self._ready_events.append(
@@ -719,7 +718,7 @@ class BlockingConnection:
 
         See also `ConnectionParameters.blocked_connection_timeout`.
 
-        :param callable callback: Callback to call on `Connection.Blocked`,
+        :param callback: Callback to call on `Connection.Blocked`,
             having the signature `callback(connection, pika.frame.Method)`,
             where connection is the `BlockingConnection` instance and the method
             frame's `method` member is of type `pika.spec.Connection.Blocked`
@@ -741,7 +740,7 @@ class BlockingConnection:
         connection gets unblocked (`Connection.Unblocked` frame is received from
         RabbitMQ) letting publishers know it's ok to start publishing again.
 
-        :param callable callback: Callback to call on Connection.Unblocked`,
+        :param callback: Callback to call on Connection.Unblocked`,
             having the signature `callback(connection, pika.frame.Method)`,
             where connection is the `BlockingConnection` instance and the method
             frame's `method` member is of type `pika.spec.Connection.Unblocked`
@@ -764,8 +763,8 @@ class BlockingConnection:
         `BlockingConnection.process_data_events()` and
         `BlockingChannel.start_consuming()`.
 
-        :param float delay: The number of seconds to wait to call callback
-        :param callable callback: The callback method with the signature
+        :param delay: The number of seconds to wait to call callback
+        :param callback: The callback method with the signature
             callback()
         :returns: Opaque timer id
         :rtype: int
@@ -806,7 +805,7 @@ class BlockingConnection:
         the connection it is more efficient to use the
         `BlockingConnection.call_later()` method with a delay of 0.
 
-        :param callable callback: The callback method; must be callable
+        :param callback: The callback method; must be callable
         :raises pika.exceptions.ConnectionWrongStateError: if connection is
             closed
         """
@@ -867,8 +866,8 @@ class BlockingConnection:
         have active consumers will attempt to send a Basic.Cancel to RabbitMQ
         to cleanly stop the delivery of messages prior to closing the channel.
 
-        :param int reply_code: The code number for the close
-        :param str reply_text: The text reason for the close
+        :param reply_code: The code number for the close
+        :param reply_text: The text reason for the close
 
         :raises pika.exceptions.ConnectionWrongStateError: if called on a closed
             connection (NEW in v1.0.0)
@@ -905,7 +904,7 @@ class BlockingConnection:
         should be called periodically in order to respond to heartbeats and other
         data events. See `examples/long_running_publisher.py` for an example.
 
-        :param float time_limit: suggested upper bound on processing time in
+        :param time_limit: suggested upper bound on processing time in
             seconds. The actual blocking time depends on the granularity of the
             underlying ioloop. Zero means return as soon as possible. None means
             there is no limit on processing time and the function will block
@@ -942,7 +941,7 @@ class BlockingConnection:
         connection will "sleep" or block the number of seconds specified in
         duration in small intervals.
 
-        :param float duration: The time to sleep in seconds
+        :param duration: The time to sleep in seconds
 
         """
         assert duration >= 0, duration
@@ -963,7 +962,7 @@ class BlockingConnection:
         numbers.
 
         :rtype: pika.adapters.blocking_connection.BlockingChannel
-        :param int|None channel_number: optional channel number to use
+        :param channel_number: optional channel number to use
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -1064,10 +1063,10 @@ class _ConsumerDeliveryEvt(_ChannelPendingEvt):
     def __init__(self, method: pika.spec.Basic.Deliver,
                  properties: pika.spec.BasicProperties, body: bytes) -> None:
         """
-        :param spec.Basic.Deliver method: NOTE: consumer_tag and delivery_tag
+        :param method: NOTE: consumer_tag and delivery_tag
           are valid only within source channel
-        :param spec.BasicProperties properties: message properties
-        :param bytes body: message body; empty string if no body
+        :param properties: message properties
+        :param body: message body; empty string if no body
         """
         self.method = method
         self.properties = properties
@@ -1087,7 +1086,7 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):
             self,
             method_frame: pika.frame.Method[pika.spec.Basic.Cancel]) -> None:
         """
-        :param pika.frame.Method method_frame: method frame with method of type
+        :param method_frame: method frame with method of type
             `spec.Basic.Cancel`
         """
         self.method_frame = method_frame
@@ -1114,16 +1113,16 @@ class _ReturnedMessageEvt(_ChannelPendingEvt):
     ], None], channel: BlockingChannel, method: pika.spec.Basic.Return,
                  properties: pika.spec.BasicProperties, body: bytes) -> None:
         """
-        :param callable callback: user's callback, having the signature
+        :param callback: user's callback, having the signature
             callback(channel, method, properties, body), where
              - channel: pika.Channel
              - method: pika.spec.Basic.Return
              - properties: pika.spec.BasicProperties
              - body: bytes
-        :param pika.Channel channel:
-        :param pika.spec.Basic.Return method:
-        :param pika.spec.BasicProperties properties:
-        :param bytes body:
+        :param channel:
+        :param method:
+        :param properties:
+        :param body:
         """
         self.callback = callback
         self.channel = channel
@@ -1152,9 +1151,9 @@ class ReturnedMessage:
     def __init__(self, method: pika.spec.Basic.Return,
                  properties: pika.spec.BasicProperties, body: bytes) -> None:
         """
-        :param spec.Basic.Return method:
-        :param spec.BasicProperties properties: message properties
-        :param bytes body: message body; empty string if no body
+        :param method:
+        :param properties: message properties
+        :param body: message body; empty string if no body
         """
         self.method = method
         self.properties = properties
@@ -1192,16 +1191,16 @@ class _ConsumerInfo:
         """
         NOTE: exactly one of callback/alternate_event_sink musts be non-None.
 
-        :param str consumer_tag:
-        :param bool auto_ack: the no-ack value for the consumer
-        :param callable on_message_callback: The function for dispatching messages to
+        :param consumer_tag:
+        :param auto_ack: the no-ack value for the consumer
+        :param on_message_callback: The function for dispatching messages to
             user, having the signature:
             on_message_callback(channel, method, properties, body)
              - channel: BlockingChannel
              - method: spec.Basic.Deliver
              - properties: spec.BasicProperties
              - body: bytes
-        :param callable alternate_event_sink: if specified, _ConsumerDeliveryEvt
+        :param alternate_event_sink: if specified, _ConsumerDeliveryEvt
             and _ConsumerCancellationEvt objects will be diverted to this
             callback instead of being deposited in the channel's
             `_pending_events` container. Signature:
@@ -1255,7 +1254,7 @@ class _QueueConsumerGeneratorInfo:
         """
         :params tuple params: a three-tuple (queue, auto_ack, exclusive) that were
            used to create the queue consumer
-        :param str consumer_tag: consumer tag
+        :param consumer_tag: consumer tag
         """
         self.params = params
         self.consumer_tag = consumer_tag
@@ -1310,9 +1309,9 @@ class BlockingChannel:
                  connection: BlockingConnection) -> None:
         """Create a new instance of the Channel
 
-        :param pika.channel.Channel channel_impl: Channel implementation object
+        :param channel_impl: Channel implementation object
             as returned from SelectConnection.channel()
-        :param BlockingConnection connection: The connection object
+        :param connection: The connection object
 
         """
         self._impl = channel_impl
@@ -1474,10 +1473,10 @@ class BlockingChannel:
         publisher-acknowledgements mode. Saves the info as a ReturnedMessage
         instance in self._puback_return.
 
-        :param pika.Channel channel: our self._impl channel
-        :param pika.spec.Basic.Return method:
-        :param pika.spec.BasicProperties properties: message properties
-        :param bytes body: returned message body; empty string if no body
+        :param channel: our self._impl channel
+        :param method:
+        :param properties: message properties
+        :param body: returned message body; empty string if no body
         """
         assert channel is self._impl, (channel.channel_number,
                                        self.channel_number)
@@ -1524,8 +1523,8 @@ class BlockingChannel:
 
         See `pika.Channel.add_on_close_callback()` for additional documentation.
 
-        :param pika.Channel _channel: (unused)
-        :param Exception reason:
+        :param _channel: (unused)
+        :param reason:
 
         """
         LOGGER.debug('_on_channel_closed: %r; %r', reason, self)
@@ -1549,7 +1548,7 @@ class BlockingChannel:
         of queue being consumed as well as failure of a HA node responsible for
         the queue being consumed.
 
-        :param pika.frame.Method method_frame: method frame with the
+        :param method_frame: method frame with the
             `spec.Basic.Cancel` method
 
         """
@@ -1572,10 +1571,10 @@ class BlockingChannel:
                                       body: bytes) -> None:
         """Called by impl when a message is delivered for a consumer
 
-        :param Channel _channel: The implementation channel object
-        :param spec.Basic.Deliver method:
-        :param pika.spec.BasicProperties properties: message properties
-        :param bytes body: delivered message body; empty string if no body
+        :param _channel: The implementation channel object
+        :param method:
+        :param properties: message properties
+        :param body: delivered message body; empty string if no body
         """
         evt = _ConsumerDeliveryEvt(method, properties, body)
 
@@ -1645,8 +1644,8 @@ class BlockingChannel:
               reply_text: str = "Normal shutdown") -> None:
         """Will invoke a clean shutdown of the channel with the AMQP Broker.
 
-        :param int reply_code: The reply code to close the channel with
-        :param str reply_text: The reply text to close the channel with
+        :param reply_code: The reply code to close the channel with
+        :param reply_text: The reply text to close the channel with
 
         """
         LOGGER.debug('Channel.close(%s, %s)', reply_code, reply_text)
@@ -1675,7 +1674,7 @@ class BlockingChannel:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
-        :param bool active: Turn flow on (True) or off (False)
+        :param active: Turn flow on (True) or off (False)
         :returns: True if broker will start or continue sending; False if not
         :rtype: bool
 
@@ -1694,7 +1693,7 @@ class BlockingChannel:
         is sent by the broker. The callback function should receive a method
         frame parameter.
 
-        :param callable callback: a callable for handling broker's Basic.Cancel
+        :param callback: a callable for handling broker's Basic.Cancel
             notification with the call signature: callback(method_frame)
             where method_frame is of type `pika.frame.Method` with method of
             type `spec.Basic.Cancel`
@@ -1714,7 +1713,7 @@ class BlockingChannel:
         """Pass a callback function that will be called when a published
         message is rejected and returned by the server via `Basic.Return`.
 
-        :param callable callback: The method to call on callback with the
+        :param callback: The method to call on callback with the
             signature callback(channel, method, properties, body), where
             - channel: pika.Channel
             - method: pika.spec.Basic.Return
@@ -1749,22 +1748,22 @@ class BlockingChannel:
         For more information about Basic.Consume, see:
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
-        :param str queue: The queue from which to consume
-        :param callable on_message_callback: Required function for dispatching messages
+        :param queue: The queue from which to consume
+        :param on_message_callback: Required function for dispatching messages
             to user, having the signature:
             on_message_callback(channel, method, properties, body)
             - channel: BlockingChannel
             - method: spec.Basic.Deliver
             - properties: spec.BasicProperties
             - body: bytes
-        :param bool auto_ack: if set to True, automatic acknowledgement mode will be used
+        :param auto_ack: if set to True, automatic acknowledgement mode will be used
                               (see https://www.rabbitmq.com/confirms.html). This corresponds
                               with the 'no_ack' parameter in the basic.consume AMQP 0.9.1
                               method
-        :param bool exclusive: Don't allow other consumers on the queue
-        :param str consumer_tag: You may specify your own consumer tag; if left
+        :param exclusive: Don't allow other consumers on the queue
+        :param consumer_tag: You may specify your own consumer tag; if left
           empty, a consumer tag will be generated automatically
-        :param dict arguments: Custom key/value pair arguments for the consumer
+        :param arguments: Custom key/value pair arguments for the consumer
         :returns: consumer tag
         :rtype: str
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
@@ -1803,7 +1802,7 @@ class BlockingChannel:
         This method has one additional parameter alternate_event_sink over the
         args described in `basic_consume`.
 
-        :param callable alternate_event_sink: if specified, _ConsumerDeliveryEvt
+        :param alternate_event_sink: if specified, _ConsumerDeliveryEvt
             and _ConsumerCancellationEvt objects will be diverted to this
             callback instead of being deposited in the channel's
             `_pending_events` container. Signature:
@@ -1812,12 +1811,12 @@ class BlockingChannel:
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
             consumer_tag is already present.
 
-        :param str queue: Queue name
-        :param bool auto_ack: If True, the broker acknowledges messages automatically
-        :param bool exclusive: If True, restrict access to the current connection
-        :param str|None consumer_tag: if specified, only the consumer with the given tag will be cancelled
-        :param dict[str,Any]|None arguments: Custom key/value pair arguments for the consumer
-        :param None|Callable[[BlockingChannel,pika.spec.Basic.Deliver,pika.spec.BasicProperties,bytes],None] on_message_callback: Callback for delivered messages
+        :param queue: Queue name
+        :param auto_ack: If True, the broker acknowledges messages automatically
+        :param exclusive: If True, restrict access to the current connection
+        :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param arguments: Custom key/value pair arguments for the consumer
+        :param on_message_callback: Callback for delivered messages
         :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
@@ -1887,7 +1886,7 @@ class BlockingChannel:
         a auto_ack=True consumer, this method will return any pending messages
         that arrived before broker confirmed the cancellation.
 
-        :param str consumer_tag: Identifier for the consumer; the result of
+        :param consumer_tag: Identifier for the consumer; the result of
             passing a consumer_tag that was created on another channel is
             undefined (bad things will happen)
         :returns: (NEW IN pika 0.10.0) empty sequence for a auto_ack=False
@@ -1975,7 +1974,7 @@ class BlockingChannel:
         """Extract _ConsumerDeliveryEvt objects destined for the given consumer
         from pending events, discarding the _ConsumerCancellationEvt, if any
 
-        :param str consumer_tag:
+        :param consumer_tag:
 
         :returns: a (possibly empty) sequence of _ConsumerDeliveryEvt destined
             for the given consumer tag
@@ -2034,7 +2033,7 @@ class BlockingChannel:
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
 
-        :param str|None consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
         """
         if consumer_tag:
             self.basic_cancel(consumer_tag)
@@ -2071,11 +2070,11 @@ class BlockingChannel:
         will resume the existing consumer generator; however, calling with
         different parameters will result in an exception.
 
-        :param str queue: The queue name to consume
-        :param bool auto_ack: Tell the broker to not expect a ack/nack response
-        :param bool exclusive: Don't allow other consumers on the queue
-        :param dict arguments: Custom key/value pair arguments for the consumer
-        :param float inactivity_timeout: if a number is given (in
+        :param queue: The queue name to consume
+        :param auto_ack: Tell the broker to not expect a ack/nack response
+        :param exclusive: Don't allow other consumers on the queue
+        :param arguments: Custom key/value pair arguments for the consumer
+        :param inactivity_timeout: if a number is given (in
             seconds), will cause the method to yield (None, None, None) after the
             given period of inactivity; this permits for pseudo-regular maintenance
             activities to be carried out by the user while waiting for messages
@@ -2083,7 +2082,7 @@ class BlockingChannel:
             the next event arrives. NOTE that timing granularity is limited by
             the timer resolution of the underlying implementation.
             NEW in pika 0.10.0.
-        :param str consumer_tag: Specify your own consumer tag
+        :param consumer_tag: Specify your own consumer tag
 
         :yields: tuple(spec.Basic.Deliver, spec.BasicProperties, bytes)
 
@@ -2190,7 +2189,7 @@ class BlockingChannel:
         See `BlockingConnection.process_data_events()` for documentation of args
         and behavior.
 
-        :param float time_limit:
+        :param time_limit:
 
         """
         self.connection.process_data_events(time_limit=time_limit)
@@ -2269,8 +2268,8 @@ class BlockingChannel:
         confirm mode. The acknowledgement can be for a single message or a
         set of messages up to and including a specific message.
 
-        :param int delivery_tag: The server-assigned delivery tag
-        :param bool multiple: If set to True, the delivery tag is treated as
+        :param delivery_tag: The server-assigned delivery tag
+        :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
                               to False, the delivery tag refers to a single
@@ -2289,15 +2288,15 @@ class BlockingChannel:
         It can be used to interrupt and cancel large incoming messages, or
         return untreatable messages to their original queue.
 
-        :param int delivery_tag: The server-assigned delivery tag
-        :param bool multiple: If set to True, the delivery tag is treated as
+        :param delivery_tag: The server-assigned delivery tag
+        :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
                               to False, the delivery tag refers to a single
                               message. If the multiple field is 1, and the
                               delivery tag is zero, this indicates
                               acknowledgement of all outstanding messages.
-        :param bool requeue: If requeue is true, the server will attempt to
+        :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or
                              dead-lettered.
@@ -2317,8 +2316,8 @@ class BlockingChannel:
         """Get a single message from the AMQP broker. Returns a sequence with
         the method frame, message properties, and body.
 
-        :param str queue: Name of queue from which to get a message
-        :param bool auto_ack: Tell the broker to not expect a reply
+        :param queue: Name of queue from which to get a message
+        :param auto_ack: Tell the broker to not expect a reply
         :returns: a three-tuple; (None, None, None) if the queue was empty;
             otherwise (method, properties, body); NOTE: body may be None
         :rtype: (spec.Basic.GetOk|None, spec.BasicProperties|None, bytes|None)
@@ -2359,11 +2358,11 @@ class BlockingChannel:
           synchronous implementation has no way to know how long to wait for
           the Basic.Return.
 
-        :param str exchange: The exchange to publish to
-        :param str routing_key: The routing key to bind on
-        :param bytes body: The message body; empty string if no body
-        :param pika.spec.BasicProperties properties: message properties
-        :param bool mandatory: The mandatory flag
+        :param exchange: The exchange to publish to
+        :param routing_key: The routing key to bind on
+        :param body: The message body; empty string if no body
+        :param properties: message properties
+        :param mandatory: The mandatory flag
 
         :raises UnroutableError: raised when a message published in
             publisher-acknowledgments mode (see
@@ -2432,7 +2431,7 @@ class BlockingChannel:
         following message is already held locally, rather than needing to be
         sent down the channel. Prefetching gives a performance improvement.
 
-        :param int prefetch_size:  This field specifies the prefetch window
+        :param prefetch_size:  This field specifies the prefetch window
                                    size. The server will send a message in
                                    advance if it is equal to or smaller in size
                                    than the available prefetch size (and also
@@ -2441,7 +2440,7 @@ class BlockingChannel:
                                    although other prefetch limits may still
                                    apply. The prefetch-size is ignored if the
                                    no-ack option is set in the consumer.
-        :param int prefetch_count: Specifies a prefetch window in terms of whole
+        :param prefetch_count: Specifies a prefetch window in terms of whole
                                    messages. This field may be used in
                                    combination with the prefetch-size field; a
                                    message will only be sent in advance if both
@@ -2449,7 +2448,7 @@ class BlockingChannel:
                                    and connection level) allow it. The
                                    prefetch-count is ignored if the no-ack
                                    option is set in the consumer.
-        :param bool global_qos:    Should the QoS apply to all channels on the
+        :param global_qos:    Should the QoS apply to all channels on the
                                    connection.
 
         """
@@ -2465,7 +2464,7 @@ class BlockingChannel:
         on a specified channel. Zero or more messages may be redelivered. This
         method replaces the asynchronous Recover.
 
-        :param bool requeue: If False, the message will be redelivered to the
+        :param requeue: If False, the message will be redelivered to the
                              original recipient. If True, the server will
                              attempt to requeue the message, potentially then
                              delivering it to an alternative subscriber.
@@ -2481,8 +2480,8 @@ class BlockingChannel:
         message. It can be used to interrupt and cancel large incoming messages,
         or return untreatable messages to their original queue.
 
-        :param int delivery_tag: The server-assigned delivery tag
-        :param bool requeue: If requeue is true, the server will attempt to
+        :param delivery_tag: The server-assigned delivery tag
+        :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or
                              dead-lettered.
@@ -2535,15 +2534,15 @@ class BlockingChannel:
         exchange does not already exist, the server MUST raise a channel
         exception with reply code 404 (not found).
 
-        :param str exchange: The exchange name consists of a non-empty sequence of
+        :param exchange: The exchange name consists of a non-empty sequence of
                           these characters: letters, digits, hyphen, underscore,
                           period, or colon.
-        :param str exchange_type: The exchange type to use
-        :param bool passive: Perform a declare or just check to see if it exists
-        :param bool durable: Survive a reboot of RabbitMQ
-        :param bool auto_delete: Remove when no more queues are bound to it
-        :param bool internal: Can only be published to by other exchanges
-        :param dict arguments: Custom key/value pair arguments for the exchange
+        :param exchange_type: The exchange type to use
+        :param passive: Perform a declare or just check to see if it exists
+        :param durable: Survive a reboot of RabbitMQ
+        :param auto_delete: Remove when no more queues are bound to it
+        :param internal: Can only be published to by other exchanges
+        :param arguments: Custom key/value pair arguments for the exchange
         :returns: Method frame from the Exchange.Declare-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
             `spec.Exchange.DeclareOk`
@@ -2571,8 +2570,8 @@ class BlockingChannel:
                        ) -> pika.frame.Method[pika.spec.Exchange.DeleteOk]:
         """Delete the exchange.
 
-        :param str exchange: The exchange name
-        :param bool if_unused: only delete if the exchange is unused
+        :param exchange: The exchange name
+        :param if_unused: only delete if the exchange is unused
         :returns: Method frame from the Exchange.Delete-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
             `spec.Exchange.DeleteOk`
@@ -2596,10 +2595,10 @@ class BlockingChannel:
     ) -> pika.frame.Method[pika.spec.Exchange.BindOk]:
         """Bind an exchange to another exchange.
 
-        :param str destination: The destination exchange to bind
-        :param str source: The source exchange to bind to
-        :param str routing_key: The routing key to bind on
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param destination: The destination exchange to bind
+        :param source: The source exchange to bind to
+        :param routing_key: The routing key to bind on
+        :param arguments: Custom key/value pair arguments for the binding
         :returns: Method frame from the Exchange.Bind-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
           `spec.Exchange.BindOk`
@@ -2627,10 +2626,10 @@ class BlockingChannel:
     ) -> pika.frame.Method[pika.spec.Exchange.UnbindOk]:
         """Unbind an exchange from another exchange.
 
-        :param str destination: The destination exchange to unbind
-        :param str source: The source exchange to unbind from
-        :param str routing_key: The routing key to unbind
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param destination: The destination exchange to unbind
+        :param source: The source exchange to unbind from
+        :param routing_key: The routing key to unbind
+        :param arguments: Custom key/value pair arguments for the binding
         :returns: Method frame from the Exchange.Unbind-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
             `spec.Exchange.UnbindOk`
@@ -2665,14 +2664,14 @@ class BlockingChannel:
         one. Retrieve this auto-generated queue name from the returned
         `spec.Queue.DeclareOk` method frame.
 
-        :param str queue: The queue name; if empty string, the broker will
+        :param queue: The queue name; if empty string, the broker will
             create a unique queue name
-        :param bool passive: Only check to see if the queue exists and raise
+        :param passive: Only check to see if the queue exists and raise
           `ChannelClosed` if it doesn't
-        :param bool durable: Survive reboots of the broker
-        :param bool exclusive: Only allow access by the current connection
-        :param bool auto_delete: Delete after consumer cancels or disconnects
-        :param dict arguments: Custom key/value arguments for the queue
+        :param durable: Survive reboots of the broker
+        :param exclusive: Only allow access by the current connection
+        :param auto_delete: Delete after consumer cancels or disconnects
+        :param arguments: Custom key/value arguments for the queue
         :returns: Method frame from the Queue.Declare-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
             `spec.Queue.DeclareOk`
@@ -2699,9 +2698,9 @@ class BlockingChannel:
                     ) -> pika.frame.Method[pika.spec.Queue.DeleteOk]:
         """Delete a queue from the broker.
 
-        :param str queue: The queue to delete
-        :param bool if_unused: only delete if it's unused
-        :param bool if_empty: only delete if the queue is empty
+        :param queue: The queue to delete
+        :param if_unused: only delete if it's unused
+        :param if_empty: only delete if the queue is empty
         :returns: Method frame from the Queue.Delete-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
             `spec.Queue.DeleteOk`
@@ -2721,7 +2720,7 @@ class BlockingChannel:
                     queue: str) -> pika.frame.Method[pika.spec.Queue.PurgeOk]:
         """Purge all of the messages from the specified queue
 
-        :param str queue: The queue to purge
+        :param queue: The queue to purge
         :returns: Method frame from the Queue.Purge-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
             `spec.Queue.PurgeOk`
@@ -2743,10 +2742,10 @@ class BlockingChannel:
     ) -> pika.frame.Method[pika.spec.Queue.BindOk]:
         """Bind the queue to the specified exchange
 
-        :param str queue: The queue to bind to the exchange
-        :param str exchange: The source exchange to bind to
-        :param str routing_key: The routing key to bind on
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param queue: The queue to bind to the exchange
+        :param exchange: The source exchange to bind to
+        :param routing_key: The routing key to bind on
+        :param arguments: Custom key/value pair arguments for the binding
 
         :returns: Method frame from the Queue.Bind-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type
@@ -2774,10 +2773,10 @@ class BlockingChannel:
     ) -> pika.frame.Method[pika.spec.Queue.UnbindOk]:
         """Unbind a queue from an exchange.
 
-        :param str queue: The queue to unbind from the exchange
-        :param str exchange: The source exchange to bind from
-        :param str routing_key: The routing key to unbind
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param queue: The queue to unbind from the exchange
+        :param exchange: The source exchange to bind from
+        :param routing_key: The routing key to unbind
+        :param arguments: Custom key/value pair arguments for the binding
 
         :returns: Method frame from the Queue.Unbind-ok response
         :rtype: `pika.frame.Method` having `method` attribute of type

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -963,7 +963,7 @@ class BlockingConnection:
         numbers.
 
         :rtype: pika.adapters.blocking_connection.BlockingChannel
-        :param channel_number: optional channel number to use
+        :param int | None channel_number: optional channel number to use
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -1815,9 +1815,9 @@ class BlockingChannel:
         :param str queue: Queue name
         :param bool auto_ack: If True, the broker acknowledges messages automatically
         :param bool exclusive: If True, restrict access to the current connection
-        :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
-        :param arguments: Custom key/value pair arguments for the consumer
-        :param on_message_callback: Callback for delivered messages
+        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param dict[str, Any] | None arguments: Custom key/value pair arguments for the consumer
+        :param None | Callable[[BlockingChannel, pika.spec.Basic.Deliver, pika.spec.BasicProperties, bytes], None] on_message_callback: Callback for delivered messages
         :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
@@ -2034,7 +2034,7 @@ class BlockingChannel:
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
 
-        :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
         """
         if consumer_tag:
             self.basic_cancel(consumer_tag)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -963,7 +963,7 @@ class BlockingConnection:
         numbers.
 
         :rtype: pika.adapters.blocking_connection.BlockingChannel
-        :param int | None channel_number: optional channel number to use
+        :param channel_number: optional channel number to use
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -1815,9 +1815,9 @@ class BlockingChannel:
         :param str queue: Queue name
         :param bool auto_ack: If True, the broker acknowledges messages automatically
         :param bool exclusive: If True, restrict access to the current connection
-        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
-        :param dict[str, Any] | None arguments: Custom key/value pair arguments for the consumer
-        :param None | Callable[[BlockingChannel, pika.spec.Basic.Deliver, pika.spec.BasicProperties, bytes], None] on_message_callback: Callback for delivered messages
+        :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param arguments: Custom key/value pair arguments for the consumer
+        :param on_message_callback: Callback for delivered messages
         :rtype: str
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
@@ -2034,7 +2034,7 @@ class BlockingChannel:
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
 
-        :param str | None consumer_tag: if specified, only the consumer with the given tag will be cancelled
+        :param consumer_tag: if specified, only the consumer with the given tag will be cancelled
         """
         if consumer_tag:
             self.basic_cancel(consumer_tag)

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -114,14 +114,21 @@ class GeventConnection(BaseConnection):
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
+        :param gevent._interfaces.ILoop | None custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         custom_ioloop = (custom_ioloop or
                          _GeventSelectorIOLoop(gevent.get_hub()))
 
         nbio = _GeventSelectorIOServicesAdapter(custom_ioloop)
 
-        def connection_factory(params):
-            """Connection factory."""
+        def connection_factory(params) -> GeventConnection:
+            """Connection factory.
+            :rtype: Self
+            """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
                                  'instance, but got None in params arg.')
@@ -157,7 +164,9 @@ class _TSafeCallbackQueue:
 
     @property
     def fd(self) -> int:
-        """The file-descriptor to register for READ events in the IO loop."""
+        """The file-descriptor to register for READ events in the IO loop.
+        :rtype: int
+        """
         return self._read_fd
 
     def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
@@ -216,7 +225,7 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         # For adding callbacks from other threads. See `add_callback(..)`.
         self._callback_queue = _TSafeCallbackQueue()
 
-        def run_callback_in_main_thread(fd, events):
+        def run_callback_in_main_thread(fd, events) -> None:
             """Swallow the fd and events arguments."""
             del fd
             del events
@@ -351,6 +360,14 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
                     proto: int = 0,
                     flags: int = 0) -> nbio_interface.AbstractIOReference:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
+        :param str host: Hostname or IP address
+        :param int port: TCP port number
+        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
+        :param int family: Socket address family (e.g. ``socket.AF_INET``)
+        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param int proto: Protocol number (0 for default)
+        :param int flags: :func:`socket.getaddrinfo` flags
+        :rtype: nbio_interface.AbstractIOReference
         """
         resolver = _GeventAddressResolver(native_loop=self._loop,
                                           host=host,

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -55,15 +55,15 @@ class GeventConnection(BaseConnection):
         """Create a new GeventConnection instance and connect to RabbitMQ on
         Gevent's event-loop.
 
-        :param parameters: The connection
+        :param pika.connection.Parameters|None parameters: The connection
             parameters
-        :param on_open_callback: The method to call when the
+        :param callable|None on_open_callback: The method to call when the
             connection is open
-        :param on_open_error_callback: Called if the connection
+        :param callable|None on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`:
             on_open_error_callback(Connection, exception)
-        :param on_close_callback: Called when a previously fully
+        :param callable|None on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
@@ -114,10 +114,10 @@ class GeventConnection(BaseConnection):
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
-        :param connection_configs: One or more connection parameter objects
-        :param on_done: Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
-        :param workflow: Optional connection workflow instance to use
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
+        :param gevent._interfaces.ILoop | None custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         custom_ioloop = (custom_ioloop or
@@ -362,7 +362,7 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
         :param str host: Hostname or IP address
         :param int port: TCP port number
-        :param on_done: The callback to call with the result of getaddrinfo
+        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
         :param int family: Socket address family (e.g. ``socket.AF_INET``)
         :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param int proto: Protocol number (0 for default)

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -115,9 +115,9 @@ class GeventConnection(BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
         :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
-        :param gevent._interfaces.ILoop | None custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done: Callback to report when connection workflow is done
+        :param gevent._interfaces.ILoop|None custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
+        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         custom_ioloop = (custom_ioloop or

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -115,7 +115,9 @@ class GeventConnection(BaseConnection):
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
         :param connection_configs: One or more connection parameter objects
         :param on_done: Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
+        :param custom_ioloop: Optional custom Gevent ILoop to use for the
+            connection workflow; if None, a new _GeventSelectorIOLoop will be
+            created
         :param workflow: Optional connection workflow instance to use
         """
         custom_ioloop = (custom_ioloop or

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -117,7 +117,6 @@ class GeventConnection(BaseConnection):
         :param on_done: Callback to report when connection workflow is done
         :param custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
         :param workflow: Optional connection workflow instance to use
-        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         custom_ioloop = (custom_ioloop or
                          _GeventSelectorIOLoop(gevent.get_hub()))
@@ -128,7 +127,6 @@ class GeventConnection(BaseConnection):
             """Connection factory.
 
             :param params: Connection parameters
-            :rtype: Self
             """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
@@ -165,9 +163,7 @@ class _TSafeCallbackQueue:
 
     @property
     def fd(self) -> int:
-        """The file-descriptor to register for READ events in the IO loop.
-        :rtype: int
-        """
+        """The file-descriptor to register for READ events in the IO loop."""
         return self._read_fd
 
     def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
@@ -368,7 +364,6 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
         :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param proto: Protocol number (0 for default)
         :param flags: :func:`socket.getaddrinfo` flags
-        :rtype: nbio_interface.AbstractIOReference
         """
         resolver = _GeventAddressResolver(native_loop=self._loop,
                                           host=host,

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -55,23 +55,22 @@ class GeventConnection(BaseConnection):
         """Create a new GeventConnection instance and connect to RabbitMQ on
         Gevent's event-loop.
 
-        :param pika.connection.Parameters|None parameters: The connection
+        :param parameters: The connection
             parameters
-        :param callable|None on_open_callback: The method to call when the
+        :param on_open_callback: The method to call when the
             connection is open
-        :param callable|None on_open_error_callback: Called if the connection
+        :param on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`:
             on_open_error_callback(Connection, exception)
-        :param callable|None on_close_callback: Called when a previously fully
+        :param on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the
             cause of connection failure
-        :param custom_ioloop: Use a custom Gevent ILoop.
-            Type: `gevent._interfaces.ILoop | nbio_interface.AbstractIOServices | None`.
-        :param bool internal_connection_workflow: True for autonomous connection
+        :param Type: `gevent._interfaces.ILoop | nbio_interface.AbstractIOServices | None`.
+        :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory
         """
@@ -114,10 +113,10 @@ class GeventConnection(BaseConnection):
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done: Callback to report when connection workflow is done
-        :param gevent._interfaces.ILoop|None custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
-        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :param connection_configs: One or more connection parameter objects
+        :param on_done: Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
+        :param workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         custom_ioloop = (custom_ioloop or
@@ -215,7 +214,7 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
 
     def __init__(self, gevent_hub: gevent.hub.Hub | None = None) -> None:
         """
-        :param gevent.hub.Hub gevent_hub: Gevent hub to use.
+        :param gevent_hub: Gevent hub to use.
         """
         self._hub = gevent_hub or gevent.get_hub()
         self._io_watchers_by_fd: dict[int, Any] = {}
@@ -270,7 +269,7 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         ioloop that is running in a different thread via
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
-        :param callable callback: The callback method
+        :param callback: The callback method
         """
         if gevent.get_hub() == self._hub:
             # We're in the main thread; just add the callback.
@@ -292,8 +291,8 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         from the time of call on best-effort basis. Returns a handle to the
         timeout.
 
-        :param float delay: The number of seconds to wait to call callback
-        :param callable callback: The callback method
+        :param delay: The number of seconds to wait to call callback
+        :param callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
         :rtype: object
@@ -314,10 +313,10 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
                     events: int) -> None:
         """Start watching the given file descriptor for events
 
-        :param int fd: The file descriptor
-        :param callable handler: When requested event(s) occur,
+        :param fd: The file descriptor
+        :param handler: When requested event(s) occur,
             `handler(fd, events)` will be called.
-        :param int events: The event mask (READ|WRITE)
+        :param events: The event mask (READ|WRITE)
         """
         io_watcher = self._hub.loop.io(
             fd, events)  # pyright: ignore[reportOptionalMemberAccess]
@@ -327,8 +326,8 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
     def update_handler(self, fd: int, events: int) -> None:
         """Change the events being watched for.
 
-        :param int fd: The file descriptor
-        :param int events: The new event mask (READ|WRITE)
+        :param fd: The file descriptor
+        :param events: The new event mask (READ|WRITE)
         """
         io_watcher = self._io_watchers_by_fd[fd]
         # Save callback from the original watcher. The close the old watcher
@@ -341,7 +340,7 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
     def remove_handler(self, fd: int) -> None:
         """Stop watching the given file descriptor for events
 
-        :param int fd: The file descriptor
+        :param fd: The file descriptor
         """
         io_watcher = self._io_watchers_by_fd[fd]
         io_watcher.close()
@@ -360,13 +359,13 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
                     proto: int = 0,
                     flags: int = 0) -> nbio_interface.AbstractIOReference:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
-        :param str host: Hostname or IP address
-        :param int port: TCP port number
-        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
-        :param int family: Socket address family (e.g. ``socket.AF_INET``)
-        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
-        :param int proto: Protocol number (0 for default)
-        :param int flags: :func:`socket.getaddrinfo` flags
+        :param host: Hostname or IP address
+        :param port: TCP port number
+        :param on_done: The callback to call with the result of getaddrinfo
+        :param family: Socket address family (e.g. ``socket.AF_INET``)
+        :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param proto: Protocol number (0 for default)
+        :param flags: :func:`socket.getaddrinfo` flags
         :rtype: nbio_interface.AbstractIOReference
         """
         resolver = _GeventAddressResolver(native_loop=self._loop,
@@ -427,7 +426,7 @@ class _GeventAddressResolver:
                  on_done: Callable[..., None]) -> None:
         """Initialize the `_GeventAddressResolver`.
 
-        :param AbstractSelectorIOLoop native_loop:
+        :param native_loop:
         :param host: `see socket.getaddrinfo()`
         :param port: `see socket.getaddrinfo()`
         :param family: `see socket.getaddrinfo()`

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -126,6 +126,8 @@ class GeventConnection(BaseConnection):
 
         def connection_factory(params) -> GeventConnection:
             """Connection factory.
+
+            :param params: Connection parameters
             :rtype: Self
             """
             if params is None:

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -69,7 +69,7 @@ class GeventConnection(BaseConnection):
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the
             cause of connection failure
-        :param Type: `gevent._interfaces.ILoop | nbio_interface.AbstractIOServices | None`.
+        :param custom_ioloop: Use a custom Gevent ILoop
         :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -55,15 +55,15 @@ class GeventConnection(BaseConnection):
         """Create a new GeventConnection instance and connect to RabbitMQ on
         Gevent's event-loop.
 
-        :param pika.connection.Parameters|None parameters: The connection
+        :param parameters: The connection
             parameters
-        :param callable|None on_open_callback: The method to call when the
+        :param on_open_callback: The method to call when the
             connection is open
-        :param callable|None on_open_error_callback: Called if the connection
+        :param on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`:
             on_open_error_callback(Connection, exception)
-        :param callable|None on_close_callback: Called when a previously fully
+        :param on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
@@ -114,10 +114,10 @@ class GeventConnection(BaseConnection):
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
-        :param gevent._interfaces.ILoop | None custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :param connection_configs: One or more connection parameter objects
+        :param on_done: Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom Gevent ILoop to use for the connection workflow; if None, a new _GeventSelectorIOLoop will be created
+        :param workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         custom_ioloop = (custom_ioloop or
@@ -362,7 +362,7 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
         :param str host: Hostname or IP address
         :param int port: TCP port number
-        :param Callable[..., None] on_done: The callback to call with the result of getaddrinfo
+        :param on_done: The callback to call with the result of getaddrinfo
         :param int family: Socket address family (e.g. ``socket.AF_INET``)
         :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param int proto: Protocol number (0 for default)

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -74,7 +74,6 @@ def _is_resumable(exc: SELECT_ERROR_T) -> bool:
     """Check if caught exception represents EINTR error.
     :param exc: exception; must be one of classes in _SELECT_ERRORS
 
-    :rtype: bool
     """
     checker = _SELECT_ERROR_CHECKERS.get(exc.__class__, None)
     if checker is not None:
@@ -153,14 +152,12 @@ class SelectConnection(BaseConnection):
         :param on_done: Callback to report when connection workflow is done
         :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
         :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
-        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())
 
         def connection_factory(params) -> SelectConnection:
             """Connection factory.
             :param params: Connection parameters
-            :rtype: Self
             """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
@@ -979,7 +976,6 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         from another thread. Socketpair() is not supported on some OS (Win)
         so use a pair of simple TCP sockets instead. The sockets will be
         closed and garbage collected by python when the ioloop itself is.
-        :rtype: tuple[socket.socket, socket.socket]
         """
         return pika._utils.nonblocking_socketpair()
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -151,9 +151,9 @@ class SelectConnection(BaseConnection):
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
         :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
-        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done: Callback to report when connection workflow is done
+        :param Any|None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -116,7 +116,7 @@ class SelectConnection(BaseConnection):
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the cause
             of connection failure.
-        :param Type: `None | IOLoop | nbio_interface.AbstractIOServices`.
+        :param custom_ioloop: Provide a custom I/O Loop object.
         :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -103,8 +103,8 @@ class SelectConnection(BaseConnection):
                  internal_connection_workflow: bool = True) -> None:
         """Create a new instance of the Connection object.
 
-        :param pika.connection.Parameters parameters: Connection parameters
-        :param callable on_open_callback: Method to call on connection open
+        :param parameters: Connection parameters
+        :param on_open_callback: Method to call on connection open
         :param on_open_error_callback: Callback (or None) with signature
             ``(Connection, BaseException) -> None``; called if the connection
             can't be established or connection establishment is interrupted by
@@ -116,9 +116,8 @@ class SelectConnection(BaseConnection):
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the cause
             of connection failure.
-        :param custom_ioloop: Provide a custom I/O Loop object.
-            Type: `None | IOLoop | nbio_interface.AbstractIOServices`.
-        :param bool internal_connection_workflow: True for autonomous connection
+        :param Type: `None | IOLoop | nbio_interface.AbstractIOServices`.
+        :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
         :raises RuntimeError:
@@ -150,10 +149,10 @@ class SelectConnection(BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done: Callback to report when connection workflow is done
-        :param Any|None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param connection_configs: One or more connection parameter objects
+        :param on_done: Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())
@@ -195,8 +194,8 @@ class _Timeout:
 
     def __init__(self, deadline: float, callback: Callable[[], None]) -> None:
         """
-        :param float deadline: timer expiration as non-negative epoch number
-        :param callable callback: callback to call when timeout expires
+        :param deadline: timer expiration as non-negative epoch number
+        :param callback: callback to call when timeout expires
         :raises ValueError, TypeError:
         """
 
@@ -280,9 +279,9 @@ class _Timer:
         NOTE: you may cancel the timer before dispatch of the callback. Timer
             Manager cancels the timer upon dispatch of the callback.
 
-        :param float delay: Non-negative number of seconds from now until
+        :param delay: Non-negative number of seconds from now until
             expiration
-        :param callable callback: The callback method, having the signature
+        :param callback: The callback method, having the signature
             `callback()`
 
         :rtype: _Timeout
@@ -484,8 +483,8 @@ class IOLoop(AbstractSelectorIOLoop):
         from the time of call on best-effort basis. Returns a handle to the
         timeout.
 
-        :param float delay: The number of seconds to wait to call callback
-        :param callable callback: The callback method
+        :param delay: The number of seconds to wait to call callback
+        :param callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
         :rtype: object
@@ -512,7 +511,7 @@ class IOLoop(AbstractSelectorIOLoop):
         ioloop that is running in a different thread via
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
-        :param callable callback: The callback method
+        :param callback: The callback method
 
         """
         if not callable(callback):
@@ -562,10 +561,10 @@ class IOLoop(AbstractSelectorIOLoop):
                     events: int) -> None:
         """Start watching the given file descriptor for events
 
-        :param int fd: The file descriptor
-        :param callable handler: When requested event(s) occur,
+        :param fd: The file descriptor
+        :param handler: When requested event(s) occur,
             `handler(fd, events)` will be called.
-        :param int events: The event mask using READ, WRITE, ERROR.
+        :param events: The event mask using READ, WRITE, ERROR.
 
         """
         self._poller.add_handler(fd, handler, events)
@@ -573,8 +572,8 @@ class IOLoop(AbstractSelectorIOLoop):
     def update_handler(self, fd: int, events: int) -> None:
         """Changes the events we watch for
 
-        :param int fd: The file descriptor
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fd: The file descriptor
+        :param events: The event mask using READ, WRITE, ERROR
 
         """
         self._poller.update_handler(fd, events)
@@ -582,7 +581,7 @@ class IOLoop(AbstractSelectorIOLoop):
     def remove_handler(self, fd: int) -> None:
         """Stop watching the given file descriptor for events
 
-        :param int fd: The file descriptor
+        :param fd: The file descriptor
 
         """
         self._poller.remove_handler(fd)
@@ -749,9 +748,9 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                     events: int) -> None:
         """Add a new fileno to the set to be monitored
 
-        :param int fileno: The file descriptor
-        :param callable handler: What is called when an event happens
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fileno: The file descriptor
+        :param handler: What is called when an event happens
+        :param events: The event mask using READ, WRITE, ERROR
 
         """
         assert self._fd_handlers is not None
@@ -765,8 +764,8 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def update_handler(self, fileno: int, events: int) -> None:
         """Set the events to the current events
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fileno: The file descriptor
+        :param events: The event mask using READ, WRITE, ERROR
 
         """
         # Record the change
@@ -781,7 +780,7 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def remove_handler(self, fileno: int) -> None:
         """Remove a file descriptor from the set
 
-        :param int fileno: The file descriptor
+        :param fileno: The file descriptor
 
         """
         assert self._fd_handlers is not None
@@ -802,8 +801,8 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Set the handler's events to the given events; internal to
         `_PollerBase`.
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events: The event mask (READ, WRITE, ERROR)
 
         :returns: a 2-tuple (events_cleared, events_set)
         :rtype: tuple
@@ -906,8 +905,8 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         register the file descriptor with the polling object. The request must
         be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events: The event mask (READ, WRITE, ERROR)
         """
         raise NotImplementedError
 
@@ -918,10 +917,10 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         modify an already registered file descriptor. The request must be
         ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: absolute events (READ, WRITE, ERROR)
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
-        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events: absolute events (READ, WRITE, ERROR)
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param events_to_set: The events to set (READ, WRITE, ERROR)
         """
         raise NotImplementedError
 
@@ -931,8 +930,8 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         unregister the file descriptor being tracked by the polling object. The
         request must be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
         """
         raise NotImplementedError
 
@@ -947,7 +946,7 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         fileno during processing of another callback and not generate
         spurious callbacks on it.
 
-        :param dict fd_event_map: Map of fds to events received on them.
+        :param fd_event_map: Map of fds to events received on them.
         """
         assert self._processing_fd_event_map is not None
         assert self._fd_events is not None
@@ -987,8 +986,8 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """ Read the interrupt byte(s). We ignore the event mask as we can ony
         get here if there's data to be read on our fd.
 
-        :param int _interrupt_fd: (unused) The file descriptor to read from
-        :param int _events: (unused) The events generated for this fd
+        :param _interrupt_fd: (unused) The file descriptor to read from
+        :param _events: (unused) The events generated for this fd
         """
         assert self._r_interrupt is not None
         try:
@@ -1060,8 +1059,8 @@ class SelectPoller(_PollerBase):
         register the file descriptor with the polling object. The request must
         be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fileno: The file descriptor
+        :param events: The event mask using READ, WRITE, ERROR
         """
         # It's a no op in SelectPoller
 
@@ -1071,10 +1070,10 @@ class SelectPoller(_PollerBase):
         modify an already registered file descriptor. The request must be
         ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: absolute events (READ, WRITE, ERROR)
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
-        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events: absolute events (READ, WRITE, ERROR)
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param events_to_set: The events to set (READ, WRITE, ERROR)
         """
         # It's a no op in SelectPoller
 
@@ -1083,8 +1082,8 @@ class SelectPoller(_PollerBase):
         unregister the file descriptor being tracked by the polling object. The
         request must be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
         """
         # It's a no op in SelectPoller
 
@@ -1168,8 +1167,8 @@ class KQueuePoller(_PollerBase):
         register the file descriptor with the polling object. The request must
         be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fileno: The file descriptor
+        :param events: The event mask using READ, WRITE, ERROR
         """
         self._modify_fd_events(fileno,
                                events=events,
@@ -1182,10 +1181,10 @@ class KQueuePoller(_PollerBase):
         modify an already registered file descriptor. The request must be
         ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: absolute events (READ, WRITE, ERROR)
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
-        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events: absolute events (READ, WRITE, ERROR)
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param events_to_set: The events to set (READ, WRITE, ERROR)
         """
         if self._kqueue is None:
             return
@@ -1232,8 +1231,8 @@ class KQueuePoller(_PollerBase):
         unregister the file descriptor being tracked by the polling object. The
         request must be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
         """
         self._modify_fd_events(fileno,
                                events=0,
@@ -1311,8 +1310,8 @@ class PollPoller(_PollerBase):
         register the file descriptor with the polling object. The request must
         be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fileno: The file descriptor
+        :param events: The event mask using READ, WRITE, ERROR
         """
         if self._poll is not None:
             self._poll.register(fileno, events)
@@ -1323,10 +1322,10 @@ class PollPoller(_PollerBase):
         modify an already registered file descriptor. The request must be
         ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events: absolute events (READ, WRITE, ERROR)
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
-        :param int events_to_set: The events to set (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events: absolute events (READ, WRITE, ERROR)
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param events_to_set: The events to set (READ, WRITE, ERROR)
         """
         if self._poll is not None:
             self._poll.modify(fileno, events)
@@ -1336,8 +1335,8 @@ class PollPoller(_PollerBase):
         unregister the file descriptor being tracked by the polling object. The
         request must be ignored if the poller is not activated.
 
-        :param int fileno: The file descriptor
-        :param int events_to_clear: The events to clear (READ, WRITE, ERROR)
+        :param fileno: The file descriptor
+        :param events_to_clear: The events to clear (READ, WRITE, ERROR)
         """
         if self._poll is not None:
             self._poll.unregister(fileno)

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -150,8 +150,10 @@ class SelectConnection(BaseConnection):
 
         :param connection_configs: One or more connection parameter objects
         :param on_done: Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param custom_ioloop: Optional custom IOLoop or nbio interface to use
+            for the connection workflow
+        :param workflow: Optional connection workflow instance to use; if None,
+            a default workflow will be created
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -159,6 +159,7 @@ class SelectConnection(BaseConnection):
 
         def connection_factory(params) -> SelectConnection:
             """Connection factory.
+            :param params: Connection parameters
             :rtype: Self
             """
             if params is None:

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -74,6 +74,7 @@ def _is_resumable(exc: SELECT_ERROR_T) -> bool:
     """Check if caught exception represents EINTR error.
     :param exc: exception; must be one of classes in _SELECT_ERRORS
 
+    :rtype: bool
     """
     checker = _SELECT_ERROR_CHECKERS.get(exc.__class__, None)
     if checker is not None:
@@ -149,11 +150,18 @@ class SelectConnection(BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
+        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())
 
-        def connection_factory(params):
-            """Connection factory."""
+        def connection_factory(params) -> SelectConnection:
+            """Connection factory.
+            :rtype: Self
+            """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
                                  'instance, but got None in params arg.')
@@ -185,7 +193,7 @@ class _Timeout:
         'deadline',
     )
 
-    def __init__(self, deadline: float, callback: Callable[[], None]):
+    def __init__(self, deadline: float, callback: Callable[[], None]) -> None:
         """
         :param float deadline: timer expiration as non-negative epoch number
         :param callable callback: callback to call when timeout expires
@@ -971,6 +979,7 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         from another thread. Socketpair() is not supported on some OS (Win)
         so use a pair of simple TCP sockets instead. The sockets will be
         closed and garbage collected by python when the ioloop itself is.
+        :rtype: tuple[socket.socket, socket.socket]
         """
         return pika._utils.nonblocking_socketpair()
 
@@ -1084,7 +1093,7 @@ class KQueuePoller(_PollerBase):
     """KQueuePoller works on BSD based systems and is faster than select"""
 
     def __init__(self, get_wait_seconds: Callable[[], float | None],
-                 process_timeouts: Callable[[], None]):
+                 process_timeouts: Callable[[], None]) -> None:
         """Create an instance of the KQueuePoller
         """
         self._kqueue = None
@@ -1240,7 +1249,7 @@ class PollPoller(_PollerBase):
     POLL_TIMEOUT_MULT = 1000
 
     def __init__(self, get_wait_seconds: Callable[[], float | None],
-                 process_timeouts: Callable[[], None]):
+                 process_timeouts: Callable[[], None]) -> None:
         """Create an instance of the PollPoller
 
         """

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -150,10 +150,10 @@ class SelectConnection(BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
-        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param connection_configs: One or more connection parameter objects
+        :param on_done: Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -311,7 +311,7 @@ class _Timer:
     def remove_timeout(self, timeout: _Timeout) -> None:
         """Cancel the timeout
 
-        :param _Timeout timeout: The timer to cancel
+        :param timeout: The timer to cancel
 
         """
         # NOTE removing from the heap is difficult, so we just deactivate the
@@ -1102,7 +1102,7 @@ class KQueuePoller(_PollerBase):
     def _map_event(kevent: Any) -> int:
         """return the event type associated with a kevent object
 
-        :param kevent kevent: a kevent object as returned by kqueue.control()
+        :param kevent: a kevent object as returned by kqueue.control()
         :rtype: int
 
         """

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -150,10 +150,10 @@ class SelectConnection(BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param connection_configs: One or more connection parameter objects
-        :param on_done: Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param workflow: Optional connection workflow instance to use; if None, a default workflow will be created
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done: Callback to report when connection workflow is done
+        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use; if None, a default workflow will be created
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -126,8 +126,10 @@ class ThreadSafeChannel:
     def _unregister_waiter(self, ready: Event,
                            error: list[BaseException | None]) -> None:
         """Remove a waiter from the blocking list.
-        :param ready: Threading event signalling that the RPC response has arrived
-        :param error: list containing an exception if the RPC response was an error, or None if it was successful
+        :param ready: Threading event signalling that the RPC response has
+            arrived
+        :param error: list containing an exception if the RPC response was an
+            error, or None if it was successful
         """
         with self._wrapper._channel_waiters_lock:
             try:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -267,10 +267,10 @@ class ThreadSafeChannel:
 
         Safe to call from any thread simultaneously.
 
-        :raises Exception: if the connection is already closed.
         :param delivery_tag: Server-assigned delivery tag
         :param multiple: If True, apply to all messages up to and including this delivery tag
         :param requeue: If True, requeue the message on the broker
+        :raises Exception: if the connection is already closed.
         """
         self._check_not_closed()
 
@@ -290,9 +290,9 @@ class ThreadSafeChannel:
 
         Safe to call from any thread simultaneously.
 
-        :raises Exception: if the connection is already closed.
         :param delivery_tag: Server-assigned delivery tag
         :param requeue: If True, requeue the message on the broker
+        :raises Exception: if the connection is already closed.
         """
         self._check_not_closed()
 

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -126,7 +126,7 @@ class ThreadSafeChannel:
                            error: list[BaseException | None]) -> None:
         """Remove a waiter from the blocking list.
         :param Event ready: Threading event signalling that the RPC response has arrived
-        :param error: list containing an exception if the RPC response was an error, or None if it was successful
+        :param list[BaseException | None] error: list containing an exception if the RPC response was an error, or None if it was successful
         """
         with self._wrapper._channel_waiters_lock:
             try:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -126,7 +126,7 @@ class ThreadSafeChannel:
                            error: list[BaseException | None]) -> None:
         """Remove a waiter from the blocking list.
         :param Event ready: Threading event signalling that the RPC response has arrived
-        :param list[BaseException | None] error: list containing an exception if the RPC response was an error, or None if it was successful
+        :param list[BaseException|None] error: list containing an exception if the RPC response was an error, or None if it was successful
         """
         with self._wrapper._channel_waiters_lock:
             try:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -10,10 +10,16 @@ This eliminates the ``IndexError: pop from an empty deque`` race seen when
 multiple threads call basic_publish() on a shared connection directly
 (issues #1144 and #511).
 """
+from __future__ import annotations
+
 import concurrent.futures
 import itertools
 import logging
 import threading
+from threading import Event
+from typing import Any, Literal
+
+from typing_extensions import Self
 
 from pika import spec
 from pika.adapters.select_connection import SelectConnection
@@ -56,7 +62,7 @@ class ThreadSafeChannel:
     blocking channel methods (which would deadlock).
     """
 
-    def __init__(self, channel, wrapper):
+    def __init__(self, channel, wrapper) -> None:
         self._channel = channel
         self._wrapper = wrapper
         self._consumer_work_pool = concurrent.futures.ThreadPoolExecutor(
@@ -64,10 +70,10 @@ class ThreadSafeChannel:
             thread_name_prefix='pika-consumer',
         )
         self._pool_shutdown = False
-        self._next_publish_seq_no = None
+        self._next_publish_seq_no: int | None = None
         self._confirm_select_ok = None
 
-    def _check_not_closed(self):
+    def _check_not_closed(self) -> None:
         """Raise if the connection is known to be closed.
 
         Called from fire-and-forget methods to prevent silently dropping
@@ -78,7 +84,7 @@ class ThreadSafeChannel:
                 raise self._wrapper._closed_reason
 
     @staticmethod
-    def _safe_dispatch(label, callback, *args):
+    def _safe_dispatch(label, callback, *args) -> None:
         """Execute *callback* on the pool worker, logging any exception.
 
         Used to wrap user callbacks before submitting them to a
@@ -96,13 +102,13 @@ class ThreadSafeChannel:
         except Exception:
             LOGGER.exception('Unhandled exception in %s', label)
 
-    def _shutdown_pool(self):
+    def _shutdown_pool(self) -> None:
         """Shut down the consumer work pool, allowing in-flight work to finish."""
         if not self._pool_shutdown:
             self._pool_shutdown = True
             self._consumer_work_pool.shutdown(wait=True)
 
-    def _register_waiter(self):
+    def _register_waiter(self) -> tuple[Event, list[BaseException | None]]:
         """Create and register a blocking waiter.
 
         :returns: (ready, error) tuple for use with ``ready.wait()``
@@ -116,16 +122,20 @@ class ThreadSafeChannel:
             self._wrapper._blocking_waiters.append((ready, error))
         return ready, error
 
-    def _unregister_waiter(self, ready, error):
-        """Remove a waiter from the blocking list."""
+    def _unregister_waiter(self, ready: Event,
+                           error: list[BaseException | None]) -> None:
+        """Remove a waiter from the blocking list.
+        :param Event ready: Threading event signalling that the RPC response has arrived
+        :param list[BaseException | None] error: list containing an exception if the RPC response was an error, or None if it was successful
+        """
         with self._wrapper._channel_waiters_lock:
             try:
                 self._wrapper._blocking_waiters.remove((ready, error))
             except ValueError:
                 pass
 
-    def _blocking_rpc(self, method_name, channel_method, timeout, *args,
-                      **kwargs):
+    def _blocking_rpc(self, method_name: str, channel_method, timeout: int,
+                      *args, **kwargs) -> Any:
         """Execute a channel RPC and block until the broker responds.
 
         Handles the waiter lifecycle: registers the calling thread's event
@@ -148,13 +158,13 @@ class ThreadSafeChannel:
         ready, error = self._register_waiter()
         result = [None]
 
-        def _invoke():
+        def _invoke() -> None:
 
-            def _on_ok(method_frame):
+            def _on_ok(method_frame) -> None:
                 result[0] = method_frame
                 ready.set()
 
-            def _on_chan_close(ch, reason):
+            def _on_chan_close(ch, reason) -> None:
                 if not ready.is_set():
                     if error[0] is None:
                         error[0] = reason
@@ -185,8 +195,8 @@ class ThreadSafeChannel:
                       routing_key,
                       body,
                       properties=None,
-                      mandatory=False,
-                      on_publish=None):
+                      mandatory: bool = False,
+                      on_publish=None) -> None:
         """Schedule a publish in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
@@ -200,10 +210,11 @@ class ThreadSafeChannel:
             :meth:`~ThreadSafeConnection.add_callback_threadsafe`
             callback).
         :raises Exception: if the connection is already closed.
+        :param bool mandatory: If True, return unroutable messages to the publisher
         """
         self._check_not_closed()
 
-        def _publish():
+        def _publish() -> None:
             try:
                 self._channel.basic_publish(
                     exchange=exchange,
@@ -223,16 +234,18 @@ class ThreadSafeChannel:
 
         self._wrapper.add_callback_threadsafe(_publish)
 
-    def basic_ack(self, delivery_tag=0, multiple=False):
+    def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
         """Schedule an acknowledgement in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
         :raises Exception: if the connection is already closed.
+        :param int delivery_tag: Server-assigned delivery tag
+        :param bool multiple: If True, apply to all messages up to and including this delivery tag
         """
         self._check_not_closed()
 
-        def _ack():
+        def _ack() -> None:
             try:
                 self._channel.basic_ack(delivery_tag=delivery_tag,
                                         multiple=multiple)
@@ -242,16 +255,22 @@ class ThreadSafeChannel:
 
         self._wrapper.add_callback_threadsafe(_ack)
 
-    def basic_nack(self, delivery_tag=0, multiple=False, requeue=True):
+    def basic_nack(self,
+                   delivery_tag: int = 0,
+                   multiple: bool = False,
+                   requeue: bool = True) -> None:
         """Schedule a negative acknowledgement in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
         :raises Exception: if the connection is already closed.
+        :param int delivery_tag: Server-assigned delivery tag
+        :param bool multiple: If True, apply to all messages up to and including this delivery tag
+        :param bool requeue: If True, requeue the message on the broker
         """
         self._check_not_closed()
 
-        def _nack():
+        def _nack() -> None:
             try:
                 self._channel.basic_nack(delivery_tag=delivery_tag,
                                          multiple=multiple,
@@ -262,16 +281,18 @@ class ThreadSafeChannel:
 
         self._wrapper.add_callback_threadsafe(_nack)
 
-    def basic_reject(self, delivery_tag=0, requeue=True):
+    def basic_reject(self, delivery_tag: int = 0, requeue: bool = True) -> None:
         """Schedule a rejection in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
         :raises Exception: if the connection is already closed.
+        :param int delivery_tag: Server-assigned delivery tag
+        :param bool requeue: If True, requeue the message on the broker
         """
         self._check_not_closed()
 
-        def _reject():
+        def _reject() -> None:
             try:
                 self._channel.basic_reject(delivery_tag=delivery_tag,
                                            requeue=requeue)
@@ -282,10 +303,10 @@ class ThreadSafeChannel:
         self._wrapper.add_callback_threadsafe(_reject)
 
     def basic_qos(self,
-                  prefetch_size=0,
-                  prefetch_count=0,
-                  global_qos=False,
-                  timeout=DEFAULT_RPC_TIMEOUT):
+                  prefetch_size: int = 0,
+                  prefetch_count: int = 0,
+                  global_qos: bool = False,
+                  timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Set channel QoS and block until Basic.QosOk arrives.
 
         Safe to call from any thread.
@@ -310,7 +331,10 @@ class ThreadSafeChannel:
             global_qos=global_qos,
         )
 
-    def basic_get(self, queue, auto_ack=False, timeout=DEFAULT_RPC_TIMEOUT):
+    def basic_get(self,
+                  queue,
+                  auto_ack: bool = False,
+                  timeout: int = DEFAULT_RPC_TIMEOUT) -> tuple[None, ...]:
         """Get a single message from the broker and block until it arrives.
 
         Returns a ``(method, properties, body)`` tuple if a message is
@@ -331,18 +355,18 @@ class ThreadSafeChannel:
         ready, error = self._register_waiter()
         result = [None, None, None]
 
-        def _get():
+        def _get() -> None:
 
-            def _on_get_ok(ch, method, properties, body):
+            def _on_get_ok(ch, method, properties, body) -> None:
                 result[0] = method
                 result[1] = properties
                 result[2] = body
                 ready.set()
 
-            def _on_get_empty(method_frame):
+            def _on_get_empty(method_frame) -> None:
                 ready.set()
 
-            def _on_chan_close(ch, reason):
+            def _on_chan_close(ch, reason) -> None:
                 if not ready.is_set():
                     if error[0] is None:
                         error[0] = reason
@@ -377,7 +401,7 @@ class ThreadSafeChannel:
             raise error[0]
         return tuple(result)
 
-    def add_on_cancel_callback(self, callback):
+    def add_on_cancel_callback(self, callback) -> None:
         """Register a callback for server-initiated consumer cancellation.
 
         The broker sends ``Basic.Cancel`` when a consumer is cancelled by
@@ -401,7 +425,7 @@ class ThreadSafeChannel:
         """
         self._check_not_closed()
 
-        def _wrapped(method_frame):
+        def _wrapped(method_frame) -> None:
             try:
                 self._consumer_work_pool.submit(self._safe_dispatch,
                                                 'cancel listener', callback,
@@ -410,7 +434,7 @@ class ThreadSafeChannel:
                 LOGGER.debug(
                     'Server-initiated cancel dropped: work pool shut down')
 
-        def _register():
+        def _register() -> None:
             try:
                 self._channel.add_on_cancel_callback(_wrapped)
             except Exception:
@@ -418,7 +442,7 @@ class ThreadSafeChannel:
 
         self._wrapper.add_callback_threadsafe(_register)
 
-    def add_on_return_callback(self, callback):
+    def add_on_return_callback(self, callback) -> None:
         """Register a callback for messages returned by the broker.
 
         When a message is published with ``mandatory=True`` and cannot be
@@ -444,7 +468,7 @@ class ThreadSafeChannel:
         """
         self._check_not_closed()
 
-        def _wrapped(_raw_ch, method, properties, body):
+        def _wrapped(_raw_ch, method, properties, body) -> None:
             try:
                 self._consumer_work_pool.submit(self._safe_dispatch,
                                                 'return listener', callback,
@@ -452,7 +476,7 @@ class ThreadSafeChannel:
             except RuntimeError:
                 LOGGER.debug('Returned message dropped: work pool shut down')
 
-        def _register():
+        def _register() -> None:
             try:
                 self._channel.add_on_return_callback(_wrapped)
             except Exception:
@@ -460,7 +484,9 @@ class ThreadSafeChannel:
 
         self._wrapper.add_callback_threadsafe(_register)
 
-    def confirm_delivery(self, ack_nack_callback, timeout=DEFAULT_RPC_TIMEOUT):
+    def confirm_delivery(self,
+                         ack_nack_callback,
+                         timeout: int = DEFAULT_RPC_TIMEOUT):
         """Enable publisher confirms and block until Confirm.SelectOk arrives.
 
         Idempotent: calling this method more than once on the same channel
@@ -490,7 +516,7 @@ class ThreadSafeChannel:
         if self._confirm_select_ok is not None:
             return self._confirm_select_ok
 
-        def _wrapped_ack_nack(method_frame):
+        def _wrapped_ack_nack(method_frame) -> None:
             try:
                 self._consumer_work_pool.submit(self._safe_dispatch,
                                                 'publisher confirm callback',
@@ -511,11 +537,11 @@ class ThreadSafeChannel:
     def basic_consume(self,
                       queue,
                       on_message_callback,
-                      auto_ack=False,
-                      exclusive=False,
+                      auto_ack: bool = False,
+                      exclusive: bool = False,
                       consumer_tag=None,
                       arguments=None,
-                      timeout=DEFAULT_RPC_TIMEOUT):
+                      timeout: int = DEFAULT_RPC_TIMEOUT):
         """Register a consumer and block until Basic.ConsumeOk arrives.
 
         The *on_message_callback* is dispatched on the channel's worker
@@ -545,7 +571,7 @@ class ThreadSafeChannel:
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
 
-        def _wrapped_callback(ch, method, properties, body):
+        def _wrapped_callback(ch, method, properties, body) -> None:
             try:
                 self._consumer_work_pool.submit(self._safe_dispatch,
                                                 'consumer callback',
@@ -567,7 +593,9 @@ class ThreadSafeChannel:
         )
         return frame.method.consumer_tag
 
-    def basic_cancel(self, consumer_tag, timeout=DEFAULT_RPC_TIMEOUT):
+    def basic_cancel(self,
+                     consumer_tag,
+                     timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Cancel a consumer and block until Basic.CancelOk arrives.
 
         Safe to call from any thread.
@@ -590,12 +618,12 @@ class ThreadSafeChannel:
 
     def queue_declare(self,
                       queue,
-                      passive=False,
-                      durable=False,
-                      exclusive=False,
-                      auto_delete=False,
+                      passive: bool = False,
+                      durable: bool = False,
+                      exclusive: bool = False,
+                      auto_delete: bool = False,
                       arguments=None,
-                      timeout=DEFAULT_RPC_TIMEOUT):
+                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Declare a queue and block the calling thread until Queue.DeclareOk arrives.
 
         Safe to call from any thread.
@@ -607,6 +635,10 @@ class ThreadSafeChannel:
         :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
+        :param bool passive: If True, only check whether the queue or exchange exists
+        :param bool durable: If True, the queue survives broker restart
+        :param bool exclusive: If True, restrict access to the current connection
+        :param bool auto_delete: If True, delete the queue or exchange when no longer in use
         """
         return self._blocking_rpc(
             'queue_declare',
@@ -622,13 +654,13 @@ class ThreadSafeChannel:
 
     def exchange_declare(self,
                          exchange,
-                         exchange_type='direct',
-                         passive=False,
-                         durable=False,
-                         auto_delete=False,
-                         internal=False,
+                         exchange_type: str = 'direct',
+                         passive: bool = False,
+                         durable: bool = False,
+                         auto_delete: bool = False,
+                         internal: bool = False,
                          arguments=None,
-                         timeout=DEFAULT_RPC_TIMEOUT):
+                         timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Declare an exchange and block until Exchange.DeclareOk arrives.
 
         Safe to call from any thread.
@@ -666,7 +698,7 @@ class ThreadSafeChannel:
                    exchange,
                    routing_key=None,
                    arguments=None,
-                   timeout=DEFAULT_RPC_TIMEOUT):
+                   timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Bind a queue to an exchange and block until Queue.BindOk arrives.
 
         Safe to call from any thread.
@@ -699,7 +731,7 @@ class ThreadSafeChannel:
                      exchange=None,
                      routing_key=None,
                      arguments=None,
-                     timeout=DEFAULT_RPC_TIMEOUT):
+                     timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Unbind a queue from an exchange and block until Queue.UnbindOk arrives.
 
         Safe to call from any thread.
@@ -729,9 +761,9 @@ class ThreadSafeChannel:
 
     def queue_delete(self,
                      queue,
-                     if_unused=False,
-                     if_empty=False,
-                     timeout=DEFAULT_RPC_TIMEOUT):
+                     if_unused: bool = False,
+                     if_empty: bool = False,
+                     timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Delete a queue and block until Queue.DeleteOk arrives.
 
         Safe to call from any thread.
@@ -756,7 +788,7 @@ class ThreadSafeChannel:
             if_empty=if_empty,
         )
 
-    def queue_purge(self, queue, timeout=DEFAULT_RPC_TIMEOUT):
+    def queue_purge(self, queue, timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Purge all messages from a queue and block until Queue.PurgeOk arrives.
 
         Safe to call from any thread.
@@ -780,9 +812,9 @@ class ThreadSafeChannel:
     def exchange_bind(self,
                       destination,
                       source,
-                      routing_key='',
+                      routing_key: str = '',
                       arguments=None,
-                      timeout=DEFAULT_RPC_TIMEOUT):
+                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Bind an exchange to another exchange and block until Exchange.BindOk.
 
         Safe to call from any thread.
@@ -812,9 +844,9 @@ class ThreadSafeChannel:
     def exchange_unbind(self,
                         destination,
                         source,
-                        routing_key='',
+                        routing_key: str = '',
                         arguments=None,
-                        timeout=DEFAULT_RPC_TIMEOUT):
+                        timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Unbind an exchange from another exchange and block until Exchange.UnbindOk.
 
         Safe to call from any thread.
@@ -843,8 +875,8 @@ class ThreadSafeChannel:
 
     def exchange_delete(self,
                         exchange=None,
-                        if_unused=False,
-                        timeout=DEFAULT_RPC_TIMEOUT):
+                        if_unused: bool = False,
+                        timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         """Delete an exchange and block until Exchange.DeleteOk arrives.
 
         Safe to call from any thread.
@@ -867,7 +899,10 @@ class ThreadSafeChannel:
             if_unused=if_unused,
         )
 
-    def close(self, reply_code=0, reply_text='Normal shutdown', timeout=10):
+    def close(self,
+              reply_code: int = 0,
+              reply_text: str = 'Normal shutdown',
+              timeout: int = 10) -> None:
         """Close the channel and block until the Channel.CloseOk arrives.
 
         Shuts down the consumer work pool after the channel is closed,
@@ -886,12 +921,12 @@ class ThreadSafeChannel:
         """
         ready, error = self._register_waiter()
 
-        def _close():
+        def _close() -> None:
             if self._channel.is_closed or self._channel.is_closing:
                 ready.set()
                 return
 
-            def _on_channel_close(channel, reason):
+            def _on_channel_close(channel, reason) -> None:
                 from pika.exceptions import ChannelClosedByClient
                 if not isinstance(reason, ChannelClosedByClient):
                     error[0] = reason
@@ -918,7 +953,10 @@ class ThreadSafeChannel:
         if error[0] is not None:
             raise error[0]
 
-    def abort(self, reply_code=0, reply_text='Normal shutdown', timeout=10):
+    def abort(self,
+              reply_code: int = 0,
+              reply_text: str = 'Normal shutdown',
+              timeout: int = 10) -> None:
         """Close the channel, swallowing any errors.
 
         Equivalent to :meth:`close` but never raises.  Useful in error-recovery
@@ -1026,7 +1064,7 @@ class ThreadSafeConnection:
                  parameters,
                  on_open_error_callback=None,
                  on_close_callback=None,
-                 timeout=DEFAULT_RPC_TIMEOUT):
+                 timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
         self._user_on_open_error_callback = on_open_error_callback
         self._user_on_close_callback = on_close_callback
 
@@ -1065,7 +1103,7 @@ class ThreadSafeConnection:
             self._shutdown_connection_pool()
             raise
 
-        def _run_ioloop():
+        def _run_ioloop() -> None:
             try:
                 self._connection.ioloop.start()
             except Exception as exc:
@@ -1117,10 +1155,10 @@ class ThreadSafeConnection:
     # IOLoop-thread callbacks
     # ------------------------------------------------------------------
 
-    def _on_connection_open(self, _connection):
+    def _on_connection_open(self, _connection) -> None:
         self._connected_event.set()
 
-    def _on_connection_open_error(self, _connection, error):
+    def _on_connection_open_error(self, _connection, error) -> None:
         self._connect_error = error
         # Stop the IOLoop so the background thread can exit cleanly.
         self._connection.ioloop.stop()
@@ -1128,7 +1166,7 @@ class ThreadSafeConnection:
         if self._user_on_open_error_callback:
             self._user_on_open_error_callback(_connection, error)
 
-    def _on_connection_closed(self, _connection, reason):
+    def _on_connection_closed(self, _connection, reason) -> None:
         # Connection is gone - stop the IOLoop so the thread exits.
         # Pool shutdown happens after ioloop.start() returns in _run_ioloop
         # (calling shutdown(wait=True) here would deadlock the IOLoop thread
@@ -1143,14 +1181,14 @@ class ThreadSafeConnection:
         if self._user_on_close_callback:
             self._user_on_close_callback(_connection, reason)
 
-    def _shutdown_all_consumer_pools(self):
+    def _shutdown_all_consumer_pools(self) -> None:
         """Shut down all tracked channel consumer pools."""
         with self._channel_waiters_lock:
             channels = list(self._channels)
         for ch in channels:
             ch._shutdown_pool()
 
-    def _shutdown_connection_pool(self):
+    def _shutdown_connection_pool(self) -> None:
         """Shut down the connection-level event-callback pool."""
         if not self._connection_pool_shutdown:
             self._connection_pool_shutdown = True
@@ -1160,7 +1198,7 @@ class ThreadSafeConnection:
     # Public API
     # ------------------------------------------------------------------
 
-    def channel(self, timeout=DEFAULT_RPC_TIMEOUT):
+    def channel(self, timeout: int = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
         """Open a new channel and return a :class:`ThreadSafeChannel`.
 
         Blocks the calling thread until the channel is open.  The returned
@@ -1182,9 +1220,9 @@ class ThreadSafeConnection:
                 raise self._closed_reason
             self._blocking_waiters.append((ready, error))
 
-        def _open():
+        def _open() -> None:
 
-            def _on_open(ch):
+            def _on_open(ch) -> None:
                 result[0] = ch
                 ready.set()
 
@@ -1221,7 +1259,7 @@ class ThreadSafeConnection:
             self._channels.append(ch)
         return ch
 
-    def close(self, timeout=10):
+    def close(self, timeout: int = 10) -> None:
         """Close the connection and block until the IOLoop thread exits.
 
         Schedules a clean Connection.Close handshake and waits up to
@@ -1253,7 +1291,7 @@ class ThreadSafeConnection:
             if self._closed_reason is not None:
                 return
 
-        def _safe_close():
+        def _safe_close() -> None:
             try:
                 self._connection.close()
             except Exception:
@@ -1284,7 +1322,7 @@ class ThreadSafeConnection:
             self._shutdown_all_consumer_pools()
             self._shutdown_connection_pool()
 
-    def abort(self, timeout=10):
+    def abort(self, timeout: int = 10) -> None:
         """Close the connection, swallowing any errors.
 
         Equivalent to :meth:`close` but never raises.  Currently
@@ -1304,14 +1342,14 @@ class ThreadSafeConnection:
         except Exception:
             LOGGER.debug('connection abort() suppressed error', exc_info=True)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type, exc_val, exc_tb) -> Literal[False]:
         self.close()
         return False
 
-    def add_callback_threadsafe(self, callback):
+    def add_callback_threadsafe(self, callback) -> None:
         """Schedule *callback* to run in the IOLoop thread.
 
         Safe to call from any thread.  Exposed so callers can schedule
@@ -1321,7 +1359,7 @@ class ThreadSafeConnection:
         """
         self._connection.ioloop.add_callback_threadsafe(callback)
 
-    def add_on_connection_blocked_callback(self, callback):
+    def add_on_connection_blocked_callback(self, callback) -> None:
         """Register a callback for ``Connection.Blocked`` notifications.
 
         RabbitMQ sends ``Connection.Blocked`` when the broker is running
@@ -1347,7 +1385,7 @@ class ThreadSafeConnection:
         self._register_connection_event_callback(
             'add_on_connection_blocked_callback', callback)
 
-    def add_on_connection_unblocked_callback(self, callback):
+    def add_on_connection_unblocked_callback(self, callback) -> None:
         """Register a callback for ``Connection.Unblocked`` notifications.
 
         Sent by RabbitMQ once a previously blocked connection is no
@@ -1370,18 +1408,20 @@ class ThreadSafeConnection:
         self._register_connection_event_callback(
             'add_on_connection_unblocked_callback', callback)
 
-    def _register_connection_event_callback(self, raw_method_name, callback):
+    def _register_connection_event_callback(self, raw_method_name: str,
+                                            callback) -> None:
         """Register a connection-level event callback via the IOLoop.
 
         Wraps the user callback so it dispatches on the connection work
         pool, then schedules registration with the underlying
         :class:`pika.connection.Connection` on the IOLoop thread.
+        :param str raw_method_name: Unqualified AMQP method name (e.g. ``"Basic.Publish"``)
         """
         with self._channel_waiters_lock:
             if self._closed_reason is not None:
                 raise self._closed_reason
 
-        def _wrapped(_raw_conn, method_frame):
+        def _wrapped(_raw_conn, method_frame) -> None:
             try:
                 self._connection_work_pool.submit(
                     ThreadSafeChannel._safe_dispatch, raw_method_name, callback,
@@ -1389,7 +1429,7 @@ class ThreadSafeConnection:
             except RuntimeError:
                 LOGGER.debug('Connection event dropped: work pool shut down')
 
-        def _register():
+        def _register() -> None:
             try:
                 getattr(self._connection, raw_method_name)(_wrapped)
             except Exception:
@@ -1398,9 +1438,9 @@ class ThreadSafeConnection:
         self._connection.ioloop.add_callback_threadsafe(_register)
 
     @property
-    def is_open(self):
+    def is_open(self) -> bool:
         return self._connection.is_open
 
     @property
-    def is_closed(self):
+    def is_closed(self) -> bool:
         return self._connection.is_closed

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -17,9 +17,9 @@ import itertools
 import logging
 import threading
 from threading import Event
-from typing import Any, Literal
+from typing import Any
 
-from typing_extensions import Self
+from typing_extensions import Literal, Self
 
 from pika import spec
 from pika.adapters.select_connection import SelectConnection

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -628,6 +628,12 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
+        :param queue: The queue name. If empty, the broker will generate a unique name.
+        :param passive: If True, only check whether the queue or exchange exists
+        :param durable: If True, the queue survives broker restart
+        :param exclusive: If True, restrict access to the current connection
+        :param auto_delete: If True, delete the queue or exchange when no longer in use
+        :param arguments: Custom arguments for the queue declaration
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -635,10 +641,6 @@ class ThreadSafeChannel:
         :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
-        :param passive: If True, only check whether the queue or exchange exists
-        :param durable: If True, the queue survives broker restart
-        :param exclusive: If True, restrict access to the current connection
-        :param auto_delete: If True, delete the queue or exchange when no longer in use
         """
         return self._blocking_rpc(
             'queue_declare',
@@ -1416,6 +1418,7 @@ class ThreadSafeConnection:
         pool, then schedules registration with the underlying
         :class:`pika.connection.Connection` on the IOLoop thread.
         :param raw_method_name: Unqualified AMQP method name (e.g. ``"Basic.Publish"``)
+        :param callback: User callback to dispatch on the connection work pool."
         """
         with self._channel_waiters_lock:
             if self._closed_reason is not None:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -93,8 +93,8 @@ class ThreadSafeChannel:
         failing dispatch does not prevent subsequent dispatches from being
         processed.
 
-        :param str label: Human-readable name of the callback for log lines.
-        :param callable callback: The user callback.
+        :param label: Human-readable name of the callback for log lines.
+        :param callback: The user callback.
         :param args: Positional arguments forwarded to *callback*.
         """
         try:
@@ -125,8 +125,8 @@ class ThreadSafeChannel:
     def _unregister_waiter(self, ready: Event,
                            error: list[BaseException | None]) -> None:
         """Remove a waiter from the blocking list.
-        :param Event ready: Threading event signalling that the RPC response has arrived
-        :param list[BaseException|None] error: list containing an exception if the RPC response was an error, or None if it was successful
+        :param ready: Threading event signalling that the RPC response has arrived
+        :param error: list containing an exception if the RPC response was an error, or None if it was successful
         """
         with self._wrapper._channel_waiters_lock:
             try:
@@ -148,8 +148,8 @@ class ThreadSafeChannel:
         the broker's response frame and must be accepted as a keyword
         argument named ``callback``.
 
-        :param str method_name: Human-readable name for timeout messages.
-        :param callable channel_method: Bound method on the raw channel.
+        :param method_name: Human-readable name for timeout messages.
+        :param channel_method: Bound method on the raw channel.
         :param timeout: Seconds to wait.
         :returns: The broker response frame.
         :raises TimeoutError: if *timeout* expires.
@@ -201,7 +201,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread simultaneously.
 
-        :param callable on_publish: Optional callback invoked on the
+        :param on_publish: Optional callback invoked on the
             **IOLoop thread** immediately after the publish frame is
             written successfully, with the delivery tag (int) as its
             sole argument.  Only meaningful when publisher confirms are
@@ -210,7 +210,7 @@ class ThreadSafeChannel:
             :meth:`~ThreadSafeConnection.add_callback_threadsafe`
             callback).
         :raises Exception: if the connection is already closed.
-        :param bool mandatory: If True, return unroutable messages to the publisher
+        :param mandatory: If True, return unroutable messages to the publisher
         """
         self._check_not_closed()
 
@@ -240,8 +240,8 @@ class ThreadSafeChannel:
         Safe to call from any thread simultaneously.
 
         :raises Exception: if the connection is already closed.
-        :param int delivery_tag: Server-assigned delivery tag
-        :param bool multiple: If True, apply to all messages up to and including this delivery tag
+        :param delivery_tag: Server-assigned delivery tag
+        :param multiple: If True, apply to all messages up to and including this delivery tag
         """
         self._check_not_closed()
 
@@ -264,9 +264,9 @@ class ThreadSafeChannel:
         Safe to call from any thread simultaneously.
 
         :raises Exception: if the connection is already closed.
-        :param int delivery_tag: Server-assigned delivery tag
-        :param bool multiple: If True, apply to all messages up to and including this delivery tag
-        :param bool requeue: If True, requeue the message on the broker
+        :param delivery_tag: Server-assigned delivery tag
+        :param multiple: If True, apply to all messages up to and including this delivery tag
+        :param requeue: If True, requeue the message on the broker
         """
         self._check_not_closed()
 
@@ -287,8 +287,8 @@ class ThreadSafeChannel:
         Safe to call from any thread simultaneously.
 
         :raises Exception: if the connection is already closed.
-        :param int delivery_tag: Server-assigned delivery tag
-        :param bool requeue: If True, requeue the message on the broker
+        :param delivery_tag: Server-assigned delivery tag
+        :param requeue: If True, requeue the message on the broker
         """
         self._check_not_closed()
 
@@ -311,9 +311,9 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param int prefetch_size: Prefetch window in octets (0 = no limit).
-        :param int prefetch_count: Prefetch window in whole messages (0 = no limit).
-        :param bool global_qos: Apply QoS to all consumers on the channel.
+        :param prefetch_size: Prefetch window in octets (0 = no limit).
+        :param prefetch_count: Prefetch window in whole messages (0 = no limit).
+        :param global_qos: Apply QoS to all consumers on the channel.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -342,8 +342,8 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str queue: The queue to get a message from.
-        :param bool auto_ack: Do not require acknowledgement.
+        :param queue: The queue to get a message from.
+        :param auto_ack: Do not require acknowledgement.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -418,7 +418,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param callable callback:
+        :param callback:
             ``callback(method_frame)`` where *method_frame* contains a
             :class:`pika.spec.Basic.Cancel`.
         :raises Exception: if the connection is already closed.
@@ -459,7 +459,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param callable callback:
+        :param callback:
             ``callback(channel, method, properties, body)`` where
             *channel* is this :class:`ThreadSafeChannel`, *method* is a
             :class:`pika.spec.Basic.Return`, *properties* is a
@@ -502,7 +502,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param callable ack_nack_callback:
+        :param ack_nack_callback:
             ``callback(method_frame)`` called for each Basic.Ack or
             Basic.Nack received from the broker.
         :param timeout: Seconds to wait for the response.
@@ -555,11 +555,11 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str queue: Queue to consume from.
-        :param callable on_message_callback:
+        :param queue: Queue to consume from.
+        :param on_message_callback:
             ``callback(channel, method, properties, body)``
-        :param bool auto_ack: Disable manual acknowledgement.
-        :param bool exclusive: Request exclusive consumer access.
+        :param auto_ack: Disable manual acknowledgement.
+        :param exclusive: Request exclusive consumer access.
         :param consumer_tag: Client-provided tag; generated if omitted.
         :param arguments: Additional AMQP arguments.
         :param timeout: Seconds to wait for the response.
@@ -600,7 +600,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str consumer_tag: Tag returned by :meth:`basic_consume`.
+        :param consumer_tag: Tag returned by :meth:`basic_consume`.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -635,10 +635,10 @@ class ThreadSafeChannel:
         :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
-        :param bool passive: If True, only check whether the queue or exchange exists
-        :param bool durable: If True, the queue survives broker restart
-        :param bool exclusive: If True, restrict access to the current connection
-        :param bool auto_delete: If True, delete the queue or exchange when no longer in use
+        :param passive: If True, only check whether the queue or exchange exists
+        :param durable: If True, the queue survives broker restart
+        :param exclusive: If True, restrict access to the current connection
+        :param auto_delete: If True, delete the queue or exchange when no longer in use
         """
         return self._blocking_rpc(
             'queue_declare',
@@ -665,12 +665,12 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str exchange: The exchange name.
-        :param str exchange_type: The exchange type (direct, fanout, topic, headers).
-        :param bool passive: Only check if the exchange exists.
-        :param bool durable: Survive broker restart.
-        :param bool auto_delete: Delete when no queues are bound.
-        :param bool internal: Can only be published to by other exchanges.
+        :param exchange: The exchange name.
+        :param exchange_type: The exchange type (direct, fanout, topic, headers).
+        :param passive: Only check if the exchange exists.
+        :param durable: Survive broker restart.
+        :param auto_delete: Delete when no queues are bound.
+        :param internal: Can only be published to by other exchanges.
         :param arguments: Custom arguments for the exchange.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
@@ -703,8 +703,8 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str queue: The queue to bind.
-        :param str exchange: The exchange to bind to.
+        :param queue: The queue to bind.
+        :param exchange: The exchange to bind to.
         :param routing_key: The routing key to bind on.
             Defaults to the queue name.
         :param arguments: Custom arguments for the binding.
@@ -736,7 +736,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str queue: The queue to unbind.
+        :param queue: The queue to unbind.
         :param exchange: The exchange to unbind from.
         :param routing_key: The routing key to unbind.
             Defaults to the queue name.
@@ -768,9 +768,9 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str queue: The queue to delete.
-        :param bool if_unused: Only delete if the queue has no consumers.
-        :param bool if_empty: Only delete if the queue is empty.
+        :param queue: The queue to delete.
+        :param if_unused: Only delete if the queue has no consumers.
+        :param if_empty: Only delete if the queue is empty.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -793,7 +793,7 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str queue: The queue to purge.
+        :param queue: The queue to purge.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -819,9 +819,9 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str destination: The destination exchange to bind.
-        :param str source: The source exchange to bind to.
-        :param str routing_key: The routing key to bind on.
+        :param destination: The destination exchange to bind.
+        :param source: The source exchange to bind to.
+        :param routing_key: The routing key to bind on.
         :param arguments: Custom arguments for the binding.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
@@ -851,9 +851,9 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param str destination: The destination exchange to unbind.
-        :param str source: The source exchange to unbind from.
-        :param str routing_key: The routing key to unbind.
+        :param destination: The destination exchange to unbind.
+        :param source: The source exchange to unbind from.
+        :param routing_key: The routing key to unbind.
         :param arguments: Custom arguments for the unbinding.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
@@ -882,7 +882,7 @@ class ThreadSafeChannel:
         Safe to call from any thread.
 
         :param exchange: The exchange name.
-        :param bool if_unused: Only delete if the exchange has no bindings.
+        :param if_unused: Only delete if the exchange has no bindings.
         :param timeout: Seconds to wait for the response.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
@@ -911,8 +911,8 @@ class ThreadSafeChannel:
         If the channel is already closed or closing, returns immediately.
         Safe to call from any thread.
 
-        :param int reply_code: Close reason code to send to the broker.
-        :param str reply_text: Close reason text to send to the broker.
+        :param reply_code: Close reason code to send to the broker.
+        :param reply_text: Close reason text to send to the broker.
         :param timeout: Seconds to wait for Channel.CloseOk
             before treating the channel as closed regardless.  Defaults to
             10 seconds.  Pass ``None`` to wait indefinitely.
@@ -965,8 +965,8 @@ class ThreadSafeChannel:
 
         Safe to call from any thread.
 
-        :param int reply_code: Close reason code to send to the broker.
-        :param str reply_text: Close reason text to send to the broker.
+        :param reply_code: Close reason code to send to the broker.
+        :param reply_text: Close reason text to send to the broker.
         :param timeout: Seconds to wait for Channel.CloseOk
             before treating the channel as closed regardless.  Defaults to
             10 seconds.  Pass ``None`` to wait indefinitely.
@@ -1355,7 +1355,7 @@ class ThreadSafeConnection:
         Safe to call from any thread.  Exposed so callers can schedule
         arbitrary work without going through the wrapper methods.
 
-        :param callable callback: Zero-argument callable.
+        :param callback: Zero-argument callable.
         """
         self._connection.ioloop.add_callback_threadsafe(callback)
 
@@ -1376,7 +1376,7 @@ class ThreadSafeConnection:
 
         Safe to call from any thread.
 
-        :param callable callback:
+        :param callback:
             ``callback(connection, method_frame)`` where *connection* is
             this :class:`ThreadSafeConnection` and *method_frame* contains
             a :class:`pika.spec.Connection.Blocked`.
@@ -1399,7 +1399,7 @@ class ThreadSafeConnection:
 
         Safe to call from any thread.
 
-        :param callable callback:
+        :param callback:
             ``callback(connection, method_frame)`` where *connection* is
             this :class:`ThreadSafeConnection` and *method_frame* contains
             a :class:`pika.spec.Connection.Unblocked`.
@@ -1415,7 +1415,7 @@ class ThreadSafeConnection:
         Wraps the user callback so it dispatches on the connection work
         pool, then schedules registration with the underlying
         :class:`pika.connection.Connection` on the IOLoop thread.
-        :param str raw_method_name: Unqualified AMQP method name (e.g. ``"Basic.Publish"``)
+        :param raw_method_name: Unqualified AMQP method name (e.g. ``"Basic.Publish"``)
         """
         with self._channel_waiters_lock:
             if self._closed_reason is not None:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -985,7 +985,7 @@ class ThreadSafeChannel:
             LOGGER.debug('channel abort() suppressed error', exc_info=True)
 
     @property
-    def next_publish_seq_no(self):
+    def next_publish_seq_no(self) -> int | None:
         """The delivery tag that will be assigned to the next published message.
 
         Returns ``None`` if publisher confirms have not been enabled via

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -17,9 +17,10 @@ import itertools
 import logging
 import threading
 from threading import Event
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from typing_extensions import Literal, Self
+if TYPE_CHECKING:
+    from typing_extensions import Literal, Self
 
 from pika import spec
 from pika.adapters.select_connection import SelectConnection

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -126,7 +126,7 @@ class ThreadSafeChannel:
                            error: list[BaseException | None]) -> None:
         """Remove a waiter from the blocking list.
         :param Event ready: Threading event signalling that the RPC response has arrived
-        :param list[BaseException | None] error: list containing an exception if the RPC response was an error, or None if it was successful
+        :param error: list containing an exception if the RPC response was an error, or None if it was successful
         """
         with self._wrapper._channel_waiters_lock:
             try:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -201,6 +201,11 @@ class ThreadSafeChannel:
 
         Safe to call from any thread simultaneously.
 
+        :param exchange: The exchange to publish to.
+        :param routing_key: The routing key to publish with.
+        :param body: The message body to publish.
+        :param properties: Properties for the message.
+        :param mandatory: If True, return unroutable messages to the publisher
         :param on_publish: Optional callback invoked on the
             **IOLoop thread** immediately after the publish frame is
             written successfully, with the delivery tag (int) as its
@@ -210,7 +215,6 @@ class ThreadSafeChannel:
             :meth:`~ThreadSafeConnection.add_callback_threadsafe`
             callback).
         :raises Exception: if the connection is already closed.
-        :param mandatory: If True, return unroutable messages to the publisher
         """
         self._check_not_closed()
 
@@ -239,9 +243,9 @@ class ThreadSafeChannel:
 
         Safe to call from any thread simultaneously.
 
-        :raises Exception: if the connection is already closed.
         :param delivery_tag: Server-assigned delivery tag
         :param multiple: If True, apply to all messages up to and including this delivery tag
+        :raises Exception: if the connection is already closed.
         """
         self._check_not_closed()
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -97,7 +97,8 @@ class TornadoConnection(base_connection.BaseConnection):
 
         :param connection_configs: One or more connection parameter objects
         :param on_done:  Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param custom_ioloop: Optional custom IOLoop or nbio interface to use
+            for the connection workflow
         :param workflow: Optional connection workflow instance to use
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -39,21 +39,21 @@ class TornadoConnection(base_connection.BaseConnection):
         """Create a new instance of the TornadoConnection class, connecting
         to RabbitMQ automatically.
 
-        :param pika.connection.Parameters|None parameters: The connection
+        :param parameters: The connection
             parameters
-        :param callable|None on_open_callback: The method to call when the
+        :param on_open_callback: The method to call when the
             connection is open
-        :param callable|None on_open_error_callback: Called if the connection
+        :param on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`:
             on_open_error_callback(Connection, exception)
-        :param callable|None on_close_callback: Called when a previously fully
+        :param on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the
             cause of connection failure
-        :param ioloop.IOLoop|nbio_interface.AbstractIOServices|None custom_ioloop:
+        :param custom_ioloop:
             Override using the global IOLoop in Tornado
         :param bool internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
@@ -95,10 +95,10 @@ class TornadoConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done:  Callback to report when connection workflow is done
-        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :param connection_configs: One or more connection parameter objects
+        :param on_done:  Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(
@@ -107,7 +107,7 @@ class TornadoConnection(base_connection.BaseConnection):
         def connection_factory(
                 params: connection.Parameters | None) -> TornadoConnection:
             """Connection factory.
-            :param connection.Parameters | None params: Connection parameters
+            :param params: Connection parameters
             :rtype: TornadoConnection
             """
             if params is None:

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -23,18 +23,19 @@ class TornadoConnection(base_connection.BaseConnection):
     """The TornadoConnection runs on the Tornado IOLoop.
     """
 
-    def __init__(
-            self,
-            parameters: connection.Parameters | None = None,
-            on_open_callback: None |
-        (Callable[[connection.Connection], None]) = None,
-            on_open_error_callback: None |
-        (Callable[[connection.Connection, BaseException], None]) = None,
-            on_close_callback: None |
-        (Callable[[connection.Connection, BaseException], None]) = None,
-            custom_ioloop: None |
-        (ioloop.IOLoop | nbio_interface.AbstractIOServices) = None,
-            internal_connection_workflow: bool = True):
+    def __init__(self,
+                 parameters: connection.Parameters | None = None,
+                 on_open_callback: None |
+                 (Callable[[connection.Connection], None]) = None,
+                 on_open_error_callback: None |
+                 (Callable[[connection.Connection, BaseException],
+                           None]) = None,
+                 on_close_callback: None |
+                 (Callable[[connection.Connection, BaseException],
+                           None]) = None,
+                 custom_ioloop: None |
+                 (ioloop.IOLoop | nbio_interface.AbstractIOServices) = None,
+                 internal_connection_workflow: bool = True) -> None:
         """Create a new instance of the TornadoConnection class, connecting
         to RabbitMQ automatically.
 
@@ -94,13 +95,21 @@ class TornadoConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done:  Callback to report when connection workflow is done
+        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(
             custom_ioloop or ioloop.IOLoop.instance())  # type: ignore[arg-type]
 
         def connection_factory(
                 params: connection.Parameters | None) -> TornadoConnection:
-            """Connection factory."""
+            """Connection factory.
+            :param connection.Parameters | None params: Connection parameters
+            :rtype: TornadoConnection
+            """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '
                                  'instance, but got None in params arg.')

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -99,7 +99,6 @@ class TornadoConnection(base_connection.BaseConnection):
         :param on_done:  Callback to report when connection workflow is done
         :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
         :param workflow: Optional connection workflow instance to use
-        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(
             custom_ioloop or ioloop.IOLoop.instance())  # type: ignore[arg-type]
@@ -108,7 +107,6 @@ class TornadoConnection(base_connection.BaseConnection):
                 params: connection.Parameters | None) -> TornadoConnection:
             """Connection factory.
             :param params: Connection parameters
-            :rtype: TornadoConnection
             """
             if params is None:
                 raise ValueError('Expected pika.connection.Parameters '

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -39,23 +39,23 @@ class TornadoConnection(base_connection.BaseConnection):
         """Create a new instance of the TornadoConnection class, connecting
         to RabbitMQ automatically.
 
-        :param pika.connection.Parameters|None parameters: The connection
+        :param parameters: The connection
             parameters
-        :param callable|None on_open_callback: The method to call when the
+        :param on_open_callback: The method to call when the
             connection is open
-        :param callable|None on_open_error_callback: Called if the connection
+        :param on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`:
             on_open_error_callback(Connection, exception)
-        :param callable|None on_close_callback: Called when a previously fully
+        :param on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the
             cause of connection failure
-        :param ioloop.IOLoop|nbio_interface.AbstractIOServices|None custom_ioloop:
+        :param custom_ioloop:
             Override using the global IOLoop in Tornado
-        :param bool internal_connection_workflow: True for autonomous connection
+        :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory
 
@@ -95,10 +95,10 @@ class TornadoConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done:  Callback to report when connection workflow is done
-        :param Any|None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :param connection_configs: One or more connection parameter objects
+        :param on_done:  Callback to report when connection workflow is done
+        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(
@@ -107,7 +107,7 @@ class TornadoConnection(base_connection.BaseConnection):
         def connection_factory(
                 params: connection.Parameters | None) -> TornadoConnection:
             """Connection factory.
-            :param connection.Parameters | None params: Connection parameters
+            :param params: Connection parameters
             :rtype: TornadoConnection
             """
             if params is None:

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -39,21 +39,21 @@ class TornadoConnection(base_connection.BaseConnection):
         """Create a new instance of the TornadoConnection class, connecting
         to RabbitMQ automatically.
 
-        :param parameters: The connection
+        :param pika.connection.Parameters|None parameters: The connection
             parameters
-        :param on_open_callback: The method to call when the
+        :param callable|None on_open_callback: The method to call when the
             connection is open
-        :param on_open_error_callback: Called if the connection
+        :param callable|None on_open_error_callback: Called if the connection
             can't be established or connection establishment is interrupted by
             `Connection.close()`:
             on_open_error_callback(Connection, exception)
-        :param on_close_callback: Called when a previously fully
+        :param callable|None on_close_callback: Called when a previously fully
             open connection is closed:
             `on_close_callback(Connection, exception)`, where `exception` is
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the
             cause of connection failure
-        :param custom_ioloop:
+        :param ioloop.IOLoop|nbio_interface.AbstractIOServices|None custom_ioloop:
             Override using the global IOLoop in Tornado
         :param bool internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
@@ -95,10 +95,10 @@ class TornadoConnection(base_connection.BaseConnection):
         """Implement
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
-        :param connection_configs: One or more connection parameter objects
-        :param on_done:  Callback to report when connection workflow is done
-        :param custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param workflow: Optional connection workflow instance to use
+        :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
+        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done:  Callback to report when connection workflow is done
+        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(
@@ -107,7 +107,7 @@ class TornadoConnection(base_connection.BaseConnection):
         def connection_factory(
                 params: connection.Parameters | None) -> TornadoConnection:
             """Connection factory.
-            :param params: Connection parameters
+            :param connection.Parameters | None params: Connection parameters
             :rtype: TornadoConnection
             """
             if params is None:

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -96,9 +96,9 @@ class TornadoConnection(base_connection.BaseConnection):
         :py:classmethod::`pika.adapters.BaseConnection.create_connection()`.
 
         :param Sequence[connection.Parameters] connection_configs: One or more connection parameter objects
-        :param Callable[[connection.Connection | connection_workflow.AMQPConnectorException], None] on_done:  Callback to report when connection workflow is done
-        :param Any | None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
-        :param None | connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
+        :param Callable[[connection.Connection|connection_workflow.AMQPConnectorException],None] on_done:  Callback to report when connection workflow is done
+        :param Any|None custom_ioloop: Optional custom IOLoop or nbio interface to use for the connection workflow
+        :param None|connection_workflow.AbstractAMQPConnectionWorkflow workflow: Optional connection workflow instance to use
         :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -59,7 +59,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         Like the original :meth:`DeferredQueue.put` method, but returns an
         errback if the queue is closed.
 
-        :param Any obj: Object to adapt into a Twisted ``IProtocol``
+        :param obj: Object to adapt into a Twisted ``IProtocol``
         :rtype: None | defer.Deferred[Any]
         """
         if self.closed:
@@ -89,7 +89,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
         Errback the pending calls to :meth:`get()`.
 
-        :param Exception|None reason: The reason for closing the queue
+        :param reason: The reason for closing the queue
         """
         if self.closed:
             LOGGER.warning('Queue was already closed with reason: %s.',
@@ -174,7 +174,7 @@ class TwistedChannel:
         of queue being consumed as well as failure of a HA node responsible for
         the queue being consumed.
 
-        :param pika.frame.Method method_frame: method frame with the
+        :param method_frame: method frame with the
             `spec.Basic.Cancel` method
 
         :rtype: pika.frame.Method[pika.spec.Basic.Cancel] | pika.frame.Method[pika.spec.Basic.CancelOk]
@@ -189,7 +189,7 @@ class TwistedChannel:
         """Called when the broker cancels a consumer via Basic.Cancel or when
         the broker responds to a Basic.Cancel request by Basic.CancelOk.
 
-        :param pika.frame.Method frame: method frame with the
+        :param frame: method frame with the
             `spec.Basic.Cancel` or `spec.Basic.CancelOk` method
 
         :rtype: pika.frame.Method[pika.spec.Basic.Cancel] | pika.frame.Method[pika.spec.Basic.CancelOk]
@@ -214,7 +214,7 @@ class TwistedChannel:
             self,
             _method_frame: pika.frame.Method[pika.spec.Basic.Get]) -> None:
         """Callback the Basic.Get deferred with None.
-        :param pika.frame.Method[pika.spec.Basic.Get] _method_frame: Method frame from Basic.Get response (unused)
+        :param _method_frame: Method frame from Basic.Get response (unused)
         """
         if self._basic_get_deferred is None:
             LOGGER.warning("Got Basic.GetEmpty but no Basic.Get calls "
@@ -229,7 +229,7 @@ class TwistedChannel:
         the original method's callback would receive more than one argument,
         the Deferred fires with a tuple of argument values.
 
-        :param str name: Attribute name to look up on the underlying channel
+        :param name: Attribute name to look up on the underlying channel
         :rtype: Callable[..., defer.Deferred[Any]]
         """
         method = getattr(self._channel, name)
@@ -322,8 +322,8 @@ class TwistedChannel:
         you'd like the Deferred to be callbacked on with the frame as callback
         value.
 
-        :param Deferred deferred: The Deferred to callback
-        :param list replies: The replies to callback on
+        :param deferred: The Deferred to callback
+        :param replies: The replies to callback on
 
         """
         self._channel.add_callback(deferred.callback, replies)
@@ -335,7 +335,7 @@ class TwistedChannel:
         """Pass a callback function that will be called when a published
         message is rejected and returned by the server via `Basic.Return`.
 
-        :param callable callback: The method to call on callback with the
+        :param callback: The method to call on callback with the
             message as only argument. The message is a named tuple with
             the following attributes
             - channel: this TwistedChannel
@@ -361,7 +361,7 @@ class TwistedChannel:
         set of messages up to and including a specific message.
 
         :param integer delivery_tag: int/long The server-assigned delivery tag
-        :param bool multiple: If set to True, the delivery tag is treated as
+        :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
                               to False, the delivery tag refers to a single
@@ -392,7 +392,7 @@ class TwistedChannel:
         <pika.channel.Channel.basic_cancel>` and closes any deferred queue
         associated with that consumer.
 
-        :param str consumer_tag: Identifier for the consumer
+        :param consumer_tag: Identifier for the consumer
         :returns: Deferred that fires on the Basic.CancelOk response
         :rtype: Deferred
         :raises ValueError:
@@ -421,15 +421,15 @@ class TwistedChannel:
         https://www.rabbitmq.com/confirms.html
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
-        :param str queue: The queue to consume from. Use the empty string to
+        :param queue: The queue to consume from. Use the empty string to
             specify the most recent server-named queue for this channel.
-        :param bool auto_ack: if set to True, automatic acknowledgement mode
+        :param auto_ack: if set to True, automatic acknowledgement mode
             will be used (see https://www.rabbitmq.com/confirms.html). This
             corresponds with the 'no_ack' parameter in the basic.consume AMQP
             0.9.1 method
-        :param bool exclusive: Don't allow other consumers on the queue
-        :param str consumer_tag: Specify your own consumer tag
-        :param dict arguments: Custom key/value pair arguments for the consumer
+        :param exclusive: Don't allow other consumers on the queue
+        :param consumer_tag: Specify your own consumer tag
+        :param arguments: Custom key/value pair arguments for the consumer
         :returns: Deferred that fires with a tuple
             ``(queue_object, consumer_tag)``. The Deferred will errback with an
             instance of :class:`exceptions.ChannelClosed` if the call fails.
@@ -505,10 +505,10 @@ class TwistedChannel:
         This method wraps :meth:`Channel.basic_get
         <pika.channel.Channel.basic_get>`.
 
-        :param str queue: The queue from which to get a message. Use the empty
+        :param queue: The queue from which to get a message. Use the empty
                       string to specify the most recent server-named queue
                       for this channel.
-        :param bool auto_ack: Tell the broker to not expect a reply
+        :param auto_ack: Tell the broker to not expect a reply
         :returns: Deferred that fires with a namedtuple whose attributes are:
              - channel: this TwistedChannel
              - method: pika.spec.Basic.GetOk
@@ -553,14 +553,14 @@ class TwistedChannel:
         return untreatable messages to their original queue.
 
         :param integer delivery_tag: int/long The server-assigned delivery tag
-        :param bool multiple: If set to True, the delivery tag is treated as
+        :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
                               to False, the delivery tag refers to a single
                               message. If the multiple field is 1, and the
                               delivery tag is zero, this indicates
                               acknowledgement of all outstanding messages.
-        :param bool requeue: If requeue is true, the server will attempt to
+        :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded
                              or dead-lettered.
@@ -588,11 +588,11 @@ class TwistedChannel:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
-        :param str exchange: The exchange to publish to
-        :param str routing_key: The routing key to bind on
-        :param bytes body: The message body
-        :param pika.spec.BasicProperties properties: Basic.properties
-        :param bool mandatory: The mandatory flag
+        :param exchange: The exchange to publish to
+        :param routing_key: The routing key to bind on
+        :param body: The message body
+        :param properties: Basic.properties
+        :param mandatory: The mandatory flag
         :returns: A Deferred that fires with the result of the channel's
             basic_publish.
         :rtype: Deferred
@@ -632,7 +632,7 @@ class TwistedChannel:
         the following message is already held locally, rather than needing to
         be sent down the channel. Prefetching gives a performance improvement.
 
-        :param int prefetch_size:  This field specifies the prefetch window
+        :param prefetch_size:  This field specifies the prefetch window
                                    size. The server will send a message in
                                    advance if it is equal to or smaller in size
                                    than the available prefetch size (and also
@@ -642,7 +642,7 @@ class TwistedChannel:
                                    apply. The prefetch-size is ignored by
                                    consumers who have enabled the no-ack
                                    option.
-        :param int prefetch_count: Specifies a prefetch window in terms of
+        :param prefetch_count: Specifies a prefetch window in terms of
                                    whole messages. This field may be used in
                                    combination with the prefetch-size field; a
                                    message will only be sent in advance if both
@@ -650,7 +650,7 @@ class TwistedChannel:
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool global_qos:    Should the QoS apply to all channels on the
+        :param global_qos:    Should the QoS apply to all channels on the
                                    connection.
         :returns: Deferred that fires on the Basic.QosOk response
         :rtype: Deferred
@@ -668,7 +668,7 @@ class TwistedChannel:
         messages, or return untreatable messages to their original queue.
 
         :param integer delivery_tag: int/long The server-assigned delivery tag
-        :param bool requeue: If requeue is true, the server will attempt to
+        :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded
                              or dead-lettered.
@@ -683,7 +683,7 @@ class TwistedChannel:
         on a specified channel. Zero or more messages may be redelivered. This
         method replaces the asynchronous Recover.
 
-        :param bool requeue: If False, the message will be redelivered to the
+        :param requeue: If False, the message will be redelivered to the
                              original recipient. If True, the server will
                              attempt to requeue the message, potentially then
                              delivering it to an alternative subscriber.
@@ -701,8 +701,8 @@ class TwistedChannel:
         If channel is OPENING, transition to CLOSING and suppress the incoming
         Channel.OpenOk, if any.
 
-        :param int reply_code: The reason code to send to broker
-        :param str reply_text: The reason text to send to broker
+        :param reply_code: The reason code to send to broker
+        :param reply_text: The reason text to send to broker
 
         :raises ChannelWrongStateError: if channel is closed or closing
 
@@ -752,7 +752,7 @@ class TwistedChannel:
         a delivery confirmation of from the list used to keep track of messages
         that are pending confirmation.
 
-        :param pika.frame.Method method_frame: Basic.Ack or Basic.Nack frame
+        :param method_frame: Basic.Ack or Basic.Nack frame
 
         """
         delivery_tag = method_frame.method.delivery_tag
@@ -802,10 +802,10 @@ class TwistedChannel:
         publisher-acknowledgements mode. Saves the info as a ReturnedMessage
         instance in self._puback_return.
 
-        :param pika.Channel channel: our self._impl channel
-        :param pika.spec.Basic.Return method:
-        :param pika.spec.BasicProperties properties: message properties
-        :param bytes body: returned message body; empty string if no body
+        :param channel: our self._impl channel
+        :param method:
+        :param properties: message properties
+        :param body: returned message body; empty string if no body
 
         """
         assert isinstance(method, spec.Basic.Return), method
@@ -831,10 +831,10 @@ class TwistedChannel:
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
         """Bind an exchange to another exchange.
 
-        :param str destination: The destination exchange to bind
-        :param str source: The source exchange to bind to
-        :param str routing_key: The routing key to bind on
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param destination: The destination exchange to bind
+        :param source: The source exchange to bind to
+        :param routing_key: The routing key to bind on
+        :param arguments: Custom key/value pair arguments for the binding
         :raises ValueError:
         :returns: Deferred that fires on the Exchange.BindOk response
         :rtype: Deferred
@@ -865,16 +865,16 @@ class TwistedChannel:
         exchange does not already exist, the server MUST raise a channel
         exception with reply code 404 (not found).
 
-        :param str exchange: The exchange name consists of a non-empty sequence
+        :param exchange: The exchange name consists of a non-empty sequence
             of these characters: letters, digits, hyphen, underscore, period,
             or colon
-        :param str exchange_type: The exchange type to use
-        :param bool passive: Perform a declare or just check to see if it
+        :param exchange_type: The exchange type to use
+        :param passive: Perform a declare or just check to see if it
             exists
-        :param bool durable: Survive a reboot of RabbitMQ
-        :param bool auto_delete: Remove when no more queues are bound to it
-        :param bool internal: Can only be published to by other exchanges
-        :param dict arguments: Custom key/value pair arguments for the exchange
+        :param durable: Survive a reboot of RabbitMQ
+        :param auto_delete: Remove when no more queues are bound to it
+        :param internal: Can only be published to by other exchanges
+        :param arguments: Custom key/value pair arguments for the exchange
         :returns: Deferred that fires on the Exchange.DeclareOk response
         :rtype: Deferred
         :raises ValueError:
@@ -895,8 +895,8 @@ class TwistedChannel:
                         if_unused: bool = False) -> defer.Deferred[Any]:
         """Delete the exchange.
 
-        :param str exchange: The exchange name
-        :param bool if_unused: only delete if the exchange is unused
+        :param exchange: The exchange name
+        :param if_unused: only delete if the exchange is unused
         :returns: Deferred that fires on the Exchange.DeleteOk response
         :rtype: Deferred
         :raises ValueError:
@@ -915,10 +915,10 @@ class TwistedChannel:
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
         """Unbind an exchange from another exchange.
 
-        :param str destination: The destination exchange to unbind
-        :param str source: The source exchange to unbind from
-        :param str routing_key: The routing key to unbind
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param destination: The destination exchange to unbind
+        :param source: The source exchange to unbind from
+        :param routing_key: The routing key to unbind
+        :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Exchange.UnbindOk response
         :rtype: Deferred
         :raises ValueError:
@@ -939,7 +939,7 @@ class TwistedChannel:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
-        :param bool active: Turn flow on or off
+        :param active: Turn flow on or off
         :returns: Deferred that fires with the channel flow state
         :rtype: Deferred
         :raises ValueError:
@@ -959,10 +959,10 @@ class TwistedChannel:
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
         """Bind the queue to the specified exchange
 
-        :param str queue: The queue to bind to the exchange
-        :param str exchange: The source exchange to bind to
-        :param str routing_key: The routing key to bind on
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param queue: The queue to bind to the exchange
+        :param exchange: The source exchange to bind to
+        :param routing_key: The routing key to bind on
+        :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Queue.BindOk response
         :rtype: Deferred
         :raises ValueError:
@@ -991,13 +991,13 @@ class TwistedChannel:
         Use an empty string as the queue name for the broker to auto-generate
         one
 
-        :param str queue: The queue name; if empty string, the broker will
+        :param queue: The queue name; if empty string, the broker will
             create a unique queue name
-        :param bool passive: Only check to see if the queue exists
-        :param bool durable: Survive reboots of the broker
-        :param bool exclusive: Only allow access by the current connection
-        :param bool auto_delete: Delete after consumer cancels or disconnects
-        :param dict arguments: Custom key/value arguments for the queue
+        :param passive: Only check to see if the queue exists
+        :param durable: Survive reboots of the broker
+        :param exclusive: Only allow access by the current connection
+        :param auto_delete: Delete after consumer cancels or disconnects
+        :param arguments: Custom key/value arguments for the queue
         :returns: Deferred that fires on the Queue.DeclareOk response
         :rtype: Deferred
         :raises ValueError:
@@ -1023,9 +1023,9 @@ class TwistedChannel:
         <pika.channel.Channel.queue_delete>`, and removes the reference to the
         queue object after it gets deleted on the server.
 
-        :param str queue: The queue to delete
-        :param bool if_unused: only delete if it's unused
-        :param bool if_empty: only delete if the queue is empty
+        :param queue: The queue to delete
+        :param if_unused: only delete if it's unused
+        :param if_empty: only delete if the queue is empty
         :returns: Deferred that fires on the Queue.DeleteOk response
         :rtype: Deferred
         :raises ValueError:
@@ -1050,7 +1050,7 @@ class TwistedChannel:
     def queue_purge(self, queue: str) -> defer.Deferred[Any]:
         """Purge all of the messages from the specified queue
 
-        :param str queue: The queue to purge
+        :param queue: The queue to purge
         :returns: Deferred that fires on the Queue.PurgeOk response
         :rtype: Deferred
         :raises ValueError:
@@ -1066,10 +1066,10 @@ class TwistedChannel:
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
         """Unbind a queue from an exchange.
 
-        :param str queue: The queue to unbind from the exchange
-        :param str exchange: The source exchange to bind from
-        :param str routing_key: The routing key to unbind
-        :param dict arguments: Custom key/value pair arguments for the binding
+        :param queue: The queue to unbind from the exchange
+        :param exchange: The source exchange to bind from
+        :param routing_key: The routing key to unbind
+        :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Queue.UnbindOk response
         :rtype: Deferred
         :raises ValueError:
@@ -1150,8 +1150,8 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_call_later()`.
 
-        :param float delay: Delay in seconds
-        :param Callable[..., None] callback: The callback to call after the delay
+        :param delay: Delay in seconds
+        :param callback: The callback to call after the delay
         :rtype: _TimerHandle
         """
         check_callback_arg(callback, 'callback')
@@ -1163,7 +1163,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_remove_timeout()`.
 
-        :param Any timeout_id: Opaque timeout handle returned by ``callLater``
+        :param timeout_id: Opaque timeout handle returned by ``callLater``
         """
         timeout_id.cancel()
 
@@ -1172,7 +1172,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_add_callback_threadsafe()`.
 
-        :param Callable[..., None] callback: The callback to call from the thread
+        :param callback: The callback to call from the thread
         """
         check_callback_arg(callback, 'callback')
         self._reactor.callFromThread(
@@ -1201,7 +1201,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement pure virtual
         :py:ref:meth:`pika.connection.Connection._adapter_emit_data()` method.
 
-        :param bytes data: Raw bytes to write to the transport
+        :param data: Raw bytes to write to the transport
         """
         assert self._transport is not None
         self._transport.write(data)  # type: ignore[call-arg, misc]
@@ -1210,7 +1210,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
             self, transport: twisted.internet.interfaces.ITransport) -> None:
         """Introduces transport to protocol after transport is connected.
 
-        :param twisted.internet.interfaces.ITransport transport:
+        :param transport:
         :raises Exception: Exception-based exception on error
 
         """
@@ -1224,7 +1224,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
 
-        :param Failure error: A Twisted Failure instance wrapping an exception.
+        :param error: A Twisted Failure instance wrapping an exception.
 
         """
         self._transport = None
@@ -1296,7 +1296,7 @@ class TwistedProtocolConnection(protocol.Protocol):
         specify but it is recommended that you let Pika manage the channel
         numbers.
 
-        :param int channel_number: The channel number to use, defaults to the
+        :param channel_number: The channel number to use, defaults to the
                                    next available.
         :returns: a Deferred that fires with an instance of a wrapper around
             the Pika Channel class.
@@ -1403,7 +1403,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
     def __init__(self, handle: twisted.internet.base.DelayedCall) -> None:
         """
 
-        :param twisted.internet.base.DelayedCall handle:
+        :param handle:
         """
         self._handle: twisted.internet.base.DelayedCall | None = handle
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -89,7 +89,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
         Errback the pending calls to :meth:`get()`.
 
-        :param Exception | None reason: The reason for closing the queue
+        :param reason: The reason for closing the queue
         """
         if self.closed:
             LOGGER.warning('Queue was already closed with reason: %s.',
@@ -214,7 +214,7 @@ class TwistedChannel:
             self,
             _method_frame: pika.frame.Method[pika.spec.Basic.Get]) -> None:
         """Callback the Basic.Get deferred with None.
-        :param pika.frame.Method[pika.spec.Basic.Get] _method_frame: Method frame from Basic.Get response (unused)
+        :param _method_frame: Method frame from Basic.Get response (unused)
         """
         if self._basic_get_deferred is None:
             LOGGER.warning("Got Basic.GetEmpty but no Basic.Get calls "
@@ -1151,7 +1151,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         :py:meth:`pika.connection.Connection._adapter_call_later()`.
 
         :param float delay: Delay in seconds
-        :param Callable[..., None] callback: The callback to call after the delay
+        :param callback: The callback to call after the delay
         :rtype: _TimerHandle
         """
         check_callback_arg(callback, 'callback')
@@ -1172,7 +1172,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_add_callback_threadsafe()`.
 
-        :param Callable[..., None] callback: The callback to call from the thread
+        :param callback: The callback to call from the thread
         """
         check_callback_arg(callback, 'callback')
         self._reactor.callFromThread(

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -89,7 +89,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
         Errback the pending calls to :meth:`get()`.
 
-        :param Exception | None reason: The reason for closing the queue
+        :param Exception|None reason: The reason for closing the queue
         """
         if self.closed:
             LOGGER.warning('Queue was already closed with reason: %s.',

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -89,7 +89,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
         Errback the pending calls to :meth:`get()`.
 
-        :param reason: The reason for closing the queue
+        :param Exception | None reason: The reason for closing the queue
         """
         if self.closed:
             LOGGER.warning('Queue was already closed with reason: %s.',
@@ -214,7 +214,7 @@ class TwistedChannel:
             self,
             _method_frame: pika.frame.Method[pika.spec.Basic.Get]) -> None:
         """Callback the Basic.Get deferred with None.
-        :param _method_frame: Method frame from Basic.Get response (unused)
+        :param pika.frame.Method[pika.spec.Basic.Get] _method_frame: Method frame from Basic.Get response (unused)
         """
         if self._basic_get_deferred is None:
             LOGGER.warning("Got Basic.GetEmpty but no Basic.Get calls "
@@ -1151,7 +1151,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         :py:meth:`pika.connection.Connection._adapter_call_later()`.
 
         :param float delay: Delay in seconds
-        :param callback: The callback to call after the delay
+        :param Callable[..., None] callback: The callback to call after the delay
         :rtype: _TimerHandle
         """
         check_callback_arg(callback, 'callback')
@@ -1172,7 +1172,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_add_callback_threadsafe()`.
 
-        :param callback: The callback to call from the thread
+        :param Callable[..., None] callback: The callback to call from the thread
         """
         check_callback_arg(callback, 'callback')
         self._reactor.callFromThread(

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -21,6 +21,7 @@ import twisted.internet.base
 import twisted.python.failure
 from twisted.internet import defer, protocol, reactor
 from twisted.internet import error as twisted_error
+from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 import pika.connection
@@ -46,7 +47,9 @@ class ClosableDeferredQueue(defer.DeferredQueue):
     to call get() or put() return a Failure wrapping that exception.
     """
 
-    def __init__(self, size: int | None = None, backlog: int | None = None):
+    def __init__(self,
+                 size: int | None = None,
+                 backlog: int | None = None) -> None:
         self.closed: Exception | None = None
         super().__init__(size, backlog)
 
@@ -56,6 +59,8 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         Like the original :meth:`DeferredQueue.put` method, but returns an
         errback if the queue is closed.
 
+        :param Any obj: Object to adapt into a Twisted ``IProtocol``
+        :rtype: None | defer.Deferred[Any]
         """
         if self.closed:
             LOGGER.error('Impossible to put to the queue, it is closed.')
@@ -84,6 +89,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
         Errback the pending calls to :meth:`get()`.
 
+        :param Exception | None reason: The reason for closing the queue
         """
         if self.closed:
             LOGGER.warning('Queue was already closed with reason: %s.',
@@ -171,6 +177,7 @@ class TwistedChannel:
         :param pika.frame.Method method_frame: method frame with the
             `spec.Basic.Cancel` method
 
+        :rtype: pika.frame.Method[pika.spec.Basic.Cancel] | pika.frame.Method[pika.spec.Basic.CancelOk]
         """
         return self._on_consumer_cancelled(method_frame)
 
@@ -185,6 +192,7 @@ class TwistedChannel:
         :param pika.frame.Method frame: method frame with the
             `spec.Basic.Cancel` or `spec.Basic.CancelOk` method
 
+        :rtype: pika.frame.Method[pika.spec.Basic.Cancel] | pika.frame.Method[pika.spec.Basic.CancelOk]
         """
         consumer_tag = frame.method.consumer_tag
         if consumer_tag not in self._consumers:
@@ -206,6 +214,7 @@ class TwistedChannel:
             self,
             _method_frame: pika.frame.Method[pika.spec.Basic.Get]) -> None:
         """Callback the Basic.Get deferred with None.
+        :param pika.frame.Method[pika.spec.Basic.Get] _method_frame: Method frame from Basic.Get response (unused)
         """
         if self._basic_get_deferred is None:
             LOGGER.warning("Got Basic.GetEmpty but no Basic.Get calls "
@@ -220,6 +229,8 @@ class TwistedChannel:
         the original method's callback would receive more than one argument,
         the Deferred fires with a tuple of argument values.
 
+        :param str name: Attribute name to look up on the underlying channel
+        :rtype: Callable[..., defer.Deferred[Any]]
         """
         method = getattr(self._channel, name)
 
@@ -232,7 +243,7 @@ class TwistedChannel:
             self._calls.add(d)
             d.addCallback(self._clear_call, d)
 
-            def single_argument(*args):
+            def single_argument(*args) -> None:
                 """
                 Make sure that the deferred is called with a single argument.
                 In case the original callback fires with more than one, convert
@@ -319,8 +330,8 @@ class TwistedChannel:
 
     # Public Channel methods
 
-    def add_on_return_callback(self, callback: Callable[[ReceivedMessage],
-                                                        None]):
+    def add_on_return_callback(
+            self, callback: Callable[[ReceivedMessage], None]) -> None:
         """Pass a callback function that will be called when a published
         message is rejected and returned by the server via `Basic.Return`.
 
@@ -441,7 +452,7 @@ class TwistedChannel:
         d: defer.Deferred[Any] = defer.Deferred()
         self._calls.add(d)
 
-        def on_consume_ok(frame):
+        def on_consume_ok(frame) -> None:
             consumer_tag = frame.method.consumer_tag
             self._queue_name_to_consumer_tags.setdefault(
                 queue, set()).add(consumer_tag)
@@ -449,7 +460,7 @@ class TwistedChannel:
             self._calls.discard(d)
             d.callback((queue_obj, consumer_tag))
 
-        def on_message_callback(_channel, method, properties, body):
+        def on_message_callback(_channel, method, properties, body) -> None:
             """Add the ReceivedMessage to the queue, while replacing the
             channel implementation.
             """
@@ -511,7 +522,7 @@ class TwistedChannel:
         if self._basic_get_deferred is not None:
             raise exceptions.DuplicateGetOkCallback()
 
-        def create_namedtuple(result):
+        def create_namedtuple(result) -> ReceivedMessage | None:
             if result is None:
                 return None
             _channel, method, properties, body = result
@@ -1122,7 +1133,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
                  (Callable[[pika.connection.Connection, Exception], Any]),
                  on_close_callback: None |
                  (Callable[[pika.connection.Connection, Exception], Any]),
-                 custom_reactor: Any = None):
+                 custom_reactor: Any = None) -> None:
         super().__init__(parameters=parameters,
                          on_open_callback=on_open_callback,
                          on_open_error_callback=on_open_error_callback,
@@ -1134,10 +1145,14 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
             twisted.internet.interfaces.ITransport
         ) = None  # to be provided by `connection_made()`
 
-    def _adapter_call_later(self, delay: float, callback: Callable[..., None]):
+    def _adapter_call_later(self, delay: float,
+                            callback: Callable[..., None]) -> _TimerHandle:
         """Implement
         :py:meth:`pika.connection.Connection._adapter_call_later()`.
 
+        :param float delay: Delay in seconds
+        :param Callable[..., None] callback: The callback to call after the delay
+        :rtype: _TimerHandle
         """
         check_callback_arg(callback, 'callback')
         return _TimerHandle(
@@ -1148,6 +1163,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_remove_timeout()`.
 
+        :param Any timeout_id: Opaque timeout handle returned by ``callLater``
         """
         timeout_id.cancel()
 
@@ -1156,6 +1172,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement
         :py:meth:`pika.connection.Connection._adapter_add_callback_threadsafe()`.
 
+        :param Callable[..., None] callback: The callback to call from the thread
         """
         check_callback_arg(callback, 'callback')
         self._reactor.callFromThread(
@@ -1184,6 +1201,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         """Implement pure virtual
         :py:ref:meth:`pika.connection.Connection._adapter_emit_data()` method.
 
+        :param bytes data: Raw bytes to write to the transport
         """
         assert self._transport is not None
         self._transport.write(data)  # type: ignore[call-arg, misc]
@@ -1250,7 +1268,7 @@ class TwistedProtocolConnection(protocol.Protocol):
 
     def __init__(self,
                  parameters: pika.connection.ConnectionParameters | None = None,
-                 custom_reactor: Any = None):
+                 custom_reactor: Any = None) -> None:
         warnings.warn(
             "TwistedProtocolConnection is deprecated and will be removed in "
             "Pika 2.0. Use ThreadSafeConnection instead, which works with any "
@@ -1271,7 +1289,8 @@ class TwistedProtocolConnection(protocol.Protocol):
         )
         self._calls: set[defer.Deferred[Any]] = set()
 
-    def channel(self, channel_number: int | None = None):
+    def channel(self,
+                channel_number: int | None = None) -> Deferred[TwistedChannel]:
         """Create a new channel with the next available channel number or pass
         in a channel number to use. Must be non-zero if you would like to
         specify but it is recommended that you let Pika manage the channel
@@ -1336,6 +1355,7 @@ class TwistedProtocolConnection(protocol.Protocol):
     ) -> (TwistedProtocolConnection | defer.Deferred[TwistedProtocolConnection]
          ):
         """This method will be called when the underlying connection is ready.
+        :rtype: TwistedProtocolConnection | defer.Deferred[TwistedProtocolConnection]
         """
         return self
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -59,8 +59,7 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         Like the original :meth:`DeferredQueue.put` method, but returns an
         errback if the queue is closed.
 
-        :param obj: Object to adapt into a Twisted ``IProtocol``
-        :rtype: None | defer.Deferred[Any]
+        :param obj: Object to put into the queue
         """
         if self.closed:
             LOGGER.error('Impossible to put to the queue, it is closed.')
@@ -177,7 +176,6 @@ class TwistedChannel:
         :param method_frame: method frame with the
             `spec.Basic.Cancel` method
 
-        :rtype: pika.frame.Method[pika.spec.Basic.Cancel] | pika.frame.Method[pika.spec.Basic.CancelOk]
         """
         return self._on_consumer_cancelled(method_frame)
 
@@ -192,7 +190,6 @@ class TwistedChannel:
         :param frame: method frame with the
             `spec.Basic.Cancel` or `spec.Basic.CancelOk` method
 
-        :rtype: pika.frame.Method[pika.spec.Basic.Cancel] | pika.frame.Method[pika.spec.Basic.CancelOk]
         """
         consumer_tag = frame.method.consumer_tag
         if consumer_tag not in self._consumers:
@@ -230,7 +227,6 @@ class TwistedChannel:
         the Deferred fires with a tuple of argument values.
 
         :param name: Attribute name to look up on the underlying channel
-        :rtype: Callable[..., defer.Deferred[Any]]
         """
         method = getattr(self._channel, name)
 
@@ -1152,7 +1148,6 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
 
         :param delay: Delay in seconds
         :param callback: The callback to call after the delay
-        :rtype: _TimerHandle
         """
         check_callback_arg(callback, 'callback')
         return _TimerHandle(
@@ -1355,7 +1350,6 @@ class TwistedProtocolConnection(protocol.Protocol):
     ) -> (TwistedProtocolConnection | defer.Deferred[TwistedProtocolConnection]
          ):
         """This method will be called when the underlying connection is ready.
-        :rtype: TwistedProtocolConnection | defer.Deferred[TwistedProtocolConnection]
         """
         return self
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -360,7 +360,7 @@ class TwistedChannel:
         confirm mode. The acknowledgement can be for a single message or a
         set of messages up to and including a specific message.
 
-        :param integer delivery_tag: int/long The server-assigned delivery tag
+        :param delivery_tag: int/long The server-assigned delivery tag
         :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
@@ -552,7 +552,7 @@ class TwistedChannel:
         It can be used to interrupt and cancel large incoming messages, or
         return untreatable messages to their original queue.
 
-        :param integer delivery_tag: int/long The server-assigned delivery tag
+        :param delivery_tag: int/long The server-assigned delivery tag
         :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
@@ -667,7 +667,7 @@ class TwistedChannel:
         message. It can be used to interrupt and cancel large incoming
         messages, or return untreatable messages to their original queue.
 
-        :param integer delivery_tag: int/long The server-assigned delivery tag
+        :param delivery_tag: int/long The server-assigned delivery tag
         :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -52,7 +52,7 @@ class AMQPConnectorPhaseErrorBase(AMQPConnectorException):
 
     """
 
-    def __init__(self, exception: BaseException, *args: Any):
+    def __init__(self, exception: BaseException, *args: Any) -> None:
         """
 
         :param BaseException exception: error that occurred while waiting for a
@@ -62,7 +62,7 @@ class AMQPConnectorPhaseErrorBase(AMQPConnectorException):
         super().__init__(*args)
         self.exception = exception
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'{self.__class__.__name__}: {self.exception!r}'
 
 
@@ -95,7 +95,7 @@ class AMQPConnectionWorkflowFailed(AMQPConnectorException):
 
     """
 
-    def __init__(self, exceptions: Sequence[BaseException], *args: Any):
+    def __init__(self, exceptions: Sequence[BaseException], *args: Any) -> None:
         """
         :param sequence exceptions: Exceptions that occurred during the
             workflow.
@@ -128,7 +128,7 @@ class AMQPConnector:
     def __init__(self,
                  conn_factory: Callable[[pika.connection.Parameters],
                                         nbio_interface.AbstractStreamProtocol],
-                 nbio: nbio_interface.AbstractIOServices):
+                 nbio: nbio_interface.AbstractIOServices) -> None:
         """
 
         :param callable conn_factory: A function that takes
@@ -685,6 +685,9 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         as the overall number of connection attempts of the entire
         `connection_configs` sequence and pause between each sequence.
 
+        :param Sequence[pika.connection.Parameters] connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
+        :param Callable[..., Any] connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
+        :param Callable[[pika.connection.Connection | AMQPConnectorException], None] on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
         """
         if self._state != self._STATE_INIT:
             raise AMQPConnectorWrongState(

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -309,7 +309,7 @@ class AMQPConnector:
         self, result: (pika.connection.Connection | BaseException)) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param pika.connection.Connection | BaseException result: value to pass
+        :param result: value to pass
             to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
@@ -390,7 +390,7 @@ class AMQPConnector:
         Reports AMQPConnectorSocketConnectError if TCP socket connection
             failed.
 
-        :param None|BaseException exc: None on success; exception object on
+        :param exc: None on success; exception object on
             failure
 
         """
@@ -445,7 +445,7 @@ class AMQPConnector:
         Reports AMQPConnectorTransportSetupError if transport ([SSL]) setup
             failed.
 
-        :param sequence|BaseException result: On success, a two-tuple
+        :param result: On success, a two-tuple
             (transport, protocol); on failure, exception instance.
 
         """
@@ -487,7 +487,7 @@ class AMQPConnector:
         Reports AMQPConnectorAMQPHandshakeError if AMQP handshake failed.
 
         :param pika.connection.Connection connection:
-        :param BaseException | None error: None on success, otherwise
+        :param error: None on success, otherwise
             failure
 
         """
@@ -613,7 +613,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
 
     def __init__(self, _until_first_amqp_attempt: bool = False) -> None:
         """
-        :param int | float retry_pause: Non-negative number of seconds to wait
+        :param retry_pause: Non-negative number of seconds to wait
             before retrying the config sequence. Meaningful only if retries is
             greater than 0. Defaults to 2 seconds.
         :param bool _until_first_amqp_attempt: INTERNAL USE ONLY; ends workflow
@@ -685,9 +685,9 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         as the overall number of connection attempts of the entire
         `connection_configs` sequence and pause between each sequence.
 
-        :param Sequence[pika.connection.Parameters] connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
-        :param Callable[..., Any] connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
-        :param Callable[[pika.connection.Connection | AMQPConnectorException], None] on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
+        :param connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
+        :param connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
+        :param on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
         """
         if self._state != self._STATE_INIT:
             raise AMQPConnectorWrongState(
@@ -778,7 +778,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
     ) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param pika.connection.Connection | AMQPConnectionWorkflowFailed result:
+        :param result:
             value to pass to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
@@ -861,7 +861,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         self, addrinfos_or_exc: (list[ADDRESS_INFO] | BaseException)) -> None:
         """Handles completion callback from asynchronous `getaddrinfo()`.
 
-        :param list | BaseException addrinfos_or_exc: resolved address records
+        :param addrinfos_or_exc: resolved address records
             returned by `getaddrinfo()` or an exception object from failure.
         """
         assert self._connection_errors is not None
@@ -911,7 +911,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         conn_or_exc: (pika.connection.Connection | BaseException)) -> None:
         """Handle completion of connection attempt by `AMQPConnector`.
 
-        :param pika.connection.Connection | BaseException conn_or_exc: See
+        :param conn_or_exc: See
             `AMQPConnector.start()` for exception details.
 
         """

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -687,6 +687,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
 
         :param connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
         :param connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
+        :param native_loop: Native I/O loop passed by app to the adapter or obtained by the adapter by default.
         :param on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
         """
         if self._state != self._STATE_INIT:

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -309,7 +309,7 @@ class AMQPConnector:
         self, result: (pika.connection.Connection | BaseException)) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param result: value to pass
+        :param pika.connection.Connection | BaseException result: value to pass
             to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
@@ -390,7 +390,7 @@ class AMQPConnector:
         Reports AMQPConnectorSocketConnectError if TCP socket connection
             failed.
 
-        :param exc: None on success; exception object on
+        :param None|BaseException exc: None on success; exception object on
             failure
 
         """
@@ -445,7 +445,7 @@ class AMQPConnector:
         Reports AMQPConnectorTransportSetupError if transport ([SSL]) setup
             failed.
 
-        :param result: On success, a two-tuple
+        :param sequence|BaseException result: On success, a two-tuple
             (transport, protocol); on failure, exception instance.
 
         """
@@ -487,7 +487,7 @@ class AMQPConnector:
         Reports AMQPConnectorAMQPHandshakeError if AMQP handshake failed.
 
         :param pika.connection.Connection connection:
-        :param error: None on success, otherwise
+        :param BaseException | None error: None on success, otherwise
             failure
 
         """
@@ -613,7 +613,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
 
     def __init__(self, _until_first_amqp_attempt: bool = False) -> None:
         """
-        :param retry_pause: Non-negative number of seconds to wait
+        :param int | float retry_pause: Non-negative number of seconds to wait
             before retrying the config sequence. Meaningful only if retries is
             greater than 0. Defaults to 2 seconds.
         :param bool _until_first_amqp_attempt: INTERNAL USE ONLY; ends workflow
@@ -685,9 +685,9 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         as the overall number of connection attempts of the entire
         `connection_configs` sequence and pause between each sequence.
 
-        :param connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
-        :param connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
-        :param on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
+        :param Sequence[pika.connection.Parameters] connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
+        :param Callable[..., Any] connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
+        :param Callable[[pika.connection.Connection | AMQPConnectorException], None] on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
         """
         if self._state != self._STATE_INIT:
             raise AMQPConnectorWrongState(
@@ -778,7 +778,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
     ) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param result:
+        :param pika.connection.Connection | AMQPConnectionWorkflowFailed result:
             value to pass to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
@@ -861,7 +861,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         self, addrinfos_or_exc: (list[ADDRESS_INFO] | BaseException)) -> None:
         """Handles completion callback from asynchronous `getaddrinfo()`.
 
-        :param addrinfos_or_exc: resolved address records
+        :param list | BaseException addrinfos_or_exc: resolved address records
             returned by `getaddrinfo()` or an exception object from failure.
         """
         assert self._connection_errors is not None
@@ -911,7 +911,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         conn_or_exc: (pika.connection.Connection | BaseException)) -> None:
         """Handle completion of connection attempt by `AMQPConnector`.
 
-        :param conn_or_exc: See
+        :param pika.connection.Connection | BaseException conn_or_exc: See
             `AMQPConnector.start()` for exception details.
 
         """

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -55,7 +55,7 @@ class AMQPConnectorPhaseErrorBase(AMQPConnectorException):
     def __init__(self, exception: BaseException, *args: Any) -> None:
         """
 
-        :param BaseException exception: error that occurred while waiting for a
+        :param exception: error that occurred while waiting for a
             subclass-specific protocol bring-up phase to complete.
         :param args: args for parent class
         """
@@ -131,12 +131,12 @@ class AMQPConnector:
                  nbio: nbio_interface.AbstractIOServices) -> None:
         """
 
-        :param callable conn_factory: A function that takes
+        :param conn_factory: A function that takes
             `pika.connection.Parameters` as its only arg and returns a brand new
             `pika.connection.Connection`-based adapter instance each time it is
             called. The factory must instantiate the connection with
             `internal_connection_workflow=False`.
-        :param pika.adapters.utils.nbio_interface.AbstractIOServices nbio:
+        :param nbio:
 
         """
         self._conn_factory: Callable[
@@ -166,10 +166,10 @@ class AMQPConnector:
     ) -> None:
         """Asynchronously perform a single TCP/[SSL]/AMQP connection attempt.
 
-        :param tuple addr_record: a single resolved address record compatible
+        :param addr_record: a single resolved address record compatible
             with `socket.getaddrinfo()` format.
-        :param pika.connection.Parameters conn_params:
-        :param callable on_done: Function to call upon completion of the
+        :param conn_params:
+        :param on_done: Function to call upon completion of the
             workflow: `on_done(pika.connection.Connection | BaseException)`. If
             exception, it's going to be one of the following:
                 `AMQPConnectorSocketConnectError`
@@ -309,7 +309,7 @@ class AMQPConnector:
         self, result: (pika.connection.Connection | BaseException)) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param pika.connection.Connection | BaseException result: value to pass
+        :param result: value to pass
             to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
@@ -390,7 +390,7 @@ class AMQPConnector:
         Reports AMQPConnectorSocketConnectError if TCP socket connection
             failed.
 
-        :param None|BaseException exc: None on success; exception object on
+        :param exc: None on success; exception object on
             failure
 
         """
@@ -445,7 +445,7 @@ class AMQPConnector:
         Reports AMQPConnectorTransportSetupError if transport ([SSL]) setup
             failed.
 
-        :param sequence|BaseException result: On success, a two-tuple
+        :param result: On success, a two-tuple
             (transport, protocol); on failure, exception instance.
 
         """
@@ -486,8 +486,8 @@ class AMQPConnector:
 
         Reports AMQPConnectorAMQPHandshakeError if AMQP handshake failed.
 
-        :param pika.connection.Connection connection:
-        :param BaseException | None error: None on success, otherwise
+        :param connection:
+        :param error: None on success, otherwise
             failure
 
         """
@@ -553,12 +553,12 @@ class AbstractAMQPConnectionWorkflow(
         :param sequence connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects. Will attempt to connect
             using each config in the given order.
-        :param callable connector_factory: call it without args to obtain a new
+        :param connector_factory: call it without args to obtain a new
             instance of `AMQPConnector` for each connection attempt.
             See `AMQPConnector` for details.
         :param native_loop: Native I/O loop passed by app to the adapter or
             obtained by the adapter by default.
-        :param callable on_done: Function to call upon completion of the
+        :param on_done: Function to call upon completion of the
             workflow:
             `on_done(pika.connection.Connection |
                      AMQPConnectionWorkflowFailed |
@@ -613,10 +613,10 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
 
     def __init__(self, _until_first_amqp_attempt: bool = False) -> None:
         """
-        :param int | float retry_pause: Non-negative number of seconds to wait
+        :param retry_pause: Non-negative number of seconds to wait
             before retrying the config sequence. Meaningful only if retries is
             greater than 0. Defaults to 2 seconds.
-        :param bool _until_first_amqp_attempt: INTERNAL USE ONLY; ends workflow
+        :param _until_first_amqp_attempt: INTERNAL USE ONLY; ends workflow
             after first AMQP handshake attempt, regardless of outcome (success
             or failure). The automatic connection logic in
             `pika.connection.Connection` enables this because it's not
@@ -667,7 +667,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         directly because `AbstractIOServices` is private to Pika
         implementation and its interface may change without notice.
 
-        :param pika.adapters.utils.nbio_interface.AbstractIOServices nbio:
+        :param nbio:
 
         """
         self._nbio = nbio
@@ -685,9 +685,9 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         as the overall number of connection attempts of the entire
         `connection_configs` sequence and pause between each sequence.
 
-        :param Sequence[pika.connection.Parameters] connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
-        :param Callable[..., Any] connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
-        :param Callable[[pika.connection.Connection | AMQPConnectorException], None] on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
+        :param connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
+        :param connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
+        :param on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
         """
         if self._state != self._STATE_INIT:
             raise AMQPConnectorWrongState(
@@ -778,7 +778,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
     ) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param pika.connection.Connection | AMQPConnectionWorkflowFailed result:
+        :param result:
             value to pass to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
@@ -797,7 +797,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         with the first Parameters object in self._connection_configs. If out of
         attempts, report `AMQPConnectionWorkflowFailed`.
 
-        :param bool first: if True, don't delay; otherwise delay next attempt by
+        :param first: if True, don't delay; otherwise delay next attempt by
             `self._retry_pause` seconds.
         """
         self._task_ref = None
@@ -861,7 +861,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         self, addrinfos_or_exc: (list[ADDRESS_INFO] | BaseException)) -> None:
         """Handles completion callback from asynchronous `getaddrinfo()`.
 
-        :param list | BaseException addrinfos_or_exc: resolved address records
+        :param addrinfos_or_exc: resolved address records
             returned by `getaddrinfo()` or an exception object from failure.
         """
         assert self._connection_errors is not None
@@ -911,7 +911,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         conn_or_exc: (pika.connection.Connection | BaseException)) -> None:
         """Handle completion of connection attempt by `AMQPConnector`.
 
-        :param pika.connection.Connection | BaseException conn_or_exc: See
+        :param conn_or_exc: See
             `AMQPConnector.start()` for exception details.
 
         """

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -684,10 +684,19 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         as the overall number of connection attempts of the entire
         `connection_configs` sequence and pause between each sequence.
 
-        :param connection_configs: A sequence of one or more `pika.connection.Parameters`-based objects.
-        :param connector_factory: call it without args to obtain a new instance of `AMQPConnector` for each connection attempt. See `AMQPConnector` for details.
-        :param native_loop: Native I/O loop passed by app to the adapter or obtained by the adapter by default.
-        :param on_done: Function to call upon completion of the workflow: `on_done(pika.connection.Connection | AMQPConnectionWorkflowFailed | AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on success, `AMQPConnectionWorkflowFailed` on failure, `AMQPConnectionWorkflowAborted` if workflow was aborted.
+        :param connection_configs: A sequence of one or more
+            `pika.connection.Parameters`-based objects.
+        :param connector_factory: call it without args to obtain a new
+            instance of `AMQPConnector` for each connection attempt. See
+            `AMQPConnector` for details.
+        :param native_loop: Native I/O loop passed by app to the adapter or
+            obtained by the adapter by default.
+        :param on_done: Function to call upon completion of the workflow.
+            Signature: `on_done(pika.connection.Connection |
+            AMQPConnectionWorkflowFailed |
+            AMQPConnectionWorkflowAborted)`. `Connection`-based adapter on
+            success, `AMQPConnectionWorkflowFailed` on failure,
+            `AMQPConnectionWorkflowAborted` if workflow was aborted.
         """
         if self._state != self._STATE_INIT:
             raise AMQPConnectorWrongState(

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -168,7 +168,7 @@ class AMQPConnector:
 
         :param addr_record: a single resolved address record compatible
             with `socket.getaddrinfo()` format.
-        :param conn_params:
+        :param conn_params: Connection parameters to use for this connection.
         :param on_done: Function to call upon completion of the
             workflow: `on_done(pika.connection.Connection | BaseException)`. If
             exception, it's going to be one of the following:
@@ -486,9 +486,8 @@ class AMQPConnector:
 
         Reports AMQPConnectorAMQPHandshakeError if AMQP handshake failed.
 
-        :param connection:
-        :param error: None on success, otherwise
-            failure
+        :param connection: AMQP connection instance from the callback.
+        :param error: None on success, otherwise failure
 
         """
         assert self._conn_params is not None
@@ -779,8 +778,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
     ) -> None:
         """Clean up and invoke client's `on_done` callback.
 
-        :param result:
-            value to pass to user's `on_done` callback.
+        :param result: value to pass to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
             _LOG.error('AMQPConnectionWorkflow - reporting failure: %r', result)

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -97,7 +97,7 @@ class AMQPConnectionWorkflowFailed(AMQPConnectorException):
 
     def __init__(self, exceptions: Sequence[BaseException], *args: Any) -> None:
         """
-        :param sequence exceptions: Exceptions that occurred during the
+        :param exceptions: Exceptions that occurred during the
             workflow.
         :param args: args to pass to base class
 
@@ -550,7 +550,7 @@ class AbstractAMQPConnectionWorkflow(
         """Asynchronously perform the workflow until success or all retries
         are exhausted. Called by the adapter.
 
-        :param sequence connection_configs: A sequence of one or more
+        :param connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects. Will attempt to connect
             using each config in the given order.
         :param connector_factory: call it without args to obtain a new

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -105,9 +105,9 @@ class SocketConnectionMixin:
         """Implement
         :py:meth:`.nbio_interface.AbstractIOServices.connect_socket()`.
 
-        :param socket.socket sock: non-blocking socket to connect
-        :param tuple resolved_addr: resolved destination address/port two-tuple
-        :param callable on_done: user callback called upon completion
+        :param sock: non-blocking socket to connect
+        :param resolved_addr: resolved destination address/port two-tuple
+        :param on_done: user callback called upon completion
         :rtype: _AsyncServiceAsyncHandle
 
         """
@@ -139,11 +139,11 @@ class StreamingConnectionMixin:
         """Implement
         :py:meth:`.nbio_interface.AbstractIOServices.create_streaming_connection()`.
 
-        :param callable protocol_factory: factory to create protocol instance
-        :param socket.socket sock: connected socket
-        :param callable on_done: completion callback
-        :param ssl.SSLContext | None ssl_context: SSL context (optional)
-        :param str | None server_hostname: server hostname for SSL (optional)
+        :param protocol_factory: factory to create protocol instance
+        :param sock: connected socket
+        :param on_done: completion callback
+        :param ssl_context: SSL context (optional)
+        :param server_hostname: server hostname for SSL (optional)
         :rtype: AbstractIOReference
 
         """
@@ -209,12 +209,12 @@ class _AsyncSocketConnector:
                  sock: socket.socket, resolved_addr: tuple[str, int],
                  on_done: Callable[[BaseException | None], None]) -> None:
         """
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
-        :param socket.socket sock: non-blocking socket that needs to be
+        :param nbio:
+        :param sock: non-blocking socket that needs to be
             connected via `socket.socket.connect()`
-        :param tuple resolved_addr: resolved destination address/port two-tuple
+        :param resolved_addr: resolved destination address/port two-tuple
             which is compatible with the given's socket's address family
-        :param callable on_done: user callback that takes None upon successful
+        :param on_done: user callback that takes None upon successful
             completion or exception upon error (check for `BaseException`) as
             its only arg. It will not be called if the operation was cancelled.
         :raises ValueError: if host portion of `resolved_addr` is not an IP
@@ -293,7 +293,7 @@ class _AsyncSocketConnector:
         """Advance to COMPLETED state, remove socket watcher, and invoke user's
         completion callback.
 
-        :param BaseException | None result: value to pass in user's callback
+        :param result: value to pass in user's callback
 
         """
         _LOGGER.debug('_AsyncSocketConnector._report_completion(%r); %s',
@@ -408,12 +408,12 @@ class _AsyncStreamConnector:
         See `AbstractIOServices.create_streaming_connection()` for detailed
         documentation of the corresponding args.
 
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
-        :param callable protocol_factory:
-        :param socket.socket sock:
-        :param ssl.SSLContext | None ssl_context:
-        :param str | None server_hostname:
-        :param callable on_done:
+        :param nbio:
+        :param protocol_factory:
+        :param sock:
+        :param ssl_context:
+        :param server_hostname:
+        :param on_done:
 
         """
         check_callback_arg(protocol_factory, 'protocol_factory')
@@ -458,7 +458,7 @@ class _AsyncStreamConnector:
     def _cleanup(self, close: bool) -> None:
         """Cancel pending async operations, if any
 
-        :param bool close: close the socket if true
+        :param close: close the socket if true
         """
         _LOGGER.debug('_AsyncStreamConnector._cleanup(%r)', close)
 
@@ -541,7 +541,7 @@ class _AsyncStreamConnector:
         """Advance to COMPLETED state, cancel async operation(s), and invoke
         user's completion callback.
 
-        :param BaseException | tuple result: value to pass in user's callback.
+        :param result: value to pass in user's callback.
             `tuple(transport, protocol)` on success, exception on error
 
         """
@@ -769,11 +769,11 @@ class _AsyncTransportBase(AbstractStreamTransport):
     ) -> None:
         """
 
-        :param socket.socket | ssl.SSLSocket sock: connected socket
-        :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
+        :param sock: connected socket
+        :param protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
 
         """
         _LOGGER.debug('_AsyncTransportBase.__init__: %s', sock)
@@ -817,7 +817,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
     def _buffer_tx_data(self, data: bytes) -> None:
         """Buffer the given data until it can be sent asynchronously.
 
-        :param bytes data:
+        :param data:
         :raises ValueError: if called with empty data
 
         """
@@ -972,7 +972,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
         call to the protocol's `connection_lost()` method. No flushing of
         output buffers will take place.
 
-        :param BaseException | None error: None if being canceled by user,
+        :param error: None if being canceled by user,
             including via falsie return value from protocol.eof_received;
             otherwise the exception corresponding to the the failed connection.
         """
@@ -1028,7 +1028,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
         by us in order to avoid reentry into user code from user's API call into
         the transport.
 
-        :param BaseException | None error: None if being canceled by user;
+        :param error: None if being canceled by user;
             otherwise the exception corresponding to the the failed connection.
         """
         _LOGGER.debug('Concluding transport shutdown: state=%s; error=%r',
@@ -1072,11 +1072,11 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
     ) -> None:
         """
 
-        :param socket.socket sock: non-blocking connected socket
-        :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
+        :param sock: non-blocking connected socket
+        :param protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
 
         """
         super().__init__(sock, protocol, nbio)
@@ -1090,7 +1090,7 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
     def write(self, data: bytes) -> None:
         """Buffer the given data until it can be sent asynchronously.
 
-        :param bytes data:
+        :param data:
         :raises ValueError: if called with empty data
 
         """
@@ -1226,11 +1226,11 @@ class _AsyncSSLTransport(_AsyncTransportBase):
     ) -> None:
         """
 
-        :param ssl.SSLSocket sock: non-blocking connected socket
-        :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
+        :param sock: non-blocking connected socket
+        :param protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
 
         """
         super().__init__(sock, protocol, nbio)
@@ -1248,7 +1248,7 @@ class _AsyncSSLTransport(_AsyncTransportBase):
     def write(self, data: bytes) -> None:
         """Buffer the given data until it can be sent asynchronously.
 
-        :param bytes data:
+        :param data:
         :raises ValueError: if called with empty data
 
         """

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -142,8 +142,8 @@ class StreamingConnectionMixin:
         :param callable protocol_factory: factory to create protocol instance
         :param socket.socket sock: connected socket
         :param callable on_done: completion callback
-        :param ssl.SSLContext | None ssl_context: SSL context (optional)
-        :param str | None server_hostname: server hostname for SSL (optional)
+        :param ssl_context: SSL context (optional)
+        :param server_hostname: server hostname for SSL (optional)
         :rtype: AbstractIOReference
 
         """
@@ -209,7 +209,7 @@ class _AsyncSocketConnector:
                  sock: socket.socket, resolved_addr: tuple[str, int],
                  on_done: Callable[[BaseException | None], None]) -> None:
         """
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
         :param socket.socket sock: non-blocking socket that needs to be
             connected via `socket.socket.connect()`
         :param tuple resolved_addr: resolved destination address/port two-tuple
@@ -293,7 +293,7 @@ class _AsyncSocketConnector:
         """Advance to COMPLETED state, remove socket watcher, and invoke user's
         completion callback.
 
-        :param BaseException | None result: value to pass in user's callback
+        :param result: value to pass in user's callback
 
         """
         _LOGGER.debug('_AsyncSocketConnector._report_completion(%r); %s',
@@ -408,11 +408,11 @@ class _AsyncStreamConnector:
         See `AbstractIOServices.create_streaming_connection()` for detailed
         documentation of the corresponding args.
 
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
         :param callable protocol_factory:
         :param socket.socket sock:
-        :param ssl.SSLContext | None ssl_context:
-        :param str | None server_hostname:
+        :param ssl_context:
+        :param server_hostname:
         :param callable on_done:
 
         """
@@ -541,7 +541,7 @@ class _AsyncStreamConnector:
         """Advance to COMPLETED state, cancel async operation(s), and invoke
         user's completion callback.
 
-        :param BaseException | tuple result: value to pass in user's callback.
+        :param result: value to pass in user's callback.
             `tuple(transport, protocol)` on success, exception on error
 
         """
@@ -769,11 +769,11 @@ class _AsyncTransportBase(AbstractStreamTransport):
     ) -> None:
         """
 
-        :param socket.socket | ssl.SSLSocket sock: connected socket
+        :param sock: connected socket
         :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
 
         """
         _LOGGER.debug('_AsyncTransportBase.__init__: %s', sock)
@@ -972,7 +972,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
         call to the protocol's `connection_lost()` method. No flushing of
         output buffers will take place.
 
-        :param BaseException | None error: None if being canceled by user,
+        :param error: None if being canceled by user,
             including via falsie return value from protocol.eof_received;
             otherwise the exception corresponding to the the failed connection.
         """
@@ -1028,7 +1028,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
         by us in order to avoid reentry into user code from user's API call into
         the transport.
 
-        :param BaseException | None error: None if being canceled by user;
+        :param error: None if being canceled by user;
             otherwise the exception corresponding to the the failed connection.
         """
         _LOGGER.debug('Concluding transport shutdown: state=%s; error=%r',
@@ -1076,7 +1076,7 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
         :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
 
         """
         super().__init__(sock, protocol, nbio)
@@ -1230,7 +1230,7 @@ class _AsyncSSLTransport(_AsyncTransportBase):
         :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
+        :param nbio:
 
         """
         super().__init__(sock, protocol, nbio)

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -142,8 +142,8 @@ class StreamingConnectionMixin:
         :param callable protocol_factory: factory to create protocol instance
         :param socket.socket sock: connected socket
         :param callable on_done: completion callback
-        :param ssl_context: SSL context (optional)
-        :param server_hostname: server hostname for SSL (optional)
+        :param ssl.SSLContext | None ssl_context: SSL context (optional)
+        :param str | None server_hostname: server hostname for SSL (optional)
         :rtype: AbstractIOReference
 
         """
@@ -209,7 +209,7 @@ class _AsyncSocketConnector:
                  sock: socket.socket, resolved_addr: tuple[str, int],
                  on_done: Callable[[BaseException | None], None]) -> None:
         """
-        :param nbio:
+        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
         :param socket.socket sock: non-blocking socket that needs to be
             connected via `socket.socket.connect()`
         :param tuple resolved_addr: resolved destination address/port two-tuple
@@ -293,7 +293,7 @@ class _AsyncSocketConnector:
         """Advance to COMPLETED state, remove socket watcher, and invoke user's
         completion callback.
 
-        :param result: value to pass in user's callback
+        :param BaseException | None result: value to pass in user's callback
 
         """
         _LOGGER.debug('_AsyncSocketConnector._report_completion(%r); %s',
@@ -408,11 +408,11 @@ class _AsyncStreamConnector:
         See `AbstractIOServices.create_streaming_connection()` for detailed
         documentation of the corresponding args.
 
-        :param nbio:
+        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
         :param callable protocol_factory:
         :param socket.socket sock:
-        :param ssl_context:
-        :param server_hostname:
+        :param ssl.SSLContext | None ssl_context:
+        :param str | None server_hostname:
         :param callable on_done:
 
         """
@@ -541,7 +541,7 @@ class _AsyncStreamConnector:
         """Advance to COMPLETED state, cancel async operation(s), and invoke
         user's completion callback.
 
-        :param result: value to pass in user's callback.
+        :param BaseException | tuple result: value to pass in user's callback.
             `tuple(transport, protocol)` on success, exception on error
 
         """
@@ -769,11 +769,11 @@ class _AsyncTransportBase(AbstractStreamTransport):
     ) -> None:
         """
 
-        :param sock: connected socket
+        :param socket.socket | ssl.SSLSocket sock: connected socket
         :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param nbio:
+        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
 
         """
         _LOGGER.debug('_AsyncTransportBase.__init__: %s', sock)
@@ -972,7 +972,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
         call to the protocol's `connection_lost()` method. No flushing of
         output buffers will take place.
 
-        :param error: None if being canceled by user,
+        :param BaseException | None error: None if being canceled by user,
             including via falsie return value from protocol.eof_received;
             otherwise the exception corresponding to the the failed connection.
         """
@@ -1028,7 +1028,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
         by us in order to avoid reentry into user code from user's API call into
         the transport.
 
-        :param error: None if being canceled by user;
+        :param BaseException | None error: None if being canceled by user;
             otherwise the exception corresponding to the the failed connection.
         """
         _LOGGER.debug('Concluding transport shutdown: state=%s; error=%r',
@@ -1076,7 +1076,7 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
         :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param nbio:
+        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
 
         """
         super().__init__(sock, protocol, nbio)
@@ -1230,7 +1230,7 @@ class _AsyncSSLTransport(_AsyncTransportBase):
         :param pika.adapters.utils.nbio_interface.AbstractStreamProtocol protocol:
             corresponding protocol in this transport/protocol pairing; the
             protocol already had its `connection_made()` method called.
-        :param nbio:
+        :param AbstractIOServices | AbstractFileDescriptorServices nbio:
 
         """
         super().__init__(sock, protocol, nbio)

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -175,7 +175,7 @@ class _AsyncServiceAsyncHandle(AbstractIOReference):
 
     """
 
-    def __init__(self, subject: Any):
+    def __init__(self, subject: Any) -> None:
         """
         :param subject: subject of the reference containing a `cancel()` method
 
@@ -207,7 +207,7 @@ class _AsyncSocketConnector:
     def __init__(self, nbio: (nbio_interface.AbstractIOServices |
                               nbio_interface.AbstractFileDescriptorServices),
                  sock: socket.socket, resolved_addr: tuple[str, int],
-                 on_done: Callable[[BaseException | None], None]):
+                 on_done: Callable[[BaseException | None], None]) -> None:
         """
         :param AbstractIOServices | AbstractFileDescriptorServices nbio:
         :param socket.socket sock: non-blocking socket that needs to be
@@ -761,10 +761,12 @@ class _AsyncTransportBase(AbstractStreamTransport):
         def __init__(self) -> None:
             super().__init__(-1, 'End of input stream (EOF)')
 
-    def __init__(self, sock: socket.socket | ssl.SSLSocket,
-                 protocol: nbio_interface.AbstractStreamProtocol,
-                 nbio: (nbio_interface.AbstractIOServices |
-                        nbio_interface.AbstractFileDescriptorServices)):
+    def __init__(
+        self, sock: socket.socket | ssl.SSLSocket,
+        protocol: nbio_interface.AbstractStreamProtocol,
+        nbio: (nbio_interface.AbstractIOServices |
+               nbio_interface.AbstractFileDescriptorServices)
+    ) -> None:
         """
 
         :param socket.socket | ssl.SSLSocket sock: connected socket
@@ -1062,10 +1064,12 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
 
     """
 
-    def __init__(self, sock: socket.socket | ssl.SSLSocket,
-                 protocol: nbio_interface.AbstractStreamProtocol,
-                 nbio: (nbio_interface.AbstractIOServices |
-                        nbio_interface.AbstractFileDescriptorServices)):
+    def __init__(
+        self, sock: socket.socket | ssl.SSLSocket,
+        protocol: nbio_interface.AbstractStreamProtocol,
+        nbio: (nbio_interface.AbstractIOServices |
+               nbio_interface.AbstractFileDescriptorServices)
+    ) -> None:
         """
 
         :param socket.socket sock: non-blocking connected socket

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -219,11 +219,11 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             contain the linked transport/protocol pair having
             AbstractStreamTransport and AbstractStreamProtocol interfaces
             respectively.
-        :param ssl_context: if None, this will proceed as
+        :param None | ssl.SSLContext ssl_context: if None, this will proceed as
             a plaintext connection; otherwise, if not None, SSL session
             establishment will be performed prior to linking the transport and
             protocol.
-        :param server_hostname: For use during SSL session
+        :param str | None server_hostname: For use during SSL session
             establishment to match against the target server's certificate. The
             value `None` disables this check (which is a huge security risk)
         :rtype: AbstractIOReference
@@ -349,7 +349,7 @@ class AbstractStreamProtocol(
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
 
-        :param error: An exception (check for
+        :param BaseException | None error: An exception (check for
             `BaseException`) indicates connection failure. None indicates that
             connection was closed on this side, such as when it's aborted or
             when `AbstractStreamProtocol.eof_received()` returns a result that

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -38,6 +38,7 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         """Returns the native I/O loop instance, such as Twisted reactor,
         asyncio's or tornado's event loop
 
+        :rtype: Any
         """
         raise NotImplementedError
 
@@ -148,6 +149,12 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             failure (check for `BaseException`) as its only arg. It will not be
             called if the operation was cancelled.
         :rtype: AbstractIOReference
+        :param str host: Hostname or IP address
+        :param int port: TCP port number
+        :param int family: Socket address family (e.g. ``socket.AF_INET``)
+        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param int proto: Protocol number (0 for default)
+        :param int flags: :func:`socket.getaddrinfo` flags
         """
         raise NotImplementedError
 

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -109,7 +109,7 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
               the connection it is more efficient to use the
               `ioloop.call_later()` method with a delay of 0.
 
-        :param callable callback: The callback method; must be callable.
+        :param callback: The callback method; must be callable.
         """
         raise NotImplementedError
 
@@ -123,8 +123,8 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         If two are scheduled for the same time, it's undefined which one will
         be called first.
 
-        :param float delay: The number of seconds to wait to call callback
-        :param callable callback: The callback method
+        :param delay: The number of seconds to wait to call callback
+        :param callback: The callback method
         :returns: A handle that can be used to cancel the request.
         :rtype: AbstractTimerReference
 
@@ -144,17 +144,17 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
 
         See `socket.getaddrinfo()` for the standard args.
 
-        :param callable on_done: user callback that takes the return value of
+        :param on_done: user callback that takes the return value of
             `socket.getaddrinfo()` upon successful completion or exception upon
             failure (check for `BaseException`) as its only arg. It will not be
             called if the operation was cancelled.
         :rtype: AbstractIOReference
-        :param str host: Hostname or IP address
-        :param int port: TCP port number
-        :param int family: Socket address family (e.g. ``socket.AF_INET``)
-        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
-        :param int proto: Protocol number (0 for default)
-        :param int flags: :func:`socket.getaddrinfo` flags
+        :param host: Hostname or IP address
+        :param port: TCP port number
+        :param family: Socket address family (e.g. ``socket.AF_INET``)
+        :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param proto: Protocol number (0 for default)
+        :param flags: :func:`socket.getaddrinfo` flags
         """
         raise NotImplementedError
 
@@ -172,13 +172,13 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             DNS resolution. Implementations can use `socket.inet_pton()` to
             verify the address.
 
-        :param socket.socket sock: non-blocking socket that needs to be
+        :param sock: non-blocking socket that needs to be
             connected via `socket.socket.connect()`
-        :param tuple resolved_addr: resolved destination address/port two-tuple
+        :param resolved_addr: resolved destination address/port two-tuple
             as per `socket.socket.connect()`, except that the first element must
             be an actual IP address that's consistent with the given socket's
             address family.
-        :param callable on_done: user callback that takes None upon successful
+        :param on_done: user callback that takes None upon successful
             completion or exception (check for `BaseException`) upon error as
             its only arg. It will not be called if the operation was cancelled.
 
@@ -204,26 +204,26 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
 
         NOTE: This method takes ownership of the socket.
 
-        :param callable protocol_factory: called without args, returns an
+        :param protocol_factory: called without args, returns an
             instance with the `AbstractStreamProtocol` interface. The protocol's
             `connection_made(transport)` method will be called to link it to
             the transport after remaining connection activity (e.g., SSL session
             establishment), if any, is completed successfully.
-        :param socket.socket sock: Already-connected, non-blocking
+        :param sock: Already-connected, non-blocking
             `socket.SOCK_STREAM` socket to be used by the transport. We take
             ownership of this socket.
-        :param callable on_done: User callback
+        :param on_done: User callback
             `on_done(BaseException | (transport, protocol))` to be notified when
             the asynchronous operation completes. An exception arg indicates
             failure (check for `BaseException`); otherwise the two-tuple will
             contain the linked transport/protocol pair having
             AbstractStreamTransport and AbstractStreamProtocol interfaces
             respectively.
-        :param None | ssl.SSLContext ssl_context: if None, this will proceed as
+        :param ssl_context: if None, this will proceed as
             a plaintext connection; otherwise, if not None, SSL session
             establishment will be performed prior to linking the transport and
             protocol.
-        :param str | None server_hostname: For use during SSL session
+        :param server_hostname: For use during SSL session
             establishment to match against the target server's certificate. The
             value `None` disables this check (which is a huge security risk)
         :rtype: AbstractIOReference
@@ -337,7 +337,7 @@ class AbstractStreamProtocol(
     def connection_made(self, transport: AbstractStreamTransport):
         """Introduces transport to protocol after transport is connected.
 
-        :param AbstractStreamTransport transport:
+        :param transport:
         :raises Exception: Exception-based exception on error
         """
         raise NotImplementedError
@@ -349,7 +349,7 @@ class AbstractStreamProtocol(
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
 
-        :param BaseException | None error: An exception (check for
+        :param error: An exception (check for
             `BaseException`) indicates connection failure. None indicates that
             connection was closed on this side, such as when it's aborted or
             when `AbstractStreamProtocol.eof_received()` returns a result that
@@ -431,7 +431,7 @@ class AbstractStreamTransport(
     def write(self, data: bytes) -> None:
         """Buffer the given data until it can be sent asynchronously.
 
-        :param bytes data:
+        :param data:
         :raises ValueError: if called with empty data
         :raises Exception: Exception-based exception on error
         """
@@ -462,7 +462,7 @@ class AbstractStreamTransport(
     #     See `asyncio.WriteTransport.get_write_buffer_limits()` for more details
     #     about the args.
     #
-    #     :param int high: non-negative high-water mark.
-    #     :param int low: non-negative low-water mark.
+    #     :param high: non-negative high-water mark.
+    #     :param low: non-negative low-water mark.
     #     """
     #     raise NotImplementedError

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -144,17 +144,17 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
 
         See `socket.getaddrinfo()` for the standard args.
 
+        :param host: Hostname or IP address
+        :param port: TCP port number
         :param on_done: user callback that takes the return value of
             `socket.getaddrinfo()` upon successful completion or exception upon
             failure (check for `BaseException`) as its only arg. It will not be
             called if the operation was cancelled.
-        :rtype: AbstractIOReference
-        :param host: Hostname or IP address
-        :param port: TCP port number
         :param family: Socket address family (e.g. ``socket.AF_INET``)
         :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param proto: Protocol number (0 for default)
         :param flags: :func:`socket.getaddrinfo` flags
+        :rtype: AbstractIOReference
         """
         raise NotImplementedError
 
@@ -249,7 +249,7 @@ class AbstractFileDescriptorServices(
         Replace prior reader, if any, for the given file descriptor.
 
         :param fd: file descriptor
-        :param callable on_readable: a callback taking no args to be notified
+        :param on_readable: a callback taking no args to be notified
             when fd becomes readable.
 
         """
@@ -281,7 +281,7 @@ class AbstractFileDescriptorServices(
             when connection establishment fails.
 
         :param fd: file descriptor
-        :param callable on_writable: a callback taking no args to be notified
+        :param on_writable: a callback taking no args to be notified
             when fd becomes writable.
 
         """

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -219,11 +219,11 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             contain the linked transport/protocol pair having
             AbstractStreamTransport and AbstractStreamProtocol interfaces
             respectively.
-        :param None | ssl.SSLContext ssl_context: if None, this will proceed as
+        :param ssl_context: if None, this will proceed as
             a plaintext connection; otherwise, if not None, SSL session
             establishment will be performed prior to linking the transport and
             protocol.
-        :param str | None server_hostname: For use during SSL session
+        :param server_hostname: For use during SSL session
             establishment to match against the target server's certificate. The
             value `None` disables this check (which is a huge security risk)
         :rtype: AbstractIOReference
@@ -349,7 +349,7 @@ class AbstractStreamProtocol(
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
 
-        :param BaseException | None error: An exception (check for
+        :param error: An exception (check for
             `BaseException`) indicates connection failure. None indicates that
             connection was closed on this side, such as when it's aborted or
             when `AbstractStreamProtocol.eof_received()` returns a result that

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -38,7 +38,6 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         """Returns the native I/O loop instance, such as Twisted reactor,
         asyncio's or tornado's event loop
 
-        :rtype: Any
         """
         raise NotImplementedError
 

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -225,6 +225,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
     def call_later(self, delay, callback: Callable[..., None]) -> _TimerHandle:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
 
+        :param delay: The number of seconds to wait to call callback
         :param callback: The callback to call after delay seconds
         :rtype: _TimerHandle
         """

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -36,7 +36,6 @@ class AbstractSelectorIOLoop:
         Implementation note: the implementations can simply replace these
         READ/WRITE/ERROR properties with class-level attributes
 
-        :rtype: int
         """
 
     @property
@@ -45,7 +44,6 @@ class AbstractSelectorIOLoop:
         """The value of the I/O loop's WRITE flag; READ/WRITE/ERROR may be used
         with bitwise operators as expected
 
-        :rtype: int
         """
 
     @property
@@ -54,7 +52,6 @@ class AbstractSelectorIOLoop:
         """The value of the I/O loop's ERROR flag; READ/WRITE/ERROR may be used
         with bitwise operators as expected
 
-        :rtype: int
         """
 
     @abc.abstractmethod
@@ -193,7 +190,6 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractIOServices.get_native_ioloop()`.
 
-        :rtype: AbstractSelectorIOLoop
         """
         return self._loop
 
@@ -227,7 +223,6 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback to call after delay seconds
-        :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback), self._loop)
 
@@ -248,7 +243,6 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param proto: Protocol number (0 for default)
         :param flags: :func:`socket.getaddrinfo` flags
-        :rtype: nbio_interface.AbstractIOReference
         """
         return _SelectorIOLoopIOHandle(
             _AddressResolver(native_loop=self._loop,
@@ -296,7 +290,6 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.remove_reader()`.
 
         :param fd: File descriptor
-        :rtype: bool
         """
         LOGGER.debug('SelectorIOServicesAdapter.remove_reader(%s)', fd)
 
@@ -364,7 +357,6 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.remove_writer()`.
 
         :param fd: File descriptor
-        :rtype: bool
         """
         LOGGER.debug('SelectorIOServicesAdapter.remove_writer(%s)', fd)
 

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -36,6 +36,7 @@ class AbstractSelectorIOLoop:
         Implementation note: the implementations can simply replace these
         READ/WRITE/ERROR properties with class-level attributes
 
+        :rtype: int
         """
 
     @property
@@ -44,6 +45,7 @@ class AbstractSelectorIOLoop:
         """The value of the I/O loop's WRITE flag; READ/WRITE/ERROR may be used
         with bitwise operators as expected
 
+        :rtype: int
         """
 
     @property
@@ -52,6 +54,7 @@ class AbstractSelectorIOLoop:
         """The value of the I/O loop's ERROR flag; READ/WRITE/ERROR may be used
         with bitwise operators as expected
 
+        :rtype: int
         """
 
     @abc.abstractmethod
@@ -166,7 +169,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
     """
 
-    def __init__(self, native_loop: AbstractSelectorIOLoop):
+    def __init__(self, native_loop: AbstractSelectorIOLoop) -> None:
         """
         :param AbstractSelectorIOLoop native_loop: An instance compatible with
             the `AbstractSelectorIOLoop` interface, but not necessarily derived
@@ -190,6 +193,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractIOServices.get_native_ioloop()`.
 
+        :rtype: AbstractSelectorIOLoop
         """
         return self._loop
 
@@ -211,7 +215,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """
         self._loop.stop()
 
-    def add_callback_threadsafe(self, callback):
+    def add_callback_threadsafe(self, callback) -> None:
         """Implement
         :py:meth:`.nbio_interface.AbstractIOServices.add_callback_threadsafe()`.
 
@@ -221,6 +225,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
     def call_later(self, delay, callback: Callable[..., None]) -> _TimerHandle:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
 
+        :param Callable[..., None] callback: The callback to call after delay seconds
+        :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback), self._loop)
 
@@ -234,6 +240,14 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
                     flags: int = 0) -> nbio_interface.AbstractIOReference:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
 
+        :param str host: Hostname or IP address
+        :param int port: TCP port number
+        :param Callable[..., None] on_done: Callback to report when done
+        :param int family: Socket address family (e.g. ``socket.AF_INET``)
+        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param int proto: Protocol number (0 for default)
+        :param int flags: :func:`socket.getaddrinfo` flags
+        :rtype: nbio_interface.AbstractIOReference
         """
         return _SelectorIOLoopIOHandle(
             _AddressResolver(native_loop=self._loop,
@@ -249,6 +263,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
+        :param int fd: File descriptor
+        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_reader(%s, %r)', fd,
                      on_readable)
@@ -278,6 +294,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.remove_reader()`.
 
+        :param int fd: File descriptor
+        :rtype: bool
         """
         LOGGER.debug('SelectorIOServicesAdapter.remove_reader(%s)', fd)
 
@@ -310,6 +328,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
+        :param int fd: File descriptor
+        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_writer(%s, %r)', fd,
                      on_writable)
@@ -342,6 +362,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.remove_writer()`.
 
+        :param int fd: File descriptor
+        :rtype: bool
         """
         LOGGER.debug('SelectorIOServicesAdapter.remove_writer(%s)', fd)
 
@@ -415,7 +437,7 @@ class _FileDescriptorCallbacks:
 
     def __init__(self,
                  reader: Callable[[], None] | None = None,
-                 writer: Callable[[], None] | None = None):
+                 writer: Callable[[], None] | None = None) -> None:
         """Initialize file descriptor callbacks.
 
         :param reader: Read callback.
@@ -431,7 +453,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
 
     """
 
-    def __init__(self, handle: object, loop: AbstractSelectorIOLoop):
+    def __init__(self, handle: object, loop: AbstractSelectorIOLoop) -> None:
         """
 
         :param opaque handle: timer handle from the underlying loop

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -225,7 +225,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
     def call_later(self, delay, callback: Callable[..., None]) -> _TimerHandle:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
 
-        :param callback: The callback to call after delay seconds
+        :param Callable[..., None] callback: The callback to call after delay seconds
         :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback), self._loop)
@@ -242,7 +242,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         :param str host: Hostname or IP address
         :param int port: TCP port number
-        :param on_done: Callback to report when done
+        :param Callable[..., None] on_done: Callback to report when done
         :param int family: Socket address family (e.g. ``socket.AF_INET``)
         :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param int proto: Protocol number (0 for default)
@@ -264,7 +264,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
         :param int fd: File descriptor
-        :param on_readable: The callback to call when the file descriptor is readable
+        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_reader(%s, %r)', fd,
                      on_readable)
@@ -329,7 +329,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
         :param int fd: File descriptor
-        :param on_writable: The callback to call when the file descriptor is writable
+        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_writer(%s, %r)', fd,
                      on_writable)

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -91,8 +91,8 @@ class AbstractSelectorIOLoop:
         from the time of call on best-effort basis. Returns a handle to the
         timeout.
 
-        :param float delay: The number of seconds to wait to call callback
-        :param callable callback: The callback method
+        :param delay: The number of seconds to wait to call callback
+        :param callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
         :rtype: object
@@ -119,7 +119,7 @@ class AbstractSelectorIOLoop:
         ioloop that is running in a different thread via
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
-        :param callable callback: The callback method
+        :param callback: The callback method
 
         """
 
@@ -128,10 +128,10 @@ class AbstractSelectorIOLoop:
                     events: int) -> None:
         """Start watching the given file descriptor for events
 
-        :param int fd: The file descriptor
-        :param callable handler: When requested event(s) occur,
+        :param fd: The file descriptor
+        :param handler: When requested event(s) occur,
             `handler(fd, events)` will be called.
-        :param int events: The event mask using READ, WRITE, ERROR.
+        :param events: The event mask using READ, WRITE, ERROR.
 
         """
 
@@ -139,8 +139,8 @@ class AbstractSelectorIOLoop:
     def update_handler(self, fd: int, events: int) -> None:
         """Changes the events we watch for
 
-        :param int fd: The file descriptor
-        :param int events: The event mask using READ, WRITE, ERROR
+        :param fd: The file descriptor
+        :param events: The event mask using READ, WRITE, ERROR
 
         """
 
@@ -148,7 +148,7 @@ class AbstractSelectorIOLoop:
     def remove_handler(self, fd: int) -> None:
         """Stop watching the given file descriptor for events
 
-        :param int fd: The file descriptor
+        :param fd: The file descriptor
 
         """
 
@@ -171,7 +171,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
     def __init__(self, native_loop: AbstractSelectorIOLoop) -> None:
         """
-        :param AbstractSelectorIOLoop native_loop: An instance compatible with
+        :param native_loop: An instance compatible with
             the `AbstractSelectorIOLoop` interface, but not necessarily derived
             from it.
         """
@@ -225,7 +225,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
     def call_later(self, delay, callback: Callable[..., None]) -> _TimerHandle:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
 
-        :param Callable[..., None] callback: The callback to call after delay seconds
+        :param callback: The callback to call after delay seconds
         :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback), self._loop)
@@ -240,13 +240,13 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
                     flags: int = 0) -> nbio_interface.AbstractIOReference:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
 
-        :param str host: Hostname or IP address
-        :param int port: TCP port number
-        :param Callable[..., None] on_done: Callback to report when done
-        :param int family: Socket address family (e.g. ``socket.AF_INET``)
-        :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
-        :param int proto: Protocol number (0 for default)
-        :param int flags: :func:`socket.getaddrinfo` flags
+        :param host: Hostname or IP address
+        :param port: TCP port number
+        :param on_done: Callback to report when done
+        :param family: Socket address family (e.g. ``socket.AF_INET``)
+        :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
+        :param proto: Protocol number (0 for default)
+        :param flags: :func:`socket.getaddrinfo` flags
         :rtype: nbio_interface.AbstractIOReference
         """
         return _SelectorIOLoopIOHandle(
@@ -263,8 +263,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
-        :param int fd: File descriptor
-        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
+        :param fd: File descriptor
+        :param on_readable: The callback to call when the file descriptor is readable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_reader(%s, %r)', fd,
                      on_readable)
@@ -294,7 +294,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.remove_reader()`.
 
-        :param int fd: File descriptor
+        :param fd: File descriptor
         :rtype: bool
         """
         LOGGER.debug('SelectorIOServicesAdapter.remove_reader(%s)', fd)
@@ -328,8 +328,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
-        :param int fd: File descriptor
-        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
+        :param fd: File descriptor
+        :param on_writable: The callback to call when the file descriptor is writable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_writer(%s, %r)', fd,
                      on_writable)
@@ -362,7 +362,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         """Implement
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.remove_writer()`.
 
-        :param int fd: File descriptor
+        :param fd: File descriptor
         :rtype: bool
         """
         LOGGER.debug('SelectorIOServicesAdapter.remove_writer(%s)', fd)
@@ -458,7 +458,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
 
         :param opaque handle: timer handle from the underlying loop
             implementation that may be passed to its `remove_timeout()` method
-        :param AbstractSelectorIOLoop loop: the I/O loop instance that created
+        :param loop: the I/O loop instance that created
             the timeout.
         """
         self._handle: object | None = handle
@@ -511,7 +511,7 @@ class _AddressResolver:
                  on_done: Callable[..., None]) -> None:
         """
 
-        :param AbstractSelectorIOLoop native_loop:
+        :param native_loop:
         :param host: `see socket.getaddrinfo()`
         :param port: `see socket.getaddrinfo()`
         :param family: `see socket.getaddrinfo()`

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -225,7 +225,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
     def call_later(self, delay, callback: Callable[..., None]) -> _TimerHandle:
         """Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
 
-        :param Callable[..., None] callback: The callback to call after delay seconds
+        :param callback: The callback to call after delay seconds
         :rtype: _TimerHandle
         """
         return _TimerHandle(self._loop.call_later(delay, callback), self._loop)
@@ -242,7 +242,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         :param str host: Hostname or IP address
         :param int port: TCP port number
-        :param Callable[..., None] on_done: Callback to report when done
+        :param on_done: Callback to report when done
         :param int family: Socket address family (e.g. ``socket.AF_INET``)
         :param int socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param int proto: Protocol number (0 for default)
@@ -264,7 +264,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_reader()`.
 
         :param int fd: File descriptor
-        :param Callable[[], None] on_readable: The callback to call when the file descriptor is readable
+        :param on_readable: The callback to call when the file descriptor is readable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_reader(%s, %r)', fd,
                      on_readable)
@@ -329,7 +329,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :py:meth:`.nbio_interface.AbstractFileDescriptorServices.set_writer()`.
 
         :param int fd: File descriptor
-        :param Callable[[], None] on_writable: The callback to call when the file descriptor is writable
+        :param on_writable: The callback to call when the file descriptor is writable
         """
         LOGGER.debug('SelectorIOServicesAdapter.set_writer(%s, %r)', fd,
                      on_writable)

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -456,7 +456,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
     def __init__(self, handle: object, loop: AbstractSelectorIOLoop) -> None:
         """
 
-        :param opaque handle: timer handle from the underlying loop
+        :param handle: timer handle from the underlying loop
             implementation that may be passed to its `remove_timeout()` method
         :param loop: the I/O loop instance that created
             the timeout.

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -43,8 +43,8 @@ class Method(AMQPObject):
         """If the method is a content frame, set the properties and body to
         be carried as attributes of the class.
 
-        :param pika.frame.Properties properties: AMQP Basic Properties
-        :param bytes body: The message body
+        :param properties: AMQP Basic Properties
+        :param body: The message body
 
         """
         self._properties = properties
@@ -77,8 +77,8 @@ class Method(AMQPObject):
     def decode(self, encoded: bytes, offset: int = 0) -> Method:
         """Decode the method from a binary format.
 
-        :param bytes encoded: The encoded method data
-        :param int offset: The offset to start decoding from
+        :param encoded: The encoded method data
+        :param offset: The offset to start decoding from
 
         :rtype: Method
         """

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -24,7 +24,7 @@ def name_or_value(value: AMQPValue) -> str:
     """Will take Frame objects, classes, etc and attempt to return a valid
     string identifier for them.
 
-    :param value: The
+    :param pika.amqp_object.AMQPObject|pika.frame.Frame|int|str value: The
         value to sanitize
     :rtype: str
 
@@ -140,8 +140,8 @@ class CallbackManager:
         CallbackManager will restrict processing of the callback to only
         the calling function/object that you specify.
 
-        :param prefix: Categorize the callback
-        :param key: The key for the callback
+        :param str|int prefix: Categorize the callback
+        :param str|dict key: The key for the callback
         :param callable callback: The callback to call
         :param bool one_shot: Remove this callback after it is called
         :param object only_caller: Only allow one_caller value to call the
@@ -201,8 +201,8 @@ class CallbackManager:
     def pending(self, prefix: _Prefix, key: AMQPValue) -> int | None:
         """Return count of callbacks for a given prefix or key or None
 
-        :param prefix: Categorize the callback
-        :param key: The key for the callback
+        :param str|int prefix: Categorize the callback
+        :param object|str|int key: The key for the callback
         :rtype: None or int
 
         """
@@ -219,8 +219,8 @@ class CallbackManager:
         require a specific function to call CallbackManager.process will
         not be processed.
 
-        :param prefix: Categorize the callback
-        :param key: The key for the callback
+        :param str|int prefix: Categorize the callback
+        :param object|str|int key: The key for the callback
         :param object caller: Who is firing the event
         :param list args: Any optional arguments
         :param dict keywords: Optional keyword arguments
@@ -333,7 +333,7 @@ class CallbackManager:
                                    event that fires the callback.
         :rtype: dict
 
-        :param arguments: arguments to attach to the callback dict
+        :param dict[str, Any] | None arguments: arguments to attach to the callback dict
         """
         value = {
             self.CALLBACK: callback,

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -202,7 +202,7 @@ class CallbackManager:
 
         :param prefix: Categorize the callback
         :param key: The key for the callback
-        :rtype: None or int
+        :rtype: int | None
 
         """
         if prefix not in self._stack or key not in self._stack[prefix]:

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -24,7 +24,7 @@ def name_or_value(value: AMQPValue) -> str:
     """Will take Frame objects, classes, etc and attempt to return a valid
     string identifier for them.
 
-    :param pika.amqp_object.AMQPObject|pika.frame.Frame|int|str value: The
+    :param value: The
         value to sanitize
     :rtype: str
 
@@ -140,8 +140,8 @@ class CallbackManager:
         CallbackManager will restrict processing of the callback to only
         the calling function/object that you specify.
 
-        :param str|int prefix: Categorize the callback
-        :param str|dict key: The key for the callback
+        :param prefix: Categorize the callback
+        :param key: The key for the callback
         :param callable callback: The callback to call
         :param bool one_shot: Remove this callback after it is called
         :param object only_caller: Only allow one_caller value to call the
@@ -201,8 +201,8 @@ class CallbackManager:
     def pending(self, prefix: _Prefix, key: AMQPValue) -> int | None:
         """Return count of callbacks for a given prefix or key or None
 
-        :param str|int prefix: Categorize the callback
-        :param object|str|int key: The key for the callback
+        :param prefix: Categorize the callback
+        :param key: The key for the callback
         :rtype: None or int
 
         """
@@ -219,8 +219,8 @@ class CallbackManager:
         require a specific function to call CallbackManager.process will
         not be processed.
 
-        :param str|int prefix: Categorize the callback
-        :param object|str|int key: The key for the callback
+        :param prefix: Categorize the callback
+        :param key: The key for the callback
         :param object caller: Who is firing the event
         :param list args: Any optional arguments
         :param dict keywords: Optional keyword arguments
@@ -333,7 +333,7 @@ class CallbackManager:
                                    event that fires the callback.
         :rtype: dict
 
-        :param dict[str, Any] | None arguments: arguments to attach to the callback dict
+        :param arguments: arguments to attach to the callback dict
         """
         value = {
             self.CALLBACK: callback,

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -24,8 +24,7 @@ def name_or_value(value: AMQPValue) -> str:
     """Will take Frame objects, classes, etc and attempt to return a valid
     string identifier for them.
 
-    :param pika.amqp_object.AMQPObject|pika.frame.Frame|int|str value: The
-        value to sanitize
+    :param value: The value to sanitize
     :rtype: str
 
     """
@@ -140,13 +139,13 @@ class CallbackManager:
         CallbackManager will restrict processing of the callback to only
         the calling function/object that you specify.
 
-        :param str|int prefix: Categorize the callback
-        :param str|dict key: The key for the callback
-        :param callable callback: The callback to call
-        :param bool one_shot: Remove this callback after it is called
-        :param object only_caller: Only allow one_caller value to call the
+        :param prefix: Categorize the callback
+        :param key: The key for the callback
+        :param callback: The callback to call
+        :param one_shot: Remove this callback after it is called
+        :param only_caller: Only allow one_caller value to call the
                                    event that fires the callback.
-        :param dict arguments: Arguments to validate when processing
+        :param arguments: Arguments to validate when processing
         :rtype: tuple(prefix, key)
 
         """
@@ -201,8 +200,8 @@ class CallbackManager:
     def pending(self, prefix: _Prefix, key: AMQPValue) -> int | None:
         """Return count of callbacks for a given prefix or key or None
 
-        :param str|int prefix: Categorize the callback
-        :param object|str|int key: The key for the callback
+        :param prefix: Categorize the callback
+        :param key: The key for the callback
         :rtype: None or int
 
         """
@@ -219,11 +218,11 @@ class CallbackManager:
         require a specific function to call CallbackManager.process will
         not be processed.
 
-        :param str|int prefix: Categorize the callback
-        :param object|str|int key: The key for the callback
-        :param object caller: Who is firing the event
-        :param list args: Any optional arguments
-        :param dict keywords: Optional keyword arguments
+        :param prefix: Categorize the callback
+        :param key: The key for the callback
+        :param caller: Who is firing the event
+        :param args: Any optional arguments
+        :param keywords: Optional keyword arguments
         :rtype: bool
 
         """
@@ -261,10 +260,10 @@ class CallbackManager:
         the callback itself. If you only pass in prefix and key, all
         callbacks for that prefix and key will be removed.
 
-        :param str or int prefix: The prefix for keeping track of callbacks with
-        :param str key: The callback key
-        :param callable callback_value: The method defined to call on callback
-        :param dict arguments: Optional arguments to check
+        :param prefix: The prefix for keeping track of callbacks with
+        :param key: The callback key
+        :param callback_value: The method defined to call on callback
+        :param arguments: Optional arguments to check
         :rtype: bool
 
         """
@@ -293,8 +292,8 @@ class CallbackManager:
     def remove_all(self, prefix: _Prefix, key: AMQPValue) -> None:
         """Remove all callbacks for the specified prefix and key.
 
-        :param str prefix: The prefix for keeping track of callbacks with
-        :param str key: The callback key
+        :param prefix: The prefix for keeping track of callbacks with
+        :param key: The callback key
 
         """
         del self._stack[prefix][key]
@@ -306,8 +305,8 @@ class CallbackManager:
         the callback_dict. We expect this to be a frame passed in to *args for
         process or passed in as a list from remove.
 
-        :param dict callback_dict: The callback dictionary to evaluate against
-        :param list args: The arguments passed in as a list
+        :param callback_dict: The callback dictionary to evaluate against
+        :param args: The arguments passed in as a list
 
         :rtype: bool
         """
@@ -327,13 +326,13 @@ class CallbackManager:
                        arguments: dict[str, Any] | None) -> dict[str, Any]:
         """Return the callback dictionary.
 
-        :param callable callback: The callback to call
-        :param bool one_shot: Remove this callback after it is called
-        :param object only_caller: Only allow one_caller value to call the
+        :param callback: The callback to call
+        :param one_shot: Remove this callback after it is called
+        :param only_caller: Only allow one_caller value to call the
                                    event that fires the callback.
+        :param arguments: arguments to attach to the callback dict
         :rtype: dict
 
-        :param dict[str, Any] | None arguments: arguments to attach to the callback dict
         """
         value = {
             self.CALLBACK: callback,
@@ -350,8 +349,8 @@ class CallbackManager:
                                key: AMQPValue | None = None) -> None:
         """Remove empty dict nodes in the callback stack.
 
-        :param str or int prefix: The prefix for keeping track of callbacks with
-        :param str key: The callback key
+        :param prefix: The prefix for keeping track of callbacks with
+        :param key: The callback key
 
         """
         if key and key in self._stack[prefix] and not self._stack[prefix][key]:
@@ -364,8 +363,8 @@ class CallbackManager:
                               expectation: dict[str, Any]) -> bool:
         """Checks an dict to see if it has attributes that meet the expectation.
 
-        :param dict value: The dict to evaluate
-        :param dict expectation: The values to check against
+        :param value: The dict to evaluate
+        :param expectation: The values to check against
         :rtype: bool
 
         """
@@ -382,8 +381,8 @@ class CallbackManager:
         """Checks an object to see if it has attributes that meet the
         expectation.
 
-        :param object value: The object to evaluate
-        :param dict expectation: The values to check against
+        :param value: The object to evaluate
+        :param expectation: The values to check against
         :rtype: bool
 
         """
@@ -402,9 +401,9 @@ class CallbackManager:
                                  caller: _Caller, args: list[Any]) -> bool:
         """Returns True if the callback should be processed.
 
-        :param dict callback_dict: The callback configuration
-        :param object caller: Who is firing the event
-        :param list args: Any optional arguments
+        :param callback_dict: The callback configuration
+        :param caller: Who is firing the event
+        :param args: Any optional arguments
         :rtype: bool
 
         """
@@ -421,9 +420,9 @@ class CallbackManager:
         """Process the one-shot callback, decrementing the use counter and
         removing it from the stack if it's now been fully used.
 
-        :param str or int prefix: The prefix for keeping track of callbacks with
-        :param str key: The callback key
-        :param dict callback_dict: The callback dict to process
+        :param prefix: The prefix for keeping track of callbacks with
+        :param key: The callback key
+        :param callback_dict: The callback dict to process
 
         """
         LOGGER.debug('Processing use of oneshot callback')

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -47,7 +47,7 @@ def name_or_value(value: AMQPValue) -> str:
 def sanitize_prefix(function: _Callback) -> _Callback:
     """Automatically call name_or_value on the prefix passed in.
 
-    :param _Callback function: The function to wrap
+    :param function: The function to wrap
     :rtype: _Callback
     """
 
@@ -74,9 +74,9 @@ def check_for_prefix_and_key(function: _Callback) -> _Callback:
     """Automatically return false if the key or prefix is not in the callbacks
     for the instance.
 
+    :param function: Callback to validate
     :rtype: _Callback
 
-    :param _Callback function: Callback to validate
     """
 
     @functools.wraps(function)
@@ -186,7 +186,7 @@ class CallbackManager:
         """Remove all callbacks from the stack by a prefix. Returns True
         if keys were there to be removed
 
-        :param str or int prefix: The prefix for keeping track of callbacks with
+        :param prefix: The prefix for keeping track of callbacks with
         :rtype: bool
 
         """

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -202,7 +202,6 @@ class CallbackManager:
 
         :param prefix: Categorize the callback
         :param key: The key for the callback
-        :rtype: int | None
 
         """
         if prefix not in self._stack or key not in self._stack[prefix]:
@@ -308,7 +307,6 @@ class CallbackManager:
         :param callback_dict: The callback dictionary to evaluate against
         :param args: The arguments passed in as a list
 
-        :rtype: bool
         """
         if callback_dict[self.ARGUMENTS] is None:
             return True

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -77,6 +77,7 @@ def check_for_prefix_and_key(function: _Callback) -> _Callback:
 
     :rtype: _Callback
 
+    :param _Callback function: Callback to validate
     """
 
     @functools.wraps(function)
@@ -308,6 +309,7 @@ class CallbackManager:
         :param dict callback_dict: The callback dictionary to evaluate against
         :param list args: The arguments passed in as a list
 
+        :rtype: bool
         """
         if callback_dict[self.ARGUMENTS] is None:
             return True
@@ -331,6 +333,7 @@ class CallbackManager:
                                    event that fires the callback.
         :rtype: dict
 
+        :param dict[str, Any] | None arguments: arguments to attach to the callback dict
         """
         value = {
             self.CALLBACK: callback,

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1435,7 +1435,7 @@ class Channel:
 
         :param pika.amqp_object.Method method: The AMQP method to invoke
         :param callable callback: The callback for the RPC response
-        :param acceptable_replies: A (possibly empty) sequence of
+        :param list|None acceptable_replies: A (possibly empty) sequence of
             replies this RPC call expects or None
 
         """
@@ -1585,7 +1585,7 @@ class ContentFrameAssembler:
         setup in the rpc process and that don't have explicit reply types
         defined. This includes Basic.Publish, Basic.GetOk and Basic.Return
 
-        :param frame_value: The frame to process
+        :param Method|Header|Body frame_value: The frame to process
 
         :rtype: tuple[frame.Method, frame.Header, bytes] | None
         """

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1435,7 +1435,7 @@ class Channel:
 
         :param pika.amqp_object.Method method: The AMQP method to invoke
         :param callable callback: The callback for the RPC response
-        :param list|None acceptable_replies: A (possibly empty) sequence of
+        :param acceptable_replies: A (possibly empty) sequence of
             replies this RPC call expects or None
 
         """
@@ -1585,7 +1585,7 @@ class ContentFrameAssembler:
         setup in the rpc process and that don't have explicit reply types
         defined. This includes Basic.Publish, Basic.GetOk and Basic.Return
 
-        :param Method|Header|Body frame_value: The frame to process
+        :param frame_value: The frame to process
 
         :rtype: tuple[frame.Method, frame.Header, bytes] | None
         """

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1587,7 +1587,6 @@ class ContentFrameAssembler:
 
         :param frame_value: The frame to process
 
-        :rtype: tuple[frame.Method, frame.Header, bytes] | None
         """
         if (isinstance(frame_value, frame.Method) and
                 spec.has_content(frame_value.method.INDEX)):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -88,9 +88,9 @@ class Channel:
                  on_open_callback: _OnOpenCallback | None) -> None:
         """Create a new instance of the Channel
 
-        :param pika.connection.Connection connection: The connection
-        :param int channel_number: The channel number for this instance
-        :param callable on_open_callback: The callback to call on channel open.
+        :param connection: The connection
+        :param channel_number: The channel number for this instance
+        :param on_open_callback: The callback to call on channel open.
             The callback will be invoked with the `Channel` instance as its only
             argument.
 
@@ -150,9 +150,9 @@ class Channel:
         RabbitMQ broker which you'd like the callback notified of. Callbacks
         should allow for the frame parameter to be passed in.
 
-        :param callable callback: The callback to call
-        :param list replies: The replies to get a callback for
-        :param bool one_shot: Only handle the first type callback
+        :param callback: The callback to call
+        :param replies: The replies to get a callback for
+        :param one_shot: Only handle the first type callback
 
         """
         for reply in replies:
@@ -163,7 +163,7 @@ class Channel:
         is sent by the server. The callback function should receive a frame
         parameter.
 
-        :param callable callback: The callback to call on Basic.Cancel from
+        :param callback: The callback to call on Basic.Cancel from
             broker
 
         """
@@ -187,7 +187,7 @@ class Channel:
         If channel was closed due to loss of connection, the callback will
         receive another exception type describing the failure.
 
-        :param callable callback: The callback, having the signature:
+        :param callback: The callback, having the signature:
             callback(Channel, Exception reason)
 
         """
@@ -199,7 +199,7 @@ class Channel:
         called by the remote server. Note that newer versions of RabbitMQ
         will not issue this but instead use TCP backpressure
 
-        :param callable callback: The callback function
+        :param callback: The callback function
 
         """
         self._has_on_flow_callback = True
@@ -210,7 +210,7 @@ class Channel:
         """Pass a callback function that will be called when basic_publish is
         sent a message that has been rejected and returned by the server.
 
-        :param callable callback: The function to call, having the signature
+        :param callback: The function to call, having the signature
                                 callback(channel, method, properties, body)
                                 where
                                 - channel: pika.channel.Channel
@@ -229,8 +229,8 @@ class Channel:
         confirm mode. The acknowledgement can be for a single message or a
         set of messages up to and including a specific message.
 
-        :param integer delivery_tag: int/long The server-assigned delivery tag
-        :param bool multiple: If set to True, the delivery tag is treated as
+        :param delivery_tag: int/long The server-assigned delivery tag
+        :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
                               to False, the delivery tag refers to a single
@@ -255,8 +255,8 @@ class Channel:
         basic.cancel from the client). This allows clients to be notified of
         the loss of consumers due to events such as queue deletion.
 
-        :param str consumer_tag: Identifier for the consumer
-        :param callable callback: callback(pika.frame.Method) for method
+        :param consumer_tag: Identifier for the consumer
+        :param callback: callback(pika.frame.Method) for method
             Basic.CancelOk. If None, do not expect a Basic.CancelOk response,
             otherwise, callback must be callable
 
@@ -320,23 +320,23 @@ class Channel:
         https://www.rabbitmq.com/confirms.html
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.consume
 
-        :param str queue: The queue to consume from. Use the empty string to
+        :param queue: The queue to consume from. Use the empty string to
             specify the most recent server-named queue for this channel
-        :param callable on_message_callback: The function to call when
+        :param on_message_callback: The function to call when
             consuming with the signature
             on_message_callback(channel, method, properties, body), where
             - channel: pika.channel.Channel
             - method: pika.spec.Basic.Deliver
             - properties: pika.spec.BasicProperties
             - body: bytes
-        :param bool auto_ack: if set to True, automatic acknowledgement mode
+        :param auto_ack: if set to True, automatic acknowledgement mode
             will be used (see https://www.rabbitmq.com/confirms.html).
             This corresponds with the 'no_ack' parameter in the basic.consume
             AMQP 0.9.1 method
-        :param bool exclusive: Don't allow other consumers on the queue
-        :param str consumer_tag: Specify your own consumer tag
-        :param dict arguments: Custom key/value pair arguments for the consumer
-        :param callable callback: callback(pika.frame.Method) for method
+        :param exclusive: Don't allow other consumers on the queue
+        :param consumer_tag: Specify your own consumer tag
+        :param arguments: Custom key/value pair arguments for the consumer
+        :param callback: callback(pika.frame.Method) for method
           Basic.ConsumeOk.
         :returns: Consumer tag which may be used to cancel the consumer.
         :rtype: str
@@ -400,16 +400,16 @@ class Channel:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.get
 
-        :param str queue: The queue from which to get a message. Use the empty
+        :param queue: The queue from which to get a message. Use the empty
             string to specify the most recent server-named queue for this
             channel
-        :param callable callback: The callback to call with a message that has
+        :param callback: The callback to call with a message that has
             the signature callback(channel, method, properties, body), where:
             - channel: pika.channel.Channel
             - method: pika.spec.Basic.GetOk
             - properties: pika.spec.BasicProperties
             - body: bytes
-        :param bool auto_ack: Tell the broker to not expect a reply
+        :param auto_ack: Tell the broker to not expect a reply
         :raises ValueError:
 
         """
@@ -432,15 +432,15 @@ class Channel:
         It can be used to interrupt and cancel large incoming messages, or
         return untreatable messages to their original queue.
 
-        :param integer delivery_tag: int/long The server-assigned delivery tag
-        :param bool multiple: If set to True, the delivery tag is treated as
+        :param delivery_tag: int/long The server-assigned delivery tag
+        :param multiple: If set to True, the delivery tag is treated as
                               "up to and including", so that multiple messages
                               can be acknowledged with a single method. If set
                               to False, the delivery tag refers to a single
                               message. If the multiple field is 1, and the
                               delivery tag is zero, this indicates
                               acknowledgement of all outstanding messages.
-        :param bool requeue: If requeue is true, the server will attempt to
+        :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or
                              dead-lettered.
@@ -461,11 +461,11 @@ class Channel:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
 
-        :param str exchange: The exchange to publish to
-        :param str routing_key: The routing key to bind on
-        :param bytes body: The message body
-        :param pika.spec.BasicProperties properties: Basic.properties
-        :param bool mandatory: The mandatory flag
+        :param exchange: The exchange to publish to
+        :param routing_key: The routing key to bind on
+        :param body: The message body
+        :param properties: Basic.properties
+        :param mandatory: The mandatory flag
 
         """
         self._raise_if_not_open()
@@ -489,7 +489,7 @@ class Channel:
         channel or shared across all consumers on the channel. Prefetching
         gives a performance improvement.
 
-        :param int prefetch_size:  This field specifies the prefetch window
+        :param prefetch_size:  This field specifies the prefetch window
                                    size. The server will send a message in
                                    advance if it is equal to or smaller in size
                                    than the available prefetch size (and also
@@ -498,7 +498,7 @@ class Channel:
                                    although other prefetch limits may still
                                    apply. The prefetch-size is ignored by
                                    consumers who have enabled the no-ack option.
-        :param int prefetch_count: Specifies a prefetch window in terms of whole
+        :param prefetch_count: Specifies a prefetch window in terms of whole
                                    messages. This field may be used in
                                    combination with the prefetch-size field; a
                                    message will only be sent in advance if both
@@ -506,9 +506,9 @@ class Channel:
                                    and connection level) allow it. The
                                    prefetch-count is ignored by consumers who
                                    have enabled the no-ack option.
-        :param bool global_qos:    Should the QoS be shared across all
+        :param global_qos:    Should the QoS be shared across all
                                    consumers on the channel.
-        :param callable callback: The callback to call for Basic.QosOk response
+        :param callback: The callback to call for Basic.QosOk response
         :returns: ``None``. Method frame from the Basic.Qos-ok response is delivered
             to ``callback`` when provided.
         :raises ValueError:
@@ -527,8 +527,8 @@ class Channel:
         message. It can be used to interrupt and cancel large incoming messages,
         or return untreatable messages to their original queue.
 
-        :param integer delivery_tag: int/long The server-assigned delivery tag
-        :param bool requeue: If requeue is true, the server will attempt to
+        :param delivery_tag: int/long The server-assigned delivery tag
+        :param requeue: If requeue is true, the server will attempt to
                              requeue the message. If requeue is false or the
                              requeue attempt fails the messages are discarded or
                              dead-lettered.
@@ -547,11 +547,11 @@ class Channel:
         on a specified channel. Zero or more messages may be redelivered. This
         method replaces the asynchronous Recover.
 
-        :param bool requeue: If False, the message will be redelivered to the
+        :param requeue: If False, the message will be redelivered to the
                              original recipient. If True, the server will
                              attempt to requeue the message, potentially then
                              delivering it to an alternative subscriber.
-        :param callable callback: callback(pika.frame.Method) for method
+        :param callback: callback(pika.frame.Method) for method
             Basic.RecoverOk
         :returns: ``None``. Method frame from the Basic.Recover-ok response is
             delivered to ``callback`` when provided.
@@ -571,8 +571,8 @@ class Channel:
         If channel is OPENING, transition to CLOSING and suppress the incoming
         Channel.OpenOk, if any.
 
-        :param int reply_code: The reason code to send to broker
-        :param str reply_text: The reason text to send to broker
+        :param reply_code: The reason code to send to broker
+        :param reply_text: The reason text to send to broker
 
         :raises ChannelWrongStateError: if channel is closed or closing
 
@@ -616,11 +616,11 @@ class Channel:
         For more information see:
             https://www.rabbitmq.com/confirms.html
 
-        :param callable ack_nack_callback: Required callback for delivery
+        :param ack_nack_callback: Required callback for delivery
             confirmations that has the following signature:
             callback(pika.frame.Method), where method_frame contains
             either method `spec.Basic.Ack` or `spec.Basic.Nack`.
-        :param callable callback: callback(pika.frame.Method) for method
+        :param callback: callback(pika.frame.Method) for method
             Confirm.SelectOk
         :raises ValueError:
 
@@ -665,11 +665,11 @@ class Channel:
                       callback: _OnExchangeBindCallback | None = None) -> None:
         """Bind an exchange to another exchange.
 
-        :param str destination: The destination exchange to bind
-        :param str source: The source exchange to bind to
-        :param str routing_key: The routing key to bind on
-        :param dict arguments: Custom key/value pair arguments for the binding
-        :param callable callback: callback(pika.frame.Method) for method Exchange.BindOk
+        :param destination: The destination exchange to bind
+        :param source: The source exchange to bind to
+        :param routing_key: The routing key to bind on
+        :param arguments: Custom key/value pair arguments for the binding
+        :param callback: callback(pika.frame.Method) for method Exchange.BindOk
         :returns: ``None``. Method frame from the Exchange.Bind-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -704,16 +704,16 @@ class Channel:
         exchange does not already exist, the server MUST raise a channel
         exception with reply code 404 (not found).
 
-        :param str exchange: The exchange name consists of a non-empty sequence
+        :param exchange: The exchange name consists of a non-empty sequence
             of these characters: letters, digits, hyphen, underscore, period,
             or colon
-        :param str exchange_type: The exchange type to use
-        :param bool passive: Perform a declare or just check to see if it exists
-        :param bool durable: Survive a reboot of RabbitMQ
-        :param bool auto_delete: Remove when no more queues are bound to it
-        :param bool internal: Can only be published to by other exchanges
-        :param dict arguments: Custom key/value pair arguments for the exchange
-        :param callable callback: callback(pika.frame.Method) for method Exchange.DeclareOk
+        :param exchange_type: The exchange type to use
+        :param passive: Perform a declare or just check to see if it exists
+        :param durable: Survive a reboot of RabbitMQ
+        :param auto_delete: Remove when no more queues are bound to it
+        :param internal: Can only be published to by other exchanges
+        :param arguments: Custom key/value pair arguments for the exchange
+        :param callback: callback(pika.frame.Method) for method Exchange.DeclareOk
         :returns: ``None``. Method frame from the Exchange.Declare-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -746,9 +746,9 @@ class Channel:
             callback: _OnExchangeDeleteCallback | None = None) -> None:
         """Delete the exchange.
 
-        :param str exchange: The exchange name
-        :param bool if_unused: only delete if the exchange is unused
-        :param callable callback: callback(pika.frame.Method) for method Exchange.DeleteOk
+        :param exchange: The exchange name
+        :param if_unused: only delete if the exchange is unused
+        :param callback: callback(pika.frame.Method) for method Exchange.DeleteOk
         :returns: ``None``. Method frame from the Exchange.Delete-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -770,11 +770,11 @@ class Channel:
             callback: _OnExchangeUnbindCallback | None = None) -> None:
         """Unbind an exchange from another exchange.
 
-        :param str destination: The destination exchange to unbind
-        :param str source: The source exchange to unbind from
-        :param str routing_key: The routing key to unbind
-        :param dict arguments: Custom key/value pair arguments for the binding
-        :param callable callback: callback(pika.frame.Method) for method Exchange.UnbindOk
+        :param destination: The destination exchange to unbind
+        :param source: The source exchange to unbind from
+        :param routing_key: The routing key to unbind
+        :param arguments: Custom key/value pair arguments for the binding
+        :param callback: callback(pika.frame.Method) for method Exchange.UnbindOk
         :returns: ``None``. Method frame from the Exchange.Unbind-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -798,8 +798,8 @@ class Channel:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
-        :param bool active: Turn flow on or off
-        :param callable callback: callback(bool) upon completion
+        :param active: Turn flow on or off
+        :param callback: callback(bool) upon completion
         :raises ValueError:
 
         """
@@ -860,11 +860,11 @@ class Channel:
                    callback: _OnQueueBindCallback | None = None) -> None:
         """Bind the queue to the specified exchange
 
-        :param str queue: The queue to bind to the exchange
-        :param str exchange: The source exchange to bind to
-        :param str routing_key: The routing key to bind on
-        :param dict arguments: Custom key/value pair arguments for the binding
-        :param callable callback: callback(pika.frame.Method) for method Queue.BindOk
+        :param queue: The queue to bind to the exchange
+        :param exchange: The source exchange to bind to
+        :param routing_key: The routing key to bind on
+        :param arguments: Custom key/value pair arguments for the binding
+        :param callback: callback(pika.frame.Method) for method Queue.BindOk
         :returns: ``None``. Method frame from the Queue.Bind-ok response is delivered
             to ``callback`` when synchronous (no ok frame in nowait mode).
         :raises ValueError:
@@ -897,14 +897,14 @@ class Channel:
         Use an empty string as the queue name for the broker to auto-generate
         one
 
-        :param str queue: The queue name; if empty string, the broker will
+        :param queue: The queue name; if empty string, the broker will
             create a unique queue name
-        :param bool passive: Only check to see if the queue exists
-        :param bool durable: Survive reboots of the broker
-        :param bool exclusive: Only allow access by the current connection
-        :param bool auto_delete: Delete after consumer cancels or disconnects
-        :param dict arguments: Custom key/value arguments for the queue
-        :param callable callback: callback(pika.frame.Method) for method Queue.DeclareOk
+        :param passive: Only check to see if the queue exists
+        :param durable: Survive reboots of the broker
+        :param exclusive: Only allow access by the current connection
+        :param auto_delete: Delete after consumer cancels or disconnects
+        :param arguments: Custom key/value arguments for the queue
+        :param callback: callback(pika.frame.Method) for method Queue.DeclareOk
         :returns: ``None``. Method frame from the Queue.Declare-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -934,10 +934,10 @@ class Channel:
                      callback: _OnQueueDeleteCallback | None = None) -> None:
         """Delete a queue from the broker.
 
-        :param str queue: The queue to delete
-        :param bool if_unused: only delete if it's unused
-        :param bool if_empty: only delete if the queue is empty
-        :param callable callback: callback(pika.frame.Method) for method Queue.DeleteOk
+        :param queue: The queue to delete
+        :param if_unused: only delete if it's unused
+        :param if_empty: only delete if the queue is empty
+        :param callback: callback(pika.frame.Method) for method Queue.DeleteOk
         :returns: ``None``. Method frame from the Queue.Delete-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -957,8 +957,8 @@ class Channel:
                     callback: _OnQueuePurgeCallback | None = None) -> None:
         """Purge all of the messages from the specified queue
 
-        :param str queue: The queue to purge
-        :param callable callback: callback(pika.frame.Method) for method Queue.PurgeOk
+        :param queue: The queue to purge
+        :param callback: callback(pika.frame.Method) for method Queue.PurgeOk
         :returns: ``None``. Method frame from the Queue.Purge-ok response is
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
@@ -979,11 +979,11 @@ class Channel:
                      callback: _OnQueueUnbindCallback | None = None) -> None:
         """Unbind a queue from an exchange.
 
-        :param str queue: The queue to unbind from the exchange
-        :param str exchange: The source exchange to bind from
-        :param str routing_key: The routing key to unbind
-        :param dict arguments: Custom key/value pair arguments for the binding
-        :param callable callback: callback(pika.frame.Method) for method Queue.UnbindOk
+        :param queue: The queue to unbind from the exchange
+        :param exchange: The source exchange to bind from
+        :param routing_key: The routing key to unbind
+        :param arguments: Custom key/value pair arguments for the binding
+        :param callback: callback(pika.frame.Method) for method Queue.UnbindOk
         :returns: ``None``. Method frame from the Queue.Unbind-ok response is
             delivered to ``callback`` when provided.
         :raises ValueError:
@@ -1001,7 +1001,7 @@ class Channel:
     def tx_commit(self, callback: _OnTxCommitCallback | None = None) -> None:
         """Commit a transaction
 
-        :param callable callback: callback(pika.frame.Method) for method Tx.CommitOk
+        :param callback: callback(pika.frame.Method) for method Tx.CommitOk
         :returns: ``None``. Method frame from the Tx.Commit-ok response is delivered
             to ``callback`` when provided.
         :raises ValueError:
@@ -1015,7 +1015,7 @@ class Channel:
                     callback: _OnTxRollbackCallback | None = None) -> None:
         """Rollback a transaction.
 
-        :param callable callback: callback(pika.frame.Method) for method Tx.RollbackOk
+        :param callback: callback(pika.frame.Method) for method Tx.RollbackOk
         :returns: ``None``. Method frame from the Tx.Rollback-ok response is delivered
             to ``callback`` when provided.
         :raises ValueError:
@@ -1030,7 +1030,7 @@ class Channel:
         standard transactions. The client must use this method at least once on
         a channel before using the Commit or Rollback methods.
 
-        :param callable callback: callback(pika.frame.Method) for method Tx.SelectOk
+        :param callback: callback(pika.frame.Method) for method Tx.SelectOk
         :returns: ``None``. Method frame from the Tx.Select-ok response is delivered
             to ``callback`` when provided.
         :raises ValueError:
@@ -1069,7 +1069,7 @@ class Channel:
         be called when the channel is being cleaned up after all channel-close
         callbacks callbacks.
 
-        :param callable callback: The callback to call, having the
+        :param callback: The callback to call, having the
             signature: callback(channel)
 
         """
@@ -1091,7 +1091,7 @@ class Channel:
         """Remove any references to the consumer tag in internal structures
         for consumer state.
 
-        :param str consumer_tag: The consumer tag to cleanup
+        :param consumer_tag: The consumer tag to cleanup
 
         """
         self._consumers_with_noack.discard(consumer_tag)
@@ -1117,7 +1117,7 @@ class Channel:
         formed message in three parts when all of the body frames have been
         received.
 
-        :param pika.amqp_object.Frame frame_value: The frame to deliver
+        :param frame_value: The frame to deliver
 
         """
         try:
@@ -1138,7 +1138,7 @@ class Channel:
         """When the broker cancels a consumer, delete it from our internal
         dictionary.
 
-        :param pika.frame.Method method_frame: The method frame received
+        :param method_frame: The method frame received
 
         """
         if method_frame.method.consumer_tag in self._cancelled:
@@ -1151,7 +1151,7 @@ class Channel:
         """Called in response to a frame from the Broker when the
          client sends Basic.Cancel
 
-        :param pika.frame.Method method_frame: The method frame received
+        :param method_frame: The method frame received
 
         """
         self._cleanup_consumer_ref(method_frame.method.consumer_tag)
@@ -1180,7 +1180,7 @@ class Channel:
     def _on_close_from_broker(self, method_frame: frame.Method) -> None:
         """Handle `Channel.Close` from broker.
 
-        :param pika.frame.Method method_frame: Method frame with Channel.Close
+        :param method_frame: Method frame with Channel.Close
             method
 
         """
@@ -1221,7 +1221,7 @@ class Channel:
         loss. We use this opportunity to transition to CLOSED state, clean up
         the channel, and dispatch the on-channel-closed callbacks.
 
-        :param Exception reason: Exception describing the reason for closing.
+        :param reason: Exception describing the reason for closing.
 
         """
         LOGGER.debug('Handling meta-close on %s: %r', self, reason)
@@ -1233,7 +1233,7 @@ class Channel:
     def _on_closeok(self, method_frame: frame.Method) -> None:
         """Invoked when RabbitMQ replies to a Channel.Close method
 
-        :param pika.frame.Method method_frame: Method frame with Channel.CloseOk
+        :param method_frame: Method frame with Channel.CloseOk
             method
 
         """
@@ -1247,9 +1247,9 @@ class Channel:
         another delivery appears for it, queue the deliveries up until it
         finally exits.
 
-        :param pika.frame.Method method_frame: The method frame received
-        :param pika.frame.Header header_frame: The header frame received
-        :param bytes body: The body received
+        :param method_frame: The method frame received
+        :param header_frame: The header frame received
+        :param body: The body received
 
         """
         consumer_tag = method_frame.method.consumer_tag
@@ -1271,7 +1271,7 @@ class Channel:
         We keep a list of what we've yet to implement so that we don't silently
         drain events that we don't support.
 
-        :param pika.frame.Method method_frame: The method frame received
+        :param method_frame: The method frame received
 
         """
         LOGGER.debug('Discarding frame %r', method_frame)
@@ -1279,7 +1279,7 @@ class Channel:
     def _on_flow(self, _method_frame_unused: frame.Method) -> None:
         """Called if the server sends a Channel.Flow frame.
 
-        :param pika.frame.Method _method_frame_unused: The Channel.Flow frame
+        :param _method_frame_unused: The Channel.Flow frame
 
         """
         if self._has_on_flow_callback is False:
@@ -1288,7 +1288,7 @@ class Channel:
     def _on_flowok(self, method_frame: frame.Method) -> None:
         """Called in response to us asking the server to toggle on Channel.Flow
 
-        :param pika.frame.Method method_frame: The method frame received
+        :param method_frame: The method frame received
 
         """
         self.flow_active = method_frame.method.active
@@ -1301,7 +1301,7 @@ class Channel:
     def _on_getempty(self, method_frame: frame.Method) -> None:
         """When we receive an empty reply do nothing but log it
 
-        :param pika.frame.Method method_frame: The method frame received
+        :param method_frame: The method frame received
 
         """
         LOGGER.debug('Received Basic.GetEmpty: %r', method_frame)
@@ -1312,9 +1312,9 @@ class Channel:
                   body: bytes) -> None:
         """Called in reply to a Basic.Get when there is a message.
 
-        :param pika.frame.Method method_frame: The method frame received
-        :param pika.frame.Header header_frame: The header frame received
-        :param bytes body: The body received
+        :param method_frame: The method frame received
+        :param header_frame: The header frame received
+        :param body: The body received
 
         """
         if self._on_getok_callback is not None:
@@ -1334,7 +1334,7 @@ class Channel:
         Suppress the state transition and callback if channel is already in
         CLOSING state.
 
-        :param pika.frame.Method method_frame: Channel.OpenOk frame
+        :param method_frame: Channel.OpenOk frame
 
         """
         # Suppress OpenOk if the user or Connection.Close started closing it
@@ -1350,9 +1350,9 @@ class Channel:
                    body: bytes) -> None:
         """Called if the server sends a Basic.Return frame.
 
-        :param pika.frame.Method method_frame: The Basic.Return frame
-        :param pika.frame.Header header_frame: The content header frame
-        :param bytes body: The message body
+        :param method_frame: The Basic.Return frame
+        :param header_frame: The content header frame
+        :param body: The message body
 
         """
         if not self.callbacks.process(self.channel_number, '_on_return', self,
@@ -1364,7 +1364,7 @@ class Channel:
     def _on_selectok(self, method_frame: frame.Method) -> None:
         """Called when the broker sends a Confirm.SelectOk frame
 
-        :param pika.frame.Method method_frame: The method frame received
+        :param method_frame: The method frame received
 
         """
         LOGGER.debug("Confirm.SelectOk Received: %r", method_frame)
@@ -1375,7 +1375,7 @@ class Channel:
         the blocking state and send all the frames that stacked up while we
         were in the blocking state.
 
-        :param pika.frame.Method _method_frame_unused: The method frame received
+        :param _method_frame_unused: The method frame received
 
         """
         LOGGER.debug('%i blocked frames', len(self._blocked))
@@ -1433,9 +1433,9 @@ class Channel:
 
         NOTE: A callback must be accompanied by non-empty acceptable_replies.
 
-        :param pika.amqp_object.Method method: The AMQP method to invoke
-        :param callable callback: The callback for the RPC response
-        :param list|None acceptable_replies: A (possibly empty) sequence of
+        :param method: The AMQP method to invoke
+        :param callback: The callback for the RPC response
+        :param acceptable_replies: A (possibly empty) sequence of
             replies this RPC call expects or None
 
         """
@@ -1529,8 +1529,8 @@ class Channel:
         """Shortcut wrapper to send a method through our connection, passing in
         the channel number
 
-        :param pika.amqp_object.Method method: The method to send
-        :param tuple content: If set, is a content frame, is tuple of
+        :param method: The method to send
+        :param content: If set, is a content frame, is tuple of
                               properties and body.
 
         """
@@ -1549,7 +1549,7 @@ class Channel:
     def _set_state(self, connection_state: int) -> None:
         """Set the channel connection state to the specified state value.
 
-        :param int connection_state: The connection_state value
+        :param connection_state: The connection_state value
 
         """
         self._state = connection_state
@@ -1557,7 +1557,7 @@ class Channel:
     def _on_unexpected_frame(self, frame_value: frame.Frame) -> None:
         """Invoked when a frame is received that is not setup to be processed.
 
-        :param pika.frame.Frame frame_value: The frame received
+        :param frame_value: The frame received
 
         """
         LOGGER.error('Unexpected frame: %r', frame_value)
@@ -1585,7 +1585,7 @@ class ContentFrameAssembler:
         setup in the rpc process and that don't have explicit reply types
         defined. This includes Basic.Publish, Basic.GetOk and Basic.Return
 
-        :param Method|Header|Body frame_value: The frame to process
+        :param frame_value: The frame to process
 
         :rtype: tuple[frame.Method, frame.Header, bytes] | None
         """
@@ -1621,7 +1621,7 @@ class ContentFrameAssembler:
         """Receive body frames and append them to the stack. When the body size
         matches, call the finish method.
 
-        :param Body body_frame: The body frame
+        :param body_frame: The body frame
         :raises: pika.exceptions.BodyTooLongError
         :rtype: tuple(pika.frame.Method, pika.frame.Header, bytes)|None
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1587,6 +1587,7 @@ class ContentFrameAssembler:
 
         :param Method|Header|Body frame_value: The frame to process
 
+        :rtype: tuple[frame.Method, frame.Header, bytes] | None
         """
         if (isinstance(frame_value, frame.Method) and
                 spec.has_content(frame_value.method.INDEX)):

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1833,9 +1833,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             method_frame: frame.Method[spec.Connection.Blocked]) -> None:
         """Handle Connection.Blocked notification from RabbitMQ broker
 
+        :param _connection: The connection instance (unused)
         :param method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
-        :param _connection: The connection instance (unused)
         """
         LOGGER.warning('Received %s from broker', method_frame)
 
@@ -1856,9 +1856,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             method_frame: frame.Method[spec.Connection.Unblocked]) -> None:
         """Handle Connection.Unblocked notification from RabbitMQ broker
 
+        :param _connection: The connection instance (unused)
         :param method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
-        :param _connection: The connection instance (unused)
         """
         LOGGER.info('Received %s from broker', method_frame)
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2329,10 +2329,11 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _send_connection_tune_ok(self) -> None:
         """Send a Connection.TuneOk frame"""
-        self._send_method(0,
-                          spec.Connection.TuneOk(
-                              self.params.channel_max, self.params.frame_max,
-                              self.params.heartbeat))
+        self._send_method(
+            0,
+            spec.Connection.TuneOk(self.params.channel_max,
+                                   self.params.frame_max,
+                                   self.params.heartbeat))
 
     def _send_frame(
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -201,7 +201,7 @@ class Parameters:
     @channel_max.setter
     def channel_max(self, value: int) -> None:
         """
-        :param int value: max preferred number of channels, between 1 and
+        :param value: max preferred number of channels, between 1 and
            `channel.MAX_CHANNELS`, inclusive
 
         """
@@ -253,7 +253,7 @@ class Parameters:
     @connection_attempts.setter
     def connection_attempts(self, value: int) -> None:
         """
-        :param int value: number of socket connection attempts of at least 1.
+        :param value: number of socket connection attempts of at least 1.
             See also `retry_delay`.
 
         """
@@ -306,7 +306,7 @@ class Parameters:
     @frame_max.setter
     def frame_max(self, value: int) -> None:
         """
-        :param int value: desired maximum AMQP frame size to use between
+        :param value: desired maximum AMQP frame size to use between
             `spec.FRAME_MIN_SIZE` and `spec.FRAME_MAX_SIZE`, inclusive
 
         """
@@ -338,7 +338,7 @@ class Parameters:
     def heartbeat(
         self, value: None | (int | Callable[[Connection, float], int])) -> None:
         """
-        :param int|None|callable value: Controls AMQP heartbeat timeout negotiation
+        :param value: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called
@@ -367,7 +367,7 @@ class Parameters:
     @host.setter
     def host(self, value: str) -> None:
         """
-        :param str value: hostname or ip address of broker
+        :param value: hostname or ip address of broker
 
         """
         validators.require_string(value, 'host')
@@ -386,7 +386,7 @@ class Parameters:
     @locale.setter
     def locale(self, value: str) -> None:
         """
-        :param str value: locale value to pass to broker; e.g., "en_US"
+        :param value: locale value to pass to broker; e.g., "en_US"
 
         """
         validators.require_string(value, 'locale')
@@ -405,7 +405,7 @@ class Parameters:
     @port.setter
     def port(self, value: int) -> None:
         """
-        :param int value: port number of broker's listening socket
+        :param value: port number of broker's listening socket
 
         """
         try:
@@ -426,7 +426,7 @@ class Parameters:
     @retry_delay.setter
     def retry_delay(self, value: float) -> None:
         """
-        :param int | float value: interval between socket connection attempts;
+        :param value: interval between socket connection attempts;
             see also `connection_attempts`.
 
         """
@@ -448,7 +448,7 @@ class Parameters:
     @socket_timeout.setter
     def socket_timeout(self, value: float | None) -> None:
         """
-        :param int | float | None value: positive socket connect timeout in
+        :param value: positive socket connect timeout in
             seconds. None to disable this timeout.
 
         """
@@ -477,7 +477,7 @@ class Parameters:
     @stack_timeout.setter
     def stack_timeout(self, value: float | None) -> None:
         """
-        :param int | float | None value: positive full protocol stack
+        :param value: positive full protocol stack
             TCP/[SSL]/AMQP bring-up timeout in seconds. It's recommended to set
             this value higher than `socket_timeout`. None to disable this
             timeout.
@@ -505,10 +505,9 @@ class Parameters:
     @ssl_options.setter
     def ssl_options(self, value: SSLOptions | None) -> None:
         """
-        :param `pika.SSLOptions`|None value: None for plaintext or
+        :param value: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
 
-        :param SSLOptions | None value: SSL options
         """
         if not isinstance(value, (SSLOptions, type(None))):
             raise TypeError(
@@ -528,7 +527,7 @@ class Parameters:
     @virtual_host.setter
     def virtual_host(self, value: str) -> None:
         """
-        :param str value: rabbitmq virtual host name
+        :param value: rabbitmq virtual host name
 
         """
         validators.require_string(value, 'virtual_host')
@@ -545,7 +544,7 @@ class Parameters:
     @tcp_options.setter
     def tcp_options(self, value: dict[str, int] | None) -> None:
         """
-        :param dict|None value: None or a dict of options to pass to the underlying
+        :param value: None or a dict of options to pass to the underlying
             socket. Currently supported are TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
             and TCP_USER_TIMEOUT. Availability of these may depend on your platform.
         """
@@ -592,30 +591,30 @@ class ConnectionParameters(Parameters):
         """Create a new ConnectionParameters instance. See `Parameters` for
         default values.
 
-        :param str host: Hostname or IP Address to connect to
-        :param int port: TCP port to connect to
-        :param str virtual_host: RabbitMQ virtual host to use
-        :param pika.credentials.PlainCredentials credentials: auth credentials
-        :param int channel_max: Maximum number of channels to allow
-        :param int frame_max: The maximum byte size for an AMQP frame
-        :param int|None|callable heartbeat: Controls AMQP heartbeat timeout negotiation
+        :param host: Hostname or IP Address to connect to
+        :param port: TCP port to connect to
+        :param virtual_host: RabbitMQ virtual host to use
+        :param credentials: auth credentials
+        :param channel_max: Maximum number of channels to allow
+        :param frame_max: The maximum byte size for an AMQP frame
+        :param heartbeat: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called
             with the connection instance and the heartbeat timeout proposed by broker
             as its arguments. The callback should return a non-negative integer that
             will be used to override the broker's proposal.
-        :param `pika.SSLOptions`|None ssl_options: None for plaintext or
+        :param ssl_options: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
-        :param int connection_attempts: Maximum number of retry attempts
-        :param int|float retry_delay: Time to wait in seconds, before the next
-        :param int|float socket_timeout: Positive socket connect timeout in
+        :param connection_attempts: Maximum number of retry attempts
+        :param retry_delay: Time to wait in seconds, before the next
+        :param socket_timeout: Positive socket connect timeout in
             seconds.
-        :param int|float stack_timeout: Positive full protocol stack
+        :param stack_timeout: Positive full protocol stack
             (TCP/[SSL]/AMQP) bring-up timeout in seconds. It's recommended to
             set this value higher than `socket_timeout`.
-        :param str locale: Set the locale value
-        :param int|float|None blocked_connection_timeout: If not None,
+        :param locale: Set the locale value
+        :param blocked_connection_timeout: If not None,
             the value is a non-negative timeout, in seconds, for the
             connection to remain blocked (triggered by Connection.Blocked from
             broker); if the timeout expires before connection becomes unblocked,
@@ -740,7 +739,7 @@ class URLParameters(Parameters):
         - tcp_options:
             Set the tcp options for the underlying socket.
 
-    :param str url: The AMQP URL to connect to
+    :param url: The AMQP URL to connect to
 
     """
 
@@ -754,7 +753,7 @@ class URLParameters(Parameters):
     def __init__(self, url: str) -> None:
         """Create a new URLParameters instance.
 
-        :param str url: The URL value
+        :param url: The URL value
 
         """
         super().__init__()
@@ -818,7 +817,7 @@ class URLParameters(Parameters):
 
     def _set_url_blocked_connection_timeout(self, value: float) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param float value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             blocked_connection_timeout = float(value)
@@ -829,7 +828,7 @@ class URLParameters(Parameters):
 
     def _set_url_channel_max(self, value: int) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param int value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             channel_max = int(value)
@@ -839,13 +838,13 @@ class URLParameters(Parameters):
 
     def _set_url_client_properties(self, value: str) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param str value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         self.client_properties = ast.literal_eval(value)
 
     def _set_url_connection_attempts(self, value: int) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param int value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             connection_attempts = int(value)
@@ -856,7 +855,7 @@ class URLParameters(Parameters):
 
     def _set_url_frame_max(self, value: int) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param int value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             frame_max = int(value)
@@ -866,7 +865,7 @@ class URLParameters(Parameters):
 
     def _set_url_heartbeat(self, value: int) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param int value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             heartbeat_timeout = int(value)
@@ -876,13 +875,13 @@ class URLParameters(Parameters):
 
     def _set_url_locale(self, value: str) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param str value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         self.locale = value
 
     def _set_url_retry_delay(self, value: float) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param float value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             retry_delay = float(value)
@@ -892,7 +891,7 @@ class URLParameters(Parameters):
 
     def _set_url_socket_timeout(self, value: float) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param float value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             socket_timeout = float(value)
@@ -902,7 +901,7 @@ class URLParameters(Parameters):
 
     def _set_url_stack_timeout(self, value: float) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param float value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         try:
             stack_timeout = float(value)
@@ -913,7 +912,7 @@ class URLParameters(Parameters):
     def _set_url_ssl_options(self, value: str) -> None:
         """Deserialize and apply the corresponding query string arg
 
-        :param str value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         opts = ast.literal_eval(value)
         if opts is None:
@@ -961,7 +960,7 @@ class URLParameters(Parameters):
 
     def _set_url_tcp_options(self, value: str) -> None:
         """Deserialize and apply the corresponding query string arg
-        :param str value: Raw query-string value to deserialize
+        :param value: Raw query-string value to deserialize
         """
         self.tcp_options = ast.literal_eval(value)
 
@@ -979,8 +978,8 @@ class SSLOptions:
                  context: ssl.SSLContext,
                  server_hostname: str | None = None) -> None:
         """
-        :param ssl.SSLContext context: SSLContext instance
-        :param str|None server_hostname: SSLContext.wrap_socket, used to enable
+        :param context: SSLContext instance
+        :param server_hostname: SSLContext.wrap_socket, used to enable
             SNI
         """
         if not isinstance(context, ssl.SSLContext):
@@ -1034,9 +1033,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         Available Parameters classes are the ConnectionParameters class and
         URLParameters class.
 
-        :param pika.connection.Parameters parameters: Read-only connection
+        :param parameters: Read-only connection
             parameters.
-        :param callable on_open_callback: Called when the connection is opened:
+        :param on_open_callback: Called when the connection is opened:
             on_open_callback(connection)
         :param on_open_error_callback: Callback (or None) with signature
             ``(Connection, Exception) -> Any``; called if the connection
@@ -1049,7 +1048,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             either an instance of `exceptions.ConnectionClosed` if closed by
             user or broker or exception of another type that describes the cause
             of connection failure.
-        :param bool internal_connection_workflow: True for autonomous connection
+        :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
 
@@ -1190,7 +1189,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         a fully-open connection was closed by user or broker or exception of
         another type that describes the cause of connection closure/failure.
 
-        :param callable callback: Callback to call on close, having the signature:
+        :param callback: Callback to call on close, having the signature:
             callback(pika.connection.Connection, exception)
 
         """
@@ -1214,7 +1213,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         See also `ConnectionParameters.blocked_connection_timeout`.
 
-        :param callable callback: Callback to call on `Connection.Blocked`,
+        :param callback: Callback to call on `Connection.Blocked`,
             having the signature `callback(connection, pika.frame.Method)`,
             where the method frame's `method` member is of type
             `pika.spec.Connection.Blocked`
@@ -1234,7 +1233,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         connection gets unblocked (`Connection.Unblocked` frame is received from
         RabbitMQ) letting publishers know it's ok to start publishing again.
 
-        :param callable callback: Callback to call on
+        :param callback: Callback to call on
             `Connection.Unblocked`, having the signature
             `callback(connection, pika.frame.Method)`, where the method frame's
             `method` member is of type `pika.spec.Connection.Unblocked`
@@ -1251,7 +1250,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Add a callback notification when the connection has opened. The
         callback will be passed the connection instance as its only arg.
 
-        :param callable callback: Callback to call when open
+        :param callback: Callback to call when open
 
         """
         validators.require_callback(callback)
@@ -1266,9 +1265,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         The callback method should accept the connection instance that could not
         connect, and either a string or an exception as its second arg.
 
-        :param callable callback: Callback to call when can't connect, having
+        :param callback: Callback to call when can't connect, having
             the signature _(Connection, Exception)
-        :param bool remove_default: Remove default exception raising callback
+        :param remove_default: Remove default exception raising callback
 
         """
         validators.require_callback(callback)
@@ -1287,9 +1286,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         specify but it is recommended that you let Pika manage the channel
         numbers.
 
-        :param int channel_number: The channel number to use, defaults to the
+        :param channel_number: The channel number to use, defaults to the
                                    next available.
-        :param callable on_open_callback: The callback when the channel is
+        :param on_open_callback: The callback when the channel is
             opened.  The callback will be invoked with the `Channel` instance
             as its only argument.
         :rtype: pika.channel.Channel
@@ -1321,9 +1320,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         It is used when secrets have an expiration date and need to be renewed, like OAuth 2 tokens.
         Pass a callback to be notified of the response from the server.
 
-        :param string new_secret: The new secret
-        :param string reason: The reason for the secret update
-        :param callable callback: Callback to call on
+        :param new_secret: The new secret
+        :param reason: The reason for the secret update
+        :param callback: Callback to call on
             `Connection.UpdateSecretOk`, having the signature
             `callback(pika.frame.Method)`, where the method frame's
             `method` member is of type `pika.spec.Connection.UpdateSecretOk`
@@ -1347,8 +1346,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         have active consumers will attempt to send a Basic.Cancel to RabbitMQ
         to cleanly stop the delivery of messages prior to closing the channel.
 
-        :param int reply_code: The code number for the close
-        :param str reply_text: The text reason for the close
+        :param reply_code: The code number for the close
+        :param reply_text: The text reason for the close
 
         :raises pika.exceptions.ConnectionWrongStateError: if connection is
             closed or closing.
@@ -1488,8 +1487,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         specified number of seconds have elapsed, using a timer, or a
         thread, or similar.
 
-        :param float|int delay: The number of seconds to wait to call callback
-        :param callable callback: The callback will be called without args.
+        :param delay: The number of seconds to wait to call callback
+        :param callback: The callback will be called without args.
         :returns: Handle that can be passed to `_adapter_remove_timeout()` to
             cancel the callback.
         :rtype: object
@@ -1516,7 +1515,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
          other manipulations of the connection must be performed from the
          connection's thread.
 
-        :param callable callback: The callback method; must be callable.
+        :param callback: The callback method; must be callable.
 
         """
         raise NotImplementedError
@@ -1553,7 +1552,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         Subclasses must override this
 
-        :param bytes data:
+        :param data:
 
         """
         raise NotImplementedError
@@ -1561,7 +1560,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _add_channel_callbacks(self, channel_number: int) -> None:
         """Add the appropriate callbacks for the specified channel number.
 
-        :param int channel_number: The channel number for the callbacks
+        :param channel_number: The channel number for the callbacks
 
         """
 
@@ -1587,7 +1586,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Invoked when starting a connection to make sure it's a supported
         protocol.
 
-        :param pika.frame.Method value: The frame to check
+        :param value: The frame to check
         :raises ProtocolVersionMismatch:
 
         """
@@ -1627,8 +1626,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Initiate graceful closing of channels that are in OPEN or OPENING
         states, passing reply_code and reply_text.
 
-        :param int reply_code: The code for why the channels are being closed
-        :param str reply_text: The text reason for why the channels are closing
+        :param reply_code: The code for why the channels are being closed
+        :param reply_text: The text reason for why the channels are closing
 
         """
         assert self.is_open, str(self)
@@ -1644,8 +1643,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Create a new channel using the specified channel number and calling
         back the method specified by on_open_callback
 
-        :param int channel_number: The channel number to use
-        :param callable on_open_callback: The callback when the channel is
+        :param channel_number: The channel number to use
+        :param on_open_callback: The callback when the channel is
             opened.  The callback will be invoked with the `Channel` instance
             as its only argument.
 
@@ -1680,7 +1679,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _deliver_frame_to_channel(self, value: frame.Frame) -> None:
         """Deliver the frame to the channel specified in the frame.
 
-        :param pika.frame.Method value: The frame to deliver
+        :param value: The frame to deliver
 
         """
         if value.channel_number not in self._channels:
@@ -1712,7 +1711,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     ) -> tuple[str, bytes | None]:
         """Get credentials for authentication.
 
-        :param pika.frame.MethodFrame method_frame: The Connection.Start frame
+        :param method_frame: The Connection.Start frame
         :rtype: tuple(str, bytes|None)
 
         """
@@ -1728,7 +1727,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Return true if there are any callbacks pending for the specified
         frame.
 
-        :param pika.frame.Method value: The frame to check
+        :param value: The frame to check
         :rtype: int|None
 
         """
@@ -1737,7 +1736,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _is_method_frame(self, value: frame.Frame) -> bool:
         """Returns true if the frame is a method frame.
 
-        :param pika.frame.Frame value: The frame to evaluate
+        :param value: The frame to evaluate
         :rtype: bool
 
         """
@@ -1748,7 +1747,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :rtype: bool
 
-        :param frame.Frame value: Frame to inspect
+        :param value: Frame to inspect
         """
         return isinstance(value, frame.ProtocolHeader)
 
@@ -1772,7 +1771,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         sent. If connection is closing and no more channels remain, proceed to
         `_on_close_ready`.
 
-        :param pika.channel.Channel channel: channel instance
+        :param channel: channel instance
 
         """
         try:
@@ -1836,9 +1835,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             method_frame: frame.Method[spec.Connection.Blocked]) -> None:
         """Handle Connection.Blocked notification from RabbitMQ broker
 
-        :param pika.frame.Method method_frame: method frame having `method`
+        :param method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
-        :param Connection _connection: The connection instance (unused)
+        :param _connection: The connection instance (unused)
         """
         LOGGER.warning('Received %s from broker', method_frame)
 
@@ -1859,9 +1858,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             method_frame: frame.Method[spec.Connection.Unblocked]) -> None:
         """Handle Connection.Unblocked notification from RabbitMQ broker
 
-        :param pika.frame.Method method_frame: method frame having `method`
+        :param method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
-        :param Connection _connection: The connection instance (unused)
+        :param _connection: The connection instance (unused)
         """
         LOGGER.info('Received %s from broker', method_frame)
 
@@ -1879,7 +1878,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Called when the connection is closed remotely via Connection.Close
         frame from broker.
 
-        :param pika.frame.Method method_frame: The Connection.Close frame
+        :param method_frame: The Connection.Close frame
 
         """
         LOGGER.debug('_on_connection_close_from_broker: frame=%s', method_frame)
@@ -1895,7 +1894,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self, method_frame: frame.Method[spec.Connection.CloseOk]) -> None:
         """Called when Connection.CloseOk is received from remote.
 
-        :param pika.frame.Method method_frame: The Connection.CloseOk frame
+        :param method_frame: The Connection.CloseOk frame
 
         """
         LOGGER.debug('_on_connection_close_ok: frame=%s', method_frame)
@@ -1909,8 +1908,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :raises Exception: the given error
 
-        :param Connection _connection_unused: The connection instance (unused)
-        :param Exception error: The exception that caused the failure
+        :param _connection_unused: The connection instance (unused)
+        :param error: The exception that caused the failure
         """
         raise error
 
@@ -1920,7 +1919,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         This is called once we have tuned the connection with the server and
         called the Connection.Open on the server and it has replied with
         Connection.Ok.
-        :param frame.Method[spec.Connection.OpenOk] method_frame: Server response frame
+        :param method_frame: Server response frame
         """
         self._opened = True
 
@@ -1937,7 +1936,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """This is called as a callback once we have received a Connection.Start
         from the server.
 
-        :param pika.frame.Method method_frame: The frame received
+        :param method_frame: The frame received
         :raises UnexpectedFrameError:
 
         """
@@ -1961,8 +1960,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         returns the other one. If both are positive integers, returns the
         smallest one.
 
-        :param int client_value: The client value
-        :param int server_value: The server value
+        :param client_value: The client value
+        :param server_value: The server value
         :rtype: int
 
         """
@@ -2017,7 +2016,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         monitor if required, send our TuneOk and then the Connection. Open rpc
         call on channel 0.
 
-        :param pika.frame.Method method_frame: The frame received
+        :param method_frame: The frame received
 
         """
         self._set_connection_state(self.CONNECTION_TUNE)
@@ -2060,7 +2059,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """This is called by our Adapter, passing in the data from the socket.
         As long as we have buffer try and map out frame data.
 
-        :param str data_in: The data that is available to read
+        :param data_in: The data that is available to read
 
         """
         self._frame_buffer += data_in
@@ -2194,7 +2193,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Process the callbacks for the frame if the frame is a method frame
         and if it has any callbacks pending.
 
-        :param pika.frame.Method frame_value: The frame to process
+        :param frame_value: The frame to process
         :rtype: bool
 
         """
@@ -2212,8 +2211,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:
         """Process an inbound frame from the socket.
 
-        :param pika.frame.Frame|pika.frame.Method frame_value: The frame to
-            process
+        :param frame_value: The frame to process
 
         """
         # Will receive a frame type of -1 if protocol version mismatch
@@ -2258,8 +2256,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Remove the callbacks for the specified channel number and list of
         method frames.
 
-        :param int channel_number: The channel number to remove the callback on
-        :param sequence method_classes: The method classes (derived from
+        :param channel_number: The channel number to remove the callback on
+        :param method_classes: The method classes (derived from
             `pika.amqp_object.Method`) for the callbacks
 
         """
@@ -2277,10 +2275,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         acceptable_replies lists out what responses we'll process from the
         server with the specified callback.
 
-        :param int channel_number: The channel number for the RPC call
-        :param pika.amqp_object.Method method: The method frame to call
-        :param callable callback: The callback for the RPC response
-        :param list acceptable_replies: The replies this RPC call expects
+        :param channel_number: The channel number for the RPC call
+        :param method: The method frame to call
+        :param callback: The callback for the RPC response
+        :param acceptable_replies: The replies this RPC call expects
 
         """
         # Validate that acceptable_replies is a list or None
@@ -2300,8 +2298,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _send_connection_close(self, reply_code: int, reply_text: str) -> None:
         """Send a Connection.Close method frame.
 
-        :param int reply_code: The reason for the close
-        :param str reply_text: The text reason for the close
+        :param reply_code: The reason for the close
+        :param reply_text: The text reason for the close
 
         """
         self._rpc(0, spec.Connection.Close(reply_code, reply_text, 0, 0),
@@ -2317,8 +2315,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                   response: bytes | None) -> None:
         """Send a Connection.StartOk frame
 
-        :param str authentication_type: The auth type value
-        :param str response: The encoded value to send
+        :param authentication_type: The auth type value
+        :param response: The encoded value to send
 
         """
         self._send_method(
@@ -2340,8 +2338,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """This appends the fully generated frame to send to the broker to the
         output buffer which will be then sent via the connection adapter.
 
-        :param pika.frame.Frame|pika.frame.ProtocolHeader frame_value: The
-            frame to write
+        :param frame_value: The frame to write
         :raises exceptions.ConnectionClosed:
 
         """
@@ -2361,9 +2358,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     ) -> None:
         """Constructs a RPC method frame and then sends it to the broker.
 
-        :param int channel_number: The channel number for the frame
-        :param pika.amqp_object.Method method: The method to send
-        :param tuple content: If set, is a content frame, is tuple of
+        :param channel_number: The channel number for the frame
+        :param method: The method to send
+        :param content: If set, is a content frame, is tuple of
                               properties and body.
 
         """
@@ -2377,9 +2374,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                       content: tuple[spec.BasicProperties, bytes]) -> None:
         """Publish a message.
 
-        :param int channel_number: The channel number for the frame
-        :param pika.object.Method method_frame: The method frame to send
-        :param tuple content: A content frame, which is tuple of properties and
+        :param channel_number: The channel number for the frame
+        :param method_frame: The method frame to send
+        :param content: A content frame, which is tuple of properties and
                               body.
 
         """
@@ -2408,7 +2405,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _set_connection_state(self, connection_state: int) -> None:
         """Set the connection state.
 
-        :param int connection_state: The connection state to set
+        :param connection_state: The connection state to set
 
         """
         LOGGER.debug('New Connection state: %s (prev=%s)',
@@ -2421,7 +2418,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self, method_frame: frame.Method[spec.Connection.Start]) -> None:
         """Set the server properties and capabilities
 
-        :param spec.connection.Start method_frame: The Connection.Start frame
+        :param method_frame: The Connection.Start frame
 
         """
         self.server_properties = method_frame.method.server_properties  # pyright: ignore[reportAttributeAccessIssue]
@@ -2436,7 +2433,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         counter that keeps track of how many bytes have been read/used from the
         socket.
 
-        :param int byte_count: The number of bytes consumed
+        :param byte_count: The number of bytes consumed
 
         """
         self._frame_buffer = self._frame_buffer[byte_count:]
@@ -2446,7 +2443,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                  marshaled_frames: Sequence[bytes]) -> None:
         """Output list of marshaled frames to buffer and update stats
 
-        :param list marshaled_frames: A list of frames marshaled to bytes
+        :param marshaled_frames: A list of frames marshaled to bytes
 
         """
         for marshaled_frame in marshaled_frames:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -338,7 +338,7 @@ class Parameters:
     def heartbeat(
         self, value: None | (int | Callable[[Connection, float], int])) -> None:
         """
-        :param int|None|callable value: Controls AMQP heartbeat timeout negotiation
+        :param value: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called
@@ -426,7 +426,7 @@ class Parameters:
     @retry_delay.setter
     def retry_delay(self, value: float) -> None:
         """
-        :param int | float value: interval between socket connection attempts;
+        :param value: interval between socket connection attempts;
             see also `connection_attempts`.
 
         """
@@ -448,7 +448,7 @@ class Parameters:
     @socket_timeout.setter
     def socket_timeout(self, value: float | None) -> None:
         """
-        :param int | float | None value: positive socket connect timeout in
+        :param value: positive socket connect timeout in
             seconds. None to disable this timeout.
 
         """
@@ -477,7 +477,7 @@ class Parameters:
     @stack_timeout.setter
     def stack_timeout(self, value: float | None) -> None:
         """
-        :param int | float | None value: positive full protocol stack
+        :param value: positive full protocol stack
             TCP/[SSL]/AMQP bring-up timeout in seconds. It's recommended to set
             this value higher than `socket_timeout`. None to disable this
             timeout.
@@ -505,10 +505,10 @@ class Parameters:
     @ssl_options.setter
     def ssl_options(self, value: SSLOptions | None) -> None:
         """
-        :param `pika.SSLOptions`|None value: None for plaintext or
+        :param value: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
 
-        :param SSLOptions | None value: SSL options
+        :param value: SSL options
         """
         if not isinstance(value, (SSLOptions, type(None))):
             raise TypeError(
@@ -545,7 +545,7 @@ class Parameters:
     @tcp_options.setter
     def tcp_options(self, value: dict[str, int] | None) -> None:
         """
-        :param dict|None value: None or a dict of options to pass to the underlying
+        :param value: None or a dict of options to pass to the underlying
             socket. Currently supported are TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
             and TCP_USER_TIMEOUT. Availability of these may depend on your platform.
         """
@@ -598,24 +598,24 @@ class ConnectionParameters(Parameters):
         :param pika.credentials.PlainCredentials credentials: auth credentials
         :param int channel_max: Maximum number of channels to allow
         :param int frame_max: The maximum byte size for an AMQP frame
-        :param int|None|callable heartbeat: Controls AMQP heartbeat timeout negotiation
+        :param heartbeat: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called
             with the connection instance and the heartbeat timeout proposed by broker
             as its arguments. The callback should return a non-negative integer that
             will be used to override the broker's proposal.
-        :param `pika.SSLOptions`|None ssl_options: None for plaintext or
+        :param ssl_options: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
         :param int connection_attempts: Maximum number of retry attempts
-        :param int|float retry_delay: Time to wait in seconds, before the next
-        :param int|float socket_timeout: Positive socket connect timeout in
+        :param retry_delay: Time to wait in seconds, before the next
+        :param socket_timeout: Positive socket connect timeout in
             seconds.
-        :param int|float stack_timeout: Positive full protocol stack
+        :param stack_timeout: Positive full protocol stack
             (TCP/[SSL]/AMQP) bring-up timeout in seconds. It's recommended to
             set this value higher than `socket_timeout`.
         :param str locale: Set the locale value
-        :param int|float|None blocked_connection_timeout: If not None,
+        :param blocked_connection_timeout: If not None,
             the value is a non-negative timeout, in seconds, for the
             connection to remain blocked (triggered by Connection.Blocked from
             broker); if the timeout expires before connection becomes unblocked,
@@ -980,7 +980,7 @@ class SSLOptions:
                  server_hostname: str | None = None) -> None:
         """
         :param ssl.SSLContext context: SSLContext instance
-        :param str|None server_hostname: SSLContext.wrap_socket, used to enable
+        :param server_hostname: SSLContext.wrap_socket, used to enable
             SNI
         """
         if not isinstance(context, ssl.SSLContext):
@@ -1488,7 +1488,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         specified number of seconds have elapsed, using a timer, or a
         thread, or similar.
 
-        :param float|int delay: The number of seconds to wait to call callback
+        :param delay: The number of seconds to wait to call callback
         :param callable callback: The callback will be called without args.
         :returns: Handle that can be passed to `_adapter_remove_timeout()` to
             cancel the callback.
@@ -1920,7 +1920,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         This is called once we have tuned the connection with the server and
         called the Connection.Open on the server and it has replied with
         Connection.Ok.
-        :param frame.Method[spec.Connection.OpenOk] method_frame: Server response frame
+        :param method_frame: Server response frame
         """
         self._opened = True
 
@@ -2212,7 +2212,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:
         """Process an inbound frame from the socket.
 
-        :param pika.frame.Frame|pika.frame.Method frame_value: The frame to
+        :param frame_value: The frame to
             process
 
         """
@@ -2340,7 +2340,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """This appends the fully generated frame to send to the broker to the
         output buffer which will be then sent via the connection adapter.
 
-        :param pika.frame.Frame|pika.frame.ProtocolHeader frame_value: The
+        :param frame_value: The
             frame to write
         :raises exceptions.ConnectionClosed:
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1408,7 +1408,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def is_closed(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
-        :rtype: bool
         """
         return self.connection_state == self.CONNECTION_CLOSED
 
@@ -1417,7 +1416,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """
         Returns True if connection is in the process of closing due to
         client-initiated `close` request, but closing is not yet complete.
-        :rtype: bool
         """
         return self.connection_state == self.CONNECTION_CLOSING
 
@@ -1425,7 +1423,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def is_open(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
-        :rtype: bool
         """
         return self.connection_state == self.CONNECTION_OPEN
 
@@ -1647,7 +1644,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             opened.  The callback will be invoked with the `Channel` instance
             as its only argument.
 
-        :rtype: Channel
         """
         LOGGER.debug('Creating channel %s', channel_number)
         return pika.channel.Channel(self, channel_number, on_open_callback)

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1033,8 +1033,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         Available Parameters classes are the ConnectionParameters class and
         URLParameters class.
 
-        :param parameters: Read-only connection
-            parameters.
+        :param parameters: Read-only connection parameters.
         :param on_open_callback: Called when the connection is opened:
             on_open_callback(connection)
         :param on_open_error_callback: Callback (or None) with signature
@@ -1500,7 +1499,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _adapter_remove_timeout(self, timeout_id: object) -> None:
         """Adapters should override: Remove a timeout
 
-        :param opaque timeout_id: The timeout handle to remove
+        :param timeout_id: The timeout handle to remove
 
         """
         raise NotImplementedError

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1744,9 +1744,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _is_protocol_header_frame(self, value: frame.Frame) -> bool:
         """Returns True if it's a protocol header frame.
 
-        :rtype: bool
-
         :param value: Frame to inspect
+        :rtype: bool
         """
         return isinstance(value, frame.ProtocolHeader)
 
@@ -1905,10 +1904,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Default behavior when the connecting connection cannot connect and
         user didn't supply own `on_connection_error` callback.
 
-        :raises Exception: the given error
-
         :param _connection_unused: The connection instance (unused)
         :param error: The exception that caused the failure
+        :raises Exception: the given error
         """
         raise error
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -508,6 +508,7 @@ class Parameters:
         :param `pika.SSLOptions`|None value: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
 
+        :param SSLOptions | None value: SSL options
         """
         if not isinstance(value, (SSLOptions, type(None))):
             raise TypeError(
@@ -816,7 +817,9 @@ class URLParameters(Parameters):
             set_value(single_value)
 
     def _set_url_blocked_connection_timeout(self, value: float) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param float value: Raw query-string value to deserialize
+        """
         try:
             blocked_connection_timeout = float(value)
         except ValueError as exc:
@@ -825,7 +828,9 @@ class URLParameters(Parameters):
         self.blocked_connection_timeout = blocked_connection_timeout
 
     def _set_url_channel_max(self, value: int) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param int value: Raw query-string value to deserialize
+        """
         try:
             channel_max = int(value)
         except ValueError as exc:
@@ -833,11 +838,15 @@ class URLParameters(Parameters):
         self.channel_max = channel_max
 
     def _set_url_client_properties(self, value: str) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param str value: Raw query-string value to deserialize
+        """
         self.client_properties = ast.literal_eval(value)
 
     def _set_url_connection_attempts(self, value: int) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param int value: Raw query-string value to deserialize
+        """
         try:
             connection_attempts = int(value)
         except ValueError as exc:
@@ -846,7 +855,9 @@ class URLParameters(Parameters):
         self.connection_attempts = connection_attempts
 
     def _set_url_frame_max(self, value: int) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param int value: Raw query-string value to deserialize
+        """
         try:
             frame_max = int(value)
         except ValueError as exc:
@@ -854,7 +865,9 @@ class URLParameters(Parameters):
         self.frame_max = frame_max
 
     def _set_url_heartbeat(self, value: int) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param int value: Raw query-string value to deserialize
+        """
         try:
             heartbeat_timeout = int(value)
         except ValueError as exc:
@@ -862,11 +875,15 @@ class URLParameters(Parameters):
         self.heartbeat = heartbeat_timeout
 
     def _set_url_locale(self, value: str) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param str value: Raw query-string value to deserialize
+        """
         self.locale = value
 
     def _set_url_retry_delay(self, value: float) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param float value: Raw query-string value to deserialize
+        """
         try:
             retry_delay = float(value)
         except ValueError as exc:
@@ -874,7 +891,9 @@ class URLParameters(Parameters):
         self.retry_delay = retry_delay
 
     def _set_url_socket_timeout(self, value: float) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param float value: Raw query-string value to deserialize
+        """
         try:
             socket_timeout = float(value)
         except ValueError as exc:
@@ -882,7 +901,9 @@ class URLParameters(Parameters):
         self.socket_timeout = socket_timeout
 
     def _set_url_stack_timeout(self, value: float) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param float value: Raw query-string value to deserialize
+        """
         try:
             stack_timeout = float(value)
         except ValueError as exc:
@@ -892,6 +913,7 @@ class URLParameters(Parameters):
     def _set_url_ssl_options(self, value: str) -> None:
         """Deserialize and apply the corresponding query string arg
 
+        :param str value: Raw query-string value to deserialize
         """
         opts = ast.literal_eval(value)
         if opts is None:
@@ -938,7 +960,9 @@ class URLParameters(Parameters):
                                                server_hostname=server_hostname)
 
     def _set_url_tcp_options(self, value: str) -> None:
-        """Deserialize and apply the corresponding query string arg"""
+        """Deserialize and apply the corresponding query string arg
+        :param str value: Raw query-string value to deserialize
+        """
         self.tcp_options = ast.literal_eval(value)
 
 
@@ -1386,6 +1410,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def is_closed(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
+        :rtype: bool
         """
         return self.connection_state == self.CONNECTION_CLOSED
 
@@ -1394,6 +1419,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """
         Returns True if connection is in the process of closing due to
         client-initiated `close` request, but closing is not yet complete.
+        :rtype: bool
         """
         return self.connection_state == self.CONNECTION_CLOSING
 
@@ -1401,6 +1427,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def is_open(self) -> bool:
         """
         Returns a boolean reporting the current connection state.
+        :rtype: bool
         """
         return self.connection_state == self.CONNECTION_OPEN
 
@@ -1622,6 +1649,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             opened.  The callback will be invoked with the `Channel` instance
             as its only argument.
 
+        :rtype: Channel
         """
         LOGGER.debug('Creating channel %s', channel_number)
         return pika.channel.Channel(self, channel_number, on_open_callback)
@@ -1720,6 +1748,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :rtype: bool
 
+        :param frame.Frame value: Frame to inspect
         """
         return isinstance(value, frame.ProtocolHeader)
 
@@ -1809,6 +1838,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :param pika.frame.Method method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
+        :param Connection _connection: The connection instance (unused)
         """
         LOGGER.warning('Received %s from broker', method_frame)
 
@@ -1831,6 +1861,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :param pika.frame.Method method_frame: method frame having `method`
             member of type `pika.spec.Connection.Blocked`
+        :param Connection _connection: The connection instance (unused)
         """
         LOGGER.info('Received %s from broker', method_frame)
 
@@ -1878,6 +1909,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :raises Exception: the given error
 
+        :param Connection _connection_unused: The connection instance (unused)
+        :param Exception error: The exception that caused the failure
         """
         raise error
 
@@ -1887,6 +1920,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         This is called once we have tuned the connection with the server and
         called the Connection.Open on the server and it has replied with
         Connection.Ok.
+        :param frame.Method[spec.Connection.OpenOk] method_frame: Server response frame
         """
         self._opened = True
 
@@ -2232,12 +2266,13 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         for method_cls in method_classes:
             self.callbacks.remove(str(channel_number), method_cls)
 
-    def _rpc(self,
-             channel_number: int,
-             method: amqp_object.Method,
-             callback: Callable[..., Any] | None = None,
-             acceptable_replies: None |
-             (Sequence[type[amqp_object.Method]]) = None):
+    def _rpc(
+        self,
+        channel_number: int,
+        method: amqp_object.Method,
+        callback: Callable[..., Any] | None = None,
+        acceptable_replies: None | (Sequence[type[amqp_object.Method]]) = None
+    ) -> None:
         """Make an RPC call for the given callback, channel number and method.
         acceptable_replies lists out what responses we'll process from the
         server with the specified callback.
@@ -2294,11 +2329,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _send_connection_tune_ok(self) -> None:
         """Send a Connection.TuneOk frame"""
-        self._send_method(
-            0,
-            spec.Connection.TuneOk(
-                self.params.channel_max, self.params.frame_max,
-                self.params.heartbeat))  # pyright: ignore[reportArgumentType]
+        self._send_method(0,
+                          spec.Connection.TuneOk(
+                              self.params.channel_max, self.params.frame_max,
+                              self.params.heartbeat))  # type: ignore[arg-type]
 
     def _send_frame(
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2332,7 +2332,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._send_method(0,
                           spec.Connection.TuneOk(
                               self.params.channel_max, self.params.frame_max,
-                              self.params.heartbeat))  # type: ignore[arg-type]
+                              self.params.heartbeat))
 
     def _send_frame(
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -338,7 +338,7 @@ class Parameters:
     def heartbeat(
         self, value: None | (int | Callable[[Connection, float], int])) -> None:
         """
-        :param value: Controls AMQP heartbeat timeout negotiation
+        :param int|None|callable value: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called
@@ -426,7 +426,7 @@ class Parameters:
     @retry_delay.setter
     def retry_delay(self, value: float) -> None:
         """
-        :param value: interval between socket connection attempts;
+        :param int | float value: interval between socket connection attempts;
             see also `connection_attempts`.
 
         """
@@ -448,7 +448,7 @@ class Parameters:
     @socket_timeout.setter
     def socket_timeout(self, value: float | None) -> None:
         """
-        :param value: positive socket connect timeout in
+        :param int | float | None value: positive socket connect timeout in
             seconds. None to disable this timeout.
 
         """
@@ -477,7 +477,7 @@ class Parameters:
     @stack_timeout.setter
     def stack_timeout(self, value: float | None) -> None:
         """
-        :param value: positive full protocol stack
+        :param int | float | None value: positive full protocol stack
             TCP/[SSL]/AMQP bring-up timeout in seconds. It's recommended to set
             this value higher than `socket_timeout`. None to disable this
             timeout.
@@ -505,10 +505,10 @@ class Parameters:
     @ssl_options.setter
     def ssl_options(self, value: SSLOptions | None) -> None:
         """
-        :param value: None for plaintext or
+        :param `pika.SSLOptions`|None value: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
 
-        :param value: SSL options
+        :param SSLOptions | None value: SSL options
         """
         if not isinstance(value, (SSLOptions, type(None))):
             raise TypeError(
@@ -545,7 +545,7 @@ class Parameters:
     @tcp_options.setter
     def tcp_options(self, value: dict[str, int] | None) -> None:
         """
-        :param value: None or a dict of options to pass to the underlying
+        :param dict|None value: None or a dict of options to pass to the underlying
             socket. Currently supported are TCP_KEEPIDLE, TCP_KEEPINTVL, TCP_KEEPCNT
             and TCP_USER_TIMEOUT. Availability of these may depend on your platform.
         """
@@ -598,24 +598,24 @@ class ConnectionParameters(Parameters):
         :param pika.credentials.PlainCredentials credentials: auth credentials
         :param int channel_max: Maximum number of channels to allow
         :param int frame_max: The maximum byte size for an AMQP frame
-        :param heartbeat: Controls AMQP heartbeat timeout negotiation
+        :param int|None|callable heartbeat: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
             proposed by broker. Use 0 to deactivate heartbeats and None to always
             accept the broker's proposal. If a callable is given, it will be called
             with the connection instance and the heartbeat timeout proposed by broker
             as its arguments. The callback should return a non-negative integer that
             will be used to override the broker's proposal.
-        :param ssl_options: None for plaintext or
+        :param `pika.SSLOptions`|None ssl_options: None for plaintext or
             `pika.SSLOptions` instance for SSL/TLS. Defaults to None.
         :param int connection_attempts: Maximum number of retry attempts
-        :param retry_delay: Time to wait in seconds, before the next
-        :param socket_timeout: Positive socket connect timeout in
+        :param int|float retry_delay: Time to wait in seconds, before the next
+        :param int|float socket_timeout: Positive socket connect timeout in
             seconds.
-        :param stack_timeout: Positive full protocol stack
+        :param int|float stack_timeout: Positive full protocol stack
             (TCP/[SSL]/AMQP) bring-up timeout in seconds. It's recommended to
             set this value higher than `socket_timeout`.
         :param str locale: Set the locale value
-        :param blocked_connection_timeout: If not None,
+        :param int|float|None blocked_connection_timeout: If not None,
             the value is a non-negative timeout, in seconds, for the
             connection to remain blocked (triggered by Connection.Blocked from
             broker); if the timeout expires before connection becomes unblocked,
@@ -980,7 +980,7 @@ class SSLOptions:
                  server_hostname: str | None = None) -> None:
         """
         :param ssl.SSLContext context: SSLContext instance
-        :param server_hostname: SSLContext.wrap_socket, used to enable
+        :param str|None server_hostname: SSLContext.wrap_socket, used to enable
             SNI
         """
         if not isinstance(context, ssl.SSLContext):
@@ -1488,7 +1488,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         specified number of seconds have elapsed, using a timer, or a
         thread, or similar.
 
-        :param delay: The number of seconds to wait to call callback
+        :param float|int delay: The number of seconds to wait to call callback
         :param callable callback: The callback will be called without args.
         :returns: Handle that can be passed to `_adapter_remove_timeout()` to
             cancel the callback.
@@ -1920,7 +1920,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         This is called once we have tuned the connection with the server and
         called the Connection.Open on the server and it has replied with
         Connection.Ok.
-        :param method_frame: Server response frame
+        :param frame.Method[spec.Connection.OpenOk] method_frame: Server response frame
         """
         self._opened = True
 
@@ -2212,7 +2212,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:
         """Process an inbound frame from the socket.
 
-        :param frame_value: The frame to
+        :param pika.frame.Frame|pika.frame.Method frame_value: The frame to
             process
 
         """
@@ -2340,7 +2340,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """This appends the fully generated frame to send to the broker to the
         output buffer which will be then sent via the connection adapter.
 
-        :param frame_value: The
+        :param pika.frame.Frame|pika.frame.ProtocolHeader frame_value: The
             frame to write
         :raises exceptions.ConnectionClosed:
 

--- a/pika/credentials.py
+++ b/pika/credentials.py
@@ -39,9 +39,9 @@ class PlainCredentials:
     If you pass True to erase_on_connect the credentials will not be stored
     in memory after the Connection attempt has been made.
 
-    :param str username: The username to authenticate with
-    :param str password: The password to authenticate with
-    :param bool erase_on_connect: erase credentials on connect.
+    :param username: The username to authenticate with
+    :param password: The password to authenticate with
+    :param erase_on_connect: erase credentials on connect.
 
     """
     TYPE = 'PLAIN'
@@ -52,9 +52,9 @@ class PlainCredentials:
                  erase_on_connect: bool = False) -> None:
         """Create a new instance of PlainCredentials
 
-        :param str username: The username to authenticate with
-        :param str password: The password to authenticate with
-        :param bool erase_on_connect: erase credentials on connect.
+        :param username: The username to authenticate with
+        :param password: The password to authenticate with
+        :param erase_on_connect: erase credentials on connect.
 
         """
         self.username: str | None = username
@@ -78,7 +78,7 @@ class PlainCredentials:
             self, start: Connection.Start) -> tuple[str | None, bytes | None]:
         """Validate that this type of authentication is supported
 
-        :param spec.Connection.Start start: Connection.Start method
+        :param start: Connection.Start method
         :rtype: tuple(str|None, bytes|None)
 
         """
@@ -122,7 +122,7 @@ class ExternalCredentials:
             self, start: Connection.Start) -> tuple[str | None, bytes | None]:
         """Validate that this type of authentication is supported
 
-        :param spec.Connection.Start start: Connection.Start method
+        :param start: Connection.Start method
         :rtype: tuple(str|None, bytes|None)
 
         """

--- a/pika/credentials.py
+++ b/pika/credentials.py
@@ -49,7 +49,7 @@ class PlainCredentials:
     def __init__(self,
                  username: str,
                  password: str,
-                 erase_on_connect: bool = False):
+                 erase_on_connect: bool = False) -> None:
         """Create a new instance of PlainCredentials
 
         :param str username: The username to authenticate with

--- a/pika/data.py
+++ b/pika/data.py
@@ -15,8 +15,8 @@ def encode_short_string(pieces: list[bytes], value: str) -> int:
     """Encode a string value as short string and append it to pieces list
     returning the size of the encoded value.
 
-    :param list pieces: Already encoded values
-    :param str value: String value to encode
+    :param pieces: Already encoded values
+    :param value: String value to encode
     :rtype: int
 
     """
@@ -45,8 +45,8 @@ def encode_short_string(pieces: list[bytes], value: str) -> int:
 def decode_short_string(encoded: bytes, offset: int) -> tuple[str | bytes, int]:
     """Decode a short string value from ``encoded`` data at ``offset``.
 
-    :param bytes encoded: encoded data
-    :param int offset: starting offset in the encoded data
+    :param encoded: encoded data
+    :param offset: starting offset in the encoded data
     :returns: tuple of (decoded value, new offset)
     :rtype: tuple[Union[str, bytes], int]
     """
@@ -65,8 +65,8 @@ def encode_table(pieces: list[bytes], table: dict[str, Any] | None) -> int:
     """Encode a dict as an AMQP table appending the encded table to the
     pieces list passed in.
 
-    :param list pieces: Already encoded frame pieces
-    :param dict table: The dict to encode
+    :param pieces: Already encoded frame pieces
+    :param table: The dict to encode
     :rtype: int
 
     """
@@ -87,8 +87,8 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
     """Encode the value passed in and append it to the pieces list returning
     the the size of the encoded value.
 
-    :param list pieces: Already encoded values
-    :param any value: The value to encode
+    :param pieces: Already encoded values
+    :param value: The value to encode
     :rtype: int
 
     """
@@ -150,8 +150,8 @@ def decode_table(encoded: bytes,
     """Decode the AMQP table passed in from the encoded value returning the
     decoded result and the number of bytes read plus the offset.
 
-    :param bytes encoded: The binary encoded data to decode
-    :param int offset: The starting byte offset
+    :param encoded: The binary encoded data to decode
+    :param offset: The starting byte offset
     :rtype: tuple
 
     """
@@ -170,8 +170,8 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
     """Decode the value passed in returning the decoded value and the number
     of bytes read in addition to the starting offset.
 
-    :param bytes encoded: The binary encoded data to decode
-    :param int offset: The starting byte offset
+    :param encoded: The binary encoded data to decode
+    :param offset: The starting byte offset
     :rtype: tuple
     :raises: pika.exceptions.InvalidFieldTypeException
 

--- a/pika/diagnostic_utils.py
+++ b/pika/diagnostic_utils.py
@@ -20,7 +20,7 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
     """Create a decorator that logs and reraises any exceptions that escape
     the decorated function
 
-    :param logging.Logger logger:
+    :param logger:
     :returns: the decorator
     :rtype: callable
 

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -85,9 +85,9 @@ class ConnectionClosed(AMQPConnectionError):
     def __init__(self, reply_code: int, reply_text: str) -> None:
         """
 
-        :param int reply_code: reply-code that was used in user's or broker's
+        :param reply_code: reply-code that was used in user's or broker's
             `Connection.Close` method. NEW in v1.0.0
-        :param str reply_text: reply-text that was used in user's or broker's
+        :param reply_text: reply-text that was used in user's or broker's
             `Connection.Close` method. Human-readable string corresponding to
             `reply_code`. NEW in v1.0.0
         """
@@ -147,10 +147,10 @@ class ChannelClosed(AMQPChannelError):
     def __init__(self, reply_code: int, reply_text: str) -> None:
         """
 
-        :param int reply_code: reply-code that was used in user's or broker's
+        :param reply_code: reply-code that was used in user's or broker's
             `Channel.Close` method. One of the AMQP-defined Channel Errors.
             NEW in v1.0.0
-        :param str reply_text: reply-text that was used in user's or broker's
+        :param reply_text: reply-text that was used in user's or broker's
             `Channel.Close` method. Human-readable string corresponding to
             `reply_code`;
             NEW in v1.0.0
@@ -223,8 +223,7 @@ class UnroutableError(AMQPChannelError):
 
     def __init__(self, messages: Sequence[ReturnedMessage]) -> None:
         """
-        :param sequence(blocking_connection.ReturnedMessage) messages: Sequence
-            of returned unroutable messages
+        :param messages: Sequence of returned unroutable messages
         """
         super().__init__(f"{len(messages)} unroutable message(s) returned")
 
@@ -243,8 +242,7 @@ class NackError(AMQPChannelError):
 
     def __init__(self, messages: Sequence[ReturnedMessage]) -> None:
         """
-        :param sequence(blocking_connection.ReturnedMessage) messages: Sequence
-            of returned unroutable messages
+        :param messages: Sequence of returned unroutable messages
         """
         super().__init__(f"{len(messages)} message(s) NACKed")
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -35,6 +35,7 @@ class Frame(amqp_object.AMQPObject):
 
         :rtype: bytes
 
+        :param list[bytes] pieces: Encoded AMQP frame fragments to assemble
         """
         payload = b''.join(pieces)
         return struct.pack('>BHI', self.frame_type, self.channel_number,
@@ -165,7 +166,7 @@ class ProtocolHeader(amqp_object.AMQPObject):
     def __init__(self,
                  major: int | None = None,
                  minor: int | None = None,
-                 revision: int | None = None):
+                 revision: int | None = None) -> None:
         """Construct a Protocol Header frame object for the specified AMQP
         version
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -23,8 +23,8 @@ class Frame(amqp_object.AMQPObject):
     def __init__(self, frame_type: int, channel_number: int) -> None:
         """Create a new instance of a frame
 
-        :param int frame_type: The frame type
-        :param int channel_number: The channel number for the frame
+        :param frame_type: The frame type
+        :param channel_number: The channel number for the frame
 
         """
         self.frame_type = frame_type
@@ -33,9 +33,9 @@ class Frame(amqp_object.AMQPObject):
     def _marshal(self, pieces: list[bytes]) -> bytes:
         """Create the full AMQP wire protocol frame data representation
 
+        :param pieces: Encoded AMQP frame fragments to assemble
         :rtype: bytes
 
-        :param list[bytes] pieces: Encoded AMQP frame fragments to assemble
         """
         payload = b''.join(pieces)
         return struct.pack('>BHI', self.frame_type, self.channel_number,
@@ -61,8 +61,8 @@ class Method(Frame, Generic[_MethodT]):
     def __init__(self, channel_number: int, method: _MethodT) -> None:
         """Create a new instance of a frame
 
-        :param int channel_number: The channel number for the frame
-        :param pika.Spec.Class.Method method: The AMQP Class.Method
+        :param channel_number: The channel number for the frame
+        :param method: The AMQP Class.Method
 
         """
         Frame.__init__(self, spec.FRAME_METHOD, channel_number)
@@ -90,9 +90,9 @@ class Header(Frame):
                  props: spec.BasicProperties) -> None:
         """Create a new instance of a AMQP ContentHeader object
 
-        :param int channel_number: The channel number for the frame
-        :param int body_size: The number of bytes for the body
-        :param pika.spec.BasicProperties props: Basic.Properties object
+        :param channel_number: The channel number for the frame
+        :param body_size: The number of bytes for the body
+        :param props: Basic.Properties object
 
         """
         Frame.__init__(self, spec.FRAME_HEADER, channel_number)
@@ -120,8 +120,8 @@ class Body(Frame):
 
     def __init__(self, channel_number: int, fragment: bytes) -> None:
         """
-        :param int channel_number: The channel number for the frame
-        :param bytes fragment: The fragment of the body
+        :param channel_number: The channel number for the frame
+        :param fragment: The fragment of the body
         """
         Frame.__init__(self, spec.FRAME_BODY, channel_number)
         self.fragment = fragment
@@ -170,9 +170,9 @@ class ProtocolHeader(amqp_object.AMQPObject):
         """Construct a Protocol Header frame object for the specified AMQP
         version
 
-        :param int major: Major version number
-        :param int minor: Minor version number
-        :param int revision: Revision
+        :param major: Major version number
+        :param minor: Minor version number
+        :param revision: Revision
 
         """
         self.frame_type = -1
@@ -195,7 +195,7 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
     """Receives raw socket data and attempts to turn it into a frame.
     Returns the number of bytes consumed from the stream and the frame.
 
-    :param bytes data_in: The raw data stream
+    :param data_in: The raw data stream
     :rtype: tuple(int, Frame|ProtocolHeader)
     :raises: pika.exceptions.InvalidFrameError
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -35,7 +35,7 @@ class Frame(amqp_object.AMQPObject):
 
         :rtype: bytes
 
-        :param list[bytes] pieces: Encoded AMQP frame fragments to assemble
+        :param pieces: Encoded AMQP frame fragments to assemble
         """
         payload = b''.join(pieces)
         return struct.pack('>BHI', self.frame_type, self.channel_number,

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -35,7 +35,7 @@ class Frame(amqp_object.AMQPObject):
 
         :rtype: bytes
 
-        :param pieces: Encoded AMQP frame fragments to assemble
+        :param list[bytes] pieces: Encoded AMQP frame fragments to assemble
         """
         payload = b''.join(pieces)
         return struct.pack('>BHI', self.frame_type, self.channel_number,

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -26,8 +26,8 @@ class HeartbeatChecker:
         calculate an interval at which a heartbeat frame is sent to the broker.
         The interval is equal to the timeout value divided by two.
 
-        :param pika.connection.Connection: Connection object
-        :param int timeout: Connection idle timeout. If no activity occurs on the
+        :param connection: Connection object
+        :param timeout: Connection idle timeout. If no activity occurs on the
                             connection nor heartbeat frames received during the
                             timeout window the connection will be closed. The
                             interval used to send heartbeats is calculated from

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -11,7 +11,7 @@ rejected.
 
 """
 
-from typing import Self
+from typing_extensions import Self
 import struct
 from pika import amqp_object
 from pika import data

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -15,7 +15,6 @@ import struct
 from pika import amqp_object
 from pika import data
 
-
 PROTOCOL_VERSION = (0, 9, 1)
 PORT = 5672
 
@@ -114,7 +113,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0014  # 60, 20; 3932180
         NAME = 'Basic.Consume'
 
-        def __init__(self, ticket=0, queue='', consumer_tag='', no_local=False, no_ack=False, exclusive=False, nowait=False, arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     queue='',
+                     consumer_tag='',
+                     no_local=False,
+                     no_ack=False,
+                     exclusive=False,
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.consumer_tag = consumer_tag
@@ -132,7 +139,8 @@ class Basic(amqp_object.Class):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
-            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(
+                encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.no_local = (bit_buffer & (1 << 0)) != 0
@@ -177,7 +185,8 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(
+                encoded, offset)
             return self
 
         def encode(self):
@@ -201,7 +210,8 @@ class Basic(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(
+                encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -231,7 +241,8 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(
+                encoded, offset)
             return self
 
         def encode(self):
@@ -246,7 +257,12 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0028  # 60, 40; 3932200
         NAME = 'Basic.Publish'
 
-        def __init__(self, ticket=0, exchange='', routing_key='', mandatory=False, immediate=False):
+        def __init__(self,
+                     ticket=0,
+                     exchange='',
+                     routing_key='',
+                     mandatory=False,
+                     immediate=False):
             self.ticket = ticket
             self.exchange = exchange
             self.routing_key = routing_key
@@ -290,7 +306,11 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0032  # 60, 50; 3932210
         NAME = 'Basic.Return'
 
-        def __init__(self, reply_code=None, reply_text='', exchange=None, routing_key=None):
+        def __init__(self,
+                     reply_code=None,
+                     reply_text='',
+                     exchange=None,
+                     routing_key=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.exchange = exchange
@@ -327,7 +347,12 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C003C  # 60, 60; 3932220
         NAME = 'Basic.Deliver'
 
-        def __init__(self, consumer_tag=None, delivery_tag=None, redelivered=False, exchange=None, routing_key=None):
+        def __init__(self,
+                     consumer_tag=None,
+                     delivery_tag=None,
+                     redelivered=False,
+                     exchange=None,
+                     routing_key=None):
             self.consumer_tag = consumer_tag
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
@@ -339,7 +364,8 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(
+                encoded, offset)
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -407,7 +433,12 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0047  # 60, 71; 3932231
         NAME = 'Basic.GetOk'
 
-        def __init__(self, delivery_tag=None, redelivered=False, exchange=None, routing_key=None, message_count=None):
+        def __init__(self,
+                     delivery_tag=None,
+                     redelivered=False,
+                     exchange=None,
+                     routing_key=None,
+                     message_count=None):
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
             self.exchange = exchange
@@ -645,7 +676,12 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A000A  # 10, 10; 655370
         NAME = 'Connection.Start'
 
-        def __init__(self, version_major=0, version_minor=9, server_properties=None, mechanisms='PLAIN', locales='en_US'):
+        def __init__(self,
+                     version_major=0,
+                     version_minor=9,
+                     server_properties=None,
+                     mechanisms='PLAIN',
+                     locales='en_US'):
             self.version_major = version_major
             self.version_minor = version_minor
             self.server_properties = server_properties
@@ -661,7 +697,8 @@ class Connection(amqp_object.Class):
             offset += 1
             self.version_minor = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
-            (self.server_properties, offset) = data.decode_table(encoded, offset)
+            (self.server_properties,
+             offset) = data.decode_table(encoded, offset)
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.mechanisms = encoded[offset:offset + length]
@@ -679,12 +716,14 @@ class Connection(amqp_object.Class):
             data.encode_table(pieces, self.server_properties)
             assert isinstance(self.mechanisms, (str, bytes)),\
                    'A non-string value was supplied for self.mechanisms'
-            value = self.mechanisms.encode('utf-8') if isinstance(self.mechanisms, str) else self.mechanisms
+            value = self.mechanisms.encode('utf-8') if isinstance(
+                self.mechanisms, str) else self.mechanisms
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.locales, (str, bytes)),\
                    'A non-string value was supplied for self.locales'
-            value = self.locales.encode('utf-8') if isinstance(self.locales, str) else self.locales
+            value = self.locales.encode('utf-8') if isinstance(
+                self.locales, str) else self.locales
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -694,7 +733,11 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A000B  # 10, 11; 655371
         NAME = 'Connection.StartOk'
 
-        def __init__(self, client_properties=None, mechanism='PLAIN', response=None, locale='en_US'):
+        def __init__(self,
+                     client_properties=None,
+                     mechanism='PLAIN',
+                     response=None,
+                     locale='en_US'):
             self.client_properties = client_properties
             self.mechanism = mechanism
             self.response = response
@@ -705,7 +748,8 @@ class Connection(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            (self.client_properties, offset) = data.decode_table(encoded, offset)
+            (self.client_properties,
+             offset) = data.decode_table(encoded, offset)
             self.mechanism, offset = data.decode_short_string(encoded, offset)
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -722,7 +766,8 @@ class Connection(amqp_object.Class):
             data.encode_short_string(pieces, self.mechanism)
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
-            value = self.response.encode('utf-8') if isinstance(self.response, str) else self.response
+            value = self.response.encode('utf-8') if isinstance(
+                self.response, str) else self.response
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.locale, (str, bytes)),\
@@ -753,7 +798,8 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.challenge, (str, bytes)),\
                    'A non-string value was supplied for self.challenge'
-            value = self.challenge.encode('utf-8') if isinstance(self.challenge, str) else self.challenge
+            value = self.challenge.encode('utf-8') if isinstance(
+                self.challenge, str) else self.challenge
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -781,7 +827,8 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
-            value = self.response.encode('utf-8') if isinstance(self.response, str) else self.response
+            value = self.response.encode('utf-8') if isinstance(
+                self.response, str) else self.response
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -861,8 +908,10 @@ class Connection(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            self.virtual_host, offset = data.decode_short_string(encoded, offset)
-            self.capabilities, offset = data.decode_short_string(encoded, offset)
+            self.virtual_host, offset = data.decode_short_string(
+                encoded, offset)
+            self.capabilities, offset = data.decode_short_string(
+                encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.insist = (bit_buffer & (1 << 0)) != 0
@@ -910,7 +959,11 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0032  # 10, 50; 655410
         NAME = 'Connection.Close'
 
-        def __init__(self, reply_code=None, reply_text='', class_id=None, method_id=None):
+        def __init__(self,
+                     reply_code=None,
+                     reply_text='',
+                     class_id=None,
+                     method_id=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
@@ -1026,7 +1079,8 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.new_secret, (str, bytes)),\
                    'A non-string value was supplied for self.new_secret'
-            value = self.new_secret.encode('utf-8') if isinstance(self.new_secret, str) else self.new_secret
+            value = self.new_secret.encode('utf-8') if isinstance(
+                self.new_secret, str) else self.new_secret
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.reason, (str, bytes)),\
@@ -1105,7 +1159,8 @@ class Channel(amqp_object.Class):
             pieces = list()
             assert isinstance(self.channel_id, (str, bytes)),\
                    'A non-string value was supplied for self.channel_id'
-            value = self.channel_id.encode('utf-8') if isinstance(self.channel_id, str) else self.channel_id
+            value = self.channel_id.encode('utf-8') if isinstance(
+                self.channel_id, str) else self.channel_id
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -1167,7 +1222,11 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140028  # 20, 40; 1310760
         NAME = 'Channel.Close'
 
-        def __init__(self, reply_code=None, reply_text='', class_id=None, method_id=None):
+        def __init__(self,
+                     reply_code=None,
+                     reply_text='',
+                     class_id=None,
+                     method_id=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
@@ -1227,7 +1286,13 @@ class Access(amqp_object.Class):
         INDEX = 0x001E000A  # 30, 10; 1966090
         NAME = 'Access.Request'
 
-        def __init__(self, realm='/data', exclusive=False, passive=True, active=True, write=True, read=True):
+        def __init__(self,
+                     realm='/data',
+                     exclusive=False,
+                     passive=True,
+                     active=True,
+                     write=True,
+                     read=True):
             self.realm = realm
             self.exclusive = exclusive
             self.passive = passive
@@ -1302,7 +1367,16 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028000A  # 40, 10; 2621450
         NAME = 'Exchange.Declare'
 
-        def __init__(self, ticket=0, exchange=None, type='direct', passive=False, durable=False, auto_delete=False, internal=False, nowait=False, arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     exchange=None,
+                     type='direct',
+                     passive=False,
+                     durable=False,
+                     auto_delete=False,
+                     internal=False,
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.exchange = exchange
             self.type = type
@@ -1380,7 +1454,11 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280014  # 40, 20; 2621460
         NAME = 'Exchange.Delete'
 
-        def __init__(self, ticket=0, exchange=None, if_unused=False, nowait=False):
+        def __init__(self,
+                     ticket=0,
+                     exchange=None,
+                     if_unused=False,
+                     nowait=False):
             self.ticket = ticket
             self.exchange = exchange
             self.if_unused = if_unused
@@ -1438,7 +1516,13 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028001E  # 40, 30; 2621470
         NAME = 'Exchange.Bind'
 
-        def __init__(self, ticket=0, destination=None, source=None, routing_key='', nowait=False, arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     destination=None,
+                     source=None,
+                     routing_key='',
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1505,7 +1589,13 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280028  # 40, 40; 2621480
         NAME = 'Exchange.Unbind'
 
-        def __init__(self, ticket=0, destination=None, source=None, routing_key='', nowait=False, arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     destination=None,
+                     source=None,
+                     routing_key='',
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1578,7 +1668,15 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032000A  # 50, 10; 3276810
         NAME = 'Queue.Declare'
 
-        def __init__(self, ticket=0, queue='', passive=False, durable=False, exclusive=False, auto_delete=False, nowait=False, arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     queue='',
+                     passive=False,
+                     durable=False,
+                     exclusive=False,
+                     auto_delete=False,
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.passive = passive
@@ -1663,7 +1761,13 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320014  # 50, 20; 3276820
         NAME = 'Queue.Bind'
 
-        def __init__(self, ticket=0, queue='', exchange=None, routing_key='', nowait=False, arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     queue='',
+                     exchange=None,
+                     routing_key='',
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1787,7 +1891,12 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320028  # 50, 40; 3276840
         NAME = 'Queue.Delete'
 
-        def __init__(self, ticket=0, queue='', if_unused=False, if_empty=False, nowait=False):
+        def __init__(self,
+                     ticket=0,
+                     queue='',
+                     if_unused=False,
+                     if_empty=False,
+                     nowait=False):
             self.ticket = ticket
             self.queue = queue
             self.if_unused = if_unused
@@ -1852,7 +1961,12 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320032  # 50, 50; 3276850
         NAME = 'Queue.Unbind'
 
-        def __init__(self, ticket=0, queue='', exchange=None, routing_key='', arguments=None):
+        def __init__(self,
+                     ticket=0,
+                     queue='',
+                     exchange=None,
+                     routing_key='',
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -2099,7 +2213,21 @@ class BasicProperties(amqp_object.Properties):
     FLAG_APP_ID = (1 << 3)
     FLAG_CLUSTER_ID = (1 << 2)
 
-    def __init__(self, content_type=None, content_encoding=None, headers=None, delivery_mode=None, priority=None, correlation_id=None, reply_to=None, expiration=None, message_id=None, timestamp=None, type=None, user_id=None, app_id=None, cluster_id=None):
+    def __init__(self,
+                 content_type=None,
+                 content_encoding=None,
+                 headers=None,
+                 delivery_mode=None,
+                 priority=None,
+                 correlation_id=None,
+                 reply_to=None,
+                 expiration=None,
+                 message_id=None,
+                 timestamp=None,
+                 type=None,
+                 user_id=None,
+                 app_id=None,
+                 cluster_id=None):
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
@@ -2126,11 +2254,13 @@ class BasicProperties(amqp_object.Properties):
                 break
             flagword_index += 1
         if flags & BasicProperties.FLAG_CONTENT_TYPE:
-            self.content_type, offset = data.decode_short_string(encoded, offset)
+            self.content_type, offset = data.decode_short_string(
+                encoded, offset)
         else:
             self.content_type = None
         if flags & BasicProperties.FLAG_CONTENT_ENCODING:
-            self.content_encoding, offset = data.decode_short_string(encoded, offset)
+            self.content_encoding, offset = data.decode_short_string(
+                encoded, offset)
         else:
             self.content_encoding = None
         if flags & BasicProperties.FLAG_HEADERS:
@@ -2148,7 +2278,8 @@ class BasicProperties(amqp_object.Properties):
         else:
             self.priority = None
         if flags & BasicProperties.FLAG_CORRELATION_ID:
-            self.correlation_id, offset = data.decode_short_string(encoded, offset)
+            self.correlation_id, offset = data.decode_short_string(
+                encoded, offset)
         else:
             self.correlation_id = None
         if flags & BasicProperties.FLAG_REPLY_TO:
@@ -2263,6 +2394,7 @@ class BasicProperties(amqp_object.Properties):
                 break
         return flag_pieces + pieces
 
+
 methods = {
     0x003C000A: Basic.Qos,
     0x003C000B: Basic.QosOk,
@@ -2332,9 +2464,7 @@ methods = {
     0x0055000B: Confirm.SelectOk
 }
 
-props = {
-    0x003C: BasicProperties
-}
+props = {0x003C: BasicProperties}
 
 
 def has_content(methodNumber):

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -11,7 +11,6 @@ rejected.
 
 """
 
-from typing_extensions import Self
 import struct
 from pika import amqp_object
 from pika import data
@@ -61,16 +60,16 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C000A  # 60, 10; 3932170
         NAME = 'Basic.Qos'
 
-        def __init__(self, prefetch_size: int=0, prefetch_count: int=0, global_qos: bool=False) -> None:
+        def __init__(self, prefetch_size=0, prefetch_count=0, global_qos=False):
             self.prefetch_size = prefetch_size
             self.prefetch_count = prefetch_count
             self.global_qos = global_qos
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.prefetch_size = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.prefetch_count = struct.unpack_from('>H', encoded, offset)[0]
@@ -80,7 +79,7 @@ class Basic(amqp_object.Class):
             self.global_qos = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>I', self.prefetch_size))
             pieces.append(struct.pack('>H', self.prefetch_count))
@@ -95,14 +94,14 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C000B  # 60, 11; 3932171
         NAME = 'Basic.QosOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -115,14 +114,14 @@ class Basic(amqp_object.Class):
         NAME = 'Basic.Consume'
 
         def __init__(self,
-                     ticket: int=0,
-                     queue: str='',
-                     consumer_tag: str='',
-                     no_local: bool=False,
-                     no_ack: bool=False,
-                     exclusive: bool=False,
-                     nowait: bool=False,
-                     arguments=None) -> None:
+                     ticket=0,
+                     queue='',
+                     consumer_tag='',
+                     no_local=False,
+                     no_ack=False,
+                     exclusive=False,
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.consumer_tag = consumer_tag
@@ -133,10 +132,10 @@ class Basic(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -151,7 +150,7 @@ class Basic(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -178,19 +177,19 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0015  # 60, 21; 3932181
         NAME = 'Basic.ConsumeOk'
 
-        def __init__(self, consumer_tag=None) -> None:
+        def __init__(self, consumer_tag=None):
             self.consumer_tag = consumer_tag
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -202,15 +201,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C001E  # 60, 30; 3932190
         NAME = 'Basic.Cancel'
 
-        def __init__(self, consumer_tag=None, nowait: bool=False) -> None:
+        def __init__(self, consumer_tag=None, nowait=False):
             self.consumer_tag = consumer_tag
             self.nowait = nowait
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -218,7 +217,7 @@ class Basic(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -234,19 +233,19 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C001F  # 60, 31; 3932191
         NAME = 'Basic.CancelOk'
 
-        def __init__(self, consumer_tag=None) -> None:
+        def __init__(self, consumer_tag=None):
             self.consumer_tag = consumer_tag
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -259,11 +258,11 @@ class Basic(amqp_object.Class):
         NAME = 'Basic.Publish'
 
         def __init__(self,
-                     ticket: int=0,
-                     exchange: str='',
-                     routing_key: str='',
-                     mandatory: bool=False,
-                     immediate: bool=False) -> None:
+                     ticket=0,
+                     exchange='',
+                     routing_key='',
+                     mandatory=False,
+                     immediate=False):
             self.ticket = ticket
             self.exchange = exchange
             self.routing_key = routing_key
@@ -271,10 +270,10 @@ class Basic(amqp_object.Class):
             self.immediate = immediate
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -285,7 +284,7 @@ class Basic(amqp_object.Class):
             self.immediate = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
@@ -309,19 +308,19 @@ class Basic(amqp_object.Class):
 
         def __init__(self,
                      reply_code=None,
-                     reply_text: str='',
+                     reply_text='',
                      exchange=None,
-                     routing_key=None) -> None:
+                     routing_key=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.exchange = exchange
             self.routing_key = routing_key
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -329,7 +328,7 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
@@ -351,9 +350,9 @@ class Basic(amqp_object.Class):
         def __init__(self,
                      consumer_tag=None,
                      delivery_tag=None,
-                     redelivered: bool=False,
+                     redelivered=False,
                      exchange=None,
-                     routing_key=None) -> None:
+                     routing_key=None):
             self.consumer_tag = consumer_tag
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
@@ -361,10 +360,10 @@ class Basic(amqp_object.Class):
             self.routing_key = routing_key
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
@@ -376,7 +375,7 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -399,16 +398,16 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0046  # 60, 70; 3932230
         NAME = 'Basic.Get'
 
-        def __init__(self, ticket: int=0, queue: str='', no_ack: bool=False) -> None:
+        def __init__(self, ticket=0, queue='', no_ack=False):
             self.ticket = ticket
             self.queue = queue
             self.no_ack = no_ack
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -417,7 +416,7 @@ class Basic(amqp_object.Class):
             self.no_ack = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -436,10 +435,10 @@ class Basic(amqp_object.Class):
 
         def __init__(self,
                      delivery_tag=None,
-                     redelivered: bool=False,
+                     redelivered=False,
                      exchange=None,
                      routing_key=None,
-                     message_count=None) -> None:
+                     message_count=None):
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
             self.exchange = exchange
@@ -447,10 +446,10 @@ class Basic(amqp_object.Class):
             self.message_count = message_count
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -462,7 +461,7 @@ class Basic(amqp_object.Class):
             offset += 4
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -483,18 +482,18 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0048  # 60, 72; 3932232
         NAME = 'Basic.GetEmpty'
 
-        def __init__(self, cluster_id: str='') -> None:
+        def __init__(self, cluster_id=''):
             self.cluster_id = cluster_id
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.cluster_id, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.cluster_id, (str, bytes)),\
                    'A non-string value was supplied for self.cluster_id'
@@ -506,15 +505,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0050  # 60, 80; 3932240
         NAME = 'Basic.Ack'
 
-        def __init__(self, delivery_tag: int=0, multiple: bool=False) -> None:
+        def __init__(self, delivery_tag=0, multiple=False):
             self.delivery_tag = delivery_tag
             self.multiple = multiple
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -522,7 +521,7 @@ class Basic(amqp_object.Class):
             self.multiple = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -536,15 +535,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C005A  # 60, 90; 3932250
         NAME = 'Basic.Reject'
 
-        def __init__(self, delivery_tag=None, requeue: bool=True) -> None:
+        def __init__(self, delivery_tag=None, requeue=True):
             self.delivery_tag = delivery_tag
             self.requeue = requeue
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -552,7 +551,7 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -566,20 +565,20 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0064  # 60, 100; 3932260
         NAME = 'Basic.RecoverAsync'
 
-        def __init__(self, requeue: bool=False) -> None:
+        def __init__(self, requeue=False):
             self.requeue = requeue
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             bit_buffer = 0
             if self.requeue:
@@ -592,20 +591,20 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C006E  # 60, 110; 3932270
         NAME = 'Basic.Recover'
 
-        def __init__(self, requeue: bool=False) -> None:
+        def __init__(self, requeue=False):
             self.requeue = requeue
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             bit_buffer = 0
             if self.requeue:
@@ -618,14 +617,14 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C006F  # 60, 111; 3932271
         NAME = 'Basic.RecoverOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -637,16 +636,16 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0078  # 60, 120; 3932280
         NAME = 'Basic.Nack'
 
-        def __init__(self, delivery_tag: int=0, multiple: bool=False, requeue: bool=True) -> None:
+        def __init__(self, delivery_tag=0, multiple=False, requeue=True):
             self.delivery_tag = delivery_tag
             self.multiple = multiple
             self.requeue = requeue
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -655,7 +654,7 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -678,11 +677,11 @@ class Connection(amqp_object.Class):
         NAME = 'Connection.Start'
 
         def __init__(self,
-                     version_major: int=0,
-                     version_minor: int=9,
+                     version_major=0,
+                     version_minor=9,
                      server_properties=None,
-                     mechanisms: str='PLAIN',
-                     locales: str='en_US') -> None:
+                     mechanisms='PLAIN',
+                     locales='en_US'):
             self.version_major = version_major
             self.version_minor = version_minor
             self.server_properties = server_properties
@@ -690,10 +689,10 @@ class Connection(amqp_object.Class):
             self.locales = locales
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.version_major = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.version_minor = struct.unpack_from('B', encoded, offset)[0]
@@ -710,7 +709,7 @@ class Connection(amqp_object.Class):
             offset += length
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('B', self.version_major))
             pieces.append(struct.pack('B', self.version_minor))
@@ -736,19 +735,19 @@ class Connection(amqp_object.Class):
 
         def __init__(self,
                      client_properties=None,
-                     mechanism: str='PLAIN',
+                     mechanism='PLAIN',
                      response=None,
-                     locale: str='en_US') -> None:
+                     locale='en_US'):
             self.client_properties = client_properties
             self.mechanism = mechanism
             self.response = response
             self.locale = locale
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             (self.client_properties,
              offset) = data.decode_table(encoded, offset)
             self.mechanism, offset = data.decode_short_string(encoded, offset)
@@ -759,7 +758,7 @@ class Connection(amqp_object.Class):
             self.locale, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             data.encode_table(pieces, self.client_properties)
             assert isinstance(self.mechanism, (str, bytes)),\
@@ -781,21 +780,21 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0014  # 10, 20; 655380
         NAME = 'Connection.Secure'
 
-        def __init__(self, challenge=None) -> None:
+        def __init__(self, challenge=None):
             self.challenge = challenge
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.challenge = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.challenge, (str, bytes)),\
                    'A non-string value was supplied for self.challenge'
@@ -810,21 +809,21 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0015  # 10, 21; 655381
         NAME = 'Connection.SecureOk'
 
-        def __init__(self, response=None) -> None:
+        def __init__(self, response=None):
             self.response = response
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.response = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
@@ -839,16 +838,16 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A001E  # 10, 30; 655390
         NAME = 'Connection.Tune'
 
-        def __init__(self, channel_max: int=0, frame_max: int=0, heartbeat: int=0) -> None:
+        def __init__(self, channel_max=0, frame_max=0, heartbeat=0):
             self.channel_max = channel_max
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
@@ -857,7 +856,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.channel_max))
             pieces.append(struct.pack('>I', self.frame_max))
@@ -869,16 +868,16 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A001F  # 10, 31; 655391
         NAME = 'Connection.TuneOk'
 
-        def __init__(self, channel_max: int=0, frame_max: int=0, heartbeat: int=0) -> None:
+        def __init__(self, channel_max=0, frame_max=0, heartbeat=0):
             self.channel_max = channel_max
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
@@ -887,7 +886,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.channel_max))
             pieces.append(struct.pack('>I', self.frame_max))
@@ -899,16 +898,16 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0028  # 10, 40; 655400
         NAME = 'Connection.Open'
 
-        def __init__(self, virtual_host: str='/', capabilities: str='', insist: bool=False) -> None:
+        def __init__(self, virtual_host='/', capabilities='', insist=False):
             self.virtual_host = virtual_host
             self.capabilities = capabilities
             self.insist = insist
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.virtual_host, offset = data.decode_short_string(
                 encoded, offset)
             self.capabilities, offset = data.decode_short_string(
@@ -918,7 +917,7 @@ class Connection(amqp_object.Class):
             self.insist = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.virtual_host, (str, bytes)),\
                    'A non-string value was supplied for self.virtual_host'
@@ -937,18 +936,18 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0029  # 10, 41; 655401
         NAME = 'Connection.OpenOk'
 
-        def __init__(self, known_hosts: str='') -> None:
+        def __init__(self, known_hosts=''):
             self.known_hosts = known_hosts
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.known_hosts, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.known_hosts, (str, bytes)),\
                    'A non-string value was supplied for self.known_hosts'
@@ -962,19 +961,19 @@ class Connection(amqp_object.Class):
 
         def __init__(self,
                      reply_code=None,
-                     reply_text: str='',
+                     reply_text='',
                      class_id=None,
-                     method_id=None) -> None:
+                     method_id=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
             self.method_id = method_id
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -984,7 +983,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
@@ -999,14 +998,14 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0033  # 10, 51; 655411
         NAME = 'Connection.CloseOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1018,18 +1017,18 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A003C  # 10, 60; 655420
         NAME = 'Connection.Blocked'
 
-        def __init__(self, reason: str='') -> None:
+        def __init__(self, reason=''):
             self.reason = reason
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.reason, (str, bytes)),\
                    'A non-string value was supplied for self.reason'
@@ -1041,14 +1040,14 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A003D  # 10, 61; 655421
         NAME = 'Connection.Unblocked'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1060,15 +1059,15 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0046  # 10, 70; 655430
         NAME = 'Connection.UpdateSecret'
 
-        def __init__(self, new_secret=None, reason=None) -> None:
+        def __init__(self, new_secret=None, reason=None):
             self.new_secret = new_secret
             self.reason = reason
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.new_secret = encoded[offset:offset + length]
@@ -1076,7 +1075,7 @@ class Connection(amqp_object.Class):
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.new_secret, (str, bytes)),\
                    'A non-string value was supplied for self.new_secret'
@@ -1094,14 +1093,14 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0047  # 10, 71; 655431
         NAME = 'Connection.UpdateSecretOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1119,18 +1118,18 @@ class Channel(amqp_object.Class):
         INDEX = 0x0014000A  # 20, 10; 1310730
         NAME = 'Channel.Open'
 
-        def __init__(self, out_of_band: str='') -> None:
+        def __init__(self, out_of_band=''):
             self.out_of_band = out_of_band
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.out_of_band, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.out_of_band, (str, bytes)),\
                    'A non-string value was supplied for self.out_of_band'
@@ -1142,21 +1141,21 @@ class Channel(amqp_object.Class):
         INDEX = 0x0014000B  # 20, 11; 1310731
         NAME = 'Channel.OpenOk'
 
-        def __init__(self, channel_id: str='') -> None:
+        def __init__(self, channel_id=''):
             self.channel_id = channel_id
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.channel_id = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.channel_id, (str, bytes)),\
                    'A non-string value was supplied for self.channel_id'
@@ -1171,20 +1170,20 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140014  # 20, 20; 1310740
         NAME = 'Channel.Flow'
 
-        def __init__(self, active=None) -> None:
+        def __init__(self, active=None):
             self.active = active
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             bit_buffer = 0
             if self.active:
@@ -1197,20 +1196,20 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140015  # 20, 21; 1310741
         NAME = 'Channel.FlowOk'
 
-        def __init__(self, active=None) -> None:
+        def __init__(self, active=None):
             self.active = active
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             bit_buffer = 0
             if self.active:
@@ -1225,19 +1224,19 @@ class Channel(amqp_object.Class):
 
         def __init__(self,
                      reply_code=None,
-                     reply_text: str='',
+                     reply_text='',
                      class_id=None,
-                     method_id=None) -> None:
+                     method_id=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
             self.method_id = method_id
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -1247,7 +1246,7 @@ class Channel(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
@@ -1262,14 +1261,14 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140029  # 20, 41; 1310761
         NAME = 'Channel.CloseOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1288,12 +1287,12 @@ class Access(amqp_object.Class):
         NAME = 'Access.Request'
 
         def __init__(self,
-                     realm: str='/data',
-                     exclusive: bool=False,
-                     passive: bool=True,
-                     active: bool=True,
-                     write: bool=True,
-                     read: bool=True) -> None:
+                     realm='/data',
+                     exclusive=False,
+                     passive=True,
+                     active=True,
+                     write=True,
+                     read=True):
             self.realm = realm
             self.exclusive = exclusive
             self.passive = passive
@@ -1302,10 +1301,10 @@ class Access(amqp_object.Class):
             self.read = read
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.realm, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
@@ -1316,7 +1315,7 @@ class Access(amqp_object.Class):
             self.read = (bit_buffer & (1 << 4)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.realm, (str, bytes)),\
                    'A non-string value was supplied for self.realm'
@@ -1340,19 +1339,19 @@ class Access(amqp_object.Class):
         INDEX = 0x001E000B  # 30, 11; 1966091
         NAME = 'Access.RequestOk'
 
-        def __init__(self, ticket: int=1) -> None:
+        def __init__(self, ticket=1):
             self.ticket = ticket
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             return pieces
@@ -1369,15 +1368,15 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Declare'
 
         def __init__(self,
-                     ticket: int=0,
+                     ticket=0,
                      exchange=None,
-                     type: str='direct',
-                     passive: bool=False,
-                     durable: bool=False,
-                     auto_delete: bool=False,
-                     internal: bool=False,
-                     nowait: bool=False,
-                     arguments=None) -> None:
+                     type='direct',
+                     passive=False,
+                     durable=False,
+                     auto_delete=False,
+                     internal=False,
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.exchange = exchange
             self.type = type
@@ -1389,10 +1388,10 @@ class Exchange(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1407,7 +1406,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
@@ -1436,14 +1435,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028000B  # 40, 11; 2621451
         NAME = 'Exchange.DeclareOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1456,20 +1455,20 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Delete'
 
         def __init__(self,
-                     ticket: int=0,
+                     ticket=0,
                      exchange=None,
-                     if_unused: bool=False,
-                     nowait: bool=False) -> None:
+                     if_unused=False,
+                     nowait=False):
             self.ticket = ticket
             self.exchange = exchange
             self.if_unused = if_unused
             self.nowait = nowait
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1479,7 +1478,7 @@ class Exchange(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
@@ -1498,14 +1497,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280015  # 40, 21; 2621461
         NAME = 'Exchange.DeleteOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1518,12 +1517,12 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Bind'
 
         def __init__(self,
-                     ticket: int=0,
+                     ticket=0,
                      destination=None,
                      source=None,
-                     routing_key: str='',
-                     nowait: bool=False,
-                     arguments=None) -> None:
+                     routing_key='',
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1532,10 +1531,10 @@ class Exchange(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
@@ -1547,7 +1546,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
@@ -1571,14 +1570,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028001F  # 40, 31; 2621471
         NAME = 'Exchange.BindOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1591,12 +1590,12 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Unbind'
 
         def __init__(self,
-                     ticket: int=0,
+                     ticket=0,
                      destination=None,
                      source=None,
-                     routing_key: str='',
-                     nowait: bool=False,
-                     arguments=None) -> None:
+                     routing_key='',
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1605,10 +1604,10 @@ class Exchange(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
@@ -1620,7 +1619,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
@@ -1644,14 +1643,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280033  # 40, 51; 2621491
         NAME = 'Exchange.UnbindOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1670,14 +1669,14 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Declare'
 
         def __init__(self,
-                     ticket: int=0,
-                     queue: str='',
-                     passive: bool=False,
-                     durable: bool=False,
-                     exclusive: bool=False,
-                     auto_delete: bool=False,
-                     nowait: bool=False,
-                     arguments=None) -> None:
+                     ticket=0,
+                     queue='',
+                     passive=False,
+                     durable=False,
+                     exclusive=False,
+                     auto_delete=False,
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.passive = passive
@@ -1688,10 +1687,10 @@ class Queue(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1705,7 +1704,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1731,16 +1730,16 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032000B  # 50, 11; 3276811
         NAME = 'Queue.DeclareOk'
 
-        def __init__(self, queue=None, message_count=None, consumer_count=None) -> None:
+        def __init__(self, queue=None, message_count=None, consumer_count=None):
             self.queue = queue
             self.message_count = message_count
             self.consumer_count = consumer_count
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -1748,7 +1747,7 @@ class Queue(amqp_object.Class):
             offset += 4
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -1763,12 +1762,12 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Bind'
 
         def __init__(self,
-                     ticket: int=0,
-                     queue: str='',
+                     ticket=0,
+                     queue='',
                      exchange=None,
-                     routing_key: str='',
-                     nowait: bool=False,
-                     arguments=None) -> None:
+                     routing_key='',
+                     nowait=False,
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1777,10 +1776,10 @@ class Queue(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1792,7 +1791,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1816,14 +1815,14 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320015  # 50, 21; 3276821
         NAME = 'Queue.BindOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -1835,16 +1834,16 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032001E  # 50, 30; 3276830
         NAME = 'Queue.Purge'
 
-        def __init__(self, ticket: int=0, queue: str='', nowait: bool=False) -> None:
+        def __init__(self, ticket=0, queue='', nowait=False):
             self.ticket = ticket
             self.queue = queue
             self.nowait = nowait
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1853,7 +1852,7 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1870,19 +1869,19 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032001F  # 50, 31; 3276831
         NAME = 'Queue.PurgeOk'
 
-        def __init__(self, message_count=None) -> None:
+        def __init__(self, message_count=None):
             self.message_count = message_count
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
@@ -1893,11 +1892,11 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Delete'
 
         def __init__(self,
-                     ticket: int=0,
-                     queue: str='',
-                     if_unused: bool=False,
-                     if_empty: bool=False,
-                     nowait: bool=False) -> None:
+                     ticket=0,
+                     queue='',
+                     if_unused=False,
+                     if_empty=False,
+                     nowait=False):
             self.ticket = ticket
             self.queue = queue
             self.if_unused = if_unused
@@ -1905,10 +1904,10 @@ class Queue(amqp_object.Class):
             self.nowait = nowait
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1919,7 +1918,7 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 2)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1940,19 +1939,19 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320029  # 50, 41; 3276841
         NAME = 'Queue.DeleteOk'
 
-        def __init__(self, message_count=None) -> None:
+        def __init__(self, message_count=None):
             self.message_count = message_count
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
@@ -1963,11 +1962,11 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Unbind'
 
         def __init__(self,
-                     ticket: int=0,
-                     queue: str='',
+                     ticket=0,
+                     queue='',
                      exchange=None,
-                     routing_key: str='',
-                     arguments=None) -> None:
+                     routing_key='',
+                     arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1975,10 +1974,10 @@ class Queue(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1987,7 +1986,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -2007,14 +2006,14 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320033  # 50, 51; 3276851
         NAME = 'Queue.UnbindOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2032,14 +2031,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A000A  # 90, 10; 5898250
         NAME = 'Tx.Select'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2051,14 +2050,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A000B  # 90, 11; 5898251
         NAME = 'Tx.SelectOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2070,14 +2069,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A0014  # 90, 20; 5898260
         NAME = 'Tx.Commit'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2089,14 +2088,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A0015  # 90, 21; 5898261
         NAME = 'Tx.CommitOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2108,14 +2107,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A001E  # 90, 30; 5898270
         NAME = 'Tx.Rollback'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2127,14 +2126,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A001F  # 90, 31; 5898271
         NAME = 'Tx.RollbackOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2152,20 +2151,20 @@ class Confirm(amqp_object.Class):
         INDEX = 0x0055000A  # 85, 10; 5570570
         NAME = 'Confirm.Select'
 
-        def __init__(self, nowait: bool=False) -> None:
+        def __init__(self, nowait=False):
             self.nowait = nowait
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return True
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self) -> list[bytes]:
+        def encode(self):
             pieces = list()
             bit_buffer = 0
             if self.nowait:
@@ -2178,14 +2177,14 @@ class Confirm(amqp_object.Class):
         INDEX = 0x0055000B  # 85, 11; 5570571
         NAME = 'Confirm.SelectOk'
 
-        def __init__(self) -> None:
+        def __init__(self):
             pass
 
         @property
-        def synchronous(self) -> bool:
+        def synchronous(self):
             return False
 
-        def decode(self, encoded, offset: int=0) -> Self:
+        def decode(self, encoded, offset=0):
             return self
 
         def encode(self):
@@ -2228,7 +2227,7 @@ class BasicProperties(amqp_object.Properties):
                  type=None,
                  user_id=None,
                  app_id=None,
-                 cluster_id=None) -> None:
+                 cluster_id=None):
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
@@ -2244,7 +2243,7 @@ class BasicProperties(amqp_object.Properties):
         self.app_id = app_id
         self.cluster_id = cluster_id
 
-    def decode(self, encoded, offset: int=0) -> Self:
+    def decode(self, encoded, offset=0):
         flags = 0
         flagword_index = 0
         while True:
@@ -2318,7 +2317,7 @@ class BasicProperties(amqp_object.Properties):
             self.cluster_id = None
         return self
 
-    def encode(self) -> list[bytes]:
+    def encode(self):
         pieces = list()
         flags = 0
         if self.content_type is not None:

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -15,6 +15,7 @@ import struct
 from pika import amqp_object
 from pika import data
 
+
 PROTOCOL_VERSION = (0, 9, 1)
 PORT = 5672
 
@@ -113,15 +114,7 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0014  # 60, 20; 3932180
         NAME = 'Basic.Consume'
 
-        def __init__(self,
-                     ticket=0,
-                     queue='',
-                     consumer_tag='',
-                     no_local=False,
-                     no_ack=False,
-                     exclusive=False,
-                     nowait=False,
-                     arguments=None):
+        def __init__(self, ticket=0, queue='', consumer_tag='', no_local=False, no_ack=False, exclusive=False, nowait=False, arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.consumer_tag = consumer_tag
@@ -139,8 +132,7 @@ class Basic(amqp_object.Class):
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
-            self.consumer_tag, offset = data.decode_short_string(
-                encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.no_local = (bit_buffer & (1 << 0)) != 0
@@ -185,8 +177,7 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(
-                encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
@@ -210,8 +201,7 @@ class Basic(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(
-                encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
@@ -241,8 +231,7 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(
-                encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             return self
 
         def encode(self):
@@ -257,12 +246,7 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0028  # 60, 40; 3932200
         NAME = 'Basic.Publish'
 
-        def __init__(self,
-                     ticket=0,
-                     exchange='',
-                     routing_key='',
-                     mandatory=False,
-                     immediate=False):
+        def __init__(self, ticket=0, exchange='', routing_key='', mandatory=False, immediate=False):
             self.ticket = ticket
             self.exchange = exchange
             self.routing_key = routing_key
@@ -306,11 +290,7 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0032  # 60, 50; 3932210
         NAME = 'Basic.Return'
 
-        def __init__(self,
-                     reply_code=None,
-                     reply_text='',
-                     exchange=None,
-                     routing_key=None):
+        def __init__(self, reply_code=None, reply_text='', exchange=None, routing_key=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.exchange = exchange
@@ -347,12 +327,7 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C003C  # 60, 60; 3932220
         NAME = 'Basic.Deliver'
 
-        def __init__(self,
-                     consumer_tag=None,
-                     delivery_tag=None,
-                     redelivered=False,
-                     exchange=None,
-                     routing_key=None):
+        def __init__(self, consumer_tag=None, delivery_tag=None, redelivered=False, exchange=None, routing_key=None):
             self.consumer_tag = consumer_tag
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
@@ -364,8 +339,7 @@ class Basic(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            self.consumer_tag, offset = data.decode_short_string(
-                encoded, offset)
+            self.consumer_tag, offset = data.decode_short_string(encoded, offset)
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -433,12 +407,7 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0047  # 60, 71; 3932231
         NAME = 'Basic.GetOk'
 
-        def __init__(self,
-                     delivery_tag=None,
-                     redelivered=False,
-                     exchange=None,
-                     routing_key=None,
-                     message_count=None):
+        def __init__(self, delivery_tag=None, redelivered=False, exchange=None, routing_key=None, message_count=None):
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
             self.exchange = exchange
@@ -676,12 +645,7 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A000A  # 10, 10; 655370
         NAME = 'Connection.Start'
 
-        def __init__(self,
-                     version_major=0,
-                     version_minor=9,
-                     server_properties=None,
-                     mechanisms='PLAIN',
-                     locales='en_US'):
+        def __init__(self, version_major=0, version_minor=9, server_properties=None, mechanisms='PLAIN', locales='en_US'):
             self.version_major = version_major
             self.version_minor = version_minor
             self.server_properties = server_properties
@@ -697,8 +661,7 @@ class Connection(amqp_object.Class):
             offset += 1
             self.version_minor = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
-            (self.server_properties,
-             offset) = data.decode_table(encoded, offset)
+            (self.server_properties, offset) = data.decode_table(encoded, offset)
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.mechanisms = encoded[offset:offset + length]
@@ -716,14 +679,12 @@ class Connection(amqp_object.Class):
             data.encode_table(pieces, self.server_properties)
             assert isinstance(self.mechanisms, (str, bytes)),\
                    'A non-string value was supplied for self.mechanisms'
-            value = self.mechanisms.encode('utf-8') if isinstance(
-                self.mechanisms, str) else self.mechanisms
+            value = self.mechanisms.encode('utf-8') if isinstance(self.mechanisms, str) else self.mechanisms
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.locales, (str, bytes)),\
                    'A non-string value was supplied for self.locales'
-            value = self.locales.encode('utf-8') if isinstance(
-                self.locales, str) else self.locales
+            value = self.locales.encode('utf-8') if isinstance(self.locales, str) else self.locales
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -733,11 +694,7 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A000B  # 10, 11; 655371
         NAME = 'Connection.StartOk'
 
-        def __init__(self,
-                     client_properties=None,
-                     mechanism='PLAIN',
-                     response=None,
-                     locale='en_US'):
+        def __init__(self, client_properties=None, mechanism='PLAIN', response=None, locale='en_US'):
             self.client_properties = client_properties
             self.mechanism = mechanism
             self.response = response
@@ -748,8 +705,7 @@ class Connection(amqp_object.Class):
             return False
 
         def decode(self, encoded, offset=0):
-            (self.client_properties,
-             offset) = data.decode_table(encoded, offset)
+            (self.client_properties, offset) = data.decode_table(encoded, offset)
             self.mechanism, offset = data.decode_short_string(encoded, offset)
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -766,8 +722,7 @@ class Connection(amqp_object.Class):
             data.encode_short_string(pieces, self.mechanism)
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
-            value = self.response.encode('utf-8') if isinstance(
-                self.response, str) else self.response
+            value = self.response.encode('utf-8') if isinstance(self.response, str) else self.response
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.locale, (str, bytes)),\
@@ -798,8 +753,7 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.challenge, (str, bytes)),\
                    'A non-string value was supplied for self.challenge'
-            value = self.challenge.encode('utf-8') if isinstance(
-                self.challenge, str) else self.challenge
+            value = self.challenge.encode('utf-8') if isinstance(self.challenge, str) else self.challenge
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -827,8 +781,7 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
-            value = self.response.encode('utf-8') if isinstance(
-                self.response, str) else self.response
+            value = self.response.encode('utf-8') if isinstance(self.response, str) else self.response
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -908,10 +861,8 @@ class Connection(amqp_object.Class):
             return True
 
         def decode(self, encoded, offset=0):
-            self.virtual_host, offset = data.decode_short_string(
-                encoded, offset)
-            self.capabilities, offset = data.decode_short_string(
-                encoded, offset)
+            self.virtual_host, offset = data.decode_short_string(encoded, offset)
+            self.capabilities, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.insist = (bit_buffer & (1 << 0)) != 0
@@ -959,11 +910,7 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0032  # 10, 50; 655410
         NAME = 'Connection.Close'
 
-        def __init__(self,
-                     reply_code=None,
-                     reply_text='',
-                     class_id=None,
-                     method_id=None):
+        def __init__(self, reply_code=None, reply_text='', class_id=None, method_id=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
@@ -1079,8 +1026,7 @@ class Connection(amqp_object.Class):
             pieces = list()
             assert isinstance(self.new_secret, (str, bytes)),\
                    'A non-string value was supplied for self.new_secret'
-            value = self.new_secret.encode('utf-8') if isinstance(
-                self.new_secret, str) else self.new_secret
+            value = self.new_secret.encode('utf-8') if isinstance(self.new_secret, str) else self.new_secret
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             assert isinstance(self.reason, (str, bytes)),\
@@ -1159,8 +1105,7 @@ class Channel(amqp_object.Class):
             pieces = list()
             assert isinstance(self.channel_id, (str, bytes)),\
                    'A non-string value was supplied for self.channel_id'
-            value = self.channel_id.encode('utf-8') if isinstance(
-                self.channel_id, str) else self.channel_id
+            value = self.channel_id.encode('utf-8') if isinstance(self.channel_id, str) else self.channel_id
             pieces.append(struct.pack('>I', len(value)))
             pieces.append(value)
             return pieces
@@ -1222,11 +1167,7 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140028  # 20, 40; 1310760
         NAME = 'Channel.Close'
 
-        def __init__(self,
-                     reply_code=None,
-                     reply_text='',
-                     class_id=None,
-                     method_id=None):
+        def __init__(self, reply_code=None, reply_text='', class_id=None, method_id=None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
@@ -1286,13 +1227,7 @@ class Access(amqp_object.Class):
         INDEX = 0x001E000A  # 30, 10; 1966090
         NAME = 'Access.Request'
 
-        def __init__(self,
-                     realm='/data',
-                     exclusive=False,
-                     passive=True,
-                     active=True,
-                     write=True,
-                     read=True):
+        def __init__(self, realm='/data', exclusive=False, passive=True, active=True, write=True, read=True):
             self.realm = realm
             self.exclusive = exclusive
             self.passive = passive
@@ -1367,16 +1302,7 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028000A  # 40, 10; 2621450
         NAME = 'Exchange.Declare'
 
-        def __init__(self,
-                     ticket=0,
-                     exchange=None,
-                     type='direct',
-                     passive=False,
-                     durable=False,
-                     auto_delete=False,
-                     internal=False,
-                     nowait=False,
-                     arguments=None):
+        def __init__(self, ticket=0, exchange=None, type='direct', passive=False, durable=False, auto_delete=False, internal=False, nowait=False, arguments=None):
             self.ticket = ticket
             self.exchange = exchange
             self.type = type
@@ -1454,11 +1380,7 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280014  # 40, 20; 2621460
         NAME = 'Exchange.Delete'
 
-        def __init__(self,
-                     ticket=0,
-                     exchange=None,
-                     if_unused=False,
-                     nowait=False):
+        def __init__(self, ticket=0, exchange=None, if_unused=False, nowait=False):
             self.ticket = ticket
             self.exchange = exchange
             self.if_unused = if_unused
@@ -1516,13 +1438,7 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028001E  # 40, 30; 2621470
         NAME = 'Exchange.Bind'
 
-        def __init__(self,
-                     ticket=0,
-                     destination=None,
-                     source=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+        def __init__(self, ticket=0, destination=None, source=None, routing_key='', nowait=False, arguments=None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1589,13 +1505,7 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280028  # 40, 40; 2621480
         NAME = 'Exchange.Unbind'
 
-        def __init__(self,
-                     ticket=0,
-                     destination=None,
-                     source=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+        def __init__(self, ticket=0, destination=None, source=None, routing_key='', nowait=False, arguments=None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1668,15 +1578,7 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032000A  # 50, 10; 3276810
         NAME = 'Queue.Declare'
 
-        def __init__(self,
-                     ticket=0,
-                     queue='',
-                     passive=False,
-                     durable=False,
-                     exclusive=False,
-                     auto_delete=False,
-                     nowait=False,
-                     arguments=None):
+        def __init__(self, ticket=0, queue='', passive=False, durable=False, exclusive=False, auto_delete=False, nowait=False, arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.passive = passive
@@ -1761,13 +1663,7 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320014  # 50, 20; 3276820
         NAME = 'Queue.Bind'
 
-        def __init__(self,
-                     ticket=0,
-                     queue='',
-                     exchange=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+        def __init__(self, ticket=0, queue='', exchange=None, routing_key='', nowait=False, arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1891,12 +1787,7 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320028  # 50, 40; 3276840
         NAME = 'Queue.Delete'
 
-        def __init__(self,
-                     ticket=0,
-                     queue='',
-                     if_unused=False,
-                     if_empty=False,
-                     nowait=False):
+        def __init__(self, ticket=0, queue='', if_unused=False, if_empty=False, nowait=False):
             self.ticket = ticket
             self.queue = queue
             self.if_unused = if_unused
@@ -1961,12 +1852,7 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320032  # 50, 50; 3276850
         NAME = 'Queue.Unbind'
 
-        def __init__(self,
-                     ticket=0,
-                     queue='',
-                     exchange=None,
-                     routing_key='',
-                     arguments=None):
+        def __init__(self, ticket=0, queue='', exchange=None, routing_key='', arguments=None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -2213,21 +2099,7 @@ class BasicProperties(amqp_object.Properties):
     FLAG_APP_ID = (1 << 3)
     FLAG_CLUSTER_ID = (1 << 2)
 
-    def __init__(self,
-                 content_type=None,
-                 content_encoding=None,
-                 headers=None,
-                 delivery_mode=None,
-                 priority=None,
-                 correlation_id=None,
-                 reply_to=None,
-                 expiration=None,
-                 message_id=None,
-                 timestamp=None,
-                 type=None,
-                 user_id=None,
-                 app_id=None,
-                 cluster_id=None):
+    def __init__(self, content_type=None, content_encoding=None, headers=None, delivery_mode=None, priority=None, correlation_id=None, reply_to=None, expiration=None, message_id=None, timestamp=None, type=None, user_id=None, app_id=None, cluster_id=None):
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
@@ -2254,13 +2126,11 @@ class BasicProperties(amqp_object.Properties):
                 break
             flagword_index += 1
         if flags & BasicProperties.FLAG_CONTENT_TYPE:
-            self.content_type, offset = data.decode_short_string(
-                encoded, offset)
+            self.content_type, offset = data.decode_short_string(encoded, offset)
         else:
             self.content_type = None
         if flags & BasicProperties.FLAG_CONTENT_ENCODING:
-            self.content_encoding, offset = data.decode_short_string(
-                encoded, offset)
+            self.content_encoding, offset = data.decode_short_string(encoded, offset)
         else:
             self.content_encoding = None
         if flags & BasicProperties.FLAG_HEADERS:
@@ -2278,8 +2148,7 @@ class BasicProperties(amqp_object.Properties):
         else:
             self.priority = None
         if flags & BasicProperties.FLAG_CORRELATION_ID:
-            self.correlation_id, offset = data.decode_short_string(
-                encoded, offset)
+            self.correlation_id, offset = data.decode_short_string(encoded, offset)
         else:
             self.correlation_id = None
         if flags & BasicProperties.FLAG_REPLY_TO:
@@ -2394,7 +2263,6 @@ class BasicProperties(amqp_object.Properties):
                 break
         return flag_pieces + pieces
 
-
 methods = {
     0x003C000A: Basic.Qos,
     0x003C000B: Basic.QosOk,
@@ -2464,7 +2332,9 @@ methods = {
     0x0055000B: Confirm.SelectOk
 }
 
-props = {0x003C: BasicProperties}
+props = {
+    0x003C: BasicProperties
+}
 
 
 def has_content(methodNumber):

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -11,6 +11,7 @@ rejected.
 
 """
 
+from typing import Self
 import struct
 from pika import amqp_object
 from pika import data
@@ -60,16 +61,16 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C000A  # 60, 10; 3932170
         NAME = 'Basic.Qos'
 
-        def __init__(self, prefetch_size=0, prefetch_count=0, global_qos=False):
+        def __init__(self, prefetch_size: int=0, prefetch_count: int=0, global_qos: bool=False) -> None:
             self.prefetch_size = prefetch_size
             self.prefetch_count = prefetch_count
             self.global_qos = global_qos
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.prefetch_size = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.prefetch_count = struct.unpack_from('>H', encoded, offset)[0]
@@ -79,7 +80,7 @@ class Basic(amqp_object.Class):
             self.global_qos = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>I', self.prefetch_size))
             pieces.append(struct.pack('>H', self.prefetch_count))
@@ -94,14 +95,14 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C000B  # 60, 11; 3932171
         NAME = 'Basic.QosOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -114,14 +115,14 @@ class Basic(amqp_object.Class):
         NAME = 'Basic.Consume'
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     consumer_tag='',
-                     no_local=False,
-                     no_ack=False,
-                     exclusive=False,
-                     nowait=False,
-                     arguments=None):
+                     ticket: int=0,
+                     queue: str='',
+                     consumer_tag: str='',
+                     no_local: bool=False,
+                     no_ack: bool=False,
+                     exclusive: bool=False,
+                     nowait: bool=False,
+                     arguments=None) -> None:
             self.ticket = ticket
             self.queue = queue
             self.consumer_tag = consumer_tag
@@ -132,10 +133,10 @@ class Basic(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -150,7 +151,7 @@ class Basic(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -177,19 +178,19 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0015  # 60, 21; 3932181
         NAME = 'Basic.ConsumeOk'
 
-        def __init__(self, consumer_tag=None):
+        def __init__(self, consumer_tag=None) -> None:
             self.consumer_tag = consumer_tag
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -201,15 +202,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C001E  # 60, 30; 3932190
         NAME = 'Basic.Cancel'
 
-        def __init__(self, consumer_tag=None, nowait=False):
+        def __init__(self, consumer_tag=None, nowait: bool=False) -> None:
             self.consumer_tag = consumer_tag
             self.nowait = nowait
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -217,7 +218,7 @@ class Basic(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -233,19 +234,19 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C001F  # 60, 31; 3932191
         NAME = 'Basic.CancelOk'
 
-        def __init__(self, consumer_tag=None):
+        def __init__(self, consumer_tag=None) -> None:
             self.consumer_tag = consumer_tag
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -258,11 +259,11 @@ class Basic(amqp_object.Class):
         NAME = 'Basic.Publish'
 
         def __init__(self,
-                     ticket=0,
-                     exchange='',
-                     routing_key='',
-                     mandatory=False,
-                     immediate=False):
+                     ticket: int=0,
+                     exchange: str='',
+                     routing_key: str='',
+                     mandatory: bool=False,
+                     immediate: bool=False) -> None:
             self.ticket = ticket
             self.exchange = exchange
             self.routing_key = routing_key
@@ -270,10 +271,10 @@ class Basic(amqp_object.Class):
             self.immediate = immediate
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -284,7 +285,7 @@ class Basic(amqp_object.Class):
             self.immediate = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
@@ -308,19 +309,19 @@ class Basic(amqp_object.Class):
 
         def __init__(self,
                      reply_code=None,
-                     reply_text='',
+                     reply_text: str='',
                      exchange=None,
-                     routing_key=None):
+                     routing_key=None) -> None:
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.exchange = exchange
             self.routing_key = routing_key
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -328,7 +329,7 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
@@ -350,9 +351,9 @@ class Basic(amqp_object.Class):
         def __init__(self,
                      consumer_tag=None,
                      delivery_tag=None,
-                     redelivered=False,
+                     redelivered: bool=False,
                      exchange=None,
-                     routing_key=None):
+                     routing_key=None) -> None:
             self.consumer_tag = consumer_tag
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
@@ -360,10 +361,10 @@ class Basic(amqp_object.Class):
             self.routing_key = routing_key
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
@@ -375,7 +376,7 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
@@ -398,16 +399,16 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0046  # 60, 70; 3932230
         NAME = 'Basic.Get'
 
-        def __init__(self, ticket=0, queue='', no_ack=False):
+        def __init__(self, ticket: int=0, queue: str='', no_ack: bool=False) -> None:
             self.ticket = ticket
             self.queue = queue
             self.no_ack = no_ack
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -416,7 +417,7 @@ class Basic(amqp_object.Class):
             self.no_ack = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -435,10 +436,10 @@ class Basic(amqp_object.Class):
 
         def __init__(self,
                      delivery_tag=None,
-                     redelivered=False,
+                     redelivered: bool=False,
                      exchange=None,
                      routing_key=None,
-                     message_count=None):
+                     message_count=None) -> None:
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
             self.exchange = exchange
@@ -446,10 +447,10 @@ class Basic(amqp_object.Class):
             self.message_count = message_count
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -461,7 +462,7 @@ class Basic(amqp_object.Class):
             offset += 4
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -482,18 +483,18 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0048  # 60, 72; 3932232
         NAME = 'Basic.GetEmpty'
 
-        def __init__(self, cluster_id=''):
+        def __init__(self, cluster_id: str='') -> None:
             self.cluster_id = cluster_id
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.cluster_id, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.cluster_id, (str, bytes)),\
                    'A non-string value was supplied for self.cluster_id'
@@ -505,15 +506,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0050  # 60, 80; 3932240
         NAME = 'Basic.Ack'
 
-        def __init__(self, delivery_tag=0, multiple=False):
+        def __init__(self, delivery_tag: int=0, multiple: bool=False) -> None:
             self.delivery_tag = delivery_tag
             self.multiple = multiple
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -521,7 +522,7 @@ class Basic(amqp_object.Class):
             self.multiple = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -535,15 +536,15 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C005A  # 60, 90; 3932250
         NAME = 'Basic.Reject'
 
-        def __init__(self, delivery_tag=None, requeue=True):
+        def __init__(self, delivery_tag=None, requeue: bool=True) -> None:
             self.delivery_tag = delivery_tag
             self.requeue = requeue
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -551,7 +552,7 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -565,20 +566,20 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0064  # 60, 100; 3932260
         NAME = 'Basic.RecoverAsync'
 
-        def __init__(self, requeue=False):
+        def __init__(self, requeue: bool=False) -> None:
             self.requeue = requeue
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             bit_buffer = 0
             if self.requeue:
@@ -591,20 +592,20 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C006E  # 60, 110; 3932270
         NAME = 'Basic.Recover'
 
-        def __init__(self, requeue=False):
+        def __init__(self, requeue: bool=False) -> None:
             self.requeue = requeue
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             bit_buffer = 0
             if self.requeue:
@@ -617,14 +618,14 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C006F  # 60, 111; 3932271
         NAME = 'Basic.RecoverOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -636,16 +637,16 @@ class Basic(amqp_object.Class):
         INDEX = 0x003C0078  # 60, 120; 3932280
         NAME = 'Basic.Nack'
 
-        def __init__(self, delivery_tag=0, multiple=False, requeue=True):
+        def __init__(self, delivery_tag: int=0, multiple: bool=False, requeue: bool=True) -> None:
             self.delivery_tag = delivery_tag
             self.multiple = multiple
             self.requeue = requeue
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -654,7 +655,7 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
@@ -677,11 +678,11 @@ class Connection(amqp_object.Class):
         NAME = 'Connection.Start'
 
         def __init__(self,
-                     version_major=0,
-                     version_minor=9,
+                     version_major: int=0,
+                     version_minor: int=9,
                      server_properties=None,
-                     mechanisms='PLAIN',
-                     locales='en_US'):
+                     mechanisms: str='PLAIN',
+                     locales: str='en_US') -> None:
             self.version_major = version_major
             self.version_minor = version_minor
             self.server_properties = server_properties
@@ -689,10 +690,10 @@ class Connection(amqp_object.Class):
             self.locales = locales
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.version_major = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.version_minor = struct.unpack_from('B', encoded, offset)[0]
@@ -709,7 +710,7 @@ class Connection(amqp_object.Class):
             offset += length
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('B', self.version_major))
             pieces.append(struct.pack('B', self.version_minor))
@@ -735,19 +736,19 @@ class Connection(amqp_object.Class):
 
         def __init__(self,
                      client_properties=None,
-                     mechanism='PLAIN',
+                     mechanism: str='PLAIN',
                      response=None,
-                     locale='en_US'):
+                     locale: str='en_US') -> None:
             self.client_properties = client_properties
             self.mechanism = mechanism
             self.response = response
             self.locale = locale
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             (self.client_properties,
              offset) = data.decode_table(encoded, offset)
             self.mechanism, offset = data.decode_short_string(encoded, offset)
@@ -758,7 +759,7 @@ class Connection(amqp_object.Class):
             self.locale, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             data.encode_table(pieces, self.client_properties)
             assert isinstance(self.mechanism, (str, bytes)),\
@@ -780,21 +781,21 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0014  # 10, 20; 655380
         NAME = 'Connection.Secure'
 
-        def __init__(self, challenge=None):
+        def __init__(self, challenge=None) -> None:
             self.challenge = challenge
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.challenge = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.challenge, (str, bytes)),\
                    'A non-string value was supplied for self.challenge'
@@ -809,21 +810,21 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0015  # 10, 21; 655381
         NAME = 'Connection.SecureOk'
 
-        def __init__(self, response=None):
+        def __init__(self, response=None) -> None:
             self.response = response
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.response = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
@@ -838,16 +839,16 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A001E  # 10, 30; 655390
         NAME = 'Connection.Tune'
 
-        def __init__(self, channel_max=0, frame_max=0, heartbeat=0):
+        def __init__(self, channel_max: int=0, frame_max: int=0, heartbeat: int=0) -> None:
             self.channel_max = channel_max
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
@@ -856,7 +857,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.channel_max))
             pieces.append(struct.pack('>I', self.frame_max))
@@ -868,16 +869,16 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A001F  # 10, 31; 655391
         NAME = 'Connection.TuneOk'
 
-        def __init__(self, channel_max=0, frame_max=0, heartbeat=0):
+        def __init__(self, channel_max: int=0, frame_max: int=0, heartbeat: int=0) -> None:
             self.channel_max = channel_max
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
@@ -886,7 +887,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.channel_max))
             pieces.append(struct.pack('>I', self.frame_max))
@@ -898,16 +899,16 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0028  # 10, 40; 655400
         NAME = 'Connection.Open'
 
-        def __init__(self, virtual_host='/', capabilities='', insist=False):
+        def __init__(self, virtual_host: str='/', capabilities: str='', insist: bool=False) -> None:
             self.virtual_host = virtual_host
             self.capabilities = capabilities
             self.insist = insist
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.virtual_host, offset = data.decode_short_string(
                 encoded, offset)
             self.capabilities, offset = data.decode_short_string(
@@ -917,7 +918,7 @@ class Connection(amqp_object.Class):
             self.insist = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.virtual_host, (str, bytes)),\
                    'A non-string value was supplied for self.virtual_host'
@@ -936,18 +937,18 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0029  # 10, 41; 655401
         NAME = 'Connection.OpenOk'
 
-        def __init__(self, known_hosts=''):
+        def __init__(self, known_hosts: str='') -> None:
             self.known_hosts = known_hosts
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.known_hosts, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.known_hosts, (str, bytes)),\
                    'A non-string value was supplied for self.known_hosts'
@@ -961,19 +962,19 @@ class Connection(amqp_object.Class):
 
         def __init__(self,
                      reply_code=None,
-                     reply_text='',
+                     reply_text: str='',
                      class_id=None,
-                     method_id=None):
+                     method_id=None) -> None:
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
             self.method_id = method_id
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -983,7 +984,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
@@ -998,14 +999,14 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0033  # 10, 51; 655411
         NAME = 'Connection.CloseOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1017,18 +1018,18 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A003C  # 10, 60; 655420
         NAME = 'Connection.Blocked'
 
-        def __init__(self, reason=''):
+        def __init__(self, reason: str='') -> None:
             self.reason = reason
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.reason, (str, bytes)),\
                    'A non-string value was supplied for self.reason'
@@ -1040,14 +1041,14 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A003D  # 10, 61; 655421
         NAME = 'Connection.Unblocked'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1059,15 +1060,15 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0046  # 10, 70; 655430
         NAME = 'Connection.UpdateSecret'
 
-        def __init__(self, new_secret=None, reason=None):
+        def __init__(self, new_secret=None, reason=None) -> None:
             self.new_secret = new_secret
             self.reason = reason
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.new_secret = encoded[offset:offset + length]
@@ -1075,7 +1076,7 @@ class Connection(amqp_object.Class):
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.new_secret, (str, bytes)),\
                    'A non-string value was supplied for self.new_secret'
@@ -1093,14 +1094,14 @@ class Connection(amqp_object.Class):
         INDEX = 0x000A0047  # 10, 71; 655431
         NAME = 'Connection.UpdateSecretOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1118,18 +1119,18 @@ class Channel(amqp_object.Class):
         INDEX = 0x0014000A  # 20, 10; 1310730
         NAME = 'Channel.Open'
 
-        def __init__(self, out_of_band=''):
+        def __init__(self, out_of_band: str='') -> None:
             self.out_of_band = out_of_band
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.out_of_band, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.out_of_band, (str, bytes)),\
                    'A non-string value was supplied for self.out_of_band'
@@ -1141,21 +1142,21 @@ class Channel(amqp_object.Class):
         INDEX = 0x0014000B  # 20, 11; 1310731
         NAME = 'Channel.OpenOk'
 
-        def __init__(self, channel_id=''):
+        def __init__(self, channel_id: str='') -> None:
             self.channel_id = channel_id
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.channel_id = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.channel_id, (str, bytes)),\
                    'A non-string value was supplied for self.channel_id'
@@ -1170,20 +1171,20 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140014  # 20, 20; 1310740
         NAME = 'Channel.Flow'
 
-        def __init__(self, active=None):
+        def __init__(self, active=None) -> None:
             self.active = active
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             bit_buffer = 0
             if self.active:
@@ -1196,20 +1197,20 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140015  # 20, 21; 1310741
         NAME = 'Channel.FlowOk'
 
-        def __init__(self, active=None):
+        def __init__(self, active=None) -> None:
             self.active = active
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             bit_buffer = 0
             if self.active:
@@ -1224,19 +1225,19 @@ class Channel(amqp_object.Class):
 
         def __init__(self,
                      reply_code=None,
-                     reply_text='',
+                     reply_text: str='',
                      class_id=None,
-                     method_id=None):
+                     method_id=None) -> None:
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
             self.method_id = method_id
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -1246,7 +1247,7 @@ class Channel(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
@@ -1261,14 +1262,14 @@ class Channel(amqp_object.Class):
         INDEX = 0x00140029  # 20, 41; 1310761
         NAME = 'Channel.CloseOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1287,12 +1288,12 @@ class Access(amqp_object.Class):
         NAME = 'Access.Request'
 
         def __init__(self,
-                     realm='/data',
-                     exclusive=False,
-                     passive=True,
-                     active=True,
-                     write=True,
-                     read=True):
+                     realm: str='/data',
+                     exclusive: bool=False,
+                     passive: bool=True,
+                     active: bool=True,
+                     write: bool=True,
+                     read: bool=True) -> None:
             self.realm = realm
             self.exclusive = exclusive
             self.passive = passive
@@ -1301,10 +1302,10 @@ class Access(amqp_object.Class):
             self.read = read
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.realm, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
@@ -1315,7 +1316,7 @@ class Access(amqp_object.Class):
             self.read = (bit_buffer & (1 << 4)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.realm, (str, bytes)),\
                    'A non-string value was supplied for self.realm'
@@ -1339,19 +1340,19 @@ class Access(amqp_object.Class):
         INDEX = 0x001E000B  # 30, 11; 1966091
         NAME = 'Access.RequestOk'
 
-        def __init__(self, ticket=1):
+        def __init__(self, ticket: int=1) -> None:
             self.ticket = ticket
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             return pieces
@@ -1368,15 +1369,15 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Declare'
 
         def __init__(self,
-                     ticket=0,
+                     ticket: int=0,
                      exchange=None,
-                     type='direct',
-                     passive=False,
-                     durable=False,
-                     auto_delete=False,
-                     internal=False,
-                     nowait=False,
-                     arguments=None):
+                     type: str='direct',
+                     passive: bool=False,
+                     durable: bool=False,
+                     auto_delete: bool=False,
+                     internal: bool=False,
+                     nowait: bool=False,
+                     arguments=None) -> None:
             self.ticket = ticket
             self.exchange = exchange
             self.type = type
@@ -1388,10 +1389,10 @@ class Exchange(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1406,7 +1407,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
@@ -1435,14 +1436,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028000B  # 40, 11; 2621451
         NAME = 'Exchange.DeclareOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1455,20 +1456,20 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Delete'
 
         def __init__(self,
-                     ticket=0,
+                     ticket: int=0,
                      exchange=None,
-                     if_unused=False,
-                     nowait=False):
+                     if_unused: bool=False,
+                     nowait: bool=False) -> None:
             self.ticket = ticket
             self.exchange = exchange
             self.if_unused = if_unused
             self.nowait = nowait
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1478,7 +1479,7 @@ class Exchange(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
@@ -1497,14 +1498,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280015  # 40, 21; 2621461
         NAME = 'Exchange.DeleteOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1517,12 +1518,12 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Bind'
 
         def __init__(self,
-                     ticket=0,
+                     ticket: int=0,
                      destination=None,
                      source=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+                     routing_key: str='',
+                     nowait: bool=False,
+                     arguments=None) -> None:
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1531,10 +1532,10 @@ class Exchange(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
@@ -1546,7 +1547,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
@@ -1570,14 +1571,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x0028001F  # 40, 31; 2621471
         NAME = 'Exchange.BindOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1590,12 +1591,12 @@ class Exchange(amqp_object.Class):
         NAME = 'Exchange.Unbind'
 
         def __init__(self,
-                     ticket=0,
+                     ticket: int=0,
                      destination=None,
                      source=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+                     routing_key: str='',
+                     nowait: bool=False,
+                     arguments=None) -> None:
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1604,10 +1605,10 @@ class Exchange(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
@@ -1619,7 +1620,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
@@ -1643,14 +1644,14 @@ class Exchange(amqp_object.Class):
         INDEX = 0x00280033  # 40, 51; 2621491
         NAME = 'Exchange.UnbindOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1669,14 +1670,14 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Declare'
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     passive=False,
-                     durable=False,
-                     exclusive=False,
-                     auto_delete=False,
-                     nowait=False,
-                     arguments=None):
+                     ticket: int=0,
+                     queue: str='',
+                     passive: bool=False,
+                     durable: bool=False,
+                     exclusive: bool=False,
+                     auto_delete: bool=False,
+                     nowait: bool=False,
+                     arguments=None) -> None:
             self.ticket = ticket
             self.queue = queue
             self.passive = passive
@@ -1687,10 +1688,10 @@ class Queue(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1704,7 +1705,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1730,16 +1731,16 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032000B  # 50, 11; 3276811
         NAME = 'Queue.DeclareOk'
 
-        def __init__(self, queue=None, message_count=None, consumer_count=None):
+        def __init__(self, queue=None, message_count=None, consumer_count=None) -> None:
             self.queue = queue
             self.message_count = message_count
             self.consumer_count = consumer_count
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -1747,7 +1748,7 @@ class Queue(amqp_object.Class):
             offset += 4
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -1762,12 +1763,12 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Bind'
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
+                     ticket: int=0,
+                     queue: str='',
                      exchange=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+                     routing_key: str='',
+                     nowait: bool=False,
+                     arguments=None) -> None:
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1776,10 +1777,10 @@ class Queue(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1791,7 +1792,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1815,14 +1816,14 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320015  # 50, 21; 3276821
         NAME = 'Queue.BindOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -1834,16 +1835,16 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032001E  # 50, 30; 3276830
         NAME = 'Queue.Purge'
 
-        def __init__(self, ticket=0, queue='', nowait=False):
+        def __init__(self, ticket: int=0, queue: str='', nowait: bool=False) -> None:
             self.ticket = ticket
             self.queue = queue
             self.nowait = nowait
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1852,7 +1853,7 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1869,19 +1870,19 @@ class Queue(amqp_object.Class):
         INDEX = 0x0032001F  # 50, 31; 3276831
         NAME = 'Queue.PurgeOk'
 
-        def __init__(self, message_count=None):
+        def __init__(self, message_count=None) -> None:
             self.message_count = message_count
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
@@ -1892,11 +1893,11 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Delete'
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     if_unused=False,
-                     if_empty=False,
-                     nowait=False):
+                     ticket: int=0,
+                     queue: str='',
+                     if_unused: bool=False,
+                     if_empty: bool=False,
+                     nowait: bool=False) -> None:
             self.ticket = ticket
             self.queue = queue
             self.if_unused = if_unused
@@ -1904,10 +1905,10 @@ class Queue(amqp_object.Class):
             self.nowait = nowait
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1918,7 +1919,7 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 2)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -1939,19 +1940,19 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320029  # 50, 41; 3276841
         NAME = 'Queue.DeleteOk'
 
-        def __init__(self, message_count=None):
+        def __init__(self, message_count=None) -> None:
             self.message_count = message_count
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
@@ -1962,11 +1963,11 @@ class Queue(amqp_object.Class):
         NAME = 'Queue.Unbind'
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
+                     ticket: int=0,
+                     queue: str='',
                      exchange=None,
-                     routing_key='',
-                     arguments=None):
+                     routing_key: str='',
+                     arguments=None) -> None:
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1974,10 +1975,10 @@ class Queue(amqp_object.Class):
             self.arguments = arguments
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1986,7 +1987,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
@@ -2006,14 +2007,14 @@ class Queue(amqp_object.Class):
         INDEX = 0x00320033  # 50, 51; 3276851
         NAME = 'Queue.UnbindOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2031,14 +2032,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A000A  # 90, 10; 5898250
         NAME = 'Tx.Select'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2050,14 +2051,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A000B  # 90, 11; 5898251
         NAME = 'Tx.SelectOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2069,14 +2070,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A0014  # 90, 20; 5898260
         NAME = 'Tx.Commit'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2088,14 +2089,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A0015  # 90, 21; 5898261
         NAME = 'Tx.CommitOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2107,14 +2108,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A001E  # 90, 30; 5898270
         NAME = 'Tx.Rollback'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2126,14 +2127,14 @@ class Tx(amqp_object.Class):
         INDEX = 0x005A001F  # 90, 31; 5898271
         NAME = 'Tx.RollbackOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2151,20 +2152,20 @@ class Confirm(amqp_object.Class):
         INDEX = 0x0055000A  # 85, 10; 5570570
         NAME = 'Confirm.Select'
 
-        def __init__(self, nowait=False):
+        def __init__(self, nowait: bool=False) -> None:
             self.nowait = nowait
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return True
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
+        def encode(self) -> list[bytes]:
             pieces = list()
             bit_buffer = 0
             if self.nowait:
@@ -2177,14 +2178,14 @@ class Confirm(amqp_object.Class):
         INDEX = 0x0055000B  # 85, 11; 5570571
         NAME = 'Confirm.SelectOk'
 
-        def __init__(self):
+        def __init__(self) -> None:
             pass
 
         @property
-        def synchronous(self):
+        def synchronous(self) -> bool:
             return False
 
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded, offset: int=0) -> Self:
             return self
 
         def encode(self):
@@ -2227,7 +2228,7 @@ class BasicProperties(amqp_object.Properties):
                  type=None,
                  user_id=None,
                  app_id=None,
-                 cluster_id=None):
+                 cluster_id=None) -> None:
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
@@ -2243,7 +2244,7 @@ class BasicProperties(amqp_object.Properties):
         self.app_id = app_id
         self.cluster_id = cluster_id
 
-    def decode(self, encoded, offset=0):
+    def decode(self, encoded, offset: int=0) -> Self:
         flags = 0
         flagword_index = 0
         while True:
@@ -2317,7 +2318,7 @@ class BasicProperties(amqp_object.Properties):
             self.cluster_id = None
         return self
 
-    def encode(self):
+    def encode(self) -> list[bytes]:
         pieces = list()
         flags = 0
         if self.content_type is not None:

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -9,6 +9,8 @@ def require_string(value: Any, value_name: str) -> None:
 
     :raises: TypeError
 
+    :param Any value: The value to validate
+    :param str value_name: Human-readable name of the value, used in error messages
     """
     if not isinstance(value, str):
         raise TypeError(f'{value_name} must be a str, but got {value!r}')
@@ -20,6 +22,8 @@ def require_callback(callback: Callable[..., Any],
 
     :raises: TypeError
 
+    :param Callable[..., Any] callback: The callback to validate
+    :param str callback_name: Human-readable name of the callback, used in error messages
     """
     if not callable(callback):
         raise TypeError(
@@ -33,6 +37,7 @@ def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
     :rtype: bool
     :raises: TypeError
 
+    :param Optional[Callable[..., Any]] callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     """
     if callback is None:
         # No callback means we will not expect a response
@@ -51,6 +56,8 @@ def zero_or_greater(name: str, value: int) -> None:
 
     :raises: ValueError
 
+    :param str name: value name to use in error message
+    :param int value: value to check
     """
     if int(value) < 0:
         errmsg = f'{name} must be >= 0, but got {value}'

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -7,10 +7,10 @@ from typing import Any, Callable, Optional
 def require_string(value: Any, value_name: str) -> None:
     """Require that value is a string
 
-    :raises: TypeError
 
-    :param Any value: The value to validate
-    :param str value_name: Human-readable name of the value, used in error messages
+    :param value: The value to validate
+    :param value_name: Human-readable name of the value, used in error messages
+    :raises: TypeError
     """
     if not isinstance(value, str):
         raise TypeError(f'{value_name} must be a str, but got {value!r}')
@@ -20,10 +20,10 @@ def require_callback(callback: Callable[..., Any],
                      callback_name: str = 'callback') -> None:
     """Require that callback is callable and is not None
 
-    :raises: TypeError
 
-    :param Callable[..., Any] callback: The callback to validate
-    :param str callback_name: Human-readable name of the callback, used in error messages
+    :param callback: The callback to validate
+    :param callback_name: Human-readable name of the callback, used in error messages
+    :raises: TypeError
     """
     if not callable(callback):
         raise TypeError(
@@ -33,11 +33,11 @@ def require_callback(callback: Callable[..., Any],
 def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
     """Verify callback is callable if not None
 
+    :param callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     :returns: boolean indicating nowait
     :rtype: bool
     :raises: TypeError
 
-    :param Optional[Callable[..., Any]] callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     """
     if callback is None:
         # No callback means we will not expect a response
@@ -54,10 +54,9 @@ def zero_or_greater(name: str, value: int) -> None:
     """Verify that value is zero or greater. If not, 'name'
     will be used in error message
 
+    :param name: value name to use in error message
+    :param value: value to check
     :raises: ValueError
-
-    :param str name: value name to use in error message
-    :param int value: value to check
     """
     if int(value) < 0:
         errmsg = f'{name} must be >= 0, but got {value}'

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -22,7 +22,7 @@ def require_callback(callback: Callable[..., Any],
 
     :raises: TypeError
 
-    :param Callable[..., Any] callback: The callback to validate
+    :param callback: The callback to validate
     :param str callback_name: Human-readable name of the callback, used in error messages
     """
     if not callable(callback):
@@ -37,7 +37,7 @@ def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
     :rtype: bool
     :raises: TypeError
 
-    :param Optional[Callable[..., Any]] callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
+    :param callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     """
     if callback is None:
         # No callback means we will not expect a response

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -22,7 +22,7 @@ def require_callback(callback: Callable[..., Any],
 
     :raises: TypeError
 
-    :param callback: The callback to validate
+    :param Callable[..., Any] callback: The callback to validate
     :param str callback_name: Human-readable name of the callback, used in error messages
     """
     if not callable(callback):
@@ -37,7 +37,7 @@ def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
     :rtype: bool
     :raises: TypeError
 
-    :param callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
+    :param Optional[Callable[..., Any]] callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     """
     if callback is None:
         # No callback means we will not expect a response


### PR DESCRIPTION
## Proposed Changes

Add missing type annotations to `pika/*.py` and adapter modules using pyrefly and MonkeyType runtime tracing combined with static inference. Also augment Sphinx docstrings with missing `:param:` and `:rtype:` entries across the codebase.

All annotations use `from __future__ import annotations` (PEP 563) so the syntax is compatible at runtime with Python 3.7+. `Self` and `Literal` are imported from `typing_extensions` rather than `typing` for the same reason.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [x] Documentation <!-- correction or otherwise -->
- [x] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1569 (partially?)

## Further Comments

**On `:param TYPE VAR_NAME:` in docstrings**

Many existing docstrings in this codebase use the Sphinx inline form `:param TYPE name: desc`. Our augmented docstrings follow the same convention for simple types (e.g. `:param int value:`), but for complex union/generic types (e.g. `Callable[[...], None]` or `X | Y`) we stripped the type from the `:param` directive entirely, leaving just `:param name: desc`.

This is worth discussing: it might be cleaner to drop the inline type from **all** `:param TYPE name:` directives going forward and rely solely on the function signature annotations instead. Reasons:

1. The inline type in `:param` duplicates what the annotation already says — two places to keep in sync.
2. Complex types with `|` or `[...]` break the docs build under `--strict` (griffe cannot parse them as field directives) and must remove spaces inbetween to fix.
3. Modern Sphinx and griffe can render parameter types directly from PEP 484 annotations, making the inline type redundant.