### PR TITLE
Add docformatter to enforce PEP 257 docstring style

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,3 +20,15 @@ jobs:
       - run: |
           python -m pip install --upgrade pip hatch
           hatch run lint-check
+
+  docformatter:
+    name: docformatter check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.10'
+      - run: |
+          python -m pip install --upgrade pip hatch
+          hatch run docfmt-check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,12 @@ examples/               # usage examples
 
 - **Formatter:** [yapf](https://pypi.org/project/yapf/) with Google style.
   Run `hatch run fmt-check` to check, `hatch run fmt` to format in place.
+- **Docstring formatter:** [docformatter](https://github.com/PyCQA/docformatter)
+  enforces [PEP 257](https://peps.python.org/pep-0257/) style. Configuration
+  is in `pyproject.toml` under `[tool.docformatter]`. Run
+  `hatch run docfmt-check` to check, `hatch run docfmt` to format in place.
+  Always run `docfmt` after `fmt` — the two tools must both be satisfied before
+  committing. `pika/spec.py` is excluded.
 - **Linter:** [ruff](https://docs.astral.sh/ruff/). Configuration is in
   `pyproject.toml` under `[tool.ruff]`. Run `hatch run lint`.
 - **Type checking:** [mypy](https://mypy-lang.org/). Configuration is in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,7 @@ examples/               # usage examples
 - **Docstring formatter:** [docformatter](https://github.com/PyCQA/docformatter)
   enforces [PEP 257](https://peps.python.org/pep-0257/) style. Configuration
   is in `pyproject.toml` under `[tool.docformatter]`. Run
-  `hatch run docfmt-check` to check, `hatch run docfmt` to format in place.
-  Always run `docfmt` after `fmt` — the two tools must both be satisfied before
-  committing. `pika/spec.py` is excluded.
+  `hatch run docfmt-check`.
 - **Linter:** [ruff](https://docs.astral.sh/ruff/). Configuration is in
   `pyproject.toml` under `[tool.ruff]`. Run `hatch run lint`.
 - **Type checking:** [mypy](https://mypy-lang.org/). Configuration is in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,4 +119,12 @@ To verify linting without modifying files (mirrors CI), use
 
     hatch run lint-check
 
-Both checks run in CI on every push and pull request.
+Please also format docstrings using [docformatter](https://github.com/PyCQA/docformatter), which enforces [PEP 257](https://peps.python.org/pep-0257/) style:
+
+    hatch run docfmt
+
+To verify docstring formatting without modifying files (mirrors CI), use
+
+    hatch run docfmt-check
+
+All three checks (`fmt-check`, `lint-check`, `docfmt-check`) run in CI on every push and pull request.

--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -11,29 +11,29 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ExampleConsumer:
-    """This is an example consumer that will handle unexpected interactions
-    with RabbitMQ such as channel and connection closures.
-
-    If RabbitMQ closes the connection, this class will stop and indicate
-    that reconnection is necessary. You should look at the output, as
-    there are limited reasons why the connection may be closed, which
-    usually are tied to permission related issues or socket timeouts.
-
-    If the channel is closed, it will indicate a problem with one of the
-    commands that were issued and that should surface in the output as well.
-
     """
+    This is an example consumer that will handle unexpected interactions with RabbitMQ such as
+    channel and connection closures.
+
+    If RabbitMQ closes the connection, this class will stop and indicate that reconnection is
+    necessary. You should look at the output, as there are limited reasons why the connection may be
+    closed, which usually are tied to permission related issues or socket timeouts.
+
+    If the channel is closed, it will indicate a problem with one of the commands that were issued
+    and that should surface in the output as well.
+    """
+
     EXCHANGE = 'message'
     EXCHANGE_TYPE = ExchangeType.topic
     QUEUE = 'text'
     ROUTING_KEY = 'example.text'
 
     def __init__(self, amqp_url):
-        """Create a new instance of the consumer class, passing in the AMQP
-        URL used to connect to RabbitMQ.
+        """
+        Create a new instance of the consumer class, passing in the AMQP URL used to connect to
+        RabbitMQ.
 
         :param str amqp_url: The AMQP url to connect with
-
         """
         self.should_reconnect = False
         self.was_consuming = False
@@ -48,11 +48,13 @@ class ExampleConsumer:
         # for higher consumer throughput
         self._prefetch_count = 1
 
-    def connect(self) -> pika.SelectConnection:
-        """This method connects to RabbitMQ, returning the connection handle.
-        When the connection is established, the on_connection_open method
-        will be invoked by pika.
+    def connect(self):
+        """
+        This method connects to RabbitMQ, returning the connection handle.
 
+        When the connection is established, the on_connection_open method will be invoked by pika.
+
+        :rtype: pika.SelectConnection
         """
         LOGGER.info('Connecting to %s', self._url)
         return pika.SelectConnection(
@@ -70,36 +72,35 @@ class ExampleConsumer:
             self._connection.close()
 
     def on_connection_open(self, _unused_connection):
-        """This method is called by pika once the connection to RabbitMQ has
-        been established. It passes the handle to the connection object in
-        case we need it, but in this case, we'll just mark it unused.
+        """
+        This method is called by pika once the connection to RabbitMQ has been established.
+
+        It passes the handle to the connection object in case we need it, but in this case, we'll
+        just mark it unused.
 
         :param pika.SelectConnection _unused_connection: The connection
-
         """
         LOGGER.info('Connection opened')
         self.open_channel()
 
     def on_connection_open_error(self, _unused_connection, err):
-        """This method is called by pika if the connection to RabbitMQ
-        can't be established.
+        """
+        This method is called by pika if the connection to RabbitMQ can't be established.
 
         :param pika.SelectConnection _unused_connection: The connection
         :param Exception err: The error
-
         """
         LOGGER.error('Connection open failed: %s', err)
         self.reconnect()
 
     def on_connection_closed(self, _connection, reason):
-        """This method is invoked by pika when the connection to RabbitMQ is
-        closed unexpectedly. Since it is unexpected, we will reconnect to
-        RabbitMQ if it disconnects.
+        """
+        This method is invoked by pika when the connection to RabbitMQ is closed unexpectedly.
+
+        Since it is unexpected, we will reconnect to RabbitMQ if it disconnects.
 
         :param pika.connection.Connection _connection: The closed connection obj
-        :param Exception reason: exception representing reason for loss of
-            connection.
-
+        :param Exception reason: exception representing reason for loss of connection.
         """
         self._channel = None
         if self._closing:
@@ -109,31 +110,33 @@ class ExampleConsumer:
             self.reconnect()
 
     def reconnect(self):
-        """Will be invoked if the connection can't be opened or is
-        closed. Indicates that a reconnect is necessary then stops the
-        ioloop.
+        """
+        Will be invoked if the connection can't be opened or is closed.
 
+        Indicates that a reconnect is necessary then stops the ioloop.
         """
         self.should_reconnect = True
         self.stop()
 
     def open_channel(self):
-        """Open a new channel with RabbitMQ by issuing the Channel.Open RPC
-        command. When RabbitMQ responds that the channel is open, the
-        on_channel_open callback will be invoked by pika.
+        """
+        Open a new channel with RabbitMQ by issuing the Channel.Open RPC command.
 
+        When RabbitMQ responds that the channel is open, the on_channel_open callback will be
+        invoked by pika.
         """
         LOGGER.info('Creating a new channel')
         self._connection.channel(on_open_callback=self.on_channel_open)
 
     def on_channel_open(self, channel):
-        """This method is invoked by pika when the channel has been opened.
+        """
+        This method is invoked by pika when the channel has been opened.
+
         The channel object is passed in so we can make use of it.
 
         Since the channel is now open, we'll declare the exchange to use.
 
         :param pika.channel.Channel channel: The channel object
-
         """
         LOGGER.info('Channel opened')
         self._channel = channel
@@ -141,34 +144,33 @@ class ExampleConsumer:
         self.setup_exchange(self.EXCHANGE)
 
     def add_on_channel_close_callback(self):
-        """This method tells pika to call the on_channel_closed method if
-        RabbitMQ unexpectedly closes the channel.
-
+        """This method tells pika to call the on_channel_closed method if RabbitMQ unexpectedly
+        closes the channel.
         """
         LOGGER.info('Adding channel close callback')
         self._channel.add_on_close_callback(self.on_channel_closed)
 
     def on_channel_closed(self, channel, reason):
-        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
-        Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an exchange or queue with
-        different parameters. In this case, we'll close the connection
-        to shutdown the object.
+        """
+        Invoked by pika when RabbitMQ unexpectedly closes the channel.
+
+        Channels are usually closed if you attempt to do something that violates the protocol, such
+        as re-declare an exchange or queue with different parameters. In this case, we'll close the
+        connection to shutdown the object.
 
         :param pika.channel.Channel: The closed channel
         :param Exception reason: why the channel was closed
-
         """
         LOGGER.warning('Channel %i was closed: %s', channel, reason)
         self.close_connection()
 
     def setup_exchange(self, exchange_name):
-        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
-        command. When it is complete, the on_exchange_declareok method will
-        be invoked by pika.
+        """
+        Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC command.
+
+        When it is complete, the on_exchange_declareok method will be invoked by pika.
 
         :param str|unicode exchange_name: The name of the exchange to declare
-
         """
         LOGGER.info('Declaring exchange: %s', exchange_name)
         # Note: using functools.partial is not required, it is demonstrating
@@ -180,38 +182,37 @@ class ExampleConsumer:
                                        callback=cb)
 
     def on_exchange_declareok(self, _frame, userdata):
-        """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
-        command.
+        """
+        Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC command.
 
-        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame
-        :param str|unicode userdata: Extra user data (exchange name)
-
+        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame :param str|unicode
+            userdata: Extra user data (exchange name)
         """
         LOGGER.info('Exchange declared: %s', userdata)
         self.setup_queue(self.QUEUE)
 
     def setup_queue(self, queue_name):
-        """Setup the queue on RabbitMQ by invoking the Queue.Declare RPC
-        command. When it is complete, the on_queue_declareok method will
-        be invoked by pika.
+        """
+        Setup the queue on RabbitMQ by invoking the Queue.Declare RPC command.
+
+        When it is complete, the on_queue_declareok method will be invoked by pika.
 
         :param str|unicode queue_name: The name of the queue to declare.
-
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
         self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
-        """Method invoked by pika when the Queue.Declare RPC call made in
-        setup_queue has completed. In this method we will bind the queue
-        and exchange together with the routing key by issuing the Queue.Bind
-        RPC command. When this command is complete, the on_bindok method will
-        be invoked by pika.
+        """
+        Method invoked by pika when the Queue.Declare RPC call made in setup_queue has completed.
 
-        :param pika.frame.Method _unused_frame: The Queue.DeclareOk frame
-        :param str|unicode userdata: Extra user data (queue name)
+        In this method we will bind the queue and exchange together with the routing key by issuing the
+        Queue.Bind RPC command. When this command is complete, the on_bindok method will be invoked
+        by pika.
 
+        :param pika.frame.Method _unused_frame: The Queue.DeclareOk frame :param str|unicode
+            userdata: Extra user data (queue name)
         """
         queue_name = userdata
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, queue_name,
@@ -223,46 +224,48 @@ class ExampleConsumer:
                                  callback=cb)
 
     def on_bindok(self, _unused_frame, userdata):
-        """Invoked by pika when the Queue.Bind method has completed. At this
-        point we will set the prefetch count for the channel.
+        """
+        Invoked by pika when the Queue.Bind method has completed.
 
-        :param pika.frame.Method _unused_frame: The Queue.BindOk response frame
-        :param str|unicode userdata: Extra user data (queue name)
+        At this point we will set the prefetch count for the channel.
 
+        :param pika.frame.Method _unused_frame: The Queue.BindOk response frame :param str|unicode
+            userdata: Extra user data (queue name)
         """
         LOGGER.info('Queue bound: %s', userdata)
         self.set_qos()
 
     def set_qos(self):
-        """This method sets up the consumer prefetch to only be delivered
-        one message at a time. The consumer must acknowledge this message
-        before RabbitMQ will deliver another one. You should experiment
-        with different prefetch values to achieve desired performance.
+        """
+        This method sets up the consumer prefetch to only be delivered one message at a time.
 
+        The consumer must acknowledge this message before RabbitMQ will deliver another one. You
+        should experiment with different prefetch values to achieve desired performance.
         """
         self._channel.basic_qos(prefetch_count=self._prefetch_count,
                                 callback=self.on_basic_qos_ok)
 
     def on_basic_qos_ok(self, _unused_frame):
-        """Invoked by pika when the Basic.QoS method has completed. At this
-        point we will start consuming messages by calling start_consuming
-        which will invoke the needed RPC commands to start the process.
+        """
+        Invoked by pika when the Basic.QoS method has completed.
+
+        At this point we will start consuming messages by calling start_consuming which will invoke
+        the needed RPC commands to start the process.
 
         :param pika.frame.Method _unused_frame: The Basic.QosOk response frame
-
         """
         LOGGER.info('QOS set to: %d', self._prefetch_count)
         self.start_consuming()
 
     def start_consuming(self):
-        """This method sets up the consumer by first calling
-        add_on_cancel_callback so that the object is notified if RabbitMQ
-        cancels the consumer. It then issues the Basic.Consume RPC command
-        which returns the consumer tag that is used to uniquely identify the
-        consumer with RabbitMQ. We keep the value to use it when we want to
-        cancel consuming. The on_message method is passed in as a callback pika
-        will invoke when a message is fully received.
+        """
+        This method sets up the consumer by first calling add_on_cancel_callback so that the object
+        is notified if RabbitMQ cancels the consumer.
 
+        It then issues the Basic.Consume RPC command which returns the consumer tag that is used to
+        uniquely identify the consumer with RabbitMQ. We keep the value to use it when we want to
+        cancel consuming. The on_message method is passed in as a callback pika will invoke when a
+        message is fully received.
         """
         LOGGER.info('Issuing consumer related RPC commands')
         self.add_on_cancel_callback()
@@ -272,57 +275,55 @@ class ExampleConsumer:
         self._consuming = True
 
     def add_on_cancel_callback(self):
-        """Add a callback that will be invoked if RabbitMQ cancels the consumer
-        for some reason. If RabbitMQ does cancel the consumer,
-        on_consumer_cancelled will be invoked by pika.
+        """
+        Add a callback that will be invoked if RabbitMQ cancels the consumer for some reason.
 
+        If RabbitMQ does cancel the consumer, on_consumer_cancelled will be invoked by pika.
         """
         LOGGER.info('Adding consumer cancellation callback')
         self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
 
     def on_consumer_cancelled(self, method_frame):
-        """Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer
-        receiving messages.
+        """
+        Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer receiving messages.
 
         :param pika.frame.Method method_frame: The Basic.Cancel frame
-
         """
         LOGGER.info('Consumer was cancelled remotely, shutting down: %r',
                     method_frame)
         self._channel.close()
 
     def on_message(self, _unused_channel, basic_deliver, properties, body):
-        """Invoked by pika when a message is delivered from RabbitMQ. The
-        channel is passed for your convenience. The basic_deliver object that
-        is passed in carries the exchange, routing key, delivery tag and
-        a redelivered flag for the message. The properties passed in is an
-        instance of BasicProperties with the message properties and the body
-        is the message that was sent.
+        """
+        Invoked by pika when a message is delivered from RabbitMQ.
+
+        The channel is passed for your convenience. The basic_deliver object that is passed in
+        carries the exchange, routing key, delivery tag and a redelivered flag for the message. The
+        properties passed in is an instance of BasicProperties with the message properties and the
+        body is the message that was sent.
 
         :param pika.channel.Channel _unused_channel: The channel object
         :param pika.Spec.Basic.Deliver: basic_deliver method
         :param pika.Spec.BasicProperties: properties
         :param bytes body: The message body
-
         """
         LOGGER.info('Received message # %s from %s: %s',
                     basic_deliver.delivery_tag, properties.app_id, body)
         self.acknowledge_message(basic_deliver.delivery_tag)
 
     def acknowledge_message(self, delivery_tag):
-        """Acknowledge the message delivery from RabbitMQ by sending a
-        Basic.Ack RPC method for the delivery tag.
+        """
+        Acknowledge the message delivery from RabbitMQ by sending a Basic.Ack RPC method for the
+        delivery tag.
 
         :param int delivery_tag: The delivery tag from the Basic.Deliver frame
-
         """
         LOGGER.info('Acknowledging message %s', delivery_tag)
         self._channel.basic_ack(delivery_tag)
 
     def stop_consuming(self):
-        """Tell RabbitMQ that you would like to stop consuming by sending the
-        Basic.Cancel RPC command.
-
+        """Tell RabbitMQ that you would like to stop consuming by sending the Basic.Cancel RPC
+        command.
         """
         if self._channel:
             LOGGER.info('Sending a Basic.Cancel RPC command to RabbitMQ')
@@ -331,14 +332,14 @@ class ExampleConsumer:
             self._channel.basic_cancel(self._consumer_tag, cb)
 
     def on_cancelok(self, _unused_frame, userdata):
-        """This method is invoked by pika when RabbitMQ acknowledges the
-        cancellation of a consumer. At this point we will close the channel.
-        This will invoke the on_channel_closed method once the channel has been
-        closed, which will in-turn close the connection.
+        """
+        This method is invoked by pika when RabbitMQ acknowledges the cancellation of a consumer.
 
-        :param pika.frame.Method _unused_frame: The Basic.CancelOk frame
-        :param str|unicode userdata: Extra user data (consumer tag)
+        At this point we will close the channel. This will invoke the on_channel_closed method once the
+        channel has been closed, which will in-turn close the connection.
 
+        :param pika.frame.Method _unused_frame: The Basic.CancelOk frame :param str|unicode
+            userdata: Extra user data (consumer tag)
         """
         self._consuming = False
         LOGGER.info(
@@ -347,31 +348,28 @@ class ExampleConsumer:
         self.close_channel()
 
     def close_channel(self):
-        """Call to close the channel with RabbitMQ cleanly by issuing the
-        Channel.Close RPC command.
-
+        """Call to close the channel with RabbitMQ cleanly by issuing the Channel.Close RPC
+        command.
         """
         LOGGER.info('Closing the channel')
         self._channel.close()
 
     def run(self):
-        """Run the example consumer by connecting to RabbitMQ and then
-        starting the IOLoop to block and allow the SelectConnection to operate.
-
+        """Run the example consumer by connecting to RabbitMQ and then starting the IOLoop to block
+        and allow the SelectConnection to operate.
         """
         self._connection = self.connect()
         self._connection.ioloop.start()
 
     def stop(self):
-        """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
-        with RabbitMQ. When RabbitMQ confirms the cancellation, on_cancelok
-        will be invoked by pika, which will then closing the channel and
-        connection. The IOLoop is started again because this method is invoked
-        when CTRL-C is pressed raising a KeyboardInterrupt exception. This
-        exception stops the IOLoop which needs to be running for pika to
-        communicate with RabbitMQ. All of the commands issued prior to starting
-        the IOLoop will be buffered but not processed.
+        """
+        Cleanly shutdown the connection to RabbitMQ by stopping the consumer with RabbitMQ.
 
+        When RabbitMQ confirms the cancellation, on_cancelok will be invoked by pika, which will
+        then closing the channel and connection. The IOLoop is started again because this method is
+        invoked when CTRL-C is pressed raising a KeyboardInterrupt exception. This exception stops
+        the IOLoop which needs to be running for pika to communicate with RabbitMQ. All of the
+        commands issued prior to starting the IOLoop will be buffered but not processed.
         """
         if not self._closing:
             self._closing = True
@@ -385,9 +383,8 @@ class ExampleConsumer:
 
 
 class ReconnectingExampleConsumer:
-    """This is an example consumer that will reconnect if the nested
-    ExampleConsumer indicates that a reconnect is necessary.
-
+    """This is an example consumer that will reconnect if the nested ExampleConsumer indicates that
+    a reconnect is necessary.
     """
 
     def __init__(self, amqp_url):

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -11,18 +11,18 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ExamplePublisher:
-    """This is an example publisher that will handle unexpected interactions
-    with RabbitMQ such as channel and connection closures.
-
-    If RabbitMQ closes the connection, it will reopen it. You should
-    look at the output, as there are limited reasons why the connection may
-    be closed, which usually are tied to permission related issues or
-    socket timeouts.
-
-    It uses delivery confirmations and illustrates one way to keep track of
-    messages that have been sent and if they've been confirmed by RabbitMQ.
-
     """
+    This is an example publisher that will handle unexpected interactions with RabbitMQ such as
+    channel and connection closures.
+
+    If RabbitMQ closes the connection, it will reopen it. You should look at the output, as there
+    are limited reasons why the connection may be closed, which usually are tied to permission
+    related issues or socket timeouts.
+
+    It uses delivery confirmations and illustrates one way to keep track of messages that have been
+    sent and if they've been confirmed by RabbitMQ.
+    """
+
     EXCHANGE = 'message'
     EXCHANGE_TYPE = ExchangeType.topic
     PUBLISH_INTERVAL = 1
@@ -30,11 +30,10 @@ class ExamplePublisher:
     ROUTING_KEY = 'example.text'
 
     def __init__(self, amqp_url):
-        """Setup the example publisher object, passing in the URL we will use
-        to connect to RabbitMQ.
+        """
+        Setup the example publisher object, passing in the URL we will use to connect to RabbitMQ.
 
         :param str amqp_url: The URL for connecting to RabbitMQ
-
         """
         self._connection = None
         self._channel = None
@@ -47,11 +46,13 @@ class ExamplePublisher:
         self._stopping = False
         self._url = amqp_url
 
-    def connect(self) -> pika.SelectConnection:
-        """This method connects to RabbitMQ, returning the connection handle.
-        When the connection is established, the on_connection_open method
-        will be invoked by pika.
+    def connect(self):
+        """
+        This method connects to RabbitMQ, returning the connection handle.
 
+        When the connection is established, the on_connection_open method will be invoked by pika.
+
+        :rtype: pika.SelectConnection
         """
         LOGGER.info('Connecting to %s', self._url)
         return pika.SelectConnection(
@@ -61,36 +62,35 @@ class ExamplePublisher:
             on_close_callback=self.on_connection_closed)
 
     def on_connection_open(self, _unused_connection):
-        """This method is called by pika once the connection to RabbitMQ has
-        been established. It passes the handle to the connection object in
-        case we need it, but in this case, we'll just mark it unused.
+        """
+        This method is called by pika once the connection to RabbitMQ has been established.
+
+        It passes the handle to the connection object in case we need it, but in this case, we'll
+        just mark it unused.
 
         :param pika.SelectConnection _unused_connection: The connection
-
         """
         LOGGER.info('Connection opened')
         self.open_channel()
 
     def on_connection_open_error(self, _unused_connection, err):
-        """This method is called by pika if the connection to RabbitMQ
-        can't be established.
+        """
+        This method is called by pika if the connection to RabbitMQ can't be established.
 
         :param pika.SelectConnection _unused_connection: The connection
         :param Exception err: The error
-
         """
         LOGGER.error('Connection open failed, reopening in 5 seconds: %s', err)
         self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
 
     def on_connection_closed(self, _connection, reason):
-        """This method is invoked by pika when the connection to RabbitMQ is
-        closed unexpectedly. Since it is unexpected, we will reconnect to
-        RabbitMQ if it disconnects.
+        """
+        This method is invoked by pika when the connection to RabbitMQ is closed unexpectedly.
+
+        Since it is unexpected, we will reconnect to RabbitMQ if it disconnects.
 
         :param pika.connection.Connection _connection: The closed connection obj
-        :param Exception reason: exception representing reason for loss of
-            connection.
-
+        :param Exception reason: exception representing reason for loss of connection.
         """
         self._channel = None
         if self._stopping:
@@ -101,23 +101,24 @@ class ExamplePublisher:
             self._connection.ioloop.call_later(5, self._connection.ioloop.stop)
 
     def open_channel(self):
-        """This method will open a new channel with RabbitMQ by issuing the
-        Channel.Open RPC command. When RabbitMQ confirms the channel is open
-        by sending the Channel.OpenOK RPC reply, the on_channel_open method
-        will be invoked.
+        """
+        This method will open a new channel with RabbitMQ by issuing the Channel.Open RPC command.
 
+        When RabbitMQ confirms the channel is open by sending the Channel.OpenOK RPC reply, the
+        on_channel_open method will be invoked.
         """
         LOGGER.info('Creating a new channel')
         self._connection.channel(on_open_callback=self.on_channel_open)
 
     def on_channel_open(self, channel):
-        """This method is invoked by pika when the channel has been opened.
+        """
+        This method is invoked by pika when the channel has been opened.
+
         The channel object is passed in so we can make use of it.
 
         Since the channel is now open, we'll declare the exchange to use.
 
         :param pika.channel.Channel channel: The channel object
-
         """
         LOGGER.info('Channel opened')
         self._channel = channel
@@ -125,23 +126,22 @@ class ExamplePublisher:
         self.setup_exchange(self.EXCHANGE)
 
     def add_on_channel_close_callback(self):
-        """This method tells pika to call the on_channel_closed method if
-        RabbitMQ unexpectedly closes the channel.
-
+        """This method tells pika to call the on_channel_closed method if RabbitMQ unexpectedly
+        closes the channel.
         """
         LOGGER.info('Adding channel close callback')
         self._channel.add_on_close_callback(self.on_channel_closed)
 
     def on_channel_closed(self, channel, reason):
-        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
-        Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an exchange or queue with
-        different parameters. In this case, we'll close the connection
-        to shutdown the object.
+        """
+        Invoked by pika when RabbitMQ unexpectedly closes the channel.
+
+        Channels are usually closed if you attempt to do something that violates the protocol, such
+        as re-declare an exchange or queue with different parameters. In this case, we'll close the
+        connection to shutdown the object.
 
         :param pika.channel.Channel channel: The closed channel
         :param Exception reason: why the channel was closed
-
         """
         LOGGER.warning('Channel %i was closed: %s', channel, reason)
         self._channel = None
@@ -149,12 +149,12 @@ class ExamplePublisher:
             self._connection.close()
 
     def setup_exchange(self, exchange_name):
-        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
-        command. When it is complete, the on_exchange_declareok method will
-        be invoked by pika.
+        """
+        Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC command.
+
+        When it is complete, the on_exchange_declareok method will be invoked by pika.
 
         :param str|unicode exchange_name: The name of the exchange to declare
-
         """
         LOGGER.info('Declaring exchange %s', exchange_name)
         # Note: using functools.partial is not required, it is demonstrating
@@ -166,23 +166,22 @@ class ExamplePublisher:
                                        callback=cb)
 
     def on_exchange_declareok(self, _frame, userdata):
-        """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
-        command.
+        """
+        Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC command.
 
-        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame
-        :param str|unicode userdata: Extra user data (exchange name)
-
+        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame :param str|unicode
+            userdata: Extra user data (exchange name)
         """
         LOGGER.info('Exchange declared: %s', userdata)
         self.setup_queue(self.QUEUE)
 
     def setup_queue(self, queue_name):
-        """Setup the queue on RabbitMQ by invoking the Queue.Declare RPC
-        command. When it is complete, the on_queue_declareok method will
-        be invoked by pika.
+        """
+        Setup the queue on RabbitMQ by invoking the Queue.Declare RPC command.
+
+        When it is complete, the on_queue_declareok method will be invoked by pika.
 
         :param str|unicode queue_name: The name of the queue to declare.
-
         """
         LOGGER.info('Declaring queue %s', queue_name)
         self._channel.queue_declare(queue=queue_name,
@@ -190,14 +189,14 @@ class ExamplePublisher:
                                     callback=self.on_queue_declareok)
 
     def on_queue_declareok(self, _frame):
-        """Method invoked by pika when the Queue.Declare RPC call made in
-        setup_queue has completed. In this method we will bind the queue
-        and exchange together with the routing key by issuing the Queue.Bind
-        RPC command. When this command is complete, the on_bindok method will
-        be invoked by pika.
+        """
+        Method invoked by pika when the Queue.Declare RPC call made in setup_queue has completed.
+
+        In this method we will bind the queue and exchange together with the routing key by issuing
+        the Queue.Bind RPC command. When this command is complete, the on_bindok method will be
+        invoked by pika.
 
         :param pika.frame.Method _frame: The Queue.DeclareOk frame
-
         """
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, self.QUEUE,
                     self.ROUTING_KEY)
@@ -207,47 +206,44 @@ class ExamplePublisher:
                                  callback=self.on_bindok)
 
     def on_bindok(self, _unused_frame):
-        """This method is invoked by pika when it receives the Queue.BindOk
-        response from RabbitMQ. Since we know we're now setup and bound, it's
-        time to start publishing."""
+        """
+        This method is invoked by pika when it receives the Queue.BindOk response from RabbitMQ.
+
+        Since we know we're now setup and bound, it's time to start publishing.
+        """
         LOGGER.info('Queue bound')
         self.start_publishing()
 
     def start_publishing(self):
-        """This method will enable delivery confirmations and schedule the
-        first message to be sent to RabbitMQ
-
+        """This method will enable delivery confirmations and schedule the first message to be sent
+        to RabbitMQ.
         """
         LOGGER.info('Issuing consumer related RPC commands')
         self.enable_delivery_confirmations()
         self.schedule_next_message()
 
     def enable_delivery_confirmations(self):
-        """Send the Confirm.Select RPC method to RabbitMQ to enable delivery
-        confirmations on the channel. The only way to turn this off is to close
-        the channel and create a new one.
+        """
+        Send the Confirm.Select RPC method to RabbitMQ to enable delivery confirmations on the
+        channel. The only way to turn this off is to close the channel and create a new one.
 
-        When the message is confirmed from RabbitMQ, the
-        on_delivery_confirmation method will be invoked passing in a Basic.Ack
-        or Basic.Nack method from RabbitMQ that will indicate which messages it
-        is confirming or rejecting.
-
+        When the message is confirmed from RabbitMQ, the on_delivery_confirmation method will be
+        invoked passing in a Basic.Ack or Basic.Nack method from RabbitMQ that will indicate which
+        messages it is confirming or rejecting.
         """
         LOGGER.info('Issuing Confirm.Select RPC command')
         self._channel.confirm_delivery(self.on_delivery_confirmation)
 
     def on_delivery_confirmation(self, method_frame):
-        """Invoked by pika when RabbitMQ responds to a Basic.Publish RPC
-        command, passing in either a Basic.Ack or Basic.Nack frame with
-        the delivery tag of the message that was published. The delivery tag
-        is an integer counter indicating the message number that was sent
-        on the channel via Basic.Publish. Here we're just doing house keeping
-        to keep track of stats and remove message numbers that we expect
-        a delivery confirmation of from the list used to keep track of messages
-        that are pending confirmation.
+        """
+        Invoked by pika when RabbitMQ responds to a Basic.Publish RPC command, passing in either a
+        Basic.Ack or Basic.Nack frame with the delivery tag of the message that was published. The
+        delivery tag is an integer counter indicating the message number that was sent on the
+        channel via Basic.Publish. Here we're just doing house keeping to keep track of stats and
+        remove message numbers that we expect a delivery confirmation of from the list used to keep
+        track of messages that are pending confirmation.
 
         :param pika.frame.Method method_frame: Basic.Ack or Basic.Nack frame
-
         """
         confirmation_type = method_frame.method.NAME.split('.')[1].lower()
         ack_multiple = method_frame.method.multiple
@@ -268,20 +264,17 @@ class ExamplePublisher:
                 if tmp_tag <= delivery_tag:
                     self._acked += 1
                     del self._deliveries[tmp_tag]
+        """NOTE: at some point you would check self._deliveries for stale entries and decide to
+        attempt re-delivery.
         """
-        NOTE: at some point you would check self._deliveries for stale
-        entries and decide to attempt re-delivery
-        """
-
         LOGGER.info(
             'Published %i messages, %i have yet to be confirmed, '
             '%i were acked and %i were nacked', self._message_number,
             len(self._deliveries), self._acked, self._nacked)
 
     def schedule_next_message(self):
-        """If we are not closing our connection to RabbitMQ, schedule another
-        message to be delivered in PUBLISH_INTERVAL seconds.
-
+        """If we are not closing our connection to RabbitMQ, schedule another message to be
+        delivered in PUBLISH_INTERVAL seconds.
         """
         LOGGER.info('Scheduling next message for %0.1f seconds',
                     self.PUBLISH_INTERVAL)
@@ -289,17 +282,15 @@ class ExamplePublisher:
                                            self.publish_message)
 
     def publish_message(self):
-        """If the class is not stopping, publish a message to RabbitMQ,
-        appending a list of deliveries with the message number that was sent.
-        This list will be used to check for delivery confirmations in the
-        on_delivery_confirmations method.
+        """
+        If the class is not stopping, publish a message to RabbitMQ, appending a list of deliveries
+        with the message number that was sent. This list will be used to check for delivery
+        confirmations in the on_delivery_confirmations method.
 
-        Once the message has been sent, schedule another message to be sent.
-        The main reason I put scheduling in was just so you can get a good idea
-        of how the process is flowing by slowing down and speeding up the
-        delivery intervals by changing the PUBLISH_INTERVAL constant in the
+        Once the message has been sent, schedule another message to be sent. The main reason I put
+        scheduling in was just so you can get a good idea of how the process is flowing by slowing
+        down and speeding up the delivery intervals by changing the PUBLISH_INTERVAL constant in the
         class.
-
         """
         if self._channel is None or not self._channel.is_open:
             return
@@ -319,9 +310,7 @@ class ExamplePublisher:
         self.schedule_next_message()
 
     def run(self):
-        """Run the example code by connecting and then starting the IOLoop.
-
-        """
+        """Run the example code by connecting and then starting the IOLoop."""
         while not self._stopping:
             self._connection = None
             self._deliveries = {}
@@ -341,13 +330,13 @@ class ExamplePublisher:
         LOGGER.info('Stopped')
 
     def stop(self):
-        """Stop the example by closing the channel and connection. We
-        set a flag here so that we stop scheduling new messages to be
-        published. The IOLoop is started because this method is
-        invoked by the Try/Catch below when KeyboardInterrupt is caught.
-        Starting the IOLoop again will allow the publisher to cleanly
-        disconnect from RabbitMQ.
+        """
+        Stop the example by closing the channel and connection.
 
+        We set a flag here so that we stop scheduling new messages to be published. The IOLoop is
+        started because this method is invoked by the Try/Catch below when KeyboardInterrupt is
+        caught. Starting the IOLoop again will allow the publisher to cleanly disconnect from
+        RabbitMQ.
         """
         LOGGER.info('Stopping')
         self._stopping = True
@@ -355,9 +344,8 @@ class ExamplePublisher:
         self.close_connection()
 
     def close_channel(self):
-        """Invoke this command to close the channel with RabbitMQ by sending
-        the Channel.Close RPC command.
-
+        """Invoke this command to close the channel with RabbitMQ by sending the Channel.Close RPC
+        command.
         """
         if self._channel is not None:
             LOGGER.info('Closing the channel')

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -12,29 +12,29 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ExampleConsumer:
-    """This is an example consumer that will handle unexpected interactions
-    with RabbitMQ such as channel and connection closures.
-
-    If RabbitMQ closes the connection, this class will stop and indicate
-    that reconnection is necessary. You should look at the output, as
-    there are limited reasons why the connection may be closed, which
-    usually are tied to permission related issues or socket timeouts.
-
-    If the channel is closed, it will indicate a problem with one of the
-    commands that were issued and that should surface in the output as well.
-
     """
+    This is an example consumer that will handle unexpected interactions with RabbitMQ such as
+    channel and connection closures.
+
+    If RabbitMQ closes the connection, this class will stop and indicate that reconnection is
+    necessary. You should look at the output, as there are limited reasons why the connection may be
+    closed, which usually are tied to permission related issues or socket timeouts.
+
+    If the channel is closed, it will indicate a problem with one of the commands that were issued
+    and that should surface in the output as well.
+    """
+
     EXCHANGE = 'message'
     EXCHANGE_TYPE = ExchangeType.topic
     QUEUE = 'text'
     ROUTING_KEY = 'example.text'
 
     def __init__(self, amqp_url):
-        """Create a new instance of the consumer class, passing in the AMQP
-        URL used to connect to RabbitMQ.
+        """
+        Create a new instance of the consumer class, passing in the AMQP URL used to connect to
+        RabbitMQ.
 
         :param str amqp_url: The AMQP url to connect with
-
         """
         self.should_reconnect = False
         self.was_consuming = False
@@ -49,11 +49,13 @@ class ExampleConsumer:
         # for higher consumer throughput
         self._prefetch_count = 1
 
-    def connect(self) -> AsyncioConnection:
-        """This method connects to RabbitMQ, returning the connection handle.
-        When the connection is established, the on_connection_open method
-        will be invoked by pika.
+    def connect(self):
+        """
+        This method connects to RabbitMQ, returning the connection handle.
 
+        When the connection is established, the on_connection_open method will be invoked by pika.
+
+        :rtype: pika.adapters.asyncio_connection.AsyncioConnection
         """
         LOGGER.info('Connecting to %s', self._url)
         return AsyncioConnection(
@@ -71,38 +73,36 @@ class ExampleConsumer:
             self._connection.close()
 
     def on_connection_open(self, _unused_connection):
-        """This method is called by pika once the connection to RabbitMQ has
-        been established. It passes the handle to the connection object in
-        case we need it, but in this case, we'll just mark it unused.
+        """
+        This method is called by pika once the connection to RabbitMQ has been established.
 
-        :param pika.adapters.asyncio_connection.AsyncioConnection _unused_connection:
-           The connection
+        It passes the handle to the connection object in case we need it, but in this case, we'll
+        just mark it unused.
 
+        :param pika.adapters.asyncio_connection.AsyncioConnection _unused_connection: The connection
         """
         LOGGER.info('Connection opened')
         self.open_channel()
 
     def on_connection_open_error(self, _unused_connection, err):
-        """This method is called by pika if the connection to RabbitMQ
-        can't be established.
+        """
+        This method is called by pika if the connection to RabbitMQ can't be established.
 
         :param pika.adapters.asyncio_connection.AsyncioConnection _unused_connection:
            The connection
         :param Exception err: The error
-
         """
         LOGGER.error('Connection open failed: %s', err)
         self.reconnect()
 
     def on_connection_closed(self, _connection, reason):
-        """This method is invoked by pika when the connection to RabbitMQ is
-        closed unexpectedly. Since it is unexpected, we will reconnect to
-        RabbitMQ if it disconnects.
+        """
+        This method is invoked by pika when the connection to RabbitMQ is closed unexpectedly.
+
+        Since it is unexpected, we will reconnect to RabbitMQ if it disconnects.
 
         :param pika.connection.Connection _connection: The closed connection obj
-        :param Exception reason: exception representing reason for loss of
-            connection.
-
+        :param Exception reason: exception representing reason for loss of connection.
         """
         self._channel = None
         if self._closing:
@@ -112,31 +112,33 @@ class ExampleConsumer:
             self.reconnect()
 
     def reconnect(self):
-        """Will be invoked if the connection can't be opened or is
-        closed. Indicates that a reconnect is necessary then stops the
-        ioloop.
+        """
+        Will be invoked if the connection can't be opened or is closed.
 
+        Indicates that a reconnect is necessary then stops the ioloop.
         """
         self.should_reconnect = True
         self.stop()
 
     def open_channel(self):
-        """Open a new channel with RabbitMQ by issuing the Channel.Open RPC
-        command. When RabbitMQ responds that the channel is open, the
-        on_channel_open callback will be invoked by pika.
+        """
+        Open a new channel with RabbitMQ by issuing the Channel.Open RPC command.
 
+        When RabbitMQ responds that the channel is open, the on_channel_open callback will be
+        invoked by pika.
         """
         LOGGER.info('Creating a new channel')
         self._connection.channel(on_open_callback=self.on_channel_open)
 
     def on_channel_open(self, channel):
-        """This method is invoked by pika when the channel has been opened.
+        """
+        This method is invoked by pika when the channel has been opened.
+
         The channel object is passed in so we can make use of it.
 
         Since the channel is now open, we'll declare the exchange to use.
 
         :param pika.channel.Channel channel: The channel object
-
         """
         LOGGER.info('Channel opened')
         self._channel = channel
@@ -144,34 +146,33 @@ class ExampleConsumer:
         self.setup_exchange(self.EXCHANGE)
 
     def add_on_channel_close_callback(self):
-        """This method tells pika to call the on_channel_closed method if
-        RabbitMQ unexpectedly closes the channel.
-
+        """This method tells pika to call the on_channel_closed method if RabbitMQ unexpectedly
+        closes the channel.
         """
         LOGGER.info('Adding channel close callback')
         self._channel.add_on_close_callback(self.on_channel_closed)
 
     def on_channel_closed(self, channel, reason):
-        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
-        Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an exchange or queue with
-        different parameters. In this case, we'll close the connection
-        to shutdown the object.
+        """
+        Invoked by pika when RabbitMQ unexpectedly closes the channel.
+
+        Channels are usually closed if you attempt to do something that violates the protocol, such
+        as re-declare an exchange or queue with different parameters. In this case, we'll close the
+        connection to shutdown the object.
 
         :param pika.channel.Channel: The closed channel
         :param Exception reason: why the channel was closed
-
         """
         LOGGER.warning('Channel %i was closed: %s', channel, reason)
         self.close_connection()
 
     def setup_exchange(self, exchange_name):
-        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
-        command. When it is complete, the on_exchange_declareok method will
-        be invoked by pika.
+        """
+        Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC command.
+
+        When it is complete, the on_exchange_declareok method will be invoked by pika.
 
         :param str|unicode exchange_name: The name of the exchange to declare
-
         """
         LOGGER.info('Declaring exchange: %s', exchange_name)
         # Note: using functools.partial is not required, it is demonstrating
@@ -183,38 +184,37 @@ class ExampleConsumer:
                                        callback=cb)
 
     def on_exchange_declareok(self, _frame, userdata):
-        """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
-        command.
+        """
+        Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC command.
 
-        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame
-        :param str|unicode userdata: Extra user data (exchange name)
-
+        :param pika.Frame.Method _frame: Exchange.DeclareOk response frame :param str|unicode
+            userdata: Extra user data (exchange name)
         """
         LOGGER.info('Exchange declared: %s', userdata)
         self.setup_queue(self.QUEUE)
 
     def setup_queue(self, queue_name):
-        """Setup the queue on RabbitMQ by invoking the Queue.Declare RPC
-        command. When it is complete, the on_queue_declareok method will
-        be invoked by pika.
+        """
+        Setup the queue on RabbitMQ by invoking the Queue.Declare RPC command.
+
+        When it is complete, the on_queue_declareok method will be invoked by pika.
 
         :param str|unicode queue_name: The name of the queue to declare.
-
         """
         LOGGER.info('Declaring queue %s', queue_name)
         cb = functools.partial(self.on_queue_declareok, userdata=queue_name)
         self._channel.queue_declare(queue=queue_name, durable=True, callback=cb)
 
     def on_queue_declareok(self, _unused_frame, userdata):
-        """Method invoked by pika when the Queue.Declare RPC call made in
-        setup_queue has completed. In this method we will bind the queue
-        and exchange together with the routing key by issuing the Queue.Bind
-        RPC command. When this command is complete, the on_bindok method will
-        be invoked by pika.
+        """
+        Method invoked by pika when the Queue.Declare RPC call made in setup_queue has completed.
 
-        :param pika.frame.Method _unused_frame: The Queue.DeclareOk frame
-        :param str|unicode userdata: Extra user data (queue name)
+        In this method we will bind the queue and exchange together with the routing key by issuing the
+        Queue.Bind RPC command. When this command is complete, the on_bindok method will be invoked
+        by pika.
 
+        :param pika.frame.Method _unused_frame: The Queue.DeclareOk frame :param str|unicode
+            userdata: Extra user data (queue name)
         """
         queue_name = userdata
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, queue_name,
@@ -226,46 +226,48 @@ class ExampleConsumer:
                                  callback=cb)
 
     def on_bindok(self, _unused_frame, userdata):
-        """Invoked by pika when the Queue.Bind method has completed. At this
-        point we will set the prefetch count for the channel.
+        """
+        Invoked by pika when the Queue.Bind method has completed.
 
-        :param pika.frame.Method _unused_frame: The Queue.BindOk response frame
-        :param str|unicode userdata: Extra user data (queue name)
+        At this point we will set the prefetch count for the channel.
 
+        :param pika.frame.Method _unused_frame: The Queue.BindOk response frame :param str|unicode
+            userdata: Extra user data (queue name)
         """
         LOGGER.info('Queue bound: %s', userdata)
         self.set_qos()
 
     def set_qos(self):
-        """This method sets up the consumer prefetch to only be delivered
-        one message at a time. The consumer must acknowledge this message
-        before RabbitMQ will deliver another one. You should experiment
-        with different prefetch values to achieve desired performance.
+        """
+        This method sets up the consumer prefetch to only be delivered one message at a time.
 
+        The consumer must acknowledge this message before RabbitMQ will deliver another one. You
+        should experiment with different prefetch values to achieve desired performance.
         """
         self._channel.basic_qos(prefetch_count=self._prefetch_count,
                                 callback=self.on_basic_qos_ok)
 
     def on_basic_qos_ok(self, _unused_frame):
-        """Invoked by pika when the Basic.QoS method has completed. At this
-        point we will start consuming messages by calling start_consuming
-        which will invoke the needed RPC commands to start the process.
+        """
+        Invoked by pika when the Basic.QoS method has completed.
+
+        At this point we will start consuming messages by calling start_consuming which will invoke
+        the needed RPC commands to start the process.
 
         :param pika.frame.Method _unused_frame: The Basic.QosOk response frame
-
         """
         LOGGER.info('QOS set to: %d', self._prefetch_count)
         self.start_consuming()
 
     def start_consuming(self):
-        """This method sets up the consumer by first calling
-        add_on_cancel_callback so that the object is notified if RabbitMQ
-        cancels the consumer. It then issues the Basic.Consume RPC command
-        which returns the consumer tag that is used to uniquely identify the
-        consumer with RabbitMQ. We keep the value to use it when we want to
-        cancel consuming. The on_message method is passed in as a callback pika
-        will invoke when a message is fully received.
+        """
+        This method sets up the consumer by first calling add_on_cancel_callback so that the object
+        is notified if RabbitMQ cancels the consumer.
 
+        It then issues the Basic.Consume RPC command which returns the consumer tag that is used to
+        uniquely identify the consumer with RabbitMQ. We keep the value to use it when we want to
+        cancel consuming. The on_message method is passed in as a callback pika will invoke when a
+        message is fully received.
         """
         LOGGER.info('Issuing consumer related RPC commands')
         self.add_on_cancel_callback()
@@ -275,20 +277,19 @@ class ExampleConsumer:
         self._consuming = True
 
     def add_on_cancel_callback(self):
-        """Add a callback that will be invoked if RabbitMQ cancels the consumer
-        for some reason. If RabbitMQ does cancel the consumer,
-        on_consumer_cancelled will be invoked by pika.
+        """
+        Add a callback that will be invoked if RabbitMQ cancels the consumer for some reason.
 
+        If RabbitMQ does cancel the consumer, on_consumer_cancelled will be invoked by pika.
         """
         LOGGER.info('Adding consumer cancellation callback')
         self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
 
     def on_consumer_cancelled(self, method_frame):
-        """Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer
-        receiving messages.
+        """
+        Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer receiving messages.
 
         :param pika.frame.Method method_frame: The Basic.Cancel frame
-
         """
         LOGGER.info('Consumer was cancelled remotely, shutting down: %r',
                     method_frame)
@@ -296,37 +297,36 @@ class ExampleConsumer:
             self._channel.close()
 
     def on_message(self, _unused_channel, basic_deliver, properties, body):
-        """Invoked by pika when a message is delivered from RabbitMQ. The
-        channel is passed for your convenience. The basic_deliver object that
-        is passed in carries the exchange, routing key, delivery tag and
-        a redelivered flag for the message. The properties passed in is an
-        instance of BasicProperties with the message properties and the body
-        is the message that was sent.
+        """
+        Invoked by pika when a message is delivered from RabbitMQ.
+
+        The channel is passed for your convenience. The basic_deliver object that is passed in
+        carries the exchange, routing key, delivery tag and a redelivered flag for the message. The
+        properties passed in is an instance of BasicProperties with the message properties and the
+        body is the message that was sent.
 
         :param pika.channel.Channel _unused_channel: The channel object
         :param pika.Spec.Basic.Deliver: basic_deliver method
         :param pika.Spec.BasicProperties: properties
         :param bytes body: The message body
-
         """
         LOGGER.info('Received message # %s from %s: %s',
                     basic_deliver.delivery_tag, properties.app_id, body)
         self.acknowledge_message(basic_deliver.delivery_tag)
 
     def acknowledge_message(self, delivery_tag):
-        """Acknowledge the message delivery from RabbitMQ by sending a
-        Basic.Ack RPC method for the delivery tag.
+        """
+        Acknowledge the message delivery from RabbitMQ by sending a Basic.Ack RPC method for the
+        delivery tag.
 
         :param int delivery_tag: The delivery tag from the Basic.Deliver frame
-
         """
         LOGGER.info('Acknowledging message %s', delivery_tag)
         self._channel.basic_ack(delivery_tag)
 
     def stop_consuming(self):
-        """Tell RabbitMQ that you would like to stop consuming by sending the
-        Basic.Cancel RPC command.
-
+        """Tell RabbitMQ that you would like to stop consuming by sending the Basic.Cancel RPC
+        command.
         """
         if self._channel:
             LOGGER.info('Sending a Basic.Cancel RPC command to RabbitMQ')
@@ -335,14 +335,14 @@ class ExampleConsumer:
             self._channel.basic_cancel(self._consumer_tag, cb)
 
     def on_cancelok(self, _unused_frame, userdata):
-        """This method is invoked by pika when RabbitMQ acknowledges the
-        cancellation of a consumer. At this point we will close the channel.
-        This will invoke the on_channel_closed method once the channel has been
-        closed, which will in-turn close the connection.
+        """
+        This method is invoked by pika when RabbitMQ acknowledges the cancellation of a consumer.
 
-        :param pika.frame.Method _unused_frame: The Basic.CancelOk frame
-        :param str|unicode userdata: Extra user data (consumer tag)
+        At this point we will close the channel. This will invoke the on_channel_closed method once the
+        channel has been closed, which will in-turn close the connection.
 
+        :param pika.frame.Method _unused_frame: The Basic.CancelOk frame :param str|unicode
+            userdata: Extra user data (consumer tag)
         """
         self._consuming = False
         LOGGER.info(
@@ -351,31 +351,28 @@ class ExampleConsumer:
         self.close_channel()
 
     def close_channel(self):
-        """Call to close the channel with RabbitMQ cleanly by issuing the
-        Channel.Close RPC command.
-
+        """Call to close the channel with RabbitMQ cleanly by issuing the Channel.Close RPC
+        command.
         """
         LOGGER.info('Closing the channel')
         self._channel.close()
 
     def run(self):
-        """Run the example consumer by connecting to RabbitMQ and then
-        starting the IOLoop to block and allow the AsyncioConnection to operate.
-
+        """Run the example consumer by connecting to RabbitMQ and then starting the IOLoop to block
+        and allow the AsyncioConnection to operate.
         """
         self._connection = self.connect()
         self._connection.ioloop.run_forever()
 
     def stop(self):
-        """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
-        with RabbitMQ. When RabbitMQ confirms the cancellation, on_cancelok
-        will be invoked by pika, which will then closing the channel and
-        connection. The IOLoop is started again because this method is invoked
-        when CTRL-C is pressed raising a KeyboardInterrupt exception. This
-        exception stops the IOLoop which needs to be running for pika to
-        communicate with RabbitMQ. All of the commands issued prior to starting
-        the IOLoop will be buffered but not processed.
+        """
+        Cleanly shutdown the connection to RabbitMQ by stopping the consumer with RabbitMQ.
 
+        When RabbitMQ confirms the cancellation, on_cancelok will be invoked by pika, which will
+        then closing the channel and connection. The IOLoop is started again because this method is
+        invoked when CTRL-C is pressed raising a KeyboardInterrupt exception. This exception stops
+        the IOLoop which needs to be running for pika to communicate with RabbitMQ. All of the
+        commands issued prior to starting the IOLoop will be buffered but not processed.
         """
         if not self._closing:
             self._closing = True
@@ -389,9 +386,8 @@ class ExampleConsumer:
 
 
 class ReconnectingExampleConsumer:
-    """This is an example consumer that will reconnect if the nested
-    ExampleConsumer indicates that a reconnect is necessary.
-
+    """This is an example consumer that will reconnect if the nested ExampleConsumer indicates that
+    a reconnect is necessary.
     """
 
     def __init__(self, amqp_url):

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -1,4 +1,5 @@
-"""Example: consuming with ThreadSafeConnection.
+"""
+Example: consuming with ThreadSafeConnection.
 
 ThreadSafeChannel dispatches each delivery on a dedicated per-channel worker
 thread, not the IOLoop thread.  Long-running work in the callback no longer
@@ -14,6 +15,7 @@ add_callback_threadsafe as the BlockingConnection-based example required.
 
 Pairs with examples/basic_publisher_threaded.py.  Run this consumer first.
 """
+
 import logging
 import random
 import threading

--- a/examples/basic_publisher_threaded.py
+++ b/examples/basic_publisher_threaded.py
@@ -1,12 +1,13 @@
-"""Example: publishing from multiple threads using ThreadSafeConnection.
+"""
+Example: publishing from multiple threads using ThreadSafeConnection.
 
-ThreadSafeConnection runs SelectConnection's IOLoop in a dedicated background
-thread.  Every call to channel.basic_publish() is routed through
-add_callback_threadsafe so that _tx_buffers is only ever touched from the
-IOLoop thread, eliminating the IndexError race seen in issues #1144 and #511.
+ThreadSafeConnection runs SelectConnection's IOLoop in a dedicated background thread.  Every call to
+channel.basic_publish() is routed through add_callback_threadsafe so that _tx_buffers is only ever
+touched from the IOLoop thread, eliminating the IndexError race seen in issues #1144 and #511.
 
 Pairs with examples/basic_consumer_threaded.py.  Run the consumer first.
 """
+
 import logging
 import threading
 

--- a/examples/blocking_consume_recover_multiple_hosts.py
+++ b/examples/blocking_consume_recover_multiple_hosts.py
@@ -1,7 +1,6 @@
 """
-This module implements a client that connects to multiple RabbitMQ brokers
-distributed across different ports (5672, 5673, 5674) and consumes messages
-from a shared queue.
+This module implements a client that connects to multiple RabbitMQ brokers distributed across
+different ports (5672, 5673, 5674) and consumes messages from a shared queue.
 
 The process follows these main steps:
 

--- a/examples/consume.py
+++ b/examples/consume.py
@@ -1,4 +1,5 @@
-"""Basic message consumer example"""
+"""Basic message consumer example."""
+
 import functools
 import logging
 
@@ -13,7 +14,11 @@ logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 
 
 def on_message(chan, method_frame, header_frame, body, userdata=None):
-    """Called when a message is received. Log message and ack it."""
+    """
+    Called when a message is received.
+
+    Log message and ack it.
+    """
     LOGGER.info('Delivery properties: %s, message metadata: %s', method_frame,
                 header_frame)
     LOGGER.info('Userdata: %s, message body: %s', userdata, body)

--- a/examples/direct_reply_to.py
+++ b/examples/direct_reply_to.py
@@ -1,6 +1,7 @@
 """
-This example demonstrates RabbitMQ's "Direct reply-to" usage via
-`pika.BlockingConnection`. See https://www.rabbitmq.com/direct-reply-to.html
+This example demonstrates RabbitMQ's "Direct reply-to" usage via `pika.BlockingConnection`.
+
+See https://www.rabbitmq.com/direct-reply-to.html
 for more info about this feature.
 """
 
@@ -10,13 +11,11 @@ SERVER_QUEUE = 'rpc.server.queue'
 
 
 def main():
-    """ Here, Client sends "Marco" to RPC Server, and RPC Server replies with
-    "Polo".
+    """
+    Here, Client sends "Marco" to RPC Server, and RPC Server replies with "Polo".
 
-    NOTE Normally, the server would be running separately from the client, but
-    in this very simple example both are running in the same thread and sharing
-    connection and channel.
-
+    NOTE Normally, the server would be running separately from the client, but in this very simple
+    example both are running in the same thread and sharing connection and channel.
     """
     with pika.BlockingConnection() as conn:
         channel = conn.channel()

--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -1,23 +1,19 @@
 """
-This example demonstrates explicit setting of heartbeat and blocked connection
-timeouts.
+This example demonstrates explicit setting of heartbeat and blocked connection timeouts.
 
-Starting with RabbitMQ 3.5.5, the broker's default hearbeat timeout decreased
-from 580 seconds to 60 seconds. As a result, applications that perform lengthy
-processing in the same thread that also runs their Pika connection may
-experience unexpected dropped connections due to heartbeat timeout. Here, we
-specify an explicit lower bound for heartbeat timeout.
+Starting with RabbitMQ 3.5.5, the broker's default hearbeat timeout decreased from 580 seconds to 60
+seconds. As a result, applications that perform lengthy processing in the same thread that also runs
+their Pika connection may experience unexpected dropped connections due to heartbeat timeout. Here,
+we specify an explicit lower bound for heartbeat timeout.
 
-When RabbitMQ broker is running out of certain resources, such as memory and
-disk space, it may block connections that are performing resource-consuming
-operations, such as publishing messages. Once a connection is blocked, RabbitMQ
-stops reading from that connection's socket, so no commands from the client will
-get through to te broker on that connection until the broker unblocks it. A
-blocked connection may last for an indefinite period of time, stalling the
-connection and possibly resulting in a hang (e.g., in BlockingConnection) until
-the connection is unblocked. Blocked Connection Timeout is intended to interrupt
-(i.e., drop) a connection that has been blocked longer than the given timeout
-value.
+When RabbitMQ broker is running out of certain resources, such as memory and disk space, it may
+block connections that are performing resource-consuming operations, such as publishing messages.
+Once a connection is blocked, RabbitMQ stops reading from that connection's socket, so no commands
+from the client will get through to te broker on that connection until the broker unblocks it. A
+blocked connection may last for an indefinite period of time, stalling the connection and possibly
+resulting in a hang (e.g., in BlockingConnection) until the connection is unblocked. Blocked
+Connection Timeout is intended to interrupt (i.e., drop) a connection that has been blocked longer
+than the given timeout value.
 """
 
 import pika

--- a/examples/tornado_consumer.py
+++ b/examples/tornado_consumer.py
@@ -10,29 +10,29 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ExampleConsumer:
-    """This is an example consumer that will handle unexpected interactions
-    with RabbitMQ such as channel and connection closures.
-
-    If RabbitMQ closes the connection, it will reopen it. You should
-    look at the output, as there are limited reasons why the connection may
-    be closed, which usually are tied to permission related issues or
-    socket timeouts.
-
-    If the channel is closed, it will indicate a problem with one of the
-    commands that were issued and that should surface in the output as well.
-
     """
+    This is an example consumer that will handle unexpected interactions with RabbitMQ such as
+    channel and connection closures.
+
+    If RabbitMQ closes the connection, it will reopen it. You should look at the output, as there
+    are limited reasons why the connection may be closed, which usually are tied to permission
+    related issues or socket timeouts.
+
+    If the channel is closed, it will indicate a problem with one of the commands that were issued
+    and that should surface in the output as well.
+    """
+
     EXCHANGE = 'message'
     EXCHANGE_TYPE = ExchangeType.topic
     QUEUE = 'text'
     ROUTING_KEY = 'example.text'
 
     def __init__(self, amqp_url):
-        """Create a new instance of the consumer class, passing in the AMQP
-        URL used to connect to RabbitMQ.
+        """
+        Create a new instance of the consumer class, passing in the AMQP URL used to connect to
+        RabbitMQ.
 
         :param str amqp_url: The AMQP url to connect with
-
         """
         self._connection = None
         self._channel = None
@@ -40,11 +40,13 @@ class ExampleConsumer:
         self._consumer_tag = None
         self._url = amqp_url
 
-    def connect(self) -> TornadoConnection:
-        """This method connects to RabbitMQ, returning the connection handle.
-        When the connection is established, the on_connection_open method
-        will be invoked by pika.
+    def connect(self):
+        """
+        This method connects to RabbitMQ, returning the connection handle.
 
+        When the connection is established, the on_connection_open method will be invoked by pika.
+
+        :rtype: pika.SelectConnection
         """
         LOGGER.info('Connecting to %s', self._url)
         return TornadoConnection(
@@ -58,22 +60,20 @@ class ExampleConsumer:
         self._connection.close()
 
     def add_on_connection_close_callback(self):
-        """This method adds an on close callback that will be invoked by pika
-        when RabbitMQ closes the connection to the publisher unexpectedly.
-
+        """This method adds an on close callback that will be invoked by pika when RabbitMQ closes
+        the connection to the publisher unexpectedly.
         """
         LOGGER.info('Adding connection close callback')
         self._connection.add_on_close_callback(self.on_connection_closed)
 
     def on_connection_closed(self, connection, reason):
-        """This method is invoked by pika when the connection to RabbitMQ is
-        closed unexpectedly. Since it is unexpected, we will reconnect to
-        RabbitMQ if it disconnects.
+        """
+        This method is invoked by pika when the connection to RabbitMQ is closed unexpectedly.
+
+        Since it is unexpected, we will reconnect to RabbitMQ if it disconnects.
 
         :param pika.connection.Connection connection: The closed connection obj
-        :param Exception reason: exception representing reason for loss of
-            connection.
-
+        :param Exception reason: exception representing reason for loss of connection.
         """
         self._channel = None
         if self._closing:
@@ -84,21 +84,23 @@ class ExampleConsumer:
             self._connection.ioloop.call_later(5, self.reconnect)
 
     def on_connection_open(self, unused_connection):
-        """This method is called by pika once the connection to RabbitMQ has
-        been established. It passes the handle to the connection object in
-        case we need it, but in this case, we'll just mark it unused.
+        """
+        This method is called by pika once the connection to RabbitMQ has been established.
+
+        It passes the handle to the connection object in case we need it, but in this case, we'll
+        just mark it unused.
 
         :param pika.SelectConnection _unused_connection: The connection
-
         """
         LOGGER.info('Connection opened')
         self.add_on_connection_close_callback()
         self.open_channel()
 
     def reconnect(self):
-        """Will be invoked by the IOLoop timer if the connection is
-        closed. See the on_connection_closed method.
+        """
+        Will be invoked by the IOLoop timer if the connection is closed.
 
+        See the on_connection_closed method.
         """
         if not self._closing:
 
@@ -106,35 +108,35 @@ class ExampleConsumer:
             self._connection = self.connect()
 
     def add_on_channel_close_callback(self):
-        """This method tells pika to call the on_channel_closed method if
-        RabbitMQ unexpectedly closes the channel.
-
+        """This method tells pika to call the on_channel_closed method if RabbitMQ unexpectedly
+        closes the channel.
         """
         LOGGER.info('Adding channel close callback')
         self._channel.add_on_close_callback(self.on_channel_closed)
 
     def on_channel_closed(self, channel, reason):
-        """Invoked by pika when RabbitMQ unexpectedly closes the channel.
-        Channels are usually closed if you attempt to do something that
-        violates the protocol, such as re-declare an exchange or queue with
-        different parameters. In this case, we'll close the connection
-        to shutdown the object.
+        """
+        Invoked by pika when RabbitMQ unexpectedly closes the channel.
+
+        Channels are usually closed if you attempt to do something that violates the protocol, such
+        as re-declare an exchange or queue with different parameters. In this case, we'll close the
+        connection to shutdown the object.
 
         :param pika.channel.Channel: The closed channel
         :param Exception reason: why the channel was closed
-
         """
         LOGGER.warning('Channel %i was closed: %s', channel, reason)
         self._connection.close()
 
     def on_channel_open(self, channel):
-        """This method is invoked by pika when the channel has been opened.
+        """
+        This method is invoked by pika when the channel has been opened.
+
         The channel object is passed in so we can make use of it.
 
         Since the channel is now open, we'll declare the exchange to use.
 
         :param pika.channel.Channel channel: The channel object
-
         """
         LOGGER.info('Channel opened')
         self._channel = channel
@@ -142,12 +144,12 @@ class ExampleConsumer:
         self.setup_exchange(self.EXCHANGE)
 
     def setup_exchange(self, exchange_name):
-        """Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC
-        command. When it is complete, the on_exchange_declareok method will
-        be invoked by pika.
+        """
+        Setup the exchange on RabbitMQ by invoking the Exchange.Declare RPC command.
+
+        When it is complete, the on_exchange_declareok method will be invoked by pika.
 
         :param str|unicode exchange_name: The name of the exchange to declare
-
         """
         LOGGER.info('Declaring exchange %s', exchange_name)
         self._channel.exchange_declare(
@@ -157,22 +159,21 @@ class ExampleConsumer:
         )
 
     def on_exchange_declareok(self, unused_frame):
-        """Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC
-        command.
+        """
+        Invoked by pika when RabbitMQ has finished the Exchange.Declare RPC command.
 
         :param pika.Frame.Method unused_frame: Exchange.DeclareOk response frame
-
         """
         LOGGER.info('Exchange declared')
         self.setup_queue(self.QUEUE)
 
     def setup_queue(self, queue_name):
-        """Setup the queue on RabbitMQ by invoking the Queue.Declare RPC
-        command. When it is complete, the on_queue_declareok method will
-        be invoked by pika.
+        """
+        Setup the queue on RabbitMQ by invoking the Queue.Declare RPC command.
+
+        When it is complete, the on_queue_declareok method will be invoked by pika.
 
         :param str|unicode queue_name: The name of the queue to declare.
-
         """
         LOGGER.info('Declaring queue %s', queue_name)
         self._channel.queue_declare(
@@ -181,14 +182,14 @@ class ExampleConsumer:
         )
 
     def on_queue_declareok(self, method_frame):
-        """Method invoked by pika when the Queue.Declare RPC call made in
-        setup_queue has completed. In this method we will bind the queue
-        and exchange together with the routing key by issuing the Queue.Bind
-        RPC command. When this command is complete, the on_bindok method will
-        be invoked by pika.
+        """
+        Method invoked by pika when the Queue.Declare RPC call made in setup_queue has completed.
+
+        In this method we will bind the queue and exchange together with the routing key by issuing
+        the Queue.Bind RPC command. When this command is complete, the on_bindok method will be
+        invoked by pika.
 
         :param pika.frame.Method method_frame: The Queue.DeclareOk frame
-
         """
         LOGGER.info('Binding %s to %s with %s', self.EXCHANGE, self.QUEUE,
                     self.ROUTING_KEY)
@@ -200,20 +201,19 @@ class ExampleConsumer:
         )
 
     def add_on_cancel_callback(self):
-        """Add a callback that will be invoked if RabbitMQ cancels the consumer
-        for some reason. If RabbitMQ does cancel the consumer,
-        on_consumer_cancelled will be invoked by pika.
+        """
+        Add a callback that will be invoked if RabbitMQ cancels the consumer for some reason.
 
+        If RabbitMQ does cancel the consumer, on_consumer_cancelled will be invoked by pika.
         """
         LOGGER.info('Adding consumer cancellation callback')
         self._channel.add_on_cancel_callback(self.on_consumer_cancelled)
 
     def on_consumer_cancelled(self, method_frame):
-        """Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer
-        receiving messages.
+        """
+        Invoked by pika when RabbitMQ sends a Basic.Cancel for a consumer receiving messages.
 
         :param pika.frame.Method method_frame: The Basic.Cancel frame
-
         """
         LOGGER.info('Consumer was cancelled remotely, shutting down: %r',
                     method_frame)
@@ -221,63 +221,62 @@ class ExampleConsumer:
             self._channel.close()
 
     def acknowledge_message(self, delivery_tag):
-        """Acknowledge the message delivery from RabbitMQ by sending a
-        Basic.Ack RPC method for the delivery tag.
+        """
+        Acknowledge the message delivery from RabbitMQ by sending a Basic.Ack RPC method for the
+        delivery tag.
 
         :param int delivery_tag: The delivery tag from the Basic.Deliver frame
-
         """
         LOGGER.info('Acknowledging message %s', delivery_tag)
         self._channel.basic_ack(delivery_tag)
 
     def on_message(self, unused_channel, basic_deliver, properties, body):
-        """Invoked by pika when a message is delivered from RabbitMQ. The
-        channel is passed for your convenience. The basic_deliver object that
-        is passed in carries the exchange, routing key, delivery tag and
-        a redelivered flag for the message. The properties passed in is an
-        instance of BasicProperties with the message properties and the body
-        is the message that was sent.
+        """
+        Invoked by pika when a message is delivered from RabbitMQ.
+
+        The channel is passed for your convenience. The basic_deliver object that is passed in
+        carries the exchange, routing key, delivery tag and a redelivered flag for the message. The
+        properties passed in is an instance of BasicProperties with the message properties and the
+        body is the message that was sent.
 
         :param pika.channel.Channel unused_channel: The channel object
         :param pika.Spec.Basic.Deliver: basic_deliver method
         :param pika.Spec.BasicProperties: properties
         :param bytes body: The message body
-
         """
         LOGGER.info('Received message # %s from %s: %s',
                     basic_deliver.delivery_tag, properties.app_id, body)
         self.acknowledge_message(basic_deliver.delivery_tag)
 
     def on_cancelok(self, unused_frame):
-        """This method is invoked by pika when RabbitMQ acknowledges the
-        cancellation of a consumer. At this point we will close the channel.
-        This will invoke the on_channel_closed method once the channel has been
-        closed, which will in-turn close the connection.
+        """
+        This method is invoked by pika when RabbitMQ acknowledges the cancellation of a consumer.
+
+        At this point we will close the channel. This will invoke the on_channel_closed method once
+        the channel has been closed, which will in-turn close the connection.
 
         :param pika.frame.Method unused_frame: The Basic.CancelOk frame
-
         """
         LOGGER.info('RabbitMQ acknowledged the cancellation of the consumer')
         self.close_channel()
 
     def stop_consuming(self):
-        """Tell RabbitMQ that you would like to stop consuming by sending the
-        Basic.Cancel RPC command.
-
+        """Tell RabbitMQ that you would like to stop consuming by sending the Basic.Cancel RPC
+        command.
         """
         if self._channel:
             LOGGER.info('Sending a Basic.Cancel RPC command to RabbitMQ')
             self._channel.basic_cancel(self.on_cancelok, self._consumer_tag)
 
     def start_consuming(self):
-        """This method sets up the consumer by first calling
-        add_on_cancel_callback so that the object is notified if RabbitMQ
-        cancels the consumer. It then issues the Basic.Consume RPC command
-        which returns the consumer tag that is used to uniquely identify the
-        consumer with RabbitMQ. We keep the value to use it when we want to
-        cancel consuming. The on_message method is passed in as a callback pika
-        will invoke when a message is fully received.
+        """
+        This method sets up the consumer by first calling add_on_cancel_callback so that the object
+        is notified if RabbitMQ cancels the consumer.
 
+        It then issues the Basic.Consume RPC command which returns the consumer tag that is used to
+        uniquely identify the consumer with RabbitMQ. We keep the value to use it when we want to
+        cancel consuming. The on_message method is passed in as a callback pika will invoke when a
+        message is fully received.
         """
         LOGGER.info('Issuing consumer related RPC commands')
         self.add_on_cancel_callback()
@@ -287,51 +286,50 @@ class ExampleConsumer:
         )
 
     def on_bindok(self, unused_frame):
-        """Invoked by pika when the Queue.Bind method has completed. At this
-        point we will start consuming messages by calling start_consuming
-        which will invoke the needed RPC commands to start the process.
+        """
+        Invoked by pika when the Queue.Bind method has completed.
+
+        At this point we will start consuming messages by calling start_consuming which will invoke
+        the needed RPC commands to start the process.
 
         :param pika.frame.Method unused_frame: The Queue.BindOk response frame
-
         """
         LOGGER.info('Queue bound')
         self.start_consuming()
 
     def close_channel(self):
-        """Call to close the channel with RabbitMQ cleanly by issuing the
-        Channel.Close RPC command.
-
+        """Call to close the channel with RabbitMQ cleanly by issuing the Channel.Close RPC
+        command.
         """
         LOGGER.info('Closing the channel')
         self._channel.close()
 
     def open_channel(self):
-        """Open a new channel with RabbitMQ by issuing the Channel.Open RPC
-        command. When RabbitMQ responds that the channel is open, the
-        on_channel_open callback will be invoked by pika.
+        """
+        Open a new channel with RabbitMQ by issuing the Channel.Open RPC command.
 
+        When RabbitMQ responds that the channel is open, the on_channel_open callback will be
+        invoked by pika.
         """
         LOGGER.info('Creating a new channel')
         self._connection.channel(on_open_callback=self.on_channel_open)
 
     def run(self):
-        """Run the example consumer by connecting to RabbitMQ and then
-        starting the IOLoop to block and allow the SelectConnection to operate.
-
+        """Run the example consumer by connecting to RabbitMQ and then starting the IOLoop to block
+        and allow the SelectConnection to operate.
         """
         self._connection = self.connect()
         self._connection.ioloop.start()
 
     def stop(self):
-        """Cleanly shutdown the connection to RabbitMQ by stopping the consumer
-        with RabbitMQ. When RabbitMQ confirms the cancellation, on_cancelok
-        will be invoked by pika, which will then closing the channel and
-        connection. The IOLoop is started again because this method is invoked
-        when CTRL-C is pressed raising a KeyboardInterrupt exception. This
-        exception stops the IOLoop which needs to be running for pika to
-        communicate with RabbitMQ. All of the commands issued prior to starting
-        the IOLoop will be buffered but not processed.
+        """
+        Cleanly shutdown the connection to RabbitMQ by stopping the consumer with RabbitMQ.
 
+        When RabbitMQ confirms the cancellation, on_cancelok will be invoked by pika, which will
+        then closing the channel and connection. The IOLoop is started again because this method is
+        invoked when CTRL-C is pressed raising a KeyboardInterrupt exception. This exception stops
+        the IOLoop which needs to be running for pika to communicate with RabbitMQ. All of the
+        commands issued prior to starting the IOLoop will be buffered but not processed.
         """
         LOGGER.info('Stopping')
         self._closing = True

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -234,10 +234,9 @@ class TestService(service.Service):
         """
         Method for a time consuming task.
 
-        This function must return a deferred. If it is successfull,
-        a `basic.ack` will be sent to AMQP. If the task was not completed a
-        `basic.nack` will be sent. In this example it will always return
-        successfully after a 2 second pause.
+        This function must return a deferred. If it is successfull, a `basic.ack` will be sent to
+        AMQP. If the task was not completed a `basic.nack` will be sent. In this example it will
+        always return successfully after a 2 second pause.
         """
         return task.deferLater(reactor, 2, lambda: log.msg("task completed"))
 

--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -1,4 +1,5 @@
 """Internal utility helpers for platform and socket compatibility."""
+
 from __future__ import annotations
 
 import abc
@@ -31,14 +32,13 @@ _LOCALHOST_V6 = '::1'
 
 
 def time_now() -> float:
-    """Returns monotonic time.
-
-    """
+    """Returns monotonic time."""
     return time.monotonic()
 
 
 def as_bytes(value: str | bytes) -> bytes:
-    """Returns value as bytes.
+    """
+    Returns value as bytes.
 
     :param value: value to convert
     """
@@ -48,7 +48,8 @@ def as_bytes(value: str | bytes) -> bytes:
 
 
 def to_digit(value: str) -> int:
-    """Returns value as an integer.
+    """
+    Returns value as an integer.
 
     :param value: string containing digits
     """
@@ -59,7 +60,8 @@ def to_digit(value: str) -> int:
 
 
 def get_linux_version(release_str: str) -> tuple[int, ...]:
-    """Gets linux version.
+    """
+    Gets linux version.
 
     :param release_str: kernel release string
     """
@@ -77,10 +79,11 @@ def nonblocking_socketpair(
         family: int = socket.AF_INET,
         socket_type: int = socket.SOCK_STREAM,
         proto: int = 0) -> tuple[socket.socket, socket.socket]:
-    """Non-blocking socket pair for use with pika's I/O loop.
+    """
+    Non-blocking socket pair for use with pika's I/O loop.
 
-    Returns a pair of sockets in the manner of socketpair with the additional
-    feature that they will be non-blocking.
+    Returns a pair of sockets in the manner of socketpair with the additional feature that they will
+    be non-blocking.
 
     :param family: socket family (default AF_INET)
     :param socket_type: socket type (default SOCK_STREAM)

--- a/pika/adapters/__init__.py
+++ b/pika/adapters/__init__.py
@@ -19,6 +19,7 @@ Pika provides multiple adapters to connect to RabbitMQ:
   use with the Twisted framework
 
 """
+
 from pika.adapters.asyncio_connection import AsyncioConnection
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.blocking_connection import BlockingConnection

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -1,4 +1,5 @@
-"""Use pika with the Asyncio EventLoop"""
+"""Use pika with the Asyncio EventLoop."""
+
 from __future__ import annotations
 
 import asyncio
@@ -19,9 +20,7 @@ if sys.platform == 'win32':
 
 
 class AsyncioConnection(base_connection.BaseConnection):
-    """ The AsyncioConnection runs on the Asyncio EventLoop.
-
-    """
+    """The AsyncioConnection runs on the Asyncio EventLoop."""
 
     def __init__(
             self,
@@ -35,8 +34,8 @@ class AsyncioConnection(base_connection.BaseConnection):
             custom_ioloop: None |
         (asyncio.AbstractEventLoop | nbio_interface.AbstractIOServices) = None,
             internal_connection_workflow: bool = True) -> None:
-        """ Create a new instance of the AsyncioConnection class, connecting
-        to RabbitMQ automatically
+        """
+        Create a new instance of the AsyncioConnection class, connecting to RabbitMQ automatically.
 
         :param parameters: Connection parameters
         :param on_open_callback: The method to call when the connection
@@ -59,7 +58,6 @@ class AsyncioConnection(base_connection.BaseConnection):
         :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
-
         """
         if isinstance(custom_ioloop, nbio_interface.AbstractIOServices):
             nbio = custom_ioloop
@@ -96,7 +94,9 @@ class AsyncioConnection(base_connection.BaseConnection):
         nbio = _AsyncioIOServicesAdapter(custom_ioloop)
 
         def connection_factory(params) -> AsyncioConnection:
-            """Connection factory.
+            """
+            Connection factory.
+
             :param params: Connection parameters
             """
             if params is None:
@@ -158,15 +158,11 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         self._loop.close()
 
     def run(self) -> None:
-        """Implement :py:meth:`.utils.nbio_interface.AbstractIOServices.run()`.
-
-        """
+        """Implement :py:meth:`.utils.nbio_interface.AbstractIOServices.run()`."""
         self._loop.run_forever()
 
     def stop(self) -> None:
-        """Implement :py:meth:`.utils.nbio_interface.AbstractIOServices.stop()`.
-
-        """
+        """Implement :py:meth:`.utils.nbio_interface.AbstractIOServices.stop()`."""
         self._loop.stop()
 
     def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
@@ -257,13 +253,13 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         on_done: Callable[[base_connection.BaseConnection | BaseException],
                           None]
     ) -> _AsyncioIOReference:
-        """Schedule the coroutine to run and return _AsyncioIOReference
+        """
+        Schedule the coroutine to run and return _AsyncioIOReference.
 
         :param coro: Coroutine to schedule.
-        :param on_done: User callback that takes the completion result
-            or exception as its only arg. It will not be called if the operation
-            was cancelled.
-
+        :param on_done: User callback that takes the completion result or exception as its only arg.
+            It will not be called if the operation was cancelled.
+        :rtype: _AsyncioIOReference which is derived from nbio_interface.AbstractIOReference
         """
         if not callable(on_done):
             raise TypeError(
@@ -274,9 +270,7 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
 
 class _TimerHandle(nbio_interface.AbstractTimerReference):
-    """This module's adaptation of `nbio_interface.AbstractTimerReference`.
-
-    """
+    """This module's adaptation of `nbio_interface.AbstractTimerReference`."""
 
     def __init__(self, handle: asyncio.Handle) -> None:
         """
@@ -286,8 +280,10 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
         self._handle: asyncio.Handle | None = handle
 
     def cancel(self) -> None:
-        """Cancel the timer handle.
+        """
+        Cancel the timer handle.
 
+        :rtype: None
         """
         if self._handle is not None:
             self._handle.cancel()
@@ -295,9 +291,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
 
 
 class _AsyncioIOReference(nbio_interface.AbstractIOReference):
-    """This module's adaptation of `nbio_interface.AbstractIOReference`.
-
-    """
+    """This module's adaptation of `nbio_interface.AbstractIOReference`."""
 
     def __init__(
         self, future: asyncio.Future,
@@ -321,7 +315,6 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
             """Handle completion callback from the future instance
             :param future: The future that completed
             """
-
             # NOTE: Asyncio schedules callback for cancelled futures, but pika
             # doesn't want that
             if not future.cancelled():
@@ -330,9 +323,10 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
         future.add_done_callback(on_done_adapter)
 
     def cancel(self) -> bool:
-        """Cancel pending operation
+        """
+        Cancel pending operation.
 
         :returns: False if was already done or cancelled; True otherwise
-
+        :rtype: bool
         """
         return self._future.cancel()

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -1,8 +1,10 @@
-"""Base class extended by connection adapters. This extends the
-connection.Connection class to encapsulate connection behavior but still
-isolate socket and low level communication.
-
 """
+Base class extended by connection adapters.
+
+This extends the connection.Connection class to encapsulate connection behavior but still isolate
+socket and low level communication.
+"""
+
 from __future__ import annotations
 
 import abc
@@ -18,10 +20,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 class BaseConnection(connection.Connection):
-    """BaseConnection class that should be extended by connection adapters.
+    """
+    BaseConnection class that should be extended by connection adapters.
 
     This class abstracts I/O loop and transport services from pika core.
-
     """
 
     def __init__(self,
@@ -34,7 +36,8 @@ class BaseConnection(connection.Connection):
                  (Callable[[connection.Connection, BaseException], None]),
                  nbio: nbio_interface.AbstractIOServices,
                  internal_connection_workflow: bool = True) -> None:
-        """Create a new instance of the Connection object.
+        """
+        Create a new instance of the Connection object.
 
         :param parameters: Connection parameters
         :param on_open_callback: Method to call on connection open
@@ -54,7 +57,6 @@ class BaseConnection(connection.Connection):
             connection workflow via the `create_connection()` factory.
         :raises: RuntimeError
         :raises: ValueError
-
         """
         if parameters and not isinstance(parameters, connection.Parameters):
             raise ValueError(
@@ -76,10 +78,10 @@ class BaseConnection(connection.Connection):
             internal_connection_workflow=internal_connection_workflow)
 
     def _init_connection_state(self) -> None:
-        """Initialize or reset all of our internal state variables for a given
-        connection. If we disconnect and reconnect, all of our state needs to
-        be wiped.
+        """
+        Initialize or reset all of our internal state variables for a given connection.
 
+        If we disconnect and reconnect, all of our state needs to be wiped.
         """
         super()._init_connection_state()
 
@@ -125,10 +127,12 @@ class BaseConnection(connection.Connection):
         workflow: None |
         (connection_workflow.AbstractAMQPConnectionWorkflow) = None
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
-        """Asynchronously create a connection to an AMQP broker using the given
-        configurations. Will attempt to connect using each config in the given
-        order, including all compatible resolved IP addresses of the hostname
-        supplied in each config, until one is established or all attempts fail.
+        """
+        Asynchronously create a connection to an AMQP broker using the given configurations.
+
+        Will attempt to connect using each config in the given order, including all compatible resolved
+        IP addresses of the hostname supplied in each config, until one is established or all
+        attempts fail.
 
         See also `_start_connection_workflow()`.
 
@@ -147,7 +151,7 @@ class BaseConnection(connection.Connection):
             `connection_workflow.AbstractAMQPConnectionWorkflow | None`.
         :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
-
+        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         raise NotImplementedError
 
@@ -160,7 +164,8 @@ class BaseConnection(connection.Connection):
         on_done: Callable[[(connection.Connection |
                             connection_workflow.AMQPConnectorException)], None]
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
-        """Helper function for custom implementations of `create_connection()`.
+        """
+        Helper function for custom implementations of `create_connection()`.
 
         :param connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects.
@@ -180,7 +185,7 @@ class BaseConnection(connection.Connection):
             :py:meth:`connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
         :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
-
+        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
         """
         if workflow is None:
             workflow = connection_workflow.AMQPConnectionWorkflow()
@@ -190,8 +195,7 @@ class BaseConnection(connection.Connection):
             workflow.set_io_services(nbio)
 
         def create_connector() -> connection_workflow.AMQPConnector:
-            """`AMQPConnector` factory.
-            """
+            """`AMQPConnector` factory."""
             return connection_workflow.AMQPConnector(
                 lambda params: _StreamingProtocolShim(connection_factory(params)
                                                      ), nbio)
@@ -212,31 +216,38 @@ class BaseConnection(connection.Connection):
             by user or the default selected by the specialized connection
             adapter (e.g., Twisted reactor, `asyncio.SelectorEventLoop`,
             `select_connection.IOLoop`, etc.)
+        :rtype: object
         """
         return self._nbio.get_native_ioloop()
 
     def _adapter_call_later(self, delay: int | float,
                             callback: Callable[[], None]) -> object:
-        """Schedule a callback to be called after a delay.
+        """
+        Schedule a callback to be called after a delay.
 
         :param delay: Delay in seconds.
         :param callback: Callback to call.
         :returns: Timeout handle that can be used to cancel.
+        :rtype: object
         """
         return self._nbio.call_later(delay, callback)
 
     def _adapter_remove_timeout(self, timeout_id: object) -> None:
-        """Remove a scheduled timeout.
+        """
+        Remove a scheduled timeout.
 
         :param timeout_id: Timeout handle to cancel.
+        :rtype: None
         """
         cast(nbio_interface.AbstractTimerReference, timeout_id).cancel()
 
     def _adapter_add_callback_threadsafe(self, callback: Callable[...,
                                                                   Any]) -> None:
-        """Add a callback to be called from the I/O loop thread.
+        """
+        Add a callback to be called from the I/O loop thread.
 
         :param callback: Callback to call.
+        :rtype: None
         """
         if not callable(callback):
             raise TypeError(
@@ -245,13 +256,12 @@ class BaseConnection(connection.Connection):
         self._nbio.add_callback_threadsafe(callback)
 
     def _adapter_connect_stream(self) -> None:
-        """Initiate full-stack connection establishment asynchronously for
-        internally-initiated connection bring-up.
+        """
+        Initiate full-stack connection establishment asynchronously for internally-initiated
+        connection bring-up.
 
-        Upon failed completion, we will invoke
-        `Connection._on_stream_terminated()`. NOTE: On success,
-        the stack will be up already, so there is no corresponding callback.
-
+        Upon failed completion, we will invoke `Connection._on_stream_terminated()`. NOTE: On
+        success, the stack will be up already, so there is no corresponding callback.
         """
         self._connection_workflow = connection_workflow.AMQPConnectionWorkflow(
             _until_first_amqp_attempt=True)
@@ -259,8 +269,7 @@ class BaseConnection(connection.Connection):
         self._connection_workflow.set_io_services(self._nbio)
 
         def create_connector() -> connection_workflow.AMQPConnector:
-            """`AMQPConnector` factory
-            """
+            """`AMQPConnector` factory."""
             return connection_workflow.AMQPConnector(
                 lambda _params: _StreamingProtocolShim(self), self._nbio)
 
@@ -289,12 +298,13 @@ class BaseConnection(connection.Connection):
         user_on_done(result)
 
     def _abort_connection_workflow(self) -> None:
-        """Asynchronously abort connection workflow. Upon
-        completion, `Connection._on_stream_terminated()` will be called with None
+        """
+        Asynchronously abort connection workflow.
+
+        Upon completion, `Connection._on_stream_terminated()` will be called with None
         as the error argument.
 
         Assumption: may be called only while connection is opening.
-
         """
         assert not self._opened, (
             '_abort_connection_workflow() may be called only when '
@@ -329,13 +339,13 @@ class BaseConnection(connection.Connection):
 
     def _on_connection_workflow_done(
             self, conn_or_exc: BaseConnection | Exception) -> None:
-        """`AMQPConnectionWorkflow` completion callback.
+        """
+        `AMQPConnectionWorkflow` completion callback.
 
         :param conn_or_exc: Our own connection
             instance on success; exception on failure. See
             `AbstractAMQPConnectionWorkflow.start()` for details.
             Type: `BaseConnection | Exception`.
-
         """
         LOGGER.debug('Full-stack connection workflow completed: %r',
                      conn_or_exc)
@@ -368,18 +378,19 @@ class BaseConnection(connection.Connection):
         else:
             # NOTE: On success, the stack will be up already, so there is no
             #       corresponding callback.
-            assert conn_or_exc is self, \
+            assert conn_or_exc is self, (
                 f'Expected self conn={self!r} from workflow, but got {conn_or_exc!r}.'
+            )
 
     def _handle_connection_workflow_failure(self,
                                             error: Exception | None) -> None:
-        """Handle failure of self-initiated stack bring-up and call
-        `Connection._on_stream_terminated()` if connection is not in closed state
-        yet. Called by adapter layer when the full-stack connection workflow
-        fails.
+        """
+        Handle failure of self-initiated stack bring-up and call
+        `Connection._on_stream_terminated()` if connection is not in closed state yet. Called by
+        adapter layer when the full-stack connection workflow fails.
 
-        :param error: Exception (or None) describing the reason
-            for failure or None if the connection workflow was aborted.
+        :param error: Exception (or None) describing the reason for failure or None if the
+            connection workflow was aborted.
         """
         if error is None:
             LOGGER.info('Self-initiated stack bring-up aborted.')
@@ -408,24 +419,23 @@ class BaseConnection(connection.Connection):
             self._transport.abort()
 
     def _adapter_emit_data(self, data: bytes) -> None:
-        """Take ownership of data and send it to AMQP server as soon as
-        possible.
+        """
+        Take ownership of data and send it to AMQP server as soon as possible.
 
         :param data:
-
         """
         assert self._transport is not None
         self._transport.write(data)
 
     def _proto_connection_made(
             self, transport: nbio_interface.AbstractStreamTransport) -> None:
-        """Introduces transport to protocol after transport is connected.
+        """
+        Introduces transport to protocol after transport is connected.
 
         :py:class:`.utils.nbio_interface.AbstractStreamProtocol` implementation.
 
         :param transport:
         :raises Exception: Exception-based exception on error
-
         """
         self._transport = transport
 
@@ -433,7 +443,8 @@ class BaseConnection(connection.Connection):
         self._on_stream_connected()
 
     def _proto_connection_lost(self, error: BaseException | None) -> None:
-        """Called upon loss or closing of TCP connection.
+        """
+        Called upon loss or closing of TCP connection.
 
         :py:class:`.utils.nbio_interface.AbstractStreamProtocol` implementation.
 
@@ -446,7 +457,6 @@ class BaseConnection(connection.Connection):
             when `AbstractStreamProtocol.eof_received()` returns a falsy result.
             Type: `BaseException | None`.
         :raises Exception: Exception-based exception on error
-
         """
         self._transport = None
 
@@ -465,15 +475,15 @@ class BaseConnection(connection.Connection):
         self._on_stream_terminated(error)
 
     def _proto_eof_received(self) -> bool:
-        """Called after the remote peer shuts its write end of the connection.
+        """
+        Called after the remote peer shuts its write end of the connection.
         :py:class:`.utils.nbio_interface.AbstractStreamProtocol` implementation.
 
-        :returns: A falsy value (including None) will cause the transport to
-            close itself, resulting in an eventual `connection_lost()` call
-            from the transport. If a truthy value is returned, it will be the
-            protocol's responsibility to close/abort the transport.
+        :returns: A falsy value (including None) will cause the transport to close itself, resulting
+            in an eventual `connection_lost()` call from the transport. If a truthy value is
+            returned, it will be the protocol's responsibility to close/abort the transport.
+        :rtype: falsy|truthy
         :raises Exception: Exception-based exception on error
-
         """
         LOGGER.error('Transport indicated EOF.')
 
@@ -487,22 +497,20 @@ class BaseConnection(connection.Connection):
         return False
 
     def _proto_data_received(self, data: bytes) -> None:
-        """Called to deliver incoming data from the server to the protocol.
+        """
+        Called to deliver incoming data from the server to the protocol.
 
         :py:class:`.utils.nbio_interface.AbstractStreamProtocol` implementation.
 
         :param data: Non-empty data bytes.
         :raises Exception: Exception-based exception on error
-
         """
         self._on_data_available(data)
 
 
 class _StreamingProtocolShim(nbio_interface.AbstractStreamProtocol):
-    """Shim for callbacks from transport so that we BaseConnection can
-    delegate to private methods, thus avoiding contamination of API with
-    methods that look public, but aren't.
-
+    """Shim for callbacks from transport so that we BaseConnection can delegate to private methods,
+    thus avoiding contamination of API with methods that look public, but aren't.
     """
 
     # Override abstract methods at class level to enable instantiation;
@@ -524,9 +532,9 @@ class _StreamingProtocolShim(nbio_interface.AbstractStreamProtocol):
         self.data_received = conn._proto_data_received
 
     def __getattr__(self, attr: str) -> Any:
-        """Proxy inexistent attribute requests to our connection instance
-        so that AMQPConnectionWorkflow/AMQPConnector may treat the shim as an
-        actual connection.
+        """
+        Proxy inexistent attribute requests to our connection instance so that
+        AMQPConnectionWorkflow/AMQPConnector may treat the shim as an actual connection.
 
         :param attr: Attribute name.
         :returns: Attribute value from connection.

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1,15 +1,15 @@
-"""The blocking connection adapter module implements blocking semantics on top
-of Pika's core AMQP driver. While most of the asynchronous expectations are
-removed when using the blocking connection adapter, it attempts to remain true
-to the asynchronous RPC nature of the AMQP protocol, supporting server sent
-RPC commands.
+"""
+The blocking connection adapter module implements blocking semantics on top of Pika's core AMQP
+driver. While most of the asynchronous expectations are removed when using the blocking connection
+adapter, it attempts to remain true to the asynchronous RPC nature of the AMQP protocol, supporting
+server sent RPC commands.
 
 The user facing classes in the module consist of the
 :py:class:`~pika.adapters.blocking_connection.BlockingConnection`
 and the :class:`~pika.adapters.blocking_connection.BlockingChannel`
 classes.
-
 """
+
 # Suppress too-many-lines
 
 # Disable "access to protected member warnings: this wrapper implementation is
@@ -61,9 +61,10 @@ LOGGER = logging.getLogger(__name__)
 
 
 class _CallbackResult:
-    """ CallbackResult is a non-thread-safe implementation for receiving
-    callback results; INTERNAL USE ONLY!
+    """CallbackResult is a non-thread-safe implementation for receiving callback results; INTERNAL
+    USE ONLY!
     """
+
     __slots__ = ('_ready', '_value_class', '_values')
 
     def __init__(self, value_class: Callable[..., Any] | None = None) -> None:
@@ -80,40 +81,41 @@ class _CallbackResult:
         self._values: tuple[Any, ...] | list[Any] | None = None
 
     def reset(self) -> None:
-        """Reset value, but not _value_class"""
+        """Reset value, but not _value_class."""
         self._ready = False
         self._values = None
 
     def __bool__(self) -> bool:
-        """Called by python runtime to implement truth value testing and the
-        built-in operation bool()
+        """Called by python runtime to implement truth value testing and the built-in operation
+        bool()
         """
         return self.is_ready()
 
     def __enter__(self) -> _CallbackResult:
-        """Entry into context manager that automatically resets the object
-        on exit; this usage pattern helps garbage-collection by eliminating
-        potential circular references.
+        """Entry into context manager that automatically resets the object on exit; this usage
+        pattern helps garbage-collection by eliminating potential circular references.
         """
         return self
 
     def __exit__(self, *args: Any, **kwargs: Any) -> None:
-        """Reset value"""
+        """Reset value."""
         self.reset()
 
     def is_ready(self) -> bool:
         """
         :returns: True if the object is in a signaled state
+        :rtype: bool
         """
         return self._ready
 
     @property
     def ready(self) -> bool:
-        """True if the object is in a signaled state"""
+        """True if the object is in a signaled state."""
         return self._ready
 
     def signal_once(self, *_args: Any, **_kwargs: Any) -> None:
-        """Set as ready
+        """
+        Set as ready.
 
         :raises AssertionError: if result was already signalled
         """
@@ -121,8 +123,8 @@ class _CallbackResult:
         self._ready = True
 
     def set_value_once(self, *args: Any, **kwargs: Any) -> None:
-        """Set as ready with value; the value may be retrieved via the `value`
-        property getter
+        """
+        Set as ready with value; the value may be retrieved via the `value` property getter.
 
         :raises AssertionError: if result was already set
         """
@@ -137,7 +139,7 @@ class _CallbackResult:
             raise
 
     def append_element(self, *args: Any, **kwargs: Any) -> None:
-        """Append an element to values"""
+        """Append an element to values."""
         assert not self._ready or isinstance(self._values, list), (
             '_CallbackResult state is incompatible with append_element: '
             f'ready={self._ready!r}; values={self._values!r}')
@@ -163,6 +165,7 @@ class _CallbackResult:
     def value(self) -> Any:
         """
         :returns: a reference to the value that was set via `set_value_once`
+        :rtype: object
         :raises AssertionError: if result was not set or value is incompatible
                                 with `set_value_once`
         """
@@ -178,6 +181,7 @@ class _CallbackResult:
         """
         :returns: a reference to the list containing one or more elements that
             were added via `append_element`
+        :rtype: list
         :raises AssertionError: if result was not set or value is incompatible
                                 with `append_element`
         """
@@ -190,8 +194,8 @@ class _CallbackResult:
 
 
 class _IoloopTimerContext:
-    """Context manager for registering and safely unregistering a
-    SelectConnection ioloop-based timer
+    """Context manager for registering and safely unregistering a SelectConnection ioloop-based
+    timer.
     """
 
     def __init__(self, duration: float,
@@ -207,13 +211,13 @@ class _IoloopTimerContext:
         self._timer_handle: object = None
 
     def __enter__(self) -> _IoloopTimerContext:
-        """Register a timer"""
+        """Register a timer."""
         self._timer_handle = self._connection._adapter_call_later(
             self._duration, self._callback_result.signal_once)
         return self
 
     def __exit__(self, *_args: Any, **_kwargs: Any) -> None:
-        """Unregister timer if it hasn't fired yet"""
+        """Unregister timer if it hasn't fired yet."""
         if not self._callback_result:
             self._connection._adapter_remove_timeout(self._timer_handle)
             self._timer_handle = None
@@ -221,12 +225,14 @@ class _IoloopTimerContext:
     def is_ready(self) -> bool:
         """
         :returns: True if timer has fired, False otherwise
+        :rtype: bool
         """
         return self._callback_result.is_ready()
 
 
 class _TimerEvt:
     """Represents a timer created via `BlockingConnection.call_later`"""
+
     __slots__ = ('_callback', 'timer_id')
 
     def __init__(self, callback: Callable[..., None]) -> None:
@@ -243,13 +249,14 @@ class _TimerEvt:
         return f'<{self.__class__.__name__} timer_id={self.timer_id} callback={self._callback}>'
 
     def dispatch(self) -> None:
-        """Dispatch the user's callback method"""
+        """Dispatch the user's callback method."""
         LOGGER.debug('_TimerEvt.dispatch: invoking callback=%r', self._callback)
         self._callback()
 
 
 class _ConnectionBlockedUnblockedEvtBase(Generic[T]):
     """Base class for `_ConnectionBlockedEvt` and `_ConnectionUnblockedEvt`"""
+
     __slots__ = ('_callback', '_method_frame')
 
     def __init__(self, callback: Callable[[pika.frame.Method[T]], None],
@@ -268,7 +275,7 @@ class _ConnectionBlockedUnblockedEvtBase(Generic[T]):
         return f'<{self.__class__.__name__} callback={self._callback}, frame={self._method_frame}>'
 
     def dispatch(self) -> None:
-        """Dispatch the user's callback method"""
+        """Dispatch the user's callback method."""
         self._callback(self._method_frame)
 
 
@@ -344,7 +351,8 @@ class BlockingConnection:
                                 Sequence[pika.connection.Parameters]) = None,
             _impl_class: select_connection.SelectConnection | None = None
     ) -> None:
-        """Create a new instance of the Connection object.
+        """
+        Create a new instance of the Connection object.
 
         :param parameters:
             Connection parameters instance or non-empty sequence of them. If
@@ -356,7 +364,6 @@ class BlockingConnection:
             None=default
 
         :raises RuntimeError:
-
         """
         warnings.warn(
             "BlockingConnection is deprecated and will be removed in Pika 2.0. "
@@ -412,9 +419,7 @@ class BlockingConnection:
             self.close()
 
     def _cleanup(self) -> None:
-        """Clean up members that might inhibit garbage collection
-
-        """
+        """Clean up members that might inhibit garbage collection."""
         with self._cleanup_mutex:
             if self._impl is not None:
                 self._impl.ioloop.close()
@@ -423,13 +428,12 @@ class BlockingConnection:
 
     @contextlib.contextmanager
     def _acquire_event_dispatch(self) -> Generator[bool, Any, None]:
-        """ Context manager that controls access to event dispatcher for
-        preventing reentrancy.
+        """
+        Context manager that controls access to event dispatcher for preventing reentrancy.
 
-        The "as" value is True if the managed code block owns the event
-        dispatcher and False if caller higher up in the call stack already owns
-        it. Only managed code that gets ownership (got True) is permitted to
-        dispatch
+        The "as" value is True if the managed code block owns the event dispatcher and False if
+        caller higher up in the call stack already owns it. Only managed code that gets ownership
+        (got True) is permitted to dispatch
         """
         try:
             # __enter__ part
@@ -445,17 +449,18 @@ class BlockingConnection:
                          Sequence[pika.connection.Parameters]) = None,
         impl_class: select_connection.SelectConnection | None = None
     ) -> select_connection.SelectConnection:
-        """Run connection workflow, blocking until it completes.
+        """
+        Run connection workflow, blocking until it completes.
 
         :param configs: Connection
             parameters instance or non-empty sequence of them.
             Type: `None | pika.connection.Parameters | sequence`.
         :param impl_class: for tests/debugging only; implementation class.
 
+        :rtype: impl_class
 
         :raises Exception: on failure
         """
-
         if configs is None:
             configs = (pika.connection.Parameters(),)
 
@@ -504,12 +509,12 @@ class BlockingConnection:
     @staticmethod
     def _reap_last_connection_workflow_error(
             error: BaseException) -> BaseException:
-        """Extract exception value from the last connection attempt
+        """
+        Extract exception value from the last connection attempt.
 
-        :param error: error passed by the `AMQPConnectionWorkflow`
-            completion callback.
-
+        :param error: error passed by the `AMQPConnectionWorkflow` completion callback.
         :returns: Exception value from the last connection attempt
+        :rtype: Exception
         """
         if isinstance(error, connection_workflow.AMQPConnectionWorkflowFailed):
             # Extract exception value from the last connection attempt
@@ -524,17 +529,16 @@ class BlockingConnection:
         return error
 
     def _flush_output(self, *waiters: Callable[[], bool]) -> None:
-        """ Flush output and process input while waiting for any of the given
-        callbacks to return true. The wait is aborted upon connection-close.
-        Otherwise, processing continues until the output is flushed AND at least
-        one of the callbacks returns true. If there are no callbacks, then
+        """
+        Flush output and process input while waiting for any of the given callbacks to return true.
+        The wait is aborted upon connection-close. Otherwise, processing continues until the output
+        is flushed AND at least one of the callbacks returns true. If there are no callbacks, then
         processing ends when all output is flushed.
 
-        :param waiters: sequence of zero or more callables taking no args and
-                        returning true when it's time to stop processing.
-                        Their results are OR'ed together.
-        :raises Exception: exceptions passed by impl if opening of connection fails or
-            connection closes.
+        :param waiters: sequence of zero or more callables taking no args and returning true when
+            it's time to stop processing. Their results are OR'ed together.
+        :raises Exception: exceptions passed by impl if opening of connection fails or connection
+            closes.
         """
         if self.is_closed:
             raise exceptions.ConnectionWrongStateError()
@@ -580,9 +584,7 @@ class BlockingConnection:
         self._channels_pending_dispatch.add(channel_number)
 
     def _dispatch_channel_events(self) -> None:
-        """Invoke the `_dispatch_events` method on open channels that requested
-        it
-        """
+        """Invoke the `_dispatch_events` method on open channels that requested it."""
         if not self._channels_pending_dispatch:
             return
 
@@ -635,13 +637,13 @@ class BlockingConnection:
                 None], _impl: select_connection.SelectConnection,
             method_frame: pika.frame.Method[pika.spec.Connection.Blocked]
     ) -> None:
-        """Handle Connection.Blocked notification from RabbitMQ broker
+        """
+        Handle Connection.Blocked notification from RabbitMQ broker.
 
-        :param user_callback: callback passed to
-           `add_on_connection_blocked_callback`
+        :param user_callback: callback passed to `add_on_connection_blocked_callback`
         :param _impl:
-        :param method_frame: method frame having `method`
-            member of type `pika.spec.Connection.Blocked`
+        :param method_frame: method frame having `method` member of type
+            `pika.spec.Connection.Blocked`
         """
         self._ready_events.append(
             _ConnectionBlockedEvt(user_callback, method_frame))
@@ -652,19 +654,19 @@ class BlockingConnection:
             None], _impl: select_connection.SelectConnection,
         method_frame: pika.frame.Method[pika.spec.Connection.Unblocked]
     ) -> None:
-        """Handle Connection.Unblocked notification from RabbitMQ broker
+        """
+        Handle Connection.Unblocked notification from RabbitMQ broker.
 
-        :param user_callback: callback passed to
-           `add_on_connection_unblocked_callback`
+        :param user_callback: callback passed to `add_on_connection_unblocked_callback`
         :param _impl:
-        :param method_frame: method frame having `method`
-            member of type `pika.spec.Connection.Blocked`
+        :param method_frame: method frame having `method` member of type
+            `pika.spec.Connection.Blocked`
         """
         self._ready_events.append(
             _ConnectionUnblockedEvt(user_callback, method_frame))
 
     def _dispatch_connection_events(self) -> None:
-        """Dispatch ready connection events"""
+        """Dispatch ready connection events."""
         if not self._ready_events:
             return
 
@@ -744,8 +746,10 @@ class BlockingConnection:
                                   cast(pika.connection.Connection, self))))
 
     def call_later(self, delay: float, callback: Callable[[], None]) -> int:
-        """Create a single-shot timer to fire after delay seconds. Do not
-        confuse with Tornado's timeout where you pass in the time you want to
+        """
+        Create a single-shot timer to fire after delay seconds.
+
+        Do not confuse with Tornado's timeout where you pass in the time you want to
         have your callback called. Only pass in the seconds until it's to be
         called.
 
@@ -758,7 +762,7 @@ class BlockingConnection:
         :param callback: The callback method with the signature
             callback()
         :returns: Opaque timer id
-
+        :rtype: int
         """
         validators.require_callback(callback)
 
@@ -772,8 +776,9 @@ class BlockingConnection:
         return timer_id
 
     def add_callback_threadsafe(self, callback: Callable[..., None]) -> None:
-        """Requests a call to the given function as soon as possible in the
-        context of this connection's thread.
+        """
+        Requests a call to the given function as soon as possible in the context of this
+        connection's thread.
 
         NOTE: This is the only thread-safe method in `BlockingConnection`. All
         other manipulations of `BlockingConnection` must be performed from the
@@ -814,10 +819,10 @@ class BlockingConnection:
                 functools.partial(self._on_threadsafe_callback, callback))
 
     def remove_timeout(self, timeout_id: int) -> None:
-        """Remove a timer if it's still in the timeout stack
+        """
+        Remove a timer if it's still in the timeout stack.
 
         :param timeout_id: The opaque timer id to remove
-
         """
         # Remove from the impl's timeout stack
         self._impl._adapter_remove_timeout(timeout_id)
@@ -843,7 +848,6 @@ class BlockingConnection:
         :raises pika.exceptions.ConnectionWrongStateError: if connection is
             not open.
         """
-
         result = _CallbackResult()
         self._impl.update_secret(new_secret, reason, result.signal_once)
         self._flush_output(result.is_ready)
@@ -851,16 +855,17 @@ class BlockingConnection:
     def close(self,
               reply_code: int = 200,
               reply_text: str = 'Normal shutdown') -> None:
-        """Disconnect from RabbitMQ. If there are any open channels, it will
-        attempt to close them prior to fully disconnecting. Channels which
-        have active consumers will attempt to send a Basic.Cancel to RabbitMQ
-        to cleanly stop the delivery of messages prior to closing the channel.
+        """
+        Disconnect from RabbitMQ.
+
+        If there are any open channels, it will attempt to close them prior to fully disconnecting.
+        Channels which have active consumers will attempt to send a Basic.Cancel to RabbitMQ to
+        cleanly stop the delivery of messages prior to closing the channel.
 
         :param reply_code: The code number for the close
         :param reply_text: The text reason for the close
-
-        :raises pika.exceptions.ConnectionWrongStateError: if called on a closed
-            connection (NEW in v1.0.0)
+        :raises pika.exceptions.ConnectionWrongStateError: if called on a closed connection (NEW in
+            v1.0.0)
         """
         if not self.is_open:
             msg = f'{self.__class__.__name__}.close({reply_code}, {reply_text!r}) called on closed connection.'
@@ -887,19 +892,20 @@ class BlockingConnection:
         self._flush_output(self._closed_result.is_ready)
 
     def process_data_events(self, time_limit: float | None = 0) -> None:
-        """Will make sure that data events are processed. Dispatches timer and
-        channel callbacks if not called from the scope of BlockingConnection or
-        BlockingChannel callback. Your app can block on this method. If your
-        application maintains a long-lived publisher connection, this method
-        should be called periodically in order to respond to heartbeats and other
-        data events. See `examples/long_running_publisher.py` for an example.
+        """
+        Will make sure that data events are processed.
 
-        :param time_limit: suggested upper bound on processing time in
-            seconds. The actual blocking time depends on the granularity of the
-            underlying ioloop. Zero means return as soon as possible. None means
-            there is no limit on processing time and the function will block
-            until I/O produces actionable events. Defaults to 0 for backward
-            compatibility. This parameter is NEW in pika 0.10.0.
+        Dispatches timer and channel callbacks if not called from the scope of BlockingConnection or
+        BlockingChannel callback. Your app can block on this method. If your application maintains a
+        long-lived publisher connection, this method should be called periodically in order to
+        respond to heartbeats and other data events. See `examples/long_running_publisher.py` for an
+        example.
+
+        :param time_limit: suggested upper bound on processing time in seconds. The actual blocking
+            time depends on the granularity of the underlying ioloop. Zero means return as soon as
+            possible. None means there is no limit on processing time and the function will block
+            until I/O produces actionable events. Defaults to 0 for backward compatibility. This
+            parameter is NEW in pika 0.10.0.
         """
         with self._acquire_event_dispatch() as dispatch_acquired:
             # Check if we can actually process pending events
@@ -926,13 +932,12 @@ class BlockingConnection:
             raise exc
 
     def sleep(self, duration: float) -> None:
-        """A safer way to sleep than calling time.sleep() directly that would
-        keep the adapter from ignoring frames sent from the broker. The
-        connection will "sleep" or block the number of seconds specified in
-        duration in small intervals.
+        """
+        A safer way to sleep than calling time.sleep() directly that would keep the adapter from
+        ignoring frames sent from the broker. The connection will "sleep" or block the number of
+        seconds specified in duration in small intervals.
 
         :param duration: The time to sleep in seconds
-
         """
         assert duration >= 0, duration
 
@@ -946,12 +951,13 @@ class BlockingConnection:
                 break
 
     def channel(self, channel_number: int | None = None) -> BlockingChannel:
-        """Create a new channel with the next available channel number or pass
-        in a channel number to use. Must be non-zero if you would like to
-        specify but it is recommended that you let Pika manage the channel
-        numbers.
+        """
+        Create a new channel with the next available channel number or pass in a channel number to
+        use. Must be non-zero if you would like to specify but it is recommended that you let Pika
+        manage the channel numbers.
 
         :param channel_number: optional channel number to use
+        :rtype: pika.adapters.blocking_connection.BlockingChannel
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -975,16 +981,12 @@ class BlockingConnection:
 
     @property
     def is_closed(self) -> bool:
-        """
-        Returns a boolean reporting the current connection state.
-        """
+        """Returns a boolean reporting the current connection state."""
         return self._impl.is_closed
 
     @property
     def is_open(self) -> bool:
-        """
-        Returns a boolean reporting the current connection state.
-        """
+        """Returns a boolean reporting the current connection state."""
         return self._impl.is_open
 
     #
@@ -993,35 +995,37 @@ class BlockingConnection:
 
     @property
     def basic_nack_supported(self) -> bool:
-        """Specifies if the server supports basic.nack on the active connection.
+        """
+        Specifies if the server supports basic.nack on the active connection.
 
-
+        :rtype: bool
         """
         return self._impl.basic_nack
 
     @property
     def consumer_cancel_notify_supported(self) -> bool:
-        """Specifies if the server supports consumer cancel notification on the
-        active connection.
+        """
+        Specifies if the server supports consumer cancel notification on the active connection.
 
-
+        :rtype: bool
         """
         return self._impl.consumer_cancel_notify
 
     @property
     def exchange_exchange_bindings_supported(self) -> bool:
-        """Specifies if the active connection supports exchange to exchange
-        bindings.
+        """
+        Specifies if the active connection supports exchange to exchange bindings.
 
-
+        :rtype: bool
         """
         return self._impl.exchange_exchange_bindings
 
     @property
     def publisher_confirms_supported(self) -> bool:
-        """Specifies if the active connection can use publisher confirmations.
+        """
+        Specifies if the active connection can use publisher confirmations.
 
-
+        :rtype: bool
         """
         return self._impl.publisher_confirms
 
@@ -1033,12 +1037,12 @@ class BlockingConnection:
 
 
 class _ChannelPendingEvt:
-    """Base class for BlockingChannel pending events"""
+    """Base class for BlockingChannel pending events."""
 
 
 class _ConsumerDeliveryEvt(_ChannelPendingEvt):
-    """This event represents consumer message delivery `Basic.Deliver`; it
-    contains method, properties, and body of the delivered message.
+    """This event represents consumer message delivery `Basic.Deliver`; it contains method,
+    properties, and body of the delivered message.
     """
 
     __slots__ = ('body', 'method', 'properties')
@@ -1057,10 +1061,12 @@ class _ConsumerDeliveryEvt(_ChannelPendingEvt):
 
 
 class _ConsumerCancellationEvt(_ChannelPendingEvt):
-    """This event represents server-initiated consumer cancellation delivered to
-    client via Basic.Cancel. After receiving Basic.Cancel, there will be no
-    further deliveries for the consumer identified by `consumer_tag` in
-    `Basic.Cancel`
+    """
+    This event represents server-initiated consumer cancellation delivered to client via
+    Basic.Cancel.
+
+    After receiving Basic.Cancel, there will be no further deliveries for the consumer identified by
+    `consumer_tag` in `Basic.Cancel`
     """
 
     __slots__ = ('method_frame',)
@@ -1079,8 +1085,7 @@ class _ConsumerCancellationEvt(_ChannelPendingEvt):
 
     @property
     def method(self) -> Basic.Cancel:
-        """method of type spec.Basic.Cancel
-        """
+        """Method of type spec.Basic.Cancel."""
         return self.method_frame.method
 
 
@@ -1119,14 +1124,12 @@ class _ReturnedMessageEvt(_ChannelPendingEvt):
             f' body={self.body!r:.300}>')
 
     def dispatch(self) -> None:
-        """Dispatch user's callback"""
+        """Dispatch user's callback."""
         self.callback(self.channel, self.method, self.properties, self.body)
 
 
 class ReturnedMessage:
-    """Represents a message returned via Basic.Return in publish-acknowledgments
-    mode
-    """
+    """Represents a message returned via Basic.Return in publish-acknowledgments mode."""
 
     __slots__ = ('body', 'method', 'properties')
 
@@ -1143,7 +1146,7 @@ class ReturnedMessage:
 
 
 class _ConsumerInfo:
-    """Information about an active consumer"""
+    """Information about an active consumer."""
 
     __slots__ = (
         'alternate_event_sink',
@@ -1200,27 +1203,28 @@ class _ConsumerInfo:
 
     @property
     def setting_up(self) -> bool:
-        """True if in SETTING_UP state"""
+        """True if in SETTING_UP state."""
         return self.state == self.SETTING_UP
 
     @property
     def active(self) -> bool:
-        """True if in ACTIVE state"""
+        """True if in ACTIVE state."""
         return self.state == self.ACTIVE
 
     @property
     def tearing_down(self) -> bool:
-        """True if in TEARING_DOWN state"""
+        """True if in TEARING_DOWN state."""
         return self.state == self.TEARING_DOWN
 
     @property
     def cancelled_by_broker(self) -> bool:
-        """True if in CANCELLED_BY_BROKER state"""
+        """True if in CANCELLED_BY_BROKER state."""
         return self.state == self.CANCELLED_BY_BROKER
 
 
 class _QueueConsumerGeneratorInfo:
-    """Container for information about the active queue consumer generator """
+    """Container for information about the active queue consumer generator."""
+
     __slots__ = ('consumer_tag', 'params', 'pending_events')
 
     def __init__(self, params: tuple[str, bool, bool],
@@ -1281,12 +1285,12 @@ class BlockingChannel:
 
     def __init__(self, channel_impl: pika.channel.Channel,
                  connection: BlockingConnection) -> None:
-        """Create a new instance of the Channel
+        """
+        Create a new instance of the Channel.
 
-        :param channel_impl: Channel implementation object
-            as returned from SelectConnection.channel()
+        :param channel_impl: Channel implementation object as returned from
+            SelectConnection.channel()
         :param connection: The connection object
-
         """
         self._impl = channel_impl
         self._connection = connection
@@ -1342,12 +1346,13 @@ class BlockingChannel:
         LOGGER.info("Created channel=%s", self.channel_number)
 
     def __int__(self) -> int:
-        """Return the channel object as its channel number
+        """
+        Return the channel object as its channel number.
 
         NOTE: inherited from legacy BlockingConnection; might be error-prone;
         use `channel_number` property instead.
 
-
+        :rtype: int
         """
         return self.channel_number
 
@@ -1363,7 +1368,7 @@ class BlockingChannel:
             self.close()
 
     def _cleanup(self) -> None:
-        """Clean up members that might inhibit garbage collection"""
+        """Clean up members that might inhibit garbage collection."""
         self._message_confirmation_result.reset()
         self._pending_events = deque()
         self._consumer_infos = {}
@@ -1371,54 +1376,53 @@ class BlockingChannel:
 
     @property
     def channel_number(self) -> int:
-        """Channel number"""
+        """Channel number."""
         return self._impl.channel_number
 
     @property
     def connection(self) -> BlockingConnection:
-        """The channel's BlockingConnection instance
-        """
+        """The channel's BlockingConnection instance."""
         return self._connection
 
     @property
     def is_closed(self) -> bool:
-        """Returns True if the channel is closed.
+        """
+        Returns True if the channel is closed.
 
-
+        :rtype: bool
         """
         return self._impl.is_closed
 
     @property
     def is_open(self) -> bool:
-        """Returns True if the channel is open.
+        """
+        Returns True if the channel is open.
 
-
+        :rtype: bool
         """
         return self._impl.is_open
 
     @property
     def consumer_tags(self) -> list[str]:
-        """Property method that returns a list of consumer tags for active
-        consumers
+        """
+        Property method that returns a list of consumer tags for active consumers.
 
-
+        :rtype: list
         """
         return list(self._consumer_infos.keys())
 
     _ALWAYS_READY_WAITERS = ((lambda: True),)
 
     def _flush_output(self, *waiters: Callable[[], bool]) -> None:
-        """ Flush output and process input while waiting for any of the given
-        callbacks to return true. The wait is aborted upon channel-close or
-        connection-close.
-        Otherwise, processing continues until the output is flushed AND at least
-        one of the callbacks returns true. If there are no callbacks, then
-        processing ends when all output is flushed.
+        """
+        Flush output and process input while waiting for any of the given callbacks to return true.
+        The wait is aborted upon channel-close or connection-close. Otherwise, processing continues
+        until the output is flushed AND at least one of the callbacks returns true. If there are no
+        callbacks, then processing ends when all output is flushed.
 
-        :param waiters: sequence of zero or more callables taking no args and
-                        returning true when it's time to stop processing.
-                        Their results are OR'ed together. An empty sequence is
-                        treated as equivalent to a waiter always returning true.
+        :param waiters: sequence of zero or more callables taking no args and returning true when
+            it's time to stop processing. Their results are OR'ed together. An empty sequence is
+            treated as equivalent to a waiter always returning true.
         """
         if self.is_closed:
             self._impl._raise_if_not_open()
@@ -1436,9 +1440,10 @@ class BlockingChannel:
                                     method: pika.spec.Basic.Return,
                                     properties: pika.spec.BasicProperties,
                                     body: bytes) -> None:
-        """Called as the result of Basic.Return from broker in
-        publisher-acknowledgements mode. Saves the info as a ReturnedMessage
-        instance in self._puback_return.
+        """
+        Called as the result of Basic.Return from broker in publisher-acknowledgements mode.
+
+        Saves the info as a ReturnedMessage instance in self._puback_return.
 
         :param channel: our self._impl channel
         :param method:
@@ -1461,9 +1466,9 @@ class BlockingChannel:
         self._puback_return = ReturnedMessage(method, properties, body)
 
     def _add_pending_event(self, evt: _ChannelPendingEvt) -> None:
-        """Append an event to the channel's list of events that are ready for
-        dispatch to user and signal our connection that this channel is ready
-        for event dispatch
+        """
+        Append an event to the channel's list of events that are ready for dispatch to user and
+        signal our connection that this channel is ready for event dispatch.
 
         :param evt: an event derived from _ChannelPendingEvt
         """
@@ -1472,9 +1477,11 @@ class BlockingChannel:
 
     def _on_channel_closed(self, _channel: pika.channel.Channel,
                            reason: Exception) -> None:
-        """Callback from impl notifying us that the channel has been closed.
-        This may be as the result of user-, broker-, or internal connection
-        clean-up initiated closing or meta-closing of the channel.
+        """
+        Callback from impl notifying us that the channel has been closed.
+
+        This may be as the result of user-, broker-, or internal connection clean-up initiated closing or meta-closing of the
+        channel.
 
         If it resulted from receiving `Channel.Close` from broker, we will
         expedite waking up of the event subsystem so that it may respond by
@@ -1492,7 +1499,6 @@ class BlockingChannel:
 
         :param _channel: (unused)
         :param reason:
-
         """
         LOGGER.debug('_on_channel_closed: %r; %r', reason, self)
 
@@ -1509,15 +1515,13 @@ class BlockingChannel:
     def _on_consumer_cancelled_by_broker(
             self,
             method_frame: pika.frame.Method[pika.spec.Basic.Cancel]) -> None:
-        """Called by impl when broker cancels consumer via Basic.Cancel.
+        """
+        Called by impl when broker cancels consumer via Basic.Cancel.
 
-        This is a RabbitMQ-specific feature. The circumstances include deletion
-        of queue being consumed as well as failure of a HA node responsible for
-        the queue being consumed.
+        This is a RabbitMQ-specific feature. The circumstances include deletion of queue being
+        consumed as well as failure of a HA node responsible for the queue being consumed.
 
-        :param method_frame: method frame with the
-            `spec.Basic.Cancel` method
-
+        :param method_frame: method frame with the `spec.Basic.Cancel` method
         """
         evt = _ConsumerCancellationEvt(method_frame)
 
@@ -1536,7 +1540,8 @@ class BlockingChannel:
                                       method: pika.spec.Basic.Deliver,
                                       properties: pika.spec.BasicProperties,
                                       body: bytes) -> None:
-        """Called by impl when a message is delivered for a consumer
+        """
+        Called by impl when a message is delivered for a consumer.
 
         :param _channel: The implementation channel object
         :param method:
@@ -1553,11 +1558,11 @@ class BlockingChannel:
             self._add_pending_event(evt)
 
     def _on_consumer_generator_event(self, evt: _ChannelPendingEvt) -> None:
-        """Sink for the queue consumer generator's consumer events; append the
-        event to queue consumer generator's pending events buffer.
+        """
+        Sink for the queue consumer generator's consumer events; append the event to queue consumer
+        generator's pending events buffer.
 
-        :param evt: an object of type _ConsumerDeliveryEvt or
-          _ConsumerCancellationEvt
+        :param evt: an object of type _ConsumerDeliveryEvt or _ConsumerCancellationEvt
         """
         assert self._queue_consumer_generator is not None
         self._queue_consumer_generator.pending_events.append(evt)
@@ -1566,11 +1571,11 @@ class BlockingChannel:
         self.connection._request_channel_dispatch(-self.channel_number)
 
     def _cancel_all_consumers(self) -> None:
-        """Cancel all consumers.
+        """
+        Cancel all consumers.
 
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
-
         """
         if self._consumer_infos:
             LOGGER.debug('Cancelling %i consumers', len(self._consumer_infos))
@@ -1584,10 +1589,10 @@ class BlockingChannel:
                 self.basic_cancel(consumer_tag)
 
     def _dispatch_events(self) -> None:
-        """Called by BlockingConnection to dispatch pending events.
+        """
+        Called by BlockingConnection to dispatch pending events.
 
-        `BlockingChannel` schedules this callback via
-        `BlockingConnection._request_channel_dispatch`
+        `BlockingChannel` schedules this callback via `BlockingConnection._request_channel_dispatch`
         """
         while self._pending_events:
             evt = self._pending_events.popleft()
@@ -1609,11 +1614,11 @@ class BlockingChannel:
     def close(self,
               reply_code: int = 0,
               reply_text: str = "Normal shutdown") -> None:
-        """Will invoke a clean shutdown of the channel with the AMQP Broker.
+        """
+        Will invoke a clean shutdown of the channel with the AMQP Broker.
 
         :param reply_code: The reply code to close the channel with
         :param reply_text: The reply text to close the channel with
-
         """
         LOGGER.debug('Channel.close(%s, %s)', reply_code, reply_text)
 
@@ -1630,7 +1635,8 @@ class BlockingChannel:
             self._cleanup()
 
     def flow(self, active: bool) -> bool:
-        """Turn Channel flow control off and on.
+        """
+        Turn Channel flow control off and on.
 
         NOTE: RabbitMQ doesn't support active=False; per
         https://www.rabbitmq.com/specification.html: "active=false is not
@@ -1643,7 +1649,7 @@ class BlockingChannel:
 
         :param active: Turn flow on (True) or off (False)
         :returns: True if broker will start or continue sending; False if not
-
+        :rtype: bool
         """
         with _CallbackResult(self._FlowOkCallbackResultArgs) as flow_ok_result:
             self._impl.flow(active=active,
@@ -1655,15 +1661,15 @@ class BlockingChannel:
         self, callback: Callable[[pika.frame.Method[pika.spec.Basic.Cancel]],
                                  None]
     ) -> None:
-        """Pass a callback function that will be called when Basic.Cancel
-        is sent by the broker. The callback function should receive a method
-        frame parameter.
+        """
+        Pass a callback function that will be called when Basic.Cancel is sent by the broker.
+
+        The callback function should receive a method frame parameter.
 
         :param callback: a callable for handling broker's Basic.Cancel
             notification with the call signature: callback(method_frame)
             where method_frame is of type `pika.frame.Method` with method of
             type `spec.Basic.Cancel`
-
         """
         self._impl.callbacks.add(self.channel_number,
                                  self._CONSUMER_CANCELLED_CB_KEY,
@@ -1676,8 +1682,9 @@ class BlockingChannel:
             BasicProperties, bytes
         ], None]
     ) -> None:
-        """Pass a callback function that will be called when a published
-        message is rejected and returned by the server via `Basic.Return`.
+        """
+        Pass a callback function that will be called when a published message is rejected and
+        returned by the server via `Basic.Return`.
 
         :param callback: The method to call on callback with the
             signature callback(channel, method, properties, body), where
@@ -1685,7 +1692,6 @@ class BlockingChannel:
             - method: pika.spec.Basic.Return
             - properties: pika.spec.BasicProperties
             - body: bytes
-
         """
         self._impl.add_on_return_callback(
             lambda _channel, method, properties, body: (self._add_pending_event(
@@ -1701,10 +1707,10 @@ class BlockingChannel:
                       exclusive: bool = False,
                       consumer_tag: str | None = None,
                       arguments: dict[str, Any] | None = None) -> str:
-        """Sends the AMQP command Basic.Consume to the broker and binds messages
-        for the consumer_tag to the consumer callback. If you do not pass in
-        a consumer_tag, one will be automatically generated for you. Returns
-        the consumer tag.
+        """
+        Sends the AMQP command Basic.Consume to the broker and binds messages for the consumer_tag
+        to the consumer callback. If you do not pass in a consumer_tag, one will be automatically
+        generated for you. Returns the consumer tag.
 
         NOTE: the consumer callbacks are dispatched only in the scope of
         specially-designated methods: see
@@ -1731,9 +1737,9 @@ class BlockingChannel:
           empty, a consumer tag will be generated automatically
         :param arguments: Custom key/value pair arguments for the consumer
         :returns: consumer tag
+        :rtype: str
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
             consumer_tag is already present.
-
         """
         validators.require_string(queue, 'queue')
         validators.require_callback(on_message_callback, 'on_message_callback')
@@ -1758,7 +1764,9 @@ class BlockingChannel:
         alternate_event_sink: None |
         (Callable[[_ChannelPendingEvt], None]) = None
     ) -> str:
-        """The low-level implementation used by `basic_consume` and `consume`.
+        """
+        The low-level implementation used by `basic_consume` and `consume`.
+
         See `basic_consume` docstring for more info.
 
         NOTE: exactly one of on_message_callback/alternate_event_sink musts be
@@ -1837,8 +1845,10 @@ class BlockingChannel:
         self, consumer_tag: str
     ) -> Sequence[tuple[pika.spec.Basic.Deliver, pika.spec.BasicProperties,
                         bytes]]:
-        """This method cancels a consumer. This does not affect already
-        delivered messages, but it does mean the server will not send any more
+        """
+        This method cancels a consumer.
+
+        This does not affect already delivered messages, but it does mean the server will not send any more
         messages for that consumer. The client may receive an arbitrary number
         of messages in between sending the cancel method and receiving the
         cancel-ok reply.
@@ -1861,6 +1871,7 @@ class BlockingChannel:
             - method: spec.Basic.Deliver
             - properties: spec.BasicProperties
             - body: bytes
+        :rtype: list
         """
         try:
             consumer_info = self._consumer_infos[consumer_tag]
@@ -1933,13 +1944,15 @@ class BlockingChannel:
 
     def _remove_pending_deliveries(
             self, consumer_tag: str) -> Sequence[_ConsumerDeliveryEvt]:
-        """Extract _ConsumerDeliveryEvt objects destined for the given consumer
-        from pending events, discarding the _ConsumerCancellationEvt, if any
+        """
+        Extract _ConsumerDeliveryEvt objects destined for the given consumer from pending events,
+        discarding the _ConsumerCancellationEvt, if any.
 
         :param consumer_tag:
 
         :returns: a (possibly empty) sequence of _ConsumerDeliveryEvt destined
             for the given consumer tag
+        :rtype: list
         """
         remaining_events: deque[Any] = deque()
         unprocessed_messages: list[Any] = []
@@ -1962,8 +1975,9 @@ class BlockingChannel:
         return unprocessed_messages
 
     def start_consuming(self) -> None:
-        """Processes I/O events and dispatches timers and `basic_consume`
-        callbacks until all consumers are cancelled.
+        """
+        Processes I/O events and dispatches timers and `basic_consume` callbacks until all consumers
+        are cancelled.
 
         NOTE: this blocking function may not be called from the scope of a
         pika callback, because dispatching `basic_consume` callbacks from this
@@ -1988,8 +2002,8 @@ class BlockingChannel:
             self._process_data_events(time_limit=None)
 
     def stop_consuming(self, consumer_tag: str | None = None) -> None:
-        """ Cancels all consumers, signalling the `start_consuming` loop to
-        exit.
+        """
+        Cancels all consumers, signalling the `start_consuming` loop to exit.
 
         NOTE: pending non-ackable messages will be lost; pending ackable
         messages will be rejected.
@@ -2011,8 +2025,10 @@ class BlockingChannel:
         consumer_tag: str | None = None
     ) -> Generator[tuple[pika.spec.Basic.Deliver | None,
                          pika.spec.BasicProperties | None, bytes | None]]:
-        """Blocking consumption of a queue instead of via a callback. This
-        method is a generator that yields each message as a tuple of method,
+        """
+        Blocking consumption of a queue instead of via a callback.
+
+        This method is a generator that yields each message as a tuple of method,
         properties, and body. The active generator iterator terminates when the
         consumer is cancelled by client via `BlockingChannel.cancel()` or by
         broker.
@@ -2051,7 +2067,6 @@ class BlockingChannel:
             of the existing queue consumer generator, if any.
             NEW in pika 0.10.0
         :raises ChannelClosed: when this channel is closed by broker.
-
         """
         self._impl._raise_if_not_open()
 
@@ -2134,9 +2149,9 @@ class BlockingChannel:
                     break
 
     def _process_data_events(self, time_limit: float | None) -> None:
-        """Wrapper for `BlockingConnection.process_data_events()` with common
-        channel-specific logic that raises ChannelClosed if broker closed this
-        channel.
+        """
+        Wrapper for `BlockingConnection.process_data_events()` with common channel-specific logic
+        that raises ChannelClosed if broker closed this channel.
 
         NOTE: We need to raise an exception in the context of user's call into
         our API to protect the integrity of the underlying implementation.
@@ -2150,7 +2165,6 @@ class BlockingChannel:
         and behavior.
 
         :param time_limit:
-
         """
         self.connection.process_data_events(time_limit=time_limit)
         if self.is_closed and isinstance(self._closing_reason,
@@ -2160,11 +2174,12 @@ class BlockingChannel:
             raise self._closing_reason
 
     def get_waiting_message_count(self) -> int:
-        """Returns the number of messages that may be retrieved from the current
-        queue consumer generator via `BlockingChannel.consume` without blocking.
-        NEW in pika 0.10.0
+        """
+        Returns the number of messages that may be retrieved from the current queue consumer
+        generator via `BlockingChannel.consume` without blocking. NEW in pika 0.10.0.
 
         :returns: The number of waiting messages
+        :rtype: int
         """
         if self._queue_consumer_generator is not None:
             pending_events = self._queue_consumer_generator.pending_events
@@ -2177,8 +2192,9 @@ class BlockingChannel:
         return count
 
     def cancel(self) -> int:
-        """Cancel the queue consumer created by `BlockingChannel.consume`,
-        rejecting all pending ackable messages.
+        """
+        Cancel the queue consumer created by `BlockingChannel.consume`, rejecting all pending
+        ackable messages.
 
         NOTE: If you're looking to cancel a consumer issued with
         BlockingChannel.basic_consume then you should call
@@ -2186,7 +2202,7 @@ class BlockingChannel:
 
         :returns: The number of messages requeued by Basic.Nack.
             NEW in 0.10.0: returns 0
-
+        :rtype: int
         """
         if self._queue_consumer_generator is None:
             LOGGER.warning('cancel: queue consumer generator is inactive '
@@ -2219,21 +2235,19 @@ class BlockingChannel:
         return 0
 
     def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
-        """Acknowledge one or more messages. When sent by the client, this
-        method acknowledges one or more messages delivered via the Deliver or
-        Get-Ok methods. When sent by server, this method acknowledges one or
-        more messages published with the Publish method on a channel in
-        confirm mode. The acknowledgement can be for a single message or a
-        set of messages up to and including a specific message.
+        """
+        Acknowledge one or more messages.
+
+        When sent by the client, this method acknowledges one or more messages delivered via the
+        Deliver or Get-Ok methods. When sent by server, this method acknowledges one or more
+        messages published with the Publish method on a channel in confirm mode. The acknowledgement
+        can be for a single message or a set of messages up to and including a specific message.
 
         :param delivery_tag: The server-assigned delivery tag
-        :param multiple: If set to True, the delivery tag is treated as
-                              "up to and including", so that multiple messages
-                              can be acknowledged with a single method. If set
-                              to False, the delivery tag refers to a single
-                              message. If the multiple field is 1, and the
-                              delivery tag is zero, this indicates
-                              acknowledgement of all outstanding messages.
+        :param multiple: If set to True, the delivery tag is treated as "up to and including", so
+            that multiple messages can be acknowledged with a single method. If set to False, the
+            delivery tag refers to a single message. If the multiple field is 1, and the delivery
+            tag is zero, this indicates acknowledgement of all outstanding messages.
         """
         self._impl.basic_ack(delivery_tag=delivery_tag, multiple=multiple)
         self._flush_output()
@@ -2242,23 +2256,20 @@ class BlockingChannel:
                    delivery_tag: int = 0,
                    multiple: bool = False,
                    requeue: bool = True) -> None:
-        """This method allows a client to reject one or more incoming messages.
-        It can be used to interrupt and cancel large incoming messages, or
-        return untreatable messages to their original queue.
+        """
+        This method allows a client to reject one or more incoming messages.
+
+        It can be used to interrupt and cancel large incoming messages, or return untreatable
+        messages to their original queue.
 
         :param delivery_tag: The server-assigned delivery tag
-        :param multiple: If set to True, the delivery tag is treated as
-                              "up to and including", so that multiple messages
-                              can be acknowledged with a single method. If set
-                              to False, the delivery tag refers to a single
-                              message. If the multiple field is 1, and the
-                              delivery tag is zero, this indicates
-                              acknowledgement of all outstanding messages.
-        :param requeue: If requeue is true, the server will attempt to
-                             requeue the message. If requeue is false or the
-                             requeue attempt fails the messages are discarded or
-                             dead-lettered.
-
+        :param multiple: If set to True, the delivery tag is treated as "up to and including", so
+            that multiple messages can be acknowledged with a single method. If set to False, the
+            delivery tag refers to a single message. If the multiple field is 1, and the delivery
+            tag is zero, this indicates acknowledgement of all outstanding messages.
+        :param requeue: If requeue is true, the server will attempt to requeue the message. If
+            requeue is false or the requeue attempt fails the messages are discarded or dead-
+            lettered.
         """
         self._impl.basic_nack(delivery_tag=delivery_tag,
                               multiple=multiple,
@@ -2271,13 +2282,16 @@ class BlockingChannel:
         auto_ack: bool = False
     ) -> tuple[pika.spec.Basic.GetOk | None, pika.spec.BasicProperties | None,
                bytes | None]:
-        """Get a single message from the AMQP broker. Returns a sequence with
-        the method frame, message properties, and body.
+        """
+        Get a single message from the AMQP broker.
+
+        Returns a sequence with the method frame, message properties, and body.
 
         :param queue: Name of queue from which to get a message
         :param auto_ack: Tell the broker to not expect a reply
-        :returns: a three-tuple; (None, None, None) if the queue was empty;
-            otherwise (method, properties, body); NOTE: body may be None
+        :returns: a three-tuple; (None, None, None) if the queue was empty; otherwise (method,
+            properties, body); NOTE: body may be None
+        :rtype: (spec.Basic.GetOk|None, spec.BasicProperties|None, bytes|None)
         """
         assert not self._basic_getempty_result
 
@@ -2303,8 +2317,8 @@ class BlockingChannel:
                       body: bytes,
                       properties: pika.spec.BasicProperties | None = None,
                       mandatory: bool = False) -> None:
-        """Publish to the channel with the given exchange, routing key, and
-        body.
+        """
+        Publish to the channel with the given exchange, routing key, and body.
 
         For more information on basic_publish and what the parameters do, see:
 
@@ -2328,7 +2342,6 @@ class BlockingChannel:
         :raises NackError: raised when a message published in
             publisher-acknowledgements mode is Nack'ed by the broker. See
             `BlockingChannel.confirm_delivery`.
-
         """
         if self._delivery_confirmation:
             # In publisher-acknowledgments mode
@@ -2381,33 +2394,25 @@ class BlockingChannel:
                   prefetch_size: int = 0,
                   prefetch_count: int = 0,
                   global_qos: bool = False) -> None:
-        """Specify quality of service. This method requests a specific quality
-        of service. The QoS can be specified for the current channel or for all
-        channels on the connection. The client can request that messages be sent
-        in advance so that when the client finishes processing a message, the
-        following message is already held locally, rather than needing to be
-        sent down the channel. Prefetching gives a performance improvement.
+        """
+        Specify quality of service.
 
-        :param prefetch_size:  This field specifies the prefetch window
-                                   size. The server will send a message in
-                                   advance if it is equal to or smaller in size
-                                   than the available prefetch size (and also
-                                   falls into other prefetch limits). May be set
-                                   to zero, meaning "no specific limit",
-                                   although other prefetch limits may still
-                                   apply. The prefetch-size is ignored if the
-                                   no-ack option is set in the consumer.
-        :param prefetch_count: Specifies a prefetch window in terms of whole
-                                   messages. This field may be used in
-                                   combination with the prefetch-size field; a
-                                   message will only be sent in advance if both
-                                   prefetch windows (and those at the channel
-                                   and connection level) allow it. The
-                                   prefetch-count is ignored if the no-ack
-                                   option is set in the consumer.
-        :param global_qos:    Should the QoS apply to all channels on the
-                                   connection.
+        This method requests a specific quality of service. The QoS can be specified for the current
+        channel or for all channels on the connection. The client can request that messages be sent
+        in advance so that when the client finishes processing a message, the following message is
+        already held locally, rather than needing to be sent down the channel. Prefetching gives a
+        performance improvement.
 
+        :param prefetch_size: This field specifies the prefetch window size. The server will send a
+            message in advance if it is equal to or smaller in size than the available prefetch size
+            (and also falls into other prefetch limits). May be set to zero, meaning "no specific
+            limit", although other prefetch limits may still apply. The prefetch-size is ignored if
+            the no-ack option is set in the consumer.
+        :param prefetch_count: Specifies a prefetch window in terms of whole messages. This field
+            may be used in combination with the prefetch-size field; a message will only be sent in
+            advance if both prefetch windows (and those at the channel and connection level) allow
+            it. The prefetch-count is ignored if the no-ack option is set in the consumer.
+        :param global_qos: Should the QoS apply to all channels on the connection.
         """
         with _CallbackResult() as qos_ok_result:
             self._impl.basic_qos(callback=qos_ok_result.signal_once,
@@ -2417,15 +2422,13 @@ class BlockingChannel:
             self._flush_output(qos_ok_result.is_ready)
 
     def basic_recover(self, requeue: bool = False) -> None:
-        """This method asks the server to redeliver all unacknowledged messages
-        on a specified channel. Zero or more messages may be redelivered. This
-        method replaces the asynchronous Recover.
+        """
+        This method asks the server to redeliver all unacknowledged messages on a specified channel.
+        Zero or more messages may be redelivered. This method replaces the asynchronous Recover.
 
-        :param requeue: If False, the message will be redelivered to the
-                             original recipient. If True, the server will
-                             attempt to requeue the message, potentially then
-                             delivering it to an alternative subscriber.
-
+        :param requeue: If False, the message will be redelivered to the original recipient. If
+            True, the server will attempt to requeue the message, potentially then delivering it to
+            an alternative subscriber.
         """
         with _CallbackResult() as recover_ok_result:
             self._impl.basic_recover(requeue=requeue,
@@ -2433,22 +2436,23 @@ class BlockingChannel:
             self._flush_output(recover_ok_result.is_ready)
 
     def basic_reject(self, delivery_tag: int = 0, requeue: bool = True) -> None:
-        """Reject an incoming message. This method allows a client to reject a
-        message. It can be used to interrupt and cancel large incoming messages,
-        or return untreatable messages to their original queue.
+        """
+        Reject an incoming message.
+
+        This method allows a client to reject a message. It can be used to interrupt and cancel
+        large incoming messages, or return untreatable messages to their original queue.
 
         :param delivery_tag: The server-assigned delivery tag
-        :param requeue: If requeue is true, the server will attempt to
-                             requeue the message. If requeue is false or the
-                             requeue attempt fails the messages are discarded or
-                             dead-lettered.
-
+        :param requeue: If requeue is true, the server will attempt to requeue the message. If
+            requeue is false or the requeue attempt fails the messages are discarded or dead-
+            lettered.
         """
         self._impl.basic_reject(delivery_tag=delivery_tag, requeue=requeue)
         self._flush_output()
 
     def confirm_delivery(self) -> None:
-        """Turn on RabbitMQ-proprietary Confirm mode in the channel.
+        """
+        Turn on RabbitMQ-proprietary Confirm mode in the channel.
 
         For more information see:
             https://www.rabbitmq.com/confirms.html
@@ -2482,9 +2486,9 @@ class BlockingChannel:
                          auto_delete: bool = False,
                          internal: bool = False,
                          arguments: dict[str, Any] | None = None) -> None:
-        """This method creates an exchange if it does not already exist, and if
-        the exchange exists, verifies that it is of the correct and expected
-        class.
+        """
+        This method creates an exchange if it does not already exist, and if the exchange exists,
+        verifies that it is of the correct and expected class.
 
         If passive set, the server will reply with Declare-Ok if the exchange
         already exists with the same name, and raise an error if not and if the
@@ -2501,7 +2505,8 @@ class BlockingChannel:
         :param internal: Can only be published to by other exchanges
         :param arguments: Custom key/value pair arguments for the exchange
         :returns: Method frame from the Exchange.Declare-ok response
-
+        :rtype: `pika.frame.Method` having `method` attribute of type
+            `spec.Exchange.DeclareOk`
         """
         validators.require_string(exchange, 'exchange')
         with _CallbackResult(
@@ -2523,12 +2528,13 @@ class BlockingChannel:
                         exchange: str | None = None,
                         if_unused: bool = False
                        ) -> pika.frame.Method[pika.spec.Exchange.DeleteOk]:
-        """Delete the exchange.
+        """
+        Delete the exchange.
 
         :param exchange: The exchange name
         :param if_unused: only delete if the exchange is unused
         :returns: Method frame from the Exchange.Delete-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Exchange.DeleteOk`
         """
         with _CallbackResult(
                 self._MethodFrameCallbackResultArgs) as delete_ok_result:
@@ -2546,19 +2552,20 @@ class BlockingChannel:
         routing_key: str = '',
         arguments: dict[str, Any] | None = None
     ) -> pika.frame.Method[pika.spec.Exchange.BindOk]:
-        """Bind an exchange to another exchange.
+        """
+        Bind an exchange to another exchange.
 
         :param destination: The destination exchange to bind
         :param source: The source exchange to bind to
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Method frame from the Exchange.Bind-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Exchange.BindOk`
         """
         validators.require_string(destination, 'destination')
         validators.require_string(source, 'source')
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                bind_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as bind_ok_result:
             self._impl.exchange_bind(destination=destination,
                                      source=source,
                                      routing_key=routing_key,
@@ -2575,14 +2582,15 @@ class BlockingChannel:
         routing_key: str = '',
         arguments: dict[str, Any] | None = None
     ) -> pika.frame.Method[pika.spec.Exchange.UnbindOk]:
-        """Unbind an exchange from another exchange.
+        """
+        Unbind an exchange from another exchange.
 
         :param destination: The destination exchange to unbind
         :param source: The source exchange to unbind from
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Method frame from the Exchange.Unbind-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Exchange.UnbindOk`
         """
         with _CallbackResult(
                 self._MethodFrameCallbackResultArgs) as unbind_ok_result:
@@ -2604,8 +2612,10 @@ class BlockingChannel:
         auto_delete: bool = False,
         arguments: dict[str, Any] | None = None
     ) -> pika.frame.Method[pika.spec.Queue.DeclareOk]:
-        """Declare queue, create if needed. This method creates or checks a
-        queue. When creating a new queue the client can specify various
+        """
+        Declare queue, create if needed.
+
+        This method creates or checks a queue. When creating a new queue the client can specify various
         properties that control the durability of the queue and its contents,
         and the level of sharing for the queue.
 
@@ -2622,11 +2632,12 @@ class BlockingChannel:
         :param auto_delete: Delete after consumer cancels or disconnects
         :param arguments: Custom key/value arguments for the queue
         :returns: Method frame from the Queue.Declare-ok response
-
+        :rtype: `pika.frame.Method` having `method` attribute of type
+            `spec.Queue.DeclareOk`
         """
         validators.require_string(queue, 'queue')
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                declare_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as declare_ok_result:
             self._impl.queue_declare(queue=queue,
                                      passive=passive,
                                      durable=durable,
@@ -2643,16 +2654,17 @@ class BlockingChannel:
                      if_unused: bool = False,
                      if_empty: bool = False
                     ) -> pika.frame.Method[pika.spec.Queue.DeleteOk]:
-        """Delete a queue from the broker.
+        """
+        Delete a queue from the broker.
 
         :param queue: The queue to delete
         :param if_unused: only delete if it's unused
         :param if_empty: only delete if the queue is empty
         :returns: Method frame from the Queue.Delete-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Queue.DeleteOk`
         """
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                delete_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as delete_ok_result:
             self._impl.queue_delete(queue=queue,
                                     if_unused=if_unused,
                                     if_empty=if_empty,
@@ -2663,14 +2675,15 @@ class BlockingChannel:
 
     def queue_purge(self,
                     queue: str) -> pika.frame.Method[pika.spec.Queue.PurgeOk]:
-        """Purge all of the messages from the specified queue
+        """
+        Purge all of the messages from the specified queue.
 
         :param queue: The queue to purge
         :returns: Method frame from the Queue.Purge-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Queue.PurgeOk`
         """
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                purge_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as purge_ok_result:
             self._impl.queue_purge(queue=queue,
                                    callback=purge_ok_result.set_value_once)
             self._flush_output(purge_ok_result.is_ready)
@@ -2683,15 +2696,15 @@ class BlockingChannel:
         routing_key: str | None = None,
         arguments: dict[str, Any] | None = None
     ) -> pika.frame.Method[pika.spec.Queue.BindOk]:
-        """Bind the queue to the specified exchange
+        """
+        Bind the queue to the specified exchange.
 
         :param queue: The queue to bind to the exchange
         :param exchange: The source exchange to bind to
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
-
         :returns: Method frame from the Queue.Bind-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Queue.BindOk`
         """
         validators.require_string(queue, 'queue')
         validators.require_string(exchange, 'exchange')
@@ -2712,18 +2725,18 @@ class BlockingChannel:
         routing_key: str | None = None,
         arguments: dict[str, Any] | None = None
     ) -> pika.frame.Method[pika.spec.Queue.UnbindOk]:
-        """Unbind a queue from an exchange.
+        """
+        Unbind a queue from an exchange.
 
         :param queue: The queue to unbind from the exchange
         :param exchange: The source exchange to bind from
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
-
         :returns: Method frame from the Queue.Unbind-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Queue.UnbindOk`
         """
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                unbind_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as unbind_ok_result:
             self._impl.queue_unbind(queue=queue,
                                     exchange=exchange,
                                     routing_key=routing_key,
@@ -2733,41 +2746,45 @@ class BlockingChannel:
             return unbind_ok_result.value.method_frame
 
     def tx_select(self) -> pika.frame.Method[pika.spec.Tx.SelectOk]:
-        """Select standard transaction mode. This method sets the channel to use
-        standard transactions. The client must use this method at least once on
-        a channel before using the Commit or Rollback methods.
+        """
+        Select standard transaction mode.
+
+        This method sets the channel to use standard transactions. The client must use this method
+        at least once on a channel before using the Commit or Rollback methods.
 
         :returns: Method frame from the Tx.Select-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Tx.SelectOk`
         """
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                select_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as select_ok_result:
             self._impl.tx_select(select_ok_result.set_value_once)
 
             self._flush_output(select_ok_result.is_ready)
             return select_ok_result.value.method_frame
 
     def tx_commit(self) -> pika.frame.Method[pika.spec.Tx.CommitOk]:
-        """Commit a transaction.
+        """
+        Commit a transaction.
 
         :returns: Method frame from the Tx.Commit-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Tx.CommitOk`
         """
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                commit_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as commit_ok_result:
             self._impl.tx_commit(commit_ok_result.set_value_once)
 
             self._flush_output(commit_ok_result.is_ready)
             return commit_ok_result.value.method_frame
 
     def tx_rollback(self) -> pika.frame.Method[pika.spec.Tx.RollbackOk]:
-        """Rollback a transaction.
+        """
+        Rollback a transaction.
 
         :returns: Method frame from the Tx.Rollback-ok response
-
+        :rtype:`pika.frame.Method` having `method` attribute of type `spec.Tx.RollbackOk`
         """
-        with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
-                rollback_ok_result:
+        with _CallbackResult(
+                self._MethodFrameCallbackResultArgs) as rollback_ok_result:
             self._impl.tx_rollback(rollback_ok_result.set_value_once)
 
             self._flush_output(rollback_ok_result.is_ready)

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -1,4 +1,5 @@
 """Use pika with the Gevent IOLoop."""
+
 from __future__ import annotations
 
 import functools
@@ -34,7 +35,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class GeventConnection(BaseConnection):
-    """Implementation of pika's ``BaseConnection``.
+    """
+    Implementation of pika's ``BaseConnection``.
 
     An async selector-based connection which integrates with Gevent.
     """
@@ -52,8 +54,8 @@ class GeventConnection(BaseConnection):
                  custom_ioloop: None |
                  (gevent._interfaces.ILoop | AbstractIOServices) = None,
                  internal_connection_workflow: bool = True) -> None:
-        """Create a new GeventConnection instance and connect to RabbitMQ on
-        Gevent's event-loop.
+        """
+        Create a new GeventConnection instance and connect to RabbitMQ on Gevent's event-loop.
 
         :param parameters: The connection
             parameters
@@ -126,7 +128,8 @@ class GeventConnection(BaseConnection):
         nbio = _GeventSelectorIOServicesAdapter(custom_ioloop)
 
         def connection_factory(params) -> GeventConnection:
-            """Connection factory.
+            """
+            Connection factory.
 
             :param params: Connection parameters
             """
@@ -146,13 +149,15 @@ class GeventConnection(BaseConnection):
 
 
 class _TSafeCallbackQueue:
-    """Dispatch callbacks from any thread to be executed in the main thread
-    efficiently with IO events.
+    """Dispatch callbacks from any thread to be executed in the main thread efficiently with IO
+    events.
     """
 
     def __init__(self) -> None:
-        """Initialize the callback queue.
+        """
+        Initialize the callback queue.
 
+        :rtype: None
         """
         # Thread-safe, blocking queue.
         self._queue: queue.Queue[Callable[[], None]] = queue.Queue()
@@ -168,10 +173,13 @@ class _TSafeCallbackQueue:
         return self._read_fd
 
     def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
-        """Add a callback to the queue from any thread. The configured handler
-        will be invoked with the callback in the main thread.
+        """
+        Add a callback to the queue from any thread.
+
+        The configured handler will be invoked with the callback in the main thread.
 
         :param callback: Callback to add to the queue.
+        :rtype: None
         """
         self._queue.put(callback)
         with self._write_lock:
@@ -179,13 +187,14 @@ class _TSafeCallbackQueue:
             os.write(self._write_fd, b'\xFF')
 
     def run_next_callback(self) -> None:
-        """Invoke the next callback from the queue.
+        """
+        Invoke the next callback from the queue.
 
-        MUST run in the main thread. If no callback was added to the queue,
-        this will block the IO loop.
+        MUST run in the main thread. If no callback was added to the queue, this will block the IO
+        loop.
 
-        Performs a blocking READ on the pipe so must only be called when the
-        pipe is ready for reading.
+        Performs a blocking READ on the pipe so must only be called when the pipe is ready for
+        reading.
         """
         try:
             callback = self._queue.get_nowait()
@@ -199,10 +208,12 @@ class _TSafeCallbackQueue:
 
 
 class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
-    """Implementation of `AbstractSelectorIOLoop` using the Gevent event loop.
+    """
+    Implementation of `AbstractSelectorIOLoop` using the Gevent event loop.
 
     Required by implementations of `SelectorIOServicesAdapter`.
     """
+
     # Gevent's READ and WRITE masks are defined as 1 and 2 respectively. No
     # ERROR mask is defined.
     # See https://www.gevent.org/api/gevent.hub.html#gevent._interfaces.ILoop.io
@@ -237,7 +248,10 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         self._hub = None
 
     def start(self) -> None:
-        """Run the I/O loop. It will loop until requested to exit. See `stop()`.
+        """
+        Run the I/O loop.
+
+        It will loop until requested to exit. See `stop()`.
         """
         LOGGER.debug("Passing control to Gevent's IOLoop")
         self._waiter.get()  # Block until 'stop()' is called.
@@ -246,19 +260,22 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         self._waiter.clear()
 
     def stop(self) -> None:
-        """Request exit from the ioloop. The loop is NOT guaranteed to
-        stop before this method returns.
+        """
+        Request exit from the ioloop.
 
-        To invoke `stop()` safely from a thread other than this IOLoop's thread,
-        call it via `add_callback_threadsafe`; e.g.,
+        The loop is NOT guaranteed to stop before this method returns.
 
-            `ioloop.add_callback(ioloop.stop)`
+        To invoke `stop()` safely from a thread other than this IOLoop's thread, call it via
+        `add_callback_threadsafe`; e.g.,
+
+        `ioloop.add_callback(ioloop.stop)`
         """
         self._waiter.switch(None)
 
     def add_callback(self, callback: Callable[[], None]) -> None:
-        """Requests a call to the given function as soon as possible in the
-        context of this IOLoop's thread.
+        """
+        Requests a call to the given function as soon as possible in the context of this IOLoop's
+        thread.
 
         NOTE: This is the only thread-safe method in IOLoop. All other
         manipulations of IOLoop must be performed from the IOLoop's thread.
@@ -285,14 +302,14 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
             self._callback_queue.add_callback_threadsafe(callback)
 
     def call_later(self, delay: float, callback: Callable[[], None]) -> Any:
-        """Add the callback to the IOLoop timer to be called after delay seconds
-        from the time of call on best-effort basis. Returns a handle to the
-        timeout.
+        """
+        Add the callback to the IOLoop timer to be called after delay seconds from the time of call
+        on best-effort basis. Returns a handle to the timeout.
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback method
-        :returns: handle to the created timeout that may be passed to
-            `remove_timeout()`
+        :returns: handle to the created timeout that may be passed to `remove_timeout()`
+        :rtype: object
         """
         timer = self._hub.loop.timer(
             delay)  # pyright: ignore[reportOptionalMemberAccess]
@@ -300,7 +317,8 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         return timer
 
     def remove_timeout(self, timeout_handle: Any) -> None:
-        """Remove a timeout
+        """
+        Remove a timeout.
 
         :param timeout_handle: Handle of timeout to remove
         """
@@ -308,11 +326,11 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
 
     def add_handler(self, fd: int, handler: Callable[[int, int], None],
                     events: int) -> None:
-        """Start watching the given file descriptor for events
+        """
+        Start watching the given file descriptor for events.
 
         :param fd: The file descriptor
-        :param handler: When requested event(s) occur,
-            `handler(fd, events)` will be called.
+        :param handler: When requested event(s) occur, `handler(fd, events)` will be called.
         :param events: The event mask (READ|WRITE)
         """
         io_watcher = self._hub.loop.io(
@@ -321,7 +339,8 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         io_watcher.start(handler, fd, events)
 
     def update_handler(self, fd: int, events: int) -> None:
-        """Change the events being watched for.
+        """
+        Change the events being watched for.
 
         :param fd: The file descriptor
         :param events: The new event mask (READ|WRITE)
@@ -335,7 +354,8 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         self.add_handler(fd, callback, events)
 
     def remove_handler(self, fd: int) -> None:
-        """Stop watching the given file descriptor for events
+        """
+        Stop watching the given file descriptor for events.
 
         :param fd: The file descriptor
         """
@@ -355,7 +375,9 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
                     socktype: int = 0,
                     proto: int = 0,
                     flags: int = 0) -> nbio_interface.AbstractIOReference:
-        """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
+        """
+        Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
+
         :param host: Hostname or IP address
         :param port: TCP port number
         :param on_done: The callback to call with the result of getaddrinfo
@@ -378,7 +400,8 @@ class _GeventSelectorIOServicesAdapter(SelectorIOServicesAdapter):
 
 
 class _GeventIOLoopIOHandle(AbstractIOReference):
-    """Implement `AbstractIOReference`.
+    """
+    Implement `AbstractIOReference`.
 
     Only used to wrap the _GeventAddressResolver.
     """
@@ -390,19 +413,23 @@ class _GeventIOLoopIOHandle(AbstractIOReference):
         self._cancel = subject.cancel
 
     def cancel(self) -> bool:
-        """Cancel pending operation
+        """
+        Cancel pending operation.
 
         :returns: False if was already done or cancelled; True otherwise
+        :rtype: bool
         """
         return self._cancel()
 
 
 class _GeventAddressResolver:
-    """Performs getaddrinfo asynchronously Gevent's configured resolver in a
-    separate greenlet and invoking the provided callback with the result.
+    """
+    Performs getaddrinfo asynchronously Gevent's configured resolver in a separate greenlet and
+    invoking the provided callback with the result.
 
     See: https://www.gevent.org/dns.html
     """
+
     __slots__ = (
         '_ga_family',
         '_ga_flags',
@@ -419,19 +446,19 @@ class _GeventAddressResolver:
     def __init__(self, native_loop: AbstractSelectorIOLoop, host: str,
                  port: int, family: int, socktype: int, proto: int, flags: int,
                  on_done: Callable[..., None]) -> None:
-        """Initialize the `_GeventAddressResolver`.
+        """
+        Initialize the `_GeventAddressResolver`.
 
         :param native_loop:
-        :param host: `see socket.getaddrinfo()`
-        :param port: `see socket.getaddrinfo()`
-        :param family: `see socket.getaddrinfo()`
-        :param socktype: `see socket.getaddrinfo()`
-        :param proto: `see socket.getaddrinfo()`
-        :param flags: `see socket.getaddrinfo()`
-        :param on_done: on_done(records|BaseException) callback for reporting
-            result from the given I/O loop. The single arg will be either an
-            exception object (check for `BaseException`) in case of failure or
-            the result returned by `socket.getaddrinfo()`.
+        :param host:`see socket.getaddrinfo()`
+        :param port:`see socket.getaddrinfo()`
+        :param family:`see socket.getaddrinfo()`
+        :param socktype:`see socket.getaddrinfo()`
+        :param proto:`see socket.getaddrinfo()`
+        :param flags:`see socket.getaddrinfo()`
+        :param on_done: on_done(records|BaseException) callback for reporting result from the given
+            I/O loop. The single arg will be either an exception object (check for `BaseException`)
+            in case of failure or the result returned by `socket.getaddrinfo()`.
         """
         check_callback_arg(on_done, 'on_done')
 
@@ -455,8 +482,10 @@ class _GeventAddressResolver:
             LOGGER.warning("_GeventAddressResolver already started")
 
     def cancel(self) -> bool:
-        """Cancel the pending resolver.
+        """
+        Cancel the pending resolver.
 
+        :rtype: bool
         """
         changed = False
 
@@ -474,7 +503,8 @@ class _GeventAddressResolver:
         self._on_done = None
 
     def _stop_greenlet(self) -> None:
-        """Stop the greenlet performing getaddrinfo if running.
+        """
+        Stop the greenlet performing getaddrinfo if running.
 
         Otherwise, this is a no-op.
         """
@@ -483,8 +513,8 @@ class _GeventAddressResolver:
             self._greenlet = None
 
     def _resolve(self) -> None:
-        """Call `getaddrinfo()` and return result via user's callback
-        function on the configured IO loop.
+        """Call `getaddrinfo()` and return result via user's callback function on the configured IO
+        loop.
         """
         try:
             result = gevent.socket.getaddrinfo(self._ga_host, self._ga_port,
@@ -504,7 +534,8 @@ class _GeventAddressResolver:
                                   (tuple[str, int] | tuple[str, int, int, int] |
                                    tuple[int, bytes])]] | Exception)
     ) -> None:
-        """Invoke the configured completion callback and any subsequent cleanup.
+        """
+        Invoke the configured completion callback and any subsequent cleanup.
 
         :param result: result from getaddrinfo, or the exception if raised.
         """

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -1,7 +1,7 @@
-"""A connection adapter that tries to use the best polling method for the
-platform pika is running on.
-
+"""A connection adapter that tries to use the best polling method for the platform pika is running
+on.
 """
+
 from __future__ import annotations
 
 import abc
@@ -71,9 +71,10 @@ _SELECT_ERRORS: tuple[type[SELECT_ERROR_T],
 
 
 def _is_resumable(exc: SELECT_ERROR_T) -> bool:
-    """Check if caught exception represents EINTR error.
-    :param exc: exception; must be one of classes in _SELECT_ERRORS
+    """
+    Check if caught exception represents EINTR error.
 
+    :param exc: exception; must be one of classes in _SELECT_ERRORS
     """
     checker = _SELECT_ERROR_CHECKERS.get(exc.__class__, None)
     if checker is not None:
@@ -82,9 +83,8 @@ def _is_resumable(exc: SELECT_ERROR_T) -> bool:
 
 
 class SelectConnection(BaseConnection):
-    """An asynchronous connection adapter that attempts to use the fastest
-    event loop adapter for the given platform.
-
+    """An asynchronous connection adapter that attempts to use the fastest event loop adapter for
+    the given platform.
     """
 
     def __init__(self,
@@ -100,7 +100,8 @@ class SelectConnection(BaseConnection):
                  custom_ioloop: None |
                  (nbio_interface.AbstractIOServices | IOLoop) = None,
                  internal_connection_workflow: bool = True) -> None:
-        """Create a new instance of the Connection object.
+        """
+        Create a new instance of the Connection object.
 
         :param parameters: Connection parameters
         :param on_open_callback: Method to call on connection open
@@ -120,7 +121,6 @@ class SelectConnection(BaseConnection):
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
         :raises RuntimeError:
-
         """
         if isinstance(custom_ioloop, nbio_interface.AbstractIOServices):
             nbio = custom_ioloop
@@ -158,7 +158,9 @@ class SelectConnection(BaseConnection):
         nbio = SelectorIOServicesAdapter(custom_ioloop or IOLoop())
 
         def connection_factory(params) -> SelectConnection:
-            """Connection factory.
+            """
+            Connection factory.
+
             :param params: Connection parameters
             """
             if params is None:
@@ -178,13 +180,14 @@ class SelectConnection(BaseConnection):
     def _get_write_buffer_size(self) -> int:
         """
         :returns: Current size of output data buffered by the transport
+        :rtype: int
         """
         assert self._transport is not None
         return self._transport.get_write_buffer_size()
 
 
 class _Timeout:
-    """Represents a timeout"""
+    """Represents a timeout."""
 
     __slots__ = (
         'callback',
@@ -197,7 +200,6 @@ class _Timeout:
         :param callback: callback to call when timeout expires
         :raises ValueError, TypeError:
         """
-
         if deadline < 0:
             raise ValueError(
                 f'deadline must be non-negative epoch number, but got {deadline!r}'
@@ -211,45 +213,45 @@ class _Timeout:
         self.callback: Callable[[], None] | None = callback
 
     def __eq__(self, other: object) -> bool:
-        """NOTE: not supporting sort stability"""
+        """NOTE: not supporting sort stability."""
         if isinstance(other, _Timeout):
             return self.deadline == other.deadline
         return NotImplemented
 
     def __ne__(self, other: object) -> bool:
-        """NOTE: not supporting sort stability"""
+        """NOTE: not supporting sort stability."""
         result = self.__eq__(other)
         if result is not NotImplemented:
             return not result
         return NotImplemented
 
     def __lt__(self, other: object) -> bool:
-        """NOTE: not supporting sort stability"""
+        """NOTE: not supporting sort stability."""
         if isinstance(other, _Timeout):
             return self.deadline < other.deadline
         return NotImplemented
 
     def __gt__(self, other: object) -> bool:
-        """NOTE: not supporting sort stability"""
+        """NOTE: not supporting sort stability."""
         if isinstance(other, _Timeout):
             return self.deadline > other.deadline
         return NotImplemented
 
     def __le__(self, other: object) -> bool:
-        """NOTE: not supporting sort stability"""
+        """NOTE: not supporting sort stability."""
         if isinstance(other, _Timeout):
             return self.deadline <= other.deadline
         return NotImplemented
 
     def __ge__(self, other: object) -> bool:
-        """NOTE: not supporting sort stability"""
+        """NOTE: not supporting sort stability."""
         if isinstance(other, _Timeout):
             return self.deadline >= other.deadline
         return NotImplemented
 
 
 class _Timer:
-    """Manage timeouts for use in ioloop"""
+    """Manage timeouts for use in ioloop."""
 
     # Cancellation count threshold for triggering garbage collection of
     # cancelled timers
@@ -262,8 +264,10 @@ class _Timer:
         self._num_cancellations = 0
 
     def close(self) -> None:
-        """Release resources. Don't use the `_Timer` instance after closing
-        it
+        """
+        Release resources.
+
+        Don't use the `_Timer` instance after closing it
         """
         # Eliminate potential reference cycles to aid garbage-collection
         if self._timeout_heap is not None:
@@ -273,7 +277,8 @@ class _Timer:
 
     def call_later(self, delay: float, callback: Callable[[],
                                                           None]) -> _Timeout:
-        """Schedule a one-shot timeout given delay seconds.
+        """
+        Schedule a one-shot timeout given delay seconds.
 
         NOTE: you may cancel the timer before dispatch of the callback. Timer
             Manager cancels the timer upon dispatch of the callback.
@@ -283,8 +288,8 @@ class _Timer:
         :param callback: The callback method, having the signature
             `callback()`
 
+        :rtype: _Timeout
         :raises ValueError, TypeError
-
         """
         if self._timeout_heap is None:
             raise ValueError("Timeout closed before call")
@@ -307,10 +312,10 @@ class _Timer:
         return timeout
 
     def remove_timeout(self, timeout: _Timeout) -> None:
-        """Cancel the timeout
+        """
+        Cancel the timeout.
 
         :param timeout: The timer to cancel
-
         """
         # NOTE removing from the heap is difficult, so we just deactivate the
         # timeout and garbage-collect it at a later time; see discussion
@@ -327,11 +332,12 @@ class _Timer:
             self._num_cancellations += 1
 
     def get_remaining_interval(self) -> float | None:
-        """Get the interval to the next timeout expiration
+        """
+        Get the interval to the next timeout expiration.
 
         :returns: non-negative number of seconds until next timer expiration;
                   None if there are no timers
-
+        :rtype: float
         """
         if self._timeout_heap:
             now = pika._utils.time_now()
@@ -342,10 +348,7 @@ class _Timer:
         return interval
 
     def process_timeouts(self) -> None:
-        """Process pending timeouts, invoking callbacks for those whose time has
-        come
-
-        """
+        """Process pending timeouts, invoking callbacks for those whose time has come."""
         if self._timeout_heap:
             now = pika._utils.time_now()
 
@@ -381,7 +384,7 @@ class _Timer:
 
 
 class PollEvents:
-    """Event flags for I/O"""
+    """Event flags for I/O."""
 
     # Use epoll's constants to keep life easy
     READ = getattr(select, 'POLLIN', 0x01)  # available for read
@@ -391,14 +394,15 @@ class PollEvents:
 
 
 class IOLoop(AbstractSelectorIOLoop):
-    """I/O loop implementation that picks a suitable poller (`select`,
-     `poll`, `epoll`, `kqueue`) to use based on platform.
-
-     Implements the
-     `pika.adapters.utils.selector_ioloop_adapter.AbstractSelectorIOLoop`
-     interface.
-
     """
+    I/O loop implementation that picks a suitable poller (`select`, `poll`, `epoll`, `kqueue`) to
+    use based on platform.
+
+    Implements the
+    `pika.adapters.utils.selector_ioloop_adapter.AbstractSelectorIOLoop`
+    interface.
+    """
+
     # READ/WRITE/ERROR per `AbstractSelectorIOLoop` requirements
     READ = PollEvents.READ  # pyright: ignore[reportIncompatibleMethodOverride, reportAssignmentType]
     WRITE = PollEvents.WRITE  # pyright: ignore[reportIncompatibleMethodOverride, reportAssignmentType]
@@ -415,12 +419,12 @@ class IOLoop(AbstractSelectorIOLoop):
                                         self.process_timeouts)
 
     def close(self) -> None:
-        """Release IOLoop's resources.
+        """
+        Release IOLoop's resources.
 
-        `IOLoop.close` is intended to be called by the application or test code
-        only after `IOLoop.start()` returns. After calling `close()`, no other
-        interaction with the closed instance of `IOLoop` should be performed.
-
+        `IOLoop.close` is intended to be called by the application or test code only after
+        `IOLoop.start()` returns. After calling `close()`, no other interaction with the closed
+        instance of `IOLoop` should be performed.
         """
         if self._callbacks is not None:
             self._poller.close()
@@ -433,8 +437,8 @@ class IOLoop(AbstractSelectorIOLoop):
     @staticmethod
     def _get_poller(get_wait_seconds: Callable[[], float | None],
                     process_timeouts: Callable[[], None]) -> _PollerBase:
-        """Determine the best poller to use for this environment and instantiate
-        it.
+        """
+        Determine the best poller to use for this environment and instantiate it.
 
         :param get_wait_seconds: Function for getting the maximum number of
                                  seconds to wait for IO for use by the poller
@@ -442,8 +446,8 @@ class IOLoop(AbstractSelectorIOLoop):
                                  poller
 
         :returns: The instantiated poller instance supporting `_PollerBase` API
+        :rtype: object
         """
-
         poller = None
 
         kwargs: POLLER_PARAMS = {
@@ -475,29 +479,29 @@ class IOLoop(AbstractSelectorIOLoop):
 
     def call_later(self, delay: float, callback: Callable[[],
                                                           None]) -> _Timeout:
-        """Add the callback to the IOLoop timer to be called after delay seconds
-        from the time of call on best-effort basis. Returns a handle to the
-        timeout.
+        """
+        Add the callback to the IOLoop timer to be called after delay seconds from the time of call
+        on best-effort basis. Returns a handle to the timeout.
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback method
-        :returns: handle to the created timeout that may be passed to
-            `remove_timeout()`
-
+        :returns: handle to the created timeout that may be passed to `remove_timeout()`
+        :rtype: object
         """
         return self._timer.call_later(delay, callback)
 
     def remove_timeout(self, timeout_handle: _Timeout) -> None:
-        """Remove a timeout
+        """
+        Remove a timeout.
 
         :param timeout_handle: Handle of timeout to remove
-
         """
         self._timer.remove_timeout(timeout_handle)
 
     def add_callback_threadsafe(self, callback: Callable[[], None]) -> None:
-        """Requests a call to the given function as soon as possible in the
-        context of this IOLoop's thread.
+        """
+        Requests a call to the given function as soon as possible in the context of this IOLoop's
+        thread.
 
         NOTE: This is the only thread-safe method in IOLoop. All other
         manipulations of IOLoop must be performed from the IOLoop's thread.
@@ -507,7 +511,6 @@ class IOLoop(AbstractSelectorIOLoop):
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
         :param callback: The callback method
-
         """
         if not callable(callback):
             raise TypeError(
@@ -525,9 +528,10 @@ class IOLoop(AbstractSelectorIOLoop):
     add_callback = add_callback_threadsafe
 
     def process_timeouts(self) -> None:
-        """[Extension] Process pending callbacks and timeouts, invoking those
-        whose time has come. Internal use only.
+        """
+        [Extension] Process pending callbacks and timeouts, invoking those whose time has come.
 
+        Internal use only.
         """
         # Avoid I/O starvation by postponing new callbacks to the next iteration
         assert isinstance(self._callbacks, collections.deque)
@@ -539,12 +543,12 @@ class IOLoop(AbstractSelectorIOLoop):
         self._timer.process_timeouts()
 
     def _get_remaining_interval(self) -> float | None:
-        """Get the remaining interval to the next callback or timeout
-        expiration.
+        """
+        Get the remaining interval to the next callback or timeout expiration.
 
-        :returns: non-negative number of seconds until next callback or timer
-                  expiration; None if there are no callbacks and timers
-
+        :returns: non-negative number of seconds until next callback or timer expiration; None if
+            there are no callbacks and timers
+        :rtype: float
         """
         if self._callbacks:
             return 0
@@ -553,62 +557,59 @@ class IOLoop(AbstractSelectorIOLoop):
 
     def add_handler(self, fd: int, handler: Callable[[int, int], None],
                     events: int) -> None:
-        """Start watching the given file descriptor for events
+        """
+        Start watching the given file descriptor for events.
 
         :param fd: The file descriptor
-        :param handler: When requested event(s) occur,
-            `handler(fd, events)` will be called.
+        :param handler: When requested event(s) occur, `handler(fd, events)` will be called.
         :param events: The event mask using READ, WRITE, ERROR.
-
         """
         self._poller.add_handler(fd, handler, events)
 
     def update_handler(self, fd: int, events: int) -> None:
-        """Changes the events we watch for
+        """
+        Changes the events we watch for.
 
         :param fd: The file descriptor
         :param events: The event mask using READ, WRITE, ERROR
-
         """
         self._poller.update_handler(fd, events)
 
     def remove_handler(self, fd: int) -> None:
-        """Stop watching the given file descriptor for events
+        """
+        Stop watching the given file descriptor for events.
 
         :param fd: The file descriptor
-
         """
         self._poller.remove_handler(fd)
 
     def start(self) -> None:
-        """[API] Start the main poller loop. It will loop until requested to
-        exit. See `IOLoop.stop`.
+        """
+        [API] Start the main poller loop.
 
+        It will loop until requested to exit. See `IOLoop.stop`.
         """
         self._poller.start()
 
     def stop(self) -> None:
-        """[API] Request exit from the ioloop. The loop is NOT guaranteed to
-        stop before this method returns.
+        """
+        [API] Request exit from the ioloop.
 
-        To invoke `stop()` safely from a thread other than this IOLoop's thread,
-        call it via `add_callback_threadsafe`; e.g.,
+        The loop is NOT guaranteed to stop before this method returns.
 
-            `ioloop.add_callback_threadsafe(ioloop.stop)`
+        To invoke `stop()` safely from a thread other than this IOLoop's thread, call it via
+        `add_callback_threadsafe`; e.g.,
 
+        `ioloop.add_callback_threadsafe(ioloop.stop)`
         """
         self._poller.stop()
 
     def activate_poller(self) -> None:
-        """[Extension] Activate the poller
-
-        """
+        """[Extension] Activate the poller."""
         self._poller.activate_poller()
 
     def deactivate_poller(self) -> None:
-        """[Extension] Deactivate the poller
-
-        """
+        """[Extension] Deactivate the poller."""
         self._poller.deactivate_poller()
 
     def poll(self) -> None:
@@ -622,7 +623,7 @@ class IOLoop(AbstractSelectorIOLoop):
 
 
 class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
-    """Base class for select-based IOLoop implementations"""
+    """Base class for select-based IOLoop implementations."""
 
     # Drop out of the poll loop every _MAX_POLL_TIMEOUT secs as a worst case;
     # this is only a backstop value; we will run timeouts when they are
@@ -673,12 +674,11 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                          PollEvents.READ)
 
     def close(self) -> None:
-        """Release poller's resources.
+        """
+        Release poller's resources.
 
-        `close()` is intended to be called after the poller's `start()` method
-        returns. After calling `close()`, no other interaction with the closed
-        poller instance should be performed.
-
+        `close()` is intended to be called after the poller's `start()` method returns. After
+        calling `close()`, no other interaction with the closed poller instance should be performed.
         """
         # Unregister and close ioloop-interrupt socket pair; mutual exclusion is
         # necessary to avoid race condition with `wake_threadsafe` executing in
@@ -701,9 +701,10 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._processing_fd_event_map = None
 
     def wake_threadsafe(self) -> None:
-        """Wake up the poller as soon as possible. As the name indicates, this
-        method is thread-safe.
+        """
+        Wake up the poller as soon as possible.
 
+        As the name indicates, this method is thread-safe.
         """
         with self._waking_mutex:
             if self._w_interrupt is None:
@@ -723,11 +724,12 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                 raise
 
     def _get_max_wait(self) -> float:
-        """Get the interval to the next timeout event, or a default interval
+        """
+        Get the interval to the next timeout event, or a default interval.
 
         :returns: maximum number of self.POLL_TIMEOUT_MULT-scaled time units
                   to wait for IO events
-
+        :rtype: float
         """
         delay = self._get_wait_seconds()
         if delay is None:
@@ -739,12 +741,12 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def add_handler(self, fileno: int, handler: Callable[..., None],
                     events: int) -> None:
-        """Add a new fileno to the set to be monitored
+        """
+        Add a new fileno to the set to be monitored.
 
         :param fileno: The file descriptor
         :param handler: What is called when an event happens
         :param events: The event mask using READ, WRITE, ERROR
-
         """
         assert self._fd_handlers is not None
         assert self._fd_events is not None
@@ -755,11 +757,11 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._register_fd(fileno, events)
 
     def update_handler(self, fileno: int, events: int) -> None:
-        """Set the events to the current events
+        """
+        Set the events to the current events.
 
         :param fileno: The file descriptor
         :param events: The event mask using READ, WRITE, ERROR
-
         """
         # Record the change
         events_cleared, events_set = self._set_handler_events(fileno, events)
@@ -771,10 +773,10 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                events_to_set=events_set)
 
     def remove_handler(self, fileno: int) -> None:
-        """Remove a file descriptor from the set
+        """
+        Remove a file descriptor from the set.
 
         :param fileno: The file descriptor
-
         """
         assert self._fd_handlers is not None
         assert self._fd_events is not None
@@ -791,13 +793,13 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._unregister_fd(fileno, events_to_clear=events_cleared)
 
     def _set_handler_events(self, fileno: int, events: int) -> tuple[int, int]:
-        """Set the handler's events to the given events; internal to
-        `_PollerBase`.
+        """
+        Set the handler's events to the given events; internal to `_PollerBase`.
 
         :param fileno: The file descriptor
         :param events: The event mask (READ, WRITE, ERROR)
-
         :returns: a 2-tuple (events_cleared, events_set)
+        :rtype: tuple
         """
         assert self._fd_events is not None
 
@@ -817,9 +819,7 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         return events_cleared, events_set
 
     def activate_poller(self) -> None:
-        """Activate the poller
-
-        """
+        """Activate the poller."""
         assert self._fd_events is not None
 
         # Activate the underlying poller and register current events
@@ -833,18 +833,17 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self._register_fd(fileno, events)
 
     def deactivate_poller(self) -> None:
-        """Deactivate the poller
-
-        """
+        """Deactivate the poller."""
         self._uninit_poller()
 
     def start(self) -> None:
-        """Start the main poller loop. It will loop until requested to exit.
-        This method is not reentrant and will raise an error if called
-        recursively (pika/pika#1095)
+        """
+        Start the main poller loop.
+
+        It will loop until requested to exit. This method is not reentrant and will raise an error
+        if called recursively (pika/pika#1095)
 
         :raises: RuntimeError
-
         """
         if self._running:
             raise RuntimeError('IOLoop is not reentrant and is already running')
@@ -867,9 +866,10 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                 self._running = False
 
     def stop(self) -> None:
-        """Request exit from the ioloop. The loop is NOT guaranteed to stop
-        before this method returns.
+        """
+        Request exit from the ioloop.
 
+        The loop is NOT guaranteed to stop before this method returns.
         """
         LOGGER.debug('Stopping IOLoop')
         self._stopping = True
@@ -877,25 +877,25 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @abc.abstractmethod
     def poll(self) -> None:
-        """Wait for events on interested filedescriptors.
-        """
+        """Wait for events on interested filedescriptors."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def _init_poller(self) -> None:
-        """Notify the implementation to allocate the poller resource"""
+        """Notify the implementation to allocate the poller resource."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def _uninit_poller(self) -> None:
-        """Notify the implementation to release the poller resource"""
+        """Notify the implementation to release the poller resource."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def _register_fd(self, fileno: int, events: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        register the file descriptor with the polling object. The request must
-        be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to register the file
+        descriptor with the polling object. The request must be ignored if the poller is not
+        activated.
 
         :param fileno: The file descriptor
         :param events: The event mask (READ, WRITE, ERROR)
@@ -905,9 +905,9 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     @abc.abstractmethod
     def _modify_fd_events(self, fileno: int, events: int, events_to_clear: int,
                           events_to_set: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        modify an already registered file descriptor. The request must be
-        ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to modify an already
+        registered file descriptor. The request must be ignored if the poller is not activated.
 
         :param fileno: The file descriptor
         :param events: absolute events (READ, WRITE, ERROR)
@@ -918,9 +918,10 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @abc.abstractmethod
     def _unregister_fd(self, fileno: int, events_to_clear: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        unregister the file descriptor being tracked by the polling object. The
-        request must be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to unregister the file
+        descriptor being tracked by the polling object. The request must be ignored if the poller is
+        not activated.
 
         :param fileno: The file descriptor
         :param events_to_clear: The events to clear (READ, WRITE, ERROR)
@@ -928,15 +929,13 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         raise NotImplementedError
 
     def _dispatch_fd_events(self, fd_event_map: dict[int, int]) -> None:
-        """ Helper to dispatch callbacks for file descriptors that received
-        events.
+        """
+        Helper to dispatch callbacks for file descriptors that received events.
 
-        Before doing so we re-calculate the event mask based on what is
-        currently set in case it has been changed under our feet by a
-        previous callback. We also take a store a refernce to the
-        fd_event_map so that we can detect removal of an
-        fileno during processing of another callback and not generate
-        spurious callbacks on it.
+        Before doing so we re-calculate the event mask based on what is currently set in case it has
+        been changed under our feet by a previous callback. We also take a store a refernce to the
+        fd_event_map so that we can detect removal of an fileno during processing of another
+        callback and not generate spurious callbacks on it.
 
         :param fd_event_map: Map of fds to events received on them.
         """
@@ -966,16 +965,19 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @staticmethod
     def _get_interrupt_pair() -> tuple[socket.socket, socket.socket]:
-        """ Use a socketpair to be able to interrupt the ioloop if called
-        from another thread. Socketpair() is not supported on some OS (Win)
-        so use a pair of simple TCP sockets instead. The sockets will be
-        closed and garbage collected by python when the ioloop itself is.
+        """
+        Use a socketpair to be able to interrupt the ioloop if called from another thread.
+
+        Socketpair() is not supported on some OS (Win) so use a pair of simple TCP sockets instead.
+        The sockets will be closed and garbage collected by python when the ioloop itself is.
         """
         return pika._utils.nonblocking_socketpair()
 
     def _read_interrupt(self, _interrupt_fd: int, _events: int) -> None:
-        """ Read the interrupt byte(s). We ignore the event mask as we can ony
-        get here if there's data to be read on our fd.
+        """
+        Read the interrupt byte(s).
+
+        We ignore the event mask as we can ony get here if there's data to be read on our fd.
 
         :param _interrupt_fd: (unused) The file descriptor to read from
         :param _events: (unused) The events generated for this fd
@@ -990,19 +992,20 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
 
 class SelectPoller(_PollerBase):
-    """Default behavior is to use Select since it's the widest supported and has
-    all of the methods we need for child classes as well. One should only need
-    to override the update_handler and start methods for additional types.
-
     """
+    Default behavior is to use Select since it's the widest supported and has all of the methods we
+    need for child classes as well.
+
+    One should only need to override the update_handler and start methods for additional types.
+    """
+
     # if the poller uses MS specify 1000
     POLL_TIMEOUT_MULT = 1
 
     def poll(self) -> None:
-        """Wait for events of interest on registered file descriptors until an
-        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
-        whichever is sooner, and dispatch the corresponding event handlers.
-
+        """Wait for events of interest on registered file descriptors until an event of interest
+        occurs or next timer deadline or _MAX_POLL_TIMEOUT, whichever is sooner, and dispatch the
+        corresponding event handlers.
         """
         assert self._fd_events is not None
 
@@ -1038,63 +1041,70 @@ class SelectPoller(_PollerBase):
         self._dispatch_fd_events(fd_event_map)
 
     def _init_poller(self) -> None:
-        """Notify the implementation to allocate the poller resource"""
+        """Notify the implementation to allocate the poller resource."""
+
         # It's a no op in SelectPoller
 
     def _uninit_poller(self) -> None:
-        """Notify the implementation to release the poller resource"""
+        """Notify the implementation to release the poller resource."""
+
         # It's a no op in SelectPoller
 
     def _register_fd(self, fileno: int, events: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        register the file descriptor with the polling object. The request must
-        be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to register the file
+        descriptor with the polling object. The request must be ignored if the poller is not
+        activated.
 
         :param fileno: The file descriptor
         :param events: The event mask using READ, WRITE, ERROR
         """
+
         # It's a no op in SelectPoller
 
     def _modify_fd_events(self, fileno: int, events: int, events_to_clear: int,
                           events_to_set: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        modify an already registered file descriptor. The request must be
-        ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to modify an already
+        registered file descriptor. The request must be ignored if the poller is not activated.
 
         :param fileno: The file descriptor
         :param events: absolute events (READ, WRITE, ERROR)
         :param events_to_clear: The events to clear (READ, WRITE, ERROR)
         :param events_to_set: The events to set (READ, WRITE, ERROR)
         """
+
         # It's a no op in SelectPoller
 
     def _unregister_fd(self, fileno: int, events_to_clear: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        unregister the file descriptor being tracked by the polling object. The
-        request must be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to unregister the file
+        descriptor being tracked by the polling object. The request must be ignored if the poller is
+        not activated.
+
+        This is a no-op in SelectPoller.
 
         :param fileno: The file descriptor
         :param events_to_clear: The events to clear (READ, WRITE, ERROR)
         """
-        # It's a no op in SelectPoller
 
 
 class KQueuePoller(_PollerBase):
-    """KQueuePoller works on BSD based systems and is faster than select"""
+    """KQueuePoller works on BSD based systems and is faster than select."""
 
     def __init__(self, get_wait_seconds: Callable[[], float | None],
                  process_timeouts: Callable[[], None]) -> None:
-        """Create an instance of the KQueuePoller
-        """
+        """Create an instance of the KQueuePoller."""
         self._kqueue = None
         super().__init__(get_wait_seconds, process_timeouts)
 
     @staticmethod
     def _map_event(kevent: Any) -> int:
-        """return the event type associated with a kevent object
+        """
+        Return the event type associated with a kevent object.
 
         :param kevent: a kevent object as returned by kqueue.control()
-
+        :rtype: int
         """
         mask = 0
         kq_filter_read = getattr(select, 'KQ_FILTER_READ')
@@ -1119,10 +1129,9 @@ class KQueuePoller(_PollerBase):
         return mask
 
     def poll(self) -> None:
-        """Wait for events of interest on registered file descriptors until an
-        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
-        whichever is sooner, and dispatch the corresponding event handlers.
-
+        """Wait for events of interest on registered file descriptors until an event of interest
+        occurs or next timer deadline or _MAX_POLL_TIMEOUT, whichever is sooner, and dispatch the
+        corresponding event handlers.
         """
         while True:
             try:
@@ -1141,21 +1150,22 @@ class KQueuePoller(_PollerBase):
         self._dispatch_fd_events(fd_event_map)
 
     def _init_poller(self) -> None:
-        """Notify the implementation to allocate the poller resource"""
+        """Notify the implementation to allocate the poller resource."""
         assert self._kqueue is None
 
         self._kqueue = select.kqueue()  # type: ignore[attr-defined, assignment, unused-ignore]  # yapf: disable
 
     def _uninit_poller(self) -> None:
-        """Notify the implementation to release the poller resource"""
+        """Notify the implementation to release the poller resource."""
         if self._kqueue is not None:
             self._kqueue.close()
             self._kqueue = None
 
     def _register_fd(self, fileno: int, events: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        register the file descriptor with the polling object. The request must
-        be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to register the file
+        descriptor with the polling object. The request must be ignored if the poller is not
+        activated.
 
         :param fileno: The file descriptor
         :param events: The event mask using READ, WRITE, ERROR
@@ -1167,9 +1177,9 @@ class KQueuePoller(_PollerBase):
 
     def _modify_fd_events(self, fileno: int, events: int, events_to_clear: int,
                           events_to_set: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        modify an already registered file descriptor. The request must be
-        ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to modify an already
+        registered file descriptor. The request must be ignored if the poller is not activated.
 
         :param fileno: The file descriptor
         :param events: absolute events (READ, WRITE, ERROR)
@@ -1217,9 +1227,10 @@ class KQueuePoller(_PollerBase):
         self._kqueue.control(kevents, 0)
 
     def _unregister_fd(self, fileno: int, events_to_clear: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        unregister the file descriptor being tracked by the polling object. The
-        request must be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to unregister the file
+        descriptor being tracked by the polling object. The request must be ignored if the poller is
+        not activated.
 
         :param fileno: The file descriptor
         :param events_to_clear: The events to clear (READ, WRITE, ERROR)
@@ -1231,31 +1242,31 @@ class KQueuePoller(_PollerBase):
 
 
 class PollPoller(_PollerBase):
-    """Poll works on Linux and can have better performance than EPoll in
-    certain scenarios.  Both are faster than select.
-
     """
+    Poll works on Linux and can have better performance than EPoll in certain scenarios.
+
+    Both are faster than select.
+    """
+
     POLL_TIMEOUT_MULT = 1000
 
     def __init__(self, get_wait_seconds: Callable[[], float | None],
                  process_timeouts: Callable[[], None]) -> None:
-        """Create an instance of the PollPoller
-
-        """
+        """Create an instance of the PollPoller."""
         self._poll: Any = None
         super().__init__(get_wait_seconds, process_timeouts)
 
     @staticmethod
     def _create_poller() -> Any:
         """
+        :rtype: `select.poll`
         """
         return getattr(select, 'poll')()
 
     def poll(self) -> None:
-        """Wait for events of interest on registered file descriptors until an
-        event of interest occurs or next timer deadline or _MAX_POLL_TIMEOUT,
-        whichever is sooner, and dispatch the corresponding event handlers.
-
+        """Wait for events of interest on registered file descriptors until an event of interest
+        occurs or next timer deadline or _MAX_POLL_TIMEOUT, whichever is sooner, and dispatch the
+        corresponding event handlers.
         """
         while True:
             try:
@@ -1280,13 +1291,13 @@ class PollPoller(_PollerBase):
         self._dispatch_fd_events(fd_event_map)
 
     def _init_poller(self) -> None:
-        """Notify the implementation to allocate the poller resource"""
+        """Notify the implementation to allocate the poller resource."""
         assert self._poll is None
 
         self._poll = self._create_poller()
 
     def _uninit_poller(self) -> None:
-        """Notify the implementation to release the poller resource"""
+        """Notify the implementation to release the poller resource."""
         if self._poll is not None:
             if hasattr(self._poll, "close"):
                 self._poll.close(
@@ -1295,9 +1306,10 @@ class PollPoller(_PollerBase):
             self._poll = None
 
     def _register_fd(self, fileno: int, events: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        register the file descriptor with the polling object. The request must
-        be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to register the file
+        descriptor with the polling object. The request must be ignored if the poller is not
+        activated.
 
         :param fileno: The file descriptor
         :param events: The event mask using READ, WRITE, ERROR
@@ -1307,9 +1319,9 @@ class PollPoller(_PollerBase):
 
     def _modify_fd_events(self, fileno: int, events: int, events_to_clear: int,
                           events_to_set: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        modify an already registered file descriptor. The request must be
-        ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to modify an already
+        registered file descriptor. The request must be ignored if the poller is not activated.
 
         :param fileno: The file descriptor
         :param events: absolute events (READ, WRITE, ERROR)
@@ -1320,9 +1332,10 @@ class PollPoller(_PollerBase):
             self._poll.modify(fileno, events)
 
     def _unregister_fd(self, fileno: int, events_to_clear: int) -> None:
-        """The base class invokes this method to notify the implementation to
-        unregister the file descriptor being tracked by the polling object. The
-        request must be ignored if the poller is not activated.
+        """
+        The base class invokes this method to notify the implementation to unregister the file
+        descriptor being tracked by the polling object. The request must be ignored if the poller is
+        not activated.
 
         :param fileno: The file descriptor
         :param events_to_clear: The events to clear (READ, WRITE, ERROR)
@@ -1332,14 +1345,17 @@ class PollPoller(_PollerBase):
 
 
 class EPollPoller(PollPoller):
-    """EPoll works on Linux and can have better performance than Poll in
-    certain scenarios. Both are faster than select.
-
     """
+    EPoll works on Linux and can have better performance than Poll in certain scenarios.
+
+    Both are faster than select.
+    """
+
     POLL_TIMEOUT_MULT = 1
 
     @staticmethod
     def _create_poller() -> Any:
         """
+        :rtype: `select.poll`
         """
         return getattr(select, 'epoll')()

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -1,4 +1,5 @@
-"""Thread-safe connection wrapper for pika.
+"""
+Thread-safe connection wrapper for pika.
 
 Runs SelectConnection's IOLoop in a dedicated background thread so that
 all socket I/O - including writes to _tx_buffers - stays confined to one
@@ -10,6 +11,7 @@ This eliminates the ``IndexError: pop from an empty deque`` race seen when
 multiple threads call basic_publish() on a shared connection directly
 (issues #1144 and #511).
 """
+
 from __future__ import annotations
 
 import concurrent.futures
@@ -31,7 +33,8 @@ DEFAULT_RPC_TIMEOUT = 10
 
 
 class ThreadSafeChannel:
-    """Thread-safe wrapper around :class:`pika.channel.Channel`.
+    """
+    Thread-safe wrapper around :class:`pika.channel.Channel`.
 
     Every write operation is routed through the parent connection's
     ``add_callback_threadsafe`` so that ``_tx_buffers`` is only ever
@@ -75,10 +78,11 @@ class ThreadSafeChannel:
         self._confirm_select_ok = None
 
     def _check_not_closed(self) -> None:
-        """Raise if the connection is known to be closed.
+        """
+        Raise if the connection is known to be closed.
 
-        Called from fire-and-forget methods to prevent silently dropping
-        work when the connection is already gone.
+        Called from fire-and-forget methods to prevent silently dropping work when the connection is
+        already gone.
         """
         with self._wrapper._channel_waiters_lock:
             if self._wrapper._closed_reason is not None:
@@ -86,7 +90,8 @@ class ThreadSafeChannel:
 
     @staticmethod
     def _safe_dispatch(label, callback, *args) -> None:
-        """Execute *callback* on the pool worker, logging any exception.
+        """
+        Execute *callback* on the pool worker, logging any exception.
 
         Used to wrap user callbacks before submitting them to a
         :class:`concurrent.futures.ThreadPoolExecutor` so that exceptions
@@ -110,7 +115,8 @@ class ThreadSafeChannel:
             self._consumer_work_pool.shutdown(wait=True)
 
     def _register_waiter(self) -> tuple[Event, list[BaseException | None]]:
-        """Create and register a blocking waiter.
+        """
+        Create and register a blocking waiter.
 
         :returns: (ready, error) tuple for use with ``ready.wait()``
         :raises Exception: if the connection is already closed.
@@ -125,7 +131,9 @@ class ThreadSafeChannel:
 
     def _unregister_waiter(self, ready: Event,
                            error: list[BaseException | None]) -> None:
-        """Remove a waiter from the blocking list.
+        """
+        Remove a waiter from the blocking list.
+
         :param ready: Threading event signalling that the RPC response has
             arrived
         :param error: list containing an exception if the RPC response was an
@@ -139,7 +147,8 @@ class ThreadSafeChannel:
 
     def _blocking_rpc(self, method_name: str, channel_method, timeout: int,
                       *args, **kwargs) -> Any:
-        """Execute a channel RPC and block until the broker responds.
+        """
+        Execute a channel RPC and block until the broker responds.
 
         Handles the waiter lifecycle: registers the calling thread's event
         in ``_blocking_waiters``, schedules the RPC on the IOLoop thread,
@@ -200,7 +209,8 @@ class ThreadSafeChannel:
                       properties=None,
                       mandatory: bool = False,
                       on_publish=None) -> None:
-        """Schedule a publish in the IOLoop thread (fire-and-forget).
+        """
+        Schedule a publish in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
@@ -242,7 +252,8 @@ class ThreadSafeChannel:
         self._wrapper.add_callback_threadsafe(_publish)
 
     def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
-        """Schedule an acknowledgement in the IOLoop thread (fire-and-forget).
+        """
+        Schedule an acknowledgement in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
@@ -266,7 +277,8 @@ class ThreadSafeChannel:
                    delivery_tag: int = 0,
                    multiple: bool = False,
                    requeue: bool = True) -> None:
-        """Schedule a negative acknowledgement in the IOLoop thread (fire-and-forget).
+        """
+        Schedule a negative acknowledgement in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
@@ -289,7 +301,8 @@ class ThreadSafeChannel:
         self._wrapper.add_callback_threadsafe(_nack)
 
     def basic_reject(self, delivery_tag: int = 0, requeue: bool = True) -> None:
-        """Schedule a rejection in the IOLoop thread (fire-and-forget).
+        """
+        Schedule a rejection in the IOLoop thread (fire-and-forget).
 
         Safe to call from any thread simultaneously.
 
@@ -325,6 +338,7 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Basic.QosOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -341,19 +355,20 @@ class ThreadSafeChannel:
                   queue,
                   auto_ack: bool = False,
                   timeout: int = DEFAULT_RPC_TIMEOUT) -> tuple[None, ...]:
-        """Get a single message from the broker and block until it arrives.
+        """
+        Get a single message from the broker and block until it arrives.
 
-        Returns a ``(method, properties, body)`` tuple if a message is
-        available, or ``(None, None, None)`` if the queue is empty.
+        Returns a ``(method, properties, body)`` tuple if a message is available, or ``(None, None,
+        None)`` if the queue is empty.
 
         Safe to call from any thread.
 
         :param queue: The queue to get a message from.
         :param auto_ack: Do not require acknowledgement.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
-        :returns: ``(method, properties, body)`` or ``(None, None, None)``.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
+        :returns:``(method, properties, body)`` or ``(None, None, None)``.
+        :rtype: tuple
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -407,24 +422,21 @@ class ThreadSafeChannel:
         return tuple(result)
 
     def add_on_cancel_callback(self, callback) -> None:
-        """Register a callback for server-initiated consumer cancellation.
+        """
+        Register a callback for server-initiated consumer cancellation.
 
-        The broker sends ``Basic.Cancel`` when a consumer is cancelled by
-        the server (for example, when the queue the consumer is bound to
-        is deleted).  Without registering this callback, a consumer can
-        silently stop receiving messages.
+        The broker sends ``Basic.Cancel`` when a consumer is cancelled by the server (for example,
+        when the queue the consumer is bound to is deleted).  Without registering this callback, a
+        consumer can silently stop receiving messages.
 
-        Dispatched on the per-channel worker thread (same as delivery
-        callbacks), so the callback may safely call any
-        :class:`ThreadSafeChannel` method.  The RabbitMQ Java and .NET
-        clients run this listener inline on the I/O thread; pika's
-        wrapper deliberately diverges so a slow listener cannot stall
-        heartbeats.
+        Dispatched on the per-channel worker thread (same as delivery callbacks), so the callback
+        may safely call any :class:`ThreadSafeChannel` method.  The RabbitMQ Java and .NET clients
+        run this listener inline on the I/O thread; pika's wrapper deliberately diverges so a slow
+        listener cannot stall heartbeats.
 
         Safe to call from any thread.
 
-        :param callback:
-            ``callback(method_frame)`` where *method_frame* contains a
+        :param callback:``callback(method_frame)`` where *method_frame* contains a
             :class:`pika.spec.Basic.Cancel`.
         :raises Exception: if the connection is already closed.
         """
@@ -448,27 +460,23 @@ class ThreadSafeChannel:
         self._wrapper.add_callback_threadsafe(_register)
 
     def add_on_return_callback(self, callback) -> None:
-        """Register a callback for messages returned by the broker.
+        """
+        Register a callback for messages returned by the broker.
 
-        When a message is published with ``mandatory=True`` and cannot be
-        routed to any queue, the broker returns it via a
-        :class:`pika.spec.Basic.Return`.  The *callback* receives the
+        When a message is published with ``mandatory=True`` and cannot be routed to any queue, the
+        broker returns it via a :class:`pika.spec.Basic.Return`.  The *callback* receives the
         returned message.
 
-        Dispatched on the per-channel worker thread (same as delivery
-        callbacks), so the callback may safely call any
-        :class:`ThreadSafeChannel` method.  The RabbitMQ Java and .NET
-        clients run this listener inline on the I/O thread; pika's
-        wrapper deliberately diverges so a slow listener cannot stall
-        heartbeats.
+        Dispatched on the per-channel worker thread (same as delivery callbacks), so the callback
+        may safely call any :class:`ThreadSafeChannel` method.  The RabbitMQ Java and .NET clients
+        run this listener inline on the I/O thread; pika's wrapper deliberately diverges so a slow
+        listener cannot stall heartbeats.
 
         Safe to call from any thread.
 
-        :param callback:
-            ``callback(channel, method, properties, body)`` where
-            *channel* is this :class:`ThreadSafeChannel`, *method* is a
-            :class:`pika.spec.Basic.Return`, *properties* is a
-            :class:`pika.spec.BasicProperties`, and *body* is :class:`bytes`.
+        :param callback:``callback(channel, method, properties, body)`` where *channel* is this
+            :class:`ThreadSafeChannel`, *method* is a :class:`pika.spec.Basic.Return`, *properties*
+            is a :class:`pika.spec.BasicProperties`, and *body* is :class:`bytes`.
         :raises Exception: if the connection is already closed.
         """
         self._check_not_closed()
@@ -492,7 +500,8 @@ class ThreadSafeChannel:
     def confirm_delivery(self,
                          ack_nack_callback,
                          timeout: int = DEFAULT_RPC_TIMEOUT):
-        """Enable publisher confirms and block until Confirm.SelectOk arrives.
+        """
+        Enable publisher confirms and block until Confirm.SelectOk arrives.
 
         Idempotent: calling this method more than once on the same channel
         returns the original Confirm.SelectOk without sending a frame to
@@ -514,6 +523,7 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Confirm.SelectOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -546,30 +556,28 @@ class ThreadSafeChannel:
                       consumer_tag=None,
                       arguments=None,
                       timeout: int = DEFAULT_RPC_TIMEOUT):
-        """Register a consumer and block until Basic.ConsumeOk arrives.
+        """
+        Register a consumer and block until Basic.ConsumeOk arrives.
 
-        The *on_message_callback* is dispatched on the channel's worker
-        thread, not the IOLoop thread.  All :class:`ThreadSafeChannel`
-        methods are safe to call from within the callback.
+        The *on_message_callback* is dispatched on the channel's worker thread, not the IOLoop
+        thread.  All :class:`ThreadSafeChannel` methods are safe to call from within the callback.
 
-        Because the channel uses a single worker thread, deliveries are
-        processed serially.  A callback that blocks (e.g. on a database
-        write or a call to :meth:`queue_declare`) delays subsequent
-        deliveries on the same channel until it returns.
+        Because the channel uses a single worker thread, deliveries are processed serially.  A
+        callback that blocks (e.g. on a database write or a call to :meth:`queue_declare`) delays
+        subsequent deliveries on the same channel until it returns.
 
         Safe to call from any thread.
 
         :param queue: Queue to consume from.
-        :param on_message_callback:
-            ``callback(channel, method, properties, body)``
+        :param on_message_callback:``callback(channel, method, properties, body)``
         :param auto_ack: Disable manual acknowledgement.
         :param exclusive: Request exclusive consumer access.
         :param consumer_tag: Client-provided tag; generated if omitted.
         :param arguments: Additional AMQP arguments.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The consumer tag assigned by the broker.
+        :rtype: str
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -599,15 +607,16 @@ class ThreadSafeChannel:
     def basic_cancel(self,
                      consumer_tag,
                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Cancel a consumer and block until Basic.CancelOk arrives.
+        """
+        Cancel a consumer and block until Basic.CancelOk arrives.
 
         Safe to call from any thread.
 
         :param consumer_tag: Tag returned by :meth:`basic_consume`.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Basic.CancelOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -626,7 +635,8 @@ class ThreadSafeChannel:
                       auto_delete: bool = False,
                       arguments=None,
                       timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Declare a queue and block the calling thread until Queue.DeclareOk arrives.
+        """
+        Declare a queue and block the calling thread until Queue.DeclareOk arrives.
 
         Safe to call from any thread.
 
@@ -636,10 +646,10 @@ class ThreadSafeChannel:
         :param exclusive: If True, restrict access to the current connection
         :param auto_delete: If True, delete the queue or exchange when no longer in use
         :param arguments: Custom arguments for the queue declaration
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Queue.DeclareOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -664,7 +674,8 @@ class ThreadSafeChannel:
                          internal: bool = False,
                          arguments=None,
                          timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Declare an exchange and block until Exchange.DeclareOk arrives.
+        """
+        Declare an exchange and block until Exchange.DeclareOk arrives.
 
         Safe to call from any thread.
 
@@ -675,10 +686,10 @@ class ThreadSafeChannel:
         :param auto_delete: Delete when no queues are bound.
         :param internal: Can only be published to by other exchanges.
         :param arguments: Custom arguments for the exchange.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Exchange.DeclareOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -701,19 +712,19 @@ class ThreadSafeChannel:
                    routing_key=None,
                    arguments=None,
                    timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Bind a queue to an exchange and block until Queue.BindOk arrives.
+        """
+        Bind a queue to an exchange and block until Queue.BindOk arrives.
 
         Safe to call from any thread.
 
         :param queue: The queue to bind.
         :param exchange: The exchange to bind to.
-        :param routing_key: The routing key to bind on.
-            Defaults to the queue name.
+        :param routing_key: The routing key to bind on. Defaults to the queue name.
         :param arguments: Custom arguments for the binding.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Queue.BindOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -733,19 +744,19 @@ class ThreadSafeChannel:
                      routing_key=None,
                      arguments=None,
                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Unbind a queue from an exchange and block until Queue.UnbindOk arrives.
+        """
+        Unbind a queue from an exchange and block until Queue.UnbindOk arrives.
 
         Safe to call from any thread.
 
         :param queue: The queue to unbind.
         :param exchange: The exchange to unbind from.
-        :param routing_key: The routing key to unbind.
-            Defaults to the queue name.
+        :param routing_key: The routing key to unbind. Defaults to the queue name.
         :param arguments: Custom arguments for the unbinding.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Queue.UnbindOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -764,17 +775,18 @@ class ThreadSafeChannel:
                      if_unused: bool = False,
                      if_empty: bool = False,
                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Delete a queue and block until Queue.DeleteOk arrives.
+        """
+        Delete a queue and block until Queue.DeleteOk arrives.
 
         Safe to call from any thread.
 
         :param queue: The queue to delete.
         :param if_unused: Only delete if the queue has no consumers.
         :param if_empty: Only delete if the queue is empty.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Queue.DeleteOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -788,15 +800,16 @@ class ThreadSafeChannel:
         )
 
     def queue_purge(self, queue, timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Purge all messages from a queue and block until Queue.PurgeOk arrives.
+        """
+        Purge all messages from a queue and block until Queue.PurgeOk arrives.
 
         Safe to call from any thread.
 
         :param queue: The queue to purge.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Queue.PurgeOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -813,7 +826,8 @@ class ThreadSafeChannel:
                       routing_key: str = '',
                       arguments=None,
                       timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Bind an exchange to another exchange and block until Exchange.BindOk.
+        """
+        Bind an exchange to another exchange and block until Exchange.BindOk.
 
         Safe to call from any thread.
 
@@ -821,10 +835,10 @@ class ThreadSafeChannel:
         :param source: The source exchange to bind to.
         :param routing_key: The routing key to bind on.
         :param arguments: Custom arguments for the binding.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Exchange.BindOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -844,7 +858,8 @@ class ThreadSafeChannel:
                         routing_key: str = '',
                         arguments=None,
                         timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Unbind an exchange from another exchange and block until Exchange.UnbindOk.
+        """
+        Unbind an exchange from another exchange and block until Exchange.UnbindOk.
 
         Safe to call from any thread.
 
@@ -852,10 +867,10 @@ class ThreadSafeChannel:
         :param source: The source exchange to unbind from.
         :param routing_key: The routing key to unbind.
         :param arguments: Custom arguments for the unbinding.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Exchange.UnbindOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -873,16 +888,17 @@ class ThreadSafeChannel:
                         exchange=None,
                         if_unused: bool = False,
                         timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
-        """Delete an exchange and block until Exchange.DeleteOk arrives.
+        """
+        Delete an exchange and block until Exchange.DeleteOk arrives.
 
         Safe to call from any thread.
 
         :param exchange: The exchange name.
         :param if_unused: Only delete if the exchange has no bindings.
-        :param timeout: Seconds to wait for the response.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for the response. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
         :returns: The Exchange.DeleteOk method frame.
+        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -898,21 +914,21 @@ class ThreadSafeChannel:
               reply_code: int = 0,
               reply_text: str = 'Normal shutdown',
               timeout: int = 10) -> None:
-        """Close the channel and block until the Channel.CloseOk arrives.
+        """
+        Close the channel and block until the Channel.CloseOk arrives.
 
-        Shuts down the consumer work pool after the channel is closed,
-        allowing any in-flight delivery callbacks to complete.
+        Shuts down the consumer work pool after the channel is closed, allowing any in-flight
+        delivery callbacks to complete.
 
-        If the channel is already closed or closing, returns immediately.
-        Safe to call from any thread.
+        If the channel is already closed or closing, returns immediately. Safe to call from any
+        thread.
 
         :param reply_code: Close reason code to send to the broker.
         :param reply_text: Close reason text to send to the broker.
-        :param timeout: Seconds to wait for Channel.CloseOk
-            before treating the channel as closed regardless.  Defaults to
-            10 seconds.  Pass ``None`` to wait indefinitely.
-        :raises Exception: if the connection is closed or the channel is closed
-            by the broker rather than by this client.
+        :param timeout: Seconds to wait for Channel.CloseOk before treating the channel as closed
+            regardless. Defaults to 10 seconds. Pass ``None`` to wait indefinitely.
+        :raises Exception: if the connection is closed or the channel is closed by the broker rather
+            than by this client.
         """
         ready, error = self._register_waiter()
 
@@ -952,19 +968,18 @@ class ThreadSafeChannel:
               reply_code: int = 0,
               reply_text: str = 'Normal shutdown',
               timeout: int = 10) -> None:
-        """Close the channel, swallowing any errors.
+        """
+        Close the channel, swallowing any errors.
 
-        Equivalent to :meth:`close` but never raises.  Useful in error-recovery
-        paths where the channel may already be in a bad state and the caller
-        only wants a best-effort shutdown.
+        Equivalent to :meth:`close` but never raises.  Useful in error-recovery paths where the
+        channel may already be in a bad state and the caller only wants a best-effort shutdown.
 
         Safe to call from any thread.
 
         :param reply_code: Close reason code to send to the broker.
         :param reply_text: Close reason text to send to the broker.
-        :param timeout: Seconds to wait for Channel.CloseOk
-            before treating the channel as closed regardless.  Defaults to
-            10 seconds.  Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for Channel.CloseOk before treating the channel as closed
+            regardless. Defaults to 10 seconds. Pass ``None`` to wait indefinitely.
         """
         try:
             self.close(reply_code=reply_code,
@@ -975,17 +990,16 @@ class ThreadSafeChannel:
 
     @property
     def next_publish_seq_no(self) -> int | None:
-        """The delivery tag that will be assigned to the next published message.
+        """
+        The delivery tag that will be assigned to the next published message.
 
-        Returns ``None`` if publisher confirms have not been enabled via
-        :meth:`confirm_delivery`.  Once confirms are enabled, returns an
-        integer starting at 1 that increments after each successful publish,
-        matching the behavior of the RabbitMQ Java and .NET clients.
+        Returns ``None`` if publisher confirms have not been enabled via :meth:`confirm_delivery`.
+        Once confirms are enabled, returns an integer starting at 1 that increments after each
+        successful publish, matching the behavior of the RabbitMQ Java and .NET clients.
 
-        This property is safe to read from any thread, but the value is
-        only stable if no other thread is concurrently publishing (the
-        counter advances on the IOLoop thread inside the scheduled publish
-        callback).
+        This property is safe to read from any thread, but the value is only stable if no other
+        thread is concurrently publishing (the counter advances on the IOLoop thread inside the
+        scheduled publish callback).
         """
         if self._next_publish_seq_no is None:
             return None
@@ -1194,14 +1208,15 @@ class ThreadSafeConnection:
     # ------------------------------------------------------------------
 
     def channel(self, timeout: int = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
-        """Open a new channel and return a :class:`ThreadSafeChannel`.
+        """
+        Open a new channel and return a :class:`ThreadSafeChannel`.
 
-        Blocks the calling thread until the channel is open.  The returned
-        channel's methods are safe to call from any thread.
+        Blocks the calling thread until the channel is open.  The returned channel's methods are
+        safe to call from any thread.
 
-        :param timeout: Seconds to wait for Channel.OpenOk.
-            Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for Channel.OpenOk. Defaults to :data:`DEFAULT_RPC_TIMEOUT`
+            (10 s). Pass ``None`` to wait indefinitely.
+        :rtype: ThreadSafeChannel
         :raises Exception: if the connection is closed before the channel opens.
         :raises TimeoutError: if *timeout* expires before the channel opens.
         """
@@ -1254,25 +1269,23 @@ class ThreadSafeConnection:
         return ch
 
     def close(self, timeout: int = 10) -> None:
-        """Close the connection and block until the IOLoop thread exits.
+        """
+        Close the connection and block until the IOLoop thread exits.
 
-        Schedules a clean Connection.Close handshake and waits up to
-        *timeout* seconds for the IOLoop thread to finish.  If the thread
-        is still alive after the timeout (e.g. the broker never sends
-        Connection.CloseOk), the IOLoop is force-stopped via
-        ``add_callback_threadsafe`` and joined once more.
+        Schedules a clean Connection.Close handshake and waits up to *timeout* seconds for the
+        IOLoop thread to finish.  If the thread is still alive after the timeout (e.g. the broker
+        never sends Connection.CloseOk), the IOLoop is force-stopped via ``add_callback_threadsafe``
+        and joined once more.
 
-        Safe to call from any thread including the IOLoop thread itself
-        (e.g. from within a channel callback).  When called from the IOLoop
-        thread the close is initiated synchronously and the method returns
-        immediately without joining.
+        Safe to call from any thread including the IOLoop thread itself (e.g. from within a channel
+        callback).  When called from the IOLoop thread the close is initiated synchronously and the
+        method returns immediately without joining.
 
         Calling ``close()`` on an already-closed connection is a no-op.
 
-        :param timeout: Seconds to wait for a clean close before
-            force-stopping the IOLoop. Defaults to 10 seconds, which is
-            sufficient for a healthy broker on any reasonable network.
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for a clean close before force-stopping the IOLoop. Defaults
+            to 10 seconds, which is sufficient for a healthy broker on any reasonable network. Pass
+            ``None`` to wait indefinitely.
         """
         if threading.current_thread() is self._ioloop_thread:
             try:
@@ -1317,19 +1330,17 @@ class ThreadSafeConnection:
             self._shutdown_connection_pool()
 
     def abort(self, timeout: int = 10) -> None:
-        """Close the connection, swallowing any errors.
+        """
+        Close the connection, swallowing any errors.
 
-        Equivalent to :meth:`close` but never raises.  Currently
-        :meth:`close` itself does not raise (it logs a warning on
-        timeout), but ``abort`` is provided for API symmetry with
-        other AMQP 0-9-1 clients and to make error-recovery intent
-        explicit at the call site.
+        Equivalent to :meth:`close` but never raises.  Currently :meth:`close` itself does not raise
+        (it logs a warning on timeout), but ``abort`` is provided for API symmetry with other AMQP
+        0-9-1 clients and to make error-recovery intent explicit at the call site.
 
         Safe to call from any thread.
 
-        :param timeout: Seconds to wait for a clean close before
-            force-stopping the IOLoop.  Defaults to 10 seconds.
-            Pass ``None`` to wait indefinitely.
+        :param timeout: Seconds to wait for a clean close before force-stopping the IOLoop. Defaults
+            to 10 seconds. Pass ``None`` to wait indefinitely.
         """
         try:
             self.close(timeout=timeout)
@@ -1344,17 +1355,19 @@ class ThreadSafeConnection:
         return False
 
     def add_callback_threadsafe(self, callback) -> None:
-        """Schedule *callback* to run in the IOLoop thread.
+        """
+        Schedule *callback* to run in the IOLoop thread.
 
-        Safe to call from any thread.  Exposed so callers can schedule
-        arbitrary work without going through the wrapper methods.
+        Safe to call from any thread.  Exposed so callers can schedule arbitrary work without going
+        through the wrapper methods.
 
         :param callback: Zero-argument callable.
         """
         self._connection.ioloop.add_callback_threadsafe(callback)
 
     def add_on_connection_blocked_callback(self, callback) -> None:
-        """Register a callback for ``Connection.Blocked`` notifications.
+        """
+        Register a callback for ``Connection.Blocked`` notifications.
 
         RabbitMQ sends ``Connection.Blocked`` when the broker is running
         low on memory or disk.  In this state RabbitMQ stops processing
@@ -1380,7 +1393,8 @@ class ThreadSafeConnection:
             'add_on_connection_blocked_callback', callback)
 
     def add_on_connection_unblocked_callback(self, callback) -> None:
-        """Register a callback for ``Connection.Unblocked`` notifications.
+        """
+        Register a callback for ``Connection.Unblocked`` notifications.
 
         Sent by RabbitMQ once a previously blocked connection is no
         longer resource-constrained, letting publishers resume.
@@ -1404,11 +1418,11 @@ class ThreadSafeConnection:
 
     def _register_connection_event_callback(self, raw_method_name: str,
                                             callback) -> None:
-        """Register a connection-level event callback via the IOLoop.
+        """
+        Register a connection-level event callback via the IOLoop.
 
-        Wraps the user callback so it dispatches on the connection work
-        pool, then schedules registration with the underlying
-        :class:`pika.connection.Connection` on the IOLoop thread.
+        Wraps the user callback so it dispatches on the connection work pool, then schedules
+        registration with the underlying :class:`pika.connection.Connection` on the IOLoop thread.
         :param raw_method_name: Unqualified AMQP method name (e.g. ``"Basic.Publish"``)
         :param callback: User callback to dispatch on the connection work pool."
         """

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -1,6 +1,5 @@
-"""Use pika with the Tornado IOLoop
+"""Use pika with the Tornado IOLoop."""
 
-"""
 from __future__ import annotations
 
 import logging
@@ -20,8 +19,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TornadoConnection(base_connection.BaseConnection):
-    """The TornadoConnection runs on the Tornado IOLoop.
-    """
+    """The TornadoConnection runs on the Tornado IOLoop."""
 
     def __init__(self,
                  parameters: connection.Parameters | None = None,
@@ -36,8 +34,8 @@ class TornadoConnection(base_connection.BaseConnection):
                  custom_ioloop: None |
                  (ioloop.IOLoop | nbio_interface.AbstractIOServices) = None,
                  internal_connection_workflow: bool = True) -> None:
-        """Create a new instance of the TornadoConnection class, connecting
-        to RabbitMQ automatically.
+        """
+        Create a new instance of the TornadoConnection class, connecting to RabbitMQ automatically.
 
         :param parameters: The connection
             parameters
@@ -58,7 +56,6 @@ class TornadoConnection(base_connection.BaseConnection):
         :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory
-
         """
         warnings.warn(
             "TornadoConnection is deprecated and will be removed in Pika 2.0. "
@@ -106,7 +103,9 @@ class TornadoConnection(base_connection.BaseConnection):
 
         def connection_factory(
                 params: connection.Parameters | None) -> TornadoConnection:
-            """Connection factory.
+            """
+            Connection factory.
+
             :param params: Connection parameters
             """
             if params is None:

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1,12 +1,11 @@
-"""Using Pika with a Twisted reactor.
+"""
+Using Pika with a Twisted reactor.
 
-The interfaces in this module are Deferred-based when possible. This means that
-the connection.channel() method and most of the channel methods return
-Deferreds instead of taking a callback argument and that basic_consume()
-returns a Twisted DeferredQueue where messages from the server will be
-stored. Refer to the docstrings for TwistedProtocolConnection.channel() and the
+The interfaces in this module are Deferred-based when possible. This means that the
+connection.channel() method and most of the channel methods return Deferreds instead of taking a
+callback argument and that basic_consume() returns a Twisted DeferredQueue where messages from the
+server will be stored. Refer to the docstrings for TwistedProtocolConnection.channel() and the
 TwistedChannel class for details.
-
 """
 
 from __future__ import annotations
@@ -41,10 +40,9 @@ LOGGER = logging.getLogger(__name__)
 
 
 class ClosableDeferredQueue(defer.DeferredQueue):
-    """
-    Like the normal Twisted DeferredQueue, but after close() is called with an
-    exception instance all pending Deferreds are errbacked and further attempts
-    to call get() or put() return a Failure wrapping that exception.
+    """Like the normal Twisted DeferredQueue, but after close() is called with an exception instance
+    all pending Deferreds are errbacked and further attempts to call get() or put() return a Failure
+    wrapping that exception.
     """
 
     def __init__(self,
@@ -56,8 +54,8 @@ class ClosableDeferredQueue(defer.DeferredQueue):
     def put(self, obj: Any) -> None | (  # type: ignore[override]
             defer.Deferred[Any]):
         """
-        Like the original :meth:`DeferredQueue.put` method, but returns an
-        errback if the queue is closed.
+        Like the original :meth:`DeferredQueue.put` method, but returns an errback if the queue is
+        closed.
 
         :param obj: Object to put into the queue
         """
@@ -69,13 +67,12 @@ class ClosableDeferredQueue(defer.DeferredQueue):
 
     def get(self) -> defer.Deferred[Any]:
         """
-        Returns a Deferred that will fire with the next item in the queue, when
-        it's available.
+        Returns a Deferred that will fire with the next item in the queue, when it's available.
 
         The Deferred will errback if the queue is closed.
 
         :returns: Deferred that fires with the next item.
-
+        :rtype: Deferred
         """
         if self.closed:
             LOGGER.error('Impossible to get from the queue, it is closed.')
@@ -83,7 +80,8 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         return defer.DeferredQueue.get(self)
 
     def close(self, reason: Exception | None) -> None:
-        """Closes the queue.
+        """
+        Closes the queue.
 
         Errback the pending calls to :meth:`get()`.
 
@@ -103,16 +101,16 @@ ReceivedMessage = namedtuple("ReceivedMessage",
 
 
 class TwistedChannel:
-    """A wrapper around Pika's Channel.
+    """
+    A wrapper around Pika's Channel.
 
-    Channel methods that normally take a callback argument are wrapped to
-    return a Deferred that fires with whatever would be passed to the callback.
-    If the channel gets closed, all pending Deferreds are errbacked with a
-    ChannelClosed exception. The returned Deferreds fire with whatever
-    arguments the callback to the original method would receive.
+    Channel methods that normally take a callback argument are wrapped to return a Deferred that
+    fires with whatever would be passed to the callback. If the channel gets closed, all pending
+    Deferreds are errbacked with a ChannelClosed exception. The returned Deferreds fire with
+    whatever arguments the callback to the original method would receive.
 
-    Some methods like basic_consume and basic_get are wrapped in a special way,
-    see their docstrings for details.
+    Some methods like basic_consume and basic_get are wrapped in a special way, see their docstrings
+    for details.
     """
 
     def __init__(self, channel: channel.Channel) -> None:
@@ -166,15 +164,13 @@ class TwistedChannel:
         self, method_frame: pika.frame.Method[pika.spec.Basic.Cancel]
     ) -> (pika.frame.Method[pika.spec.Basic.Cancel] |
           pika.frame.Method[pika.spec.Basic.CancelOk]):
-        """Called by impl when broker cancels consumer via Basic.Cancel.
+        """
+        Called by impl when broker cancels consumer via Basic.Cancel.
 
-        This is a RabbitMQ-specific feature. The circumstances include deletion
-        of queue being consumed as well as failure of a HA node responsible for
-        the queue being consumed.
+        This is a RabbitMQ-specific feature. The circumstances include deletion of queue being
+        consumed as well as failure of a HA node responsible for the queue being consumed.
 
-        :param method_frame: method frame with the
-            `spec.Basic.Cancel` method
-
+        :param method_frame: method frame with the `spec.Basic.Cancel` method
         """
         return self._on_consumer_cancelled(method_frame)
 
@@ -183,12 +179,11 @@ class TwistedChannel:
                       pika.frame.Method[pika.spec.Basic.CancelOk])
     ) -> (pika.frame.Method[pika.spec.Basic.Cancel] |
           pika.frame.Method[pika.spec.Basic.CancelOk]):
-        """Called when the broker cancels a consumer via Basic.Cancel or when
-        the broker responds to a Basic.Cancel request by Basic.CancelOk.
+        """
+        Called when the broker cancels a consumer via Basic.Cancel or when the broker responds to a
+        Basic.Cancel request by Basic.CancelOk.
 
-        :param frame: method frame with the
-            `spec.Basic.Cancel` or `spec.Basic.CancelOk` method
-
+        :param frame: method frame with the `spec.Basic.Cancel` or `spec.Basic.CancelOk` method
         """
         consumer_tag = frame.method.consumer_tag
         if consumer_tag not in self._consumers:
@@ -209,7 +204,9 @@ class TwistedChannel:
     def _on_getempty(
             self,
             _method_frame: pika.frame.Method[pika.spec.Basic.Get]) -> None:
-        """Callback the Basic.Get deferred with None.
+        """
+        Callback the Basic.Get deferred with None.
+
         :param _method_frame: Method frame from Basic.Get response (unused)
         """
         if self._basic_get_deferred is None:
@@ -220,10 +217,10 @@ class TwistedChannel:
 
     def _wrap_channel_method(self,
                              name: str) -> Callable[..., defer.Deferred[Any]]:
-        """Wrap Pika's Channel method to make it return a Deferred that fires
-        when the method completes and errbacks if the channel gets closed. If
-        the original method's callback would receive more than one argument,
-        the Deferred fires with a tuple of argument values.
+        """
+        Wrap Pika's Channel method to make it return a Deferred that fires when the method completes
+        and errbacks if the channel gets closed. If the original method's callback would receive
+        more than one argument, the Deferred fires with a tuple of argument values.
 
         :param name: Attribute name to look up on the underlying channel
         """
@@ -241,8 +238,8 @@ class TwistedChannel:
             def single_argument(*args) -> None:
                 """
                 Make sure that the deferred is called with a single argument.
-                In case the original callback fires with more than one, convert
-                to a tuple.
+
+                In case the original callback fires with more than one, convert to a tuple.
                 """
                 if len(args) > 1:
                     d.callback(tuple(args))
@@ -275,26 +272,28 @@ class TwistedChannel:
 
     @property
     def is_closed(self) -> bool:
-        """Returns True if the channel is closed.
+        """
+        Returns True if the channel is closed.
 
-
+        :rtype: bool
         """
         return self._channel.is_closed
 
     @property
     def is_closing(self) -> bool:
-        """Returns True if client-initiated closing of the channel is in
-        progress.
+        """
+        Returns True if client-initiated closing of the channel is in progress.
 
-
+        :rtype: bool
         """
         return self._channel.is_closing
 
     @property
     def is_open(self) -> bool:
-        """Returns True if the channel is open.
+        """
+        Returns True if the channel is open.
 
-
+        :rtype: bool
         """
         return self._channel.is_open
 
@@ -310,13 +309,12 @@ class TwistedChannel:
 
     def callback_deferred(self, deferred: defer.Deferred[Any],
                           replies: list[type[amqp_object.Method]]) -> None:
-        """Pass in a Deferred and a list replies from the RabbitMQ broker which
-        you'd like the Deferred to be callbacked on with the frame as callback
-        value.
+        """
+        Pass in a Deferred and a list replies from the RabbitMQ broker which you'd like the Deferred
+        to be callbacked on with the frame as callback value.
 
         :param deferred: The Deferred to callback
         :param replies: The replies to callback on
-
         """
         self._channel.add_callback(deferred.callback, replies)
 
@@ -324,8 +322,9 @@ class TwistedChannel:
 
     def add_on_return_callback(
             self, callback: Callable[[ReceivedMessage], None]) -> None:
-        """Pass a callback function that will be called when a published
-        message is rejected and returned by the server via `Basic.Return`.
+        """
+        Pass a callback function that will be called when a published message is rejected and
+        returned by the server via `Basic.Return`.
 
         :param callback: The method to call on callback with the
             message as only argument. The message is a named tuple with
@@ -345,22 +344,19 @@ class TwistedChannel:
                 )))
 
     def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
-        """Acknowledge one or more messages. When sent by the client, this
-        method acknowledges one or more messages delivered via the Deliver or
-        Get-Ok methods. When sent by server, this method acknowledges one or
-        more messages published with the Publish method on a channel in
-        confirm mode. The acknowledgement can be for a single message or a
-        set of messages up to and including a specific message.
+        """
+        Acknowledge one or more messages.
+
+        When sent by the client, this method acknowledges one or more messages delivered via the
+        Deliver or Get-Ok methods. When sent by server, this method acknowledges one or more
+        messages published with the Publish method on a channel in confirm mode. The acknowledgement
+        can be for a single message or a set of messages up to and including a specific message.
 
         :param delivery_tag: int/long The server-assigned delivery tag
-        :param multiple: If set to True, the delivery tag is treated as
-                              "up to and including", so that multiple messages
-                              can be acknowledged with a single method. If set
-                              to False, the delivery tag refers to a single
-                              message. If the multiple field is 1, and the
-                              delivery tag is zero, this indicates
-                              acknowledgement of all outstanding messages.
-
+        :param multiple: If set to True, the delivery tag is treated as "up to and including", so
+            that multiple messages can be acknowledged with a single method. If set to False, the
+            delivery tag refers to a single message. If the multiple field is 1, and the delivery
+            tag is zero, this indicates acknowledgement of all outstanding messages.
         """
         return self._channel.basic_ack(delivery_tag=delivery_tag,
                                        multiple=multiple)
@@ -370,24 +366,24 @@ class TwistedChannel:
         consumer_tag: str = ''
     ) -> defer.Deferred[(pika.frame.Method[pika.spec.Basic.CancelOk] |
                          pika.frame.Method[pika.spec.Basic.Cancel])]:
-        """This method cancels a consumer. This does not affect already
-        delivered messages, but it does mean the server will not send any more
-        messages for that consumer. The client may receive an arbitrary number
-        of messages in between sending the cancel method and receiving the
-        cancel-ok reply. It may also be sent from the server to the client in
-        the event of the consumer being unexpectedly cancelled (i.e. cancelled
-        for any reason other than the server receiving the corresponding
-        basic.cancel from the client). This allows clients to be notified of
-        the loss of consumers due to events such as queue deletion.
+        """
+        This method cancels a consumer.
 
-        This method wraps :meth:`Channel.basic_cancel
-        <pika.channel.Channel.basic_cancel>` and closes any deferred queue
-        associated with that consumer.
+        This does not affect already delivered messages, but it does mean the server will not send
+        any more messages for that consumer. The client may receive an arbitrary number of messages
+        in between sending the cancel method and receiving the cancel-ok reply. It may also be sent
+        from the server to the client in the event of the consumer being unexpectedly cancelled
+        (i.e. cancelled for any reason other than the server receiving the corresponding
+        basic.cancel from the client). This allows clients to be notified of the loss of consumers
+        due to events such as queue deletion.
+
+        This method wraps :meth:`Channel.basic_cancel <pika.channel.Channel.basic_cancel>` and
+        closes any deferred queue associated with that consumer.
 
         :param consumer_tag: Identifier for the consumer
         :returns: Deferred that fires on the Basic.CancelOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         wrapped = self._wrap_channel_method('basic_cancel')
         d = wrapped(consumer_tag=consumer_tag)
@@ -400,7 +396,8 @@ class TwistedChannel:
             exclusive: bool = False,
             consumer_tag: str | None = None,
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """Consume from a server queue.
+        """
+        Consume from a server queue.
 
         Sends the AMQP 0-9-1 command Basic.Consume to the broker and binds
         messages for the consumer_tag to a
@@ -433,7 +430,7 @@ class TwistedChannel:
             - method: pika.spec.Basic.Deliver
             - properties: pika.spec.BasicProperties
             - body: bytes
-
+        :rtype: Deferred
         """
         if self._closed:
             return defer.fail(self._closed)
@@ -451,9 +448,7 @@ class TwistedChannel:
             d.callback((queue_obj, consumer_tag))
 
         def on_message_callback(_channel, method, properties, body) -> None:
-            """Add the ReceivedMessage to the queue, while replacing the
-            channel implementation.
-            """
+            """Add the ReceivedMessage to the queue, while replacing the channel implementation."""
             queue_obj.put(
                 ReceivedMessage(
                     channel=self,
@@ -480,7 +475,8 @@ class TwistedChannel:
     def basic_get(self,
                   queue: str,
                   auto_ack: bool = False) -> defer.Deferred[Any]:
-        """Get a single message from the AMQP broker.
+        """
+        Get a single message from the AMQP broker.
 
         Will return If the queue is empty, it will return None.
         If you want to
@@ -505,8 +501,8 @@ class TwistedChannel:
              - properties: pika.spec.BasicProperties
              - body: bytes
             If the queue is empty, None will be returned.
+        :rtype: Deferred
         :raises pika.exceptions.DuplicateGetOkCallback:
-
         """
         if self._basic_get_deferred is not None:
             raise exceptions.DuplicateGetOkCallback()
@@ -537,23 +533,20 @@ class TwistedChannel:
                    delivery_tag: int = 0,
                    multiple: bool = False,
                    requeue: bool = True) -> None:
-        """This method allows a client to reject one or more incoming messages.
-        It can be used to interrupt and cancel large incoming messages, or
-        return untreatable messages to their original queue.
+        """
+        This method allows a client to reject one or more incoming messages.
+
+        It can be used to interrupt and cancel large incoming messages, or return untreatable
+        messages to their original queue.
 
         :param delivery_tag: int/long The server-assigned delivery tag
-        :param multiple: If set to True, the delivery tag is treated as
-                              "up to and including", so that multiple messages
-                              can be acknowledged with a single method. If set
-                              to False, the delivery tag refers to a single
-                              message. If the multiple field is 1, and the
-                              delivery tag is zero, this indicates
-                              acknowledgement of all outstanding messages.
-        :param requeue: If requeue is true, the server will attempt to
-                             requeue the message. If requeue is false or the
-                             requeue attempt fails the messages are discarded
-                             or dead-lettered.
-
+        :param multiple: If set to True, the delivery tag is treated as "up to and including", so
+            that multiple messages can be acknowledged with a single method. If set to False, the
+            delivery tag refers to a single message. If the multiple field is 1, and the delivery
+            tag is zero, this indicates acknowledgement of all outstanding messages.
+        :param requeue: If requeue is true, the server will attempt to requeue the message. If
+            requeue is false or the requeue attempt fails the messages are discarded or dead-
+            lettered.
         """
         return self._channel.basic_nack(
             delivery_tag=delivery_tag,
@@ -567,11 +560,11 @@ class TwistedChannel:
                       body: bytes,
                       properties: spec.BasicProperties | None = None,
                       mandatory: bool = False) -> defer.Deferred[Any]:
-        """Publish to the channel with the given exchange, routing key and body.
+        """
+        Publish to the channel with the given exchange, routing key and body.
 
-        This method wraps :meth:`Channel.basic_publish
-        <pika.channel.Channel.basic_publish>`, but makes sure the channel is
-        not closed before publishing.
+        This method wraps :meth:`Channel.basic_publish <pika.channel.Channel.basic_publish>`, but
+        makes sure the channel is not closed before publishing.
 
         For more information on basic_publish and what the parameters do, see:
 
@@ -582,16 +575,13 @@ class TwistedChannel:
         :param body: The message body
         :param properties: Basic.properties
         :param mandatory: The mandatory flag
-        :returns: A Deferred that fires with the result of the channel's
-            basic_publish.
-        :raises UnroutableError: raised when a message published in
-            publisher-acknowledgments mode (see
-            `BlockingChannel.confirm_delivery`) is returned via `Basic.Return`
-            followed by `Basic.Ack`.
-        :raises NackError: raised when a message published in
-            publisher-acknowledgements mode is Nack'ed by the broker. See
-            `BlockingChannel.confirm_delivery`.
-
+        :returns: A Deferred that fires with the result of the channel's basic_publish.
+        :rtype: Deferred
+        :raises UnroutableError: raised when a message published in publisher-acknowledgments mode
+            (see `BlockingChannel.confirm_delivery`) is returned via `Basic.Return` followed by
+            `Basic.Ack`.
+        :raises NackError: raised when a message published in publisher-acknowledgements mode is
+            Nack'ed by the broker. See `BlockingChannel.confirm_delivery`.
         """
         if self._closed:
             return defer.fail(self._closed)
@@ -613,35 +603,27 @@ class TwistedChannel:
                   prefetch_size: int = 0,
                   prefetch_count: int = 0,
                   global_qos: bool = False) -> defer.Deferred[Any]:
-        """Specify quality of service. This method requests a specific quality
-        of service. The QoS can be specified for the current channel or for all
-        channels on the connection. The client can request that messages be
-        sent in advance so that when the client finishes processing a message,
-        the following message is already held locally, rather than needing to
-        be sent down the channel. Prefetching gives a performance improvement.
+        """
+        Specify quality of service.
 
-        :param prefetch_size:  This field specifies the prefetch window
-                                   size. The server will send a message in
-                                   advance if it is equal to or smaller in size
-                                   than the available prefetch size (and also
-                                   falls into other prefetch limits). May be
-                                   set to zero, meaning "no specific limit",
-                                   although other prefetch limits may still
-                                   apply. The prefetch-size is ignored by
-                                   consumers who have enabled the no-ack
-                                   option.
-        :param prefetch_count: Specifies a prefetch window in terms of
-                                   whole messages. This field may be used in
-                                   combination with the prefetch-size field; a
-                                   message will only be sent in advance if both
-                                   prefetch windows (and those at the channel
-                                   and connection level) allow it. The
-                                   prefetch-count is ignored by consumers who
-                                   have enabled the no-ack option.
-        :param global_qos:    Should the QoS apply to all channels on the
-                                   connection.
+        This method requests a specific quality of service. The QoS can be specified for the current
+        channel or for all channels on the connection. The client can request that messages be sent
+        in advance so that when the client finishes processing a message, the following message is
+        already held locally, rather than needing to be sent down the channel. Prefetching gives a
+        performance improvement.
+
+        :param prefetch_size: This field specifies the prefetch window size. The server will send a
+            message in advance if it is equal to or smaller in size than the available prefetch size
+            (and also falls into other prefetch limits). May be set to zero, meaning "no specific
+            limit", although other prefetch limits may still apply. The prefetch-size is ignored by
+            consumers who have enabled the no-ack option.
+        :param prefetch_count: Specifies a prefetch window in terms of whole messages. This field
+            may be used in combination with the prefetch-size field; a message will only be sent in
+            advance if both prefetch windows (and those at the channel and connection level) allow
+            it. The prefetch-count is ignored by consumers who have enabled the no-ack option.
+        :param global_qos: Should the QoS apply to all channels on the connection.
         :returns: Deferred that fires on the Basic.QosOk response
-
+        :rtype: Deferred
         """
         return self._wrap_channel_method("basic_qos")(
             prefetch_size=prefetch_size,
@@ -650,61 +632,61 @@ class TwistedChannel:
         )
 
     def basic_reject(self, delivery_tag: int, requeue: bool = True) -> None:
-        """Reject an incoming message. This method allows a client to reject a
-        message. It can be used to interrupt and cancel large incoming
-        messages, or return untreatable messages to their original queue.
+        """
+        Reject an incoming message.
+
+        This method allows a client to reject a message. It can be used to interrupt and cancel
+        large incoming messages, or return untreatable messages to their original queue.
 
         :param delivery_tag: int/long The server-assigned delivery tag
-        :param requeue: If requeue is true, the server will attempt to
-                             requeue the message. If requeue is false or the
-                             requeue attempt fails the messages are discarded
-                             or dead-lettered.
+        :param requeue: If requeue is true, the server will attempt to requeue the message. If
+            requeue is false or the requeue attempt fails the messages are discarded or dead-
+            lettered.
         :raises TypeError:
-
         """
         return self._channel.basic_reject(delivery_tag=delivery_tag,
                                           requeue=requeue)
 
     def basic_recover(self, requeue: bool = False) -> defer.Deferred[Any]:
-        """This method asks the server to redeliver all unacknowledged messages
-        on a specified channel. Zero or more messages may be redelivered. This
-        method replaces the asynchronous Recover.
+        """
+        This method asks the server to redeliver all unacknowledged messages on a specified channel.
+        Zero or more messages may be redelivered. This method replaces the asynchronous Recover.
 
-        :param requeue: If False, the message will be redelivered to the
-                             original recipient. If True, the server will
-                             attempt to requeue the message, potentially then
-                             delivering it to an alternative subscriber.
+        :param requeue: If False, the message will be redelivered to the original recipient. If
+            True, the server will attempt to requeue the message, potentially then delivering it to
+            an alternative subscriber.
         :returns: Deferred that fires on the Basic.RecoverOk response
-
+        :rtype: Deferred
         """
         return self._wrap_channel_method("basic_recover")(requeue=requeue)
 
     def close(self,
               reply_code: int = 0,
               reply_text: str = "Normal shutdown") -> None:
-        """Invoke a graceful shutdown of the channel with the AMQP Broker.
+        """
+        Invoke a graceful shutdown of the channel with the AMQP Broker.
 
-        If channel is OPENING, transition to CLOSING and suppress the incoming
-        Channel.OpenOk, if any.
+        If channel is OPENING, transition to CLOSING and suppress the incoming Channel.OpenOk, if
+        any.
 
         :param reply_code: The reason code to send to broker
         :param reply_text: The reason text to send to broker
-
         :raises ChannelWrongStateError: if channel is closed or closing
-
         """
         return self._channel.close(reply_code=reply_code, reply_text=reply_text)
 
     def confirm_delivery(self) -> defer.Deferred[Any]:
-        """Turn on Confirm mode in the channel. Pass in a callback to be
-        notified by the Broker when a message has been confirmed as received or
+        """
+        Turn on Confirm mode in the channel.
+
+        Pass in a callback to be notified by the Broker when a message has been confirmed as received or
         rejected (Basic.Ack, Basic.Nack) from the broker to the publisher.
 
         For more information see:
             https://www.rabbitmq.com/confirms.html#publisher-confirms
 
         :returns: Deferred that fires on the Confirm.SelectOk response
-
+        :rtype: Deferred
         """
         if self._delivery_confirmation:
             LOGGER.error('confirm_delivery: confirmation was already enabled.')
@@ -728,17 +710,15 @@ class TwistedChannel:
         self, method_frame: (pika.frame.Method[pika.spec.Basic.Ack] |
                              pika.frame.Method[pika.spec.Basic.Nack])
     ) -> None:
-        """Invoked by pika when RabbitMQ responds to a Basic.Publish RPC
-        command, passing in either a Basic.Ack or Basic.Nack frame with
-        the delivery tag of the message that was published. The delivery tag
-        is an integer counter indicating the message number that was sent
-        on the channel via Basic.Publish. Here we're just doing house keeping
-        to keep track of stats and remove message numbers that we expect
-        a delivery confirmation of from the list used to keep track of messages
-        that are pending confirmation.
+        """
+        Invoked by pika when RabbitMQ responds to a Basic.Publish RPC command, passing in either a
+        Basic.Ack or Basic.Nack frame with the delivery tag of the message that was published. The
+        delivery tag is an integer counter indicating the message number that was sent on the
+        channel via Basic.Publish. Here we're just doing house keeping to keep track of stats and
+        remove message numbers that we expect a delivery confirmation of from the list used to keep
+        track of messages that are pending confirmation.
 
         :param method_frame: Basic.Ack or Basic.Nack frame
-
         """
         delivery_tag = method_frame.method.delivery_tag
         if delivery_tag not in self._deliveries:
@@ -783,15 +763,15 @@ class TwistedChannel:
                                     method: spec.Basic.Return,
                                     properties: spec.BasicProperties,
                                     body: bytes) -> None:
-        """Called as the result of Basic.Return from broker in
-        publisher-acknowledgements mode. Saves the info as a ReturnedMessage
-        instance in self._puback_return.
+        """
+        Called as the result of Basic.Return from broker in publisher-acknowledgements mode.
+
+        Saves the info as a ReturnedMessage instance in self._puback_return.
 
         :param channel: our self._impl channel
         :param method:
         :param properties: message properties
         :param body: returned message body; empty string if no body
-
         """
         assert isinstance(method, spec.Basic.Return), method
         assert isinstance(properties, spec.BasicProperties), properties
@@ -814,7 +794,8 @@ class TwistedChannel:
             source: str,
             routing_key: str = '',
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """Bind an exchange to another exchange.
+        """
+        Bind an exchange to another exchange.
 
         :param destination: The destination exchange to bind
         :param source: The source exchange to bind to
@@ -822,7 +803,7 @@ class TwistedChannel:
         :param arguments: Custom key/value pair arguments for the binding
         :raises ValueError:
         :returns: Deferred that fires on the Exchange.BindOk response
-
+        :rtype: Deferred
         """
         return self._wrap_channel_method("exchange_bind")(
             destination=destination,
@@ -840,9 +821,9 @@ class TwistedChannel:
             auto_delete: bool = False,
             internal: bool = False,
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """This method creates an exchange if it does not already exist, and if
-        the exchange exists, verifies that it is of the correct and expected
-        class.
+        """
+        This method creates an exchange if it does not already exist, and if the exchange exists,
+        verifies that it is of the correct and expected class.
 
         If passive set, the server will reply with Declare-Ok if the exchange
         already exists with the same name, and raise an error if not and if the
@@ -860,8 +841,8 @@ class TwistedChannel:
         :param internal: Can only be published to by other exchanges
         :param arguments: Custom key/value pair arguments for the exchange
         :returns: Deferred that fires on the Exchange.DeclareOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("exchange_declare")(
             exchange=exchange,
@@ -876,13 +857,14 @@ class TwistedChannel:
     def exchange_delete(self,
                         exchange: str | None = None,
                         if_unused: bool = False) -> defer.Deferred[Any]:
-        """Delete the exchange.
+        """
+        Delete the exchange.
 
         :param exchange: The exchange name
         :param if_unused: only delete if the exchange is unused
         :returns: Deferred that fires on the Exchange.DeleteOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("exchange_delete")(
             exchange=exchange,
@@ -895,15 +877,16 @@ class TwistedChannel:
             source: str,
             routing_key: str = '',
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """Unbind an exchange from another exchange.
+        """
+        Unbind an exchange from another exchange.
 
         :param destination: The destination exchange to unbind
         :param source: The source exchange to unbind from
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Exchange.UnbindOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("exchange_unbind")(
             destination=destination,
@@ -913,22 +896,23 @@ class TwistedChannel:
         )
 
     def flow(self, active: bool = True) -> defer.Deferred[Any]:
-        """Turn Channel flow control off and on.
+        """
+        Turn Channel flow control off and on.
 
-        Returns a Deferred that will fire with a bool indicating the channel
-        flow state. For more information, please reference:
+        Returns a Deferred that will fire with a bool indicating the channel flow state. For more
+        information, please reference:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
         :param active: Turn flow on or off
         :returns: Deferred that fires with the channel flow state
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("flow")(active=active)
 
     def open(self) -> None:
-        """Open the channel"""
+        """Open the channel."""
         return self._channel.open()
 
     def queue_bind(
@@ -937,15 +921,16 @@ class TwistedChannel:
             exchange: str,
             routing_key: str | None = None,
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """Bind the queue to the specified exchange
+        """
+        Bind the queue to the specified exchange.
 
         :param queue: The queue to bind to the exchange
         :param exchange: The source exchange to bind to
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Queue.BindOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("queue_bind")(
             queue=queue,
@@ -962,8 +947,10 @@ class TwistedChannel:
             exclusive: bool = False,
             auto_delete: bool = False,
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """Declare queue, create if needed. This method creates or checks a
-        queue. When creating a new queue the client can specify various
+        """
+        Declare queue, create if needed.
+
+        This method creates or checks a queue. When creating a new queue the client can specify various
         properties that control the durability of the queue and its contents,
         and the level of sharing for the queue.
 
@@ -978,8 +965,8 @@ class TwistedChannel:
         :param auto_delete: Delete after consumer cancels or disconnects
         :param arguments: Custom key/value arguments for the queue
         :returns: Deferred that fires on the Queue.DeclareOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("queue_declare")(
             queue=queue,
@@ -994,19 +981,18 @@ class TwistedChannel:
                      queue: str,
                      if_unused: bool = False,
                      if_empty: bool = False) -> defer.Deferred[Any]:
-        """Delete a queue from the broker.
+        """
+        Delete a queue from the broker.
 
-
-        This method wraps :meth:`Channel.queue_delete
-        <pika.channel.Channel.queue_delete>`, and removes the reference to the
-        queue object after it gets deleted on the server.
+        This method wraps :meth:`Channel.queue_delete <pika.channel.Channel.queue_delete>`, and
+        removes the reference to the queue object after it gets deleted on the server.
 
         :param queue: The queue to delete
         :param if_unused: only delete if it's unused
         :param if_empty: only delete if the queue is empty
         :returns: Deferred that fires on the Queue.DeleteOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         wrapped = self._wrap_channel_method('queue_delete')
         d = wrapped(queue=queue, if_unused=if_unused, if_empty=if_empty)
@@ -1025,12 +1011,13 @@ class TwistedChannel:
         return d.addCallback(_clear_consumer, queue)
 
     def queue_purge(self, queue: str) -> defer.Deferred[Any]:
-        """Purge all of the messages from the specified queue
+        """
+        Purge all of the messages from the specified queue.
 
         :param queue: The queue to purge
         :returns: Deferred that fires on the Queue.PurgeOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("queue_purge")(queue=queue)
 
@@ -1040,15 +1027,16 @@ class TwistedChannel:
             exchange: str | None,
             routing_key: str | None = None,
             arguments: dict[str, Any] | None = None) -> defer.Deferred[Any]:
-        """Unbind a queue from an exchange.
+        """
+        Unbind a queue from an exchange.
 
         :param queue: The queue to unbind from the exchange
         :param exchange: The source exchange to bind from
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Queue.UnbindOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("queue_unbind")(
             queue=queue,
@@ -1058,43 +1046,47 @@ class TwistedChannel:
         )
 
     def tx_commit(self) -> defer.Deferred[Any]:
-        """Commit a transaction.
+        """
+        Commit a transaction.
 
         :returns: Deferred that fires on the Tx.CommitOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("tx_commit")()
 
     def tx_rollback(self) -> defer.Deferred[Any]:
-        """Rollback a transaction.
+        """
+        Rollback a transaction.
 
         :returns: Deferred that fires on the Tx.RollbackOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("tx_rollback")()
 
     def tx_select(self) -> defer.Deferred[Any]:
-        """Select standard transaction mode. This method sets the channel to use
-        standard transactions. The client must use this method at least once on
-        a channel before using the Commit or Rollback methods.
+        """
+        Select standard transaction mode.
+
+        This method sets the channel to use standard transactions. The client must use this method
+        at least once on a channel before using the Commit or Rollback methods.
 
         :returns: Deferred that fires on the Tx.SelectOk response
+        :rtype: Deferred
         :raises ValueError:
-
         """
         return self._wrap_channel_method("tx_select")()
 
 
 class _TwistedConnectionAdapter(pika.connection.Connection):
-    """A Twisted-specific implementation of a Pika Connection.
+    """
+    A Twisted-specific implementation of a Pika Connection.
 
     NOTE: since `base_connection.BaseConnection`'s primary responsibility is
     management of the transport, we use `pika.connection.Connection` directly
     as our base class because this adapter uses a different transport
     management strategy.
-
     """
 
     def __init__(self,
@@ -1179,24 +1171,24 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
 
     def connection_made(
             self, transport: twisted.internet.interfaces.ITransport) -> None:
-        """Introduces transport to protocol after transport is connected.
+        """
+        Introduces transport to protocol after transport is connected.
 
         :param transport:
         :raises Exception: Exception-based exception on error
-
         """
         self._transport = transport
         # Let connection know that stream is available
         self._on_stream_connected()
 
     def connection_lost(self, error: Any) -> None:
-        """Called upon loss or closing of TCP connection.
+        """
+        Called upon loss or closing of TCP connection.
 
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
 
         :param error: A Twisted Failure instance wrapping an exception.
-
         """
         self._transport = None
         error = error.value  # drop the Failure wrapper
@@ -1208,18 +1200,20 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         self._on_stream_terminated(error)
 
     def data_received(self, data: bytes) -> None:
-        """Called to deliver incoming data from the server to the protocol.
+        """
+        Called to deliver incoming data from the server to the protocol.
 
         :param data: Non-empty data bytes.
         :raises Exception: Exception-based exception on error
-
         """
         self._on_data_available(data)
 
 
 class TwistedProtocolConnection(protocol.Protocol):
-    """A Pika-specific implementation of a Twisted Protocol. Allows using
-    Twisted's non-blocking connectTCP/connectSSL methods for connecting to the
+    """
+    A Pika-specific implementation of a Twisted Protocol.
+
+    Allows using Twisted's non-blocking connectTCP/connectSSL methods for connecting to the
     server.
 
     TwistedProtocolConnection objects have a `ready` instance variable that's a
@@ -1234,7 +1228,6 @@ class TwistedProtocolConnection(protocol.Protocol):
     connect callbacks, you have to implement that within Twisted. Also remember
     that the host, port and ssl values of the connection parameters are ignored
     because, yet again, it's Twisted who manages the connection.
-
     """
 
     def __init__(self,
@@ -1262,16 +1255,14 @@ class TwistedProtocolConnection(protocol.Protocol):
 
     def channel(self,
                 channel_number: int | None = None) -> Deferred[TwistedChannel]:
-        """Create a new channel with the next available channel number or pass
-        in a channel number to use. Must be non-zero if you would like to
-        specify but it is recommended that you let Pika manage the channel
-        numbers.
+        """
+        Create a new channel with the next available channel number or pass in a channel number to
+        use. Must be non-zero if you would like to specify but it is recommended that you let Pika
+        manage the channel numbers.
 
-        :param channel_number: The channel number to use, defaults to the
-                                   next available.
-        :returns: a Deferred that fires with an instance of a wrapper around
-            the Pika Channel class.
-
+        :param channel_number: The channel number to use, defaults to the next available.
+        :returns: a Deferred that fires with an instance of a wrapper around the Pika Channel class.
+        :rtype: Deferred
         """
         d: defer.Deferred[Any] = defer.Deferred()
         self._impl.channel(channel_number, d.callback)
@@ -1324,8 +1315,7 @@ class TwistedProtocolConnection(protocol.Protocol):
         self
     ) -> (TwistedProtocolConnection | defer.Deferred[TwistedProtocolConnection]
          ):
-        """This method will be called when the underlying connection is ready.
-        """
+        """This method will be called when the underlying connection is ready."""
         return self
 
     def _on_connection_ready(self,
@@ -1365,9 +1355,7 @@ class TwistedProtocolConnection(protocol.Protocol):
 
 
 class _TimerHandle(nbio_interface.AbstractTimerReference):
-    """This module's adaptation of `nbio_interface.AbstractTimerReference`.
-
-    """
+    """This module's adaptation of `nbio_interface.AbstractTimerReference`."""
 
     def __init__(self, handle: twisted.internet.base.DelayedCall) -> None:
         """

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -6,6 +6,7 @@ Defines the interface `AbstractAMQPConnectionWorkflow` that facilitates
 implementing custom connection workflows.
 
 """
+
 from __future__ import annotations
 
 import functools
@@ -30,7 +31,7 @@ _LOG = logging.getLogger(__name__)
 
 
 class AMQPConnectorException(Exception):
-    """Base exception for this module"""
+    """Base exception for this module."""
 
 
 class AMQPConnectorStackTimeout(AMQPConnectorException):
@@ -38,19 +39,17 @@ class AMQPConnectorStackTimeout(AMQPConnectorException):
 
 
 class AMQPConnectorAborted(AMQPConnectorException):
-    """Asynchronous request was aborted"""
+    """Asynchronous request was aborted."""
 
 
 class AMQPConnectorWrongState(AMQPConnectorException):
-    """AMQPConnector operation requested in wrong state, such as aborting after
-    completion was reported.
+    """AMQPConnector operation requested in wrong state, such as aborting after completion was
+    reported.
     """
 
 
 class AMQPConnectorPhaseErrorBase(AMQPConnectorException):
-    """Wrapper for exception that occurred during a particular bring-up phase.
-
-    """
+    """Wrapper for exception that occurred during a particular bring-up phase."""
 
     def __init__(self, exception: BaseException, *args: Any) -> None:
         """
@@ -67,17 +66,15 @@ class AMQPConnectorPhaseErrorBase(AMQPConnectorException):
 
 
 class AMQPConnectorSocketConnectError(AMQPConnectorPhaseErrorBase):
-    """Error connecting TCP socket to remote peer"""
+    """Error connecting TCP socket to remote peer."""
 
 
 class AMQPConnectorTransportSetupError(AMQPConnectorPhaseErrorBase):
-    """Error setting up transport after TCP connected but before AMQP handshake.
-
-    """
+    """Error setting up transport after TCP connected but before AMQP handshake."""
 
 
 class AMQPConnectorAMQPHandshakeError(AMQPConnectorPhaseErrorBase):
-    """Error during AMQP handshake"""
+    """Error during AMQP handshake."""
 
 
 class AMQPConnectionWorkflowAborted(AMQPConnectorException):
@@ -85,15 +82,13 @@ class AMQPConnectionWorkflowAborted(AMQPConnectorException):
 
 
 class AMQPConnectionWorkflowWrongState(AMQPConnectorException):
-    """AMQP Connection Workflow operation requested in wrong state, such as
-    aborting after completion was reported.
+    """AMQP Connection Workflow operation requested in wrong state, such as aborting after
+    completion was reported.
     """
 
 
 class AMQPConnectionWorkflowFailed(AMQPConnectorException):
-    """Indicates that AMQP connection workflow failed.
-
-    """
+    """Indicates that AMQP connection workflow failed."""
 
     def __init__(self, exceptions: Sequence[BaseException], *args: Any) -> None:
         """
@@ -113,9 +108,7 @@ class AMQPConnectionWorkflowFailed(AMQPConnectorException):
 
 
 class AMQPConnector:
-    """Performs a single TCP/[SSL]/AMQP connection workflow.
-
-    """
+    """Performs a single TCP/[SSL]/AMQP connection workflow."""
 
     _STATE_INIT = 0  # start() hasn't been called yet
     _STATE_TCP = 1  # TCP/IP connection establishment
@@ -164,7 +157,8 @@ class AMQPConnector:
         self, addr_record: tuple, conn_params: pika.connection.Parameters,
         on_done: Callable[[pika.connection.Connection | BaseException], None]
     ) -> None:
-        """Asynchronously perform a single TCP/[SSL]/AMQP connection attempt.
+        """
+        Asynchronously perform a single TCP/[SSL]/AMQP connection attempt.
 
         :param addr_record: a single resolved address record compatible
             with `socket.getaddrinfo()` format.
@@ -176,7 +170,6 @@ class AMQPConnector:
                 `AMQPConnectorTransportSetupError`
                 `AMQPConnectorAMQPHandshakeError`
                 `AMQPConnectorAborted`
-
         """
         if self._state != self._STATE_INIT:
             raise AMQPConnectorWrongState(
@@ -216,8 +209,10 @@ class AMQPConnector:
                 self._conn_params.stack_timeout, self._on_overall_timeout)
 
     def abort(self) -> None:
-        """Abort the workflow asynchronously. The completion callback will be
-        called with an instance of AMQPConnectorAborted.
+        """
+        Abort the workflow asynchronously.
+
+        The completion callback will be called with an instance of AMQPConnectorAborted.
 
         NOTE: we can't cancel/close synchronously because aborting pika
         Connection and its transport requires an asynchronous operation.
@@ -260,15 +255,15 @@ class AMQPConnector:
                 # so we'll just piggy back on the callback it registered
                 _LOG.debug('AMQPConnector.abort(): closing of Connection was '
                            'already initiated.')
-                assert self._state == self._STATE_TIMEOUT, \
-                    (f'Connection is closing, but not in TIMEOUT state; state={self._state}'
-                     )
+                assert self._state == self._STATE_TIMEOUT, (
+                    f'Connection is closing, but not in TIMEOUT state; state={self._state}'
+                )
 
     def _close(self) -> None:
-        """Cancel asynchronous tasks and clean up to assist garbage collection.
+        """
+        Cancel asynchronous tasks and clean up to assist garbage collection.
 
         Transition to STATE_DONE.
-
         """
         self._deactivate()
 
@@ -284,14 +279,13 @@ class AMQPConnector:
         self._state = self._STATE_DONE
 
     def _deactivate(self) -> None:
-        """Cancel asynchronous tasks.
-
-        """
+        """Cancel asynchronous tasks."""
         # NOTE: self._amqp_conn requires special handling as it doesn't support
         # synchronous closing. We special-case it elsewhere in the code where
         # needed.
-        assert self._amqp_conn is None, \
+        assert self._amqp_conn is None, (
             f'_deactivate called with self._amqp_conn not None; state={self._state}'
+        )
 
         if self._tcp_timeout_ref is not None:
             self._tcp_timeout_ref.cancel()
@@ -307,10 +301,10 @@ class AMQPConnector:
 
     def _report_completion_and_cleanup(
         self, result: (pika.connection.Connection | BaseException)) -> None:
-        """Clean up and invoke client's `on_done` callback.
+        """
+        Clean up and invoke client's `on_done` callback.
 
-        :param result: value to pass
-            to user's `on_done` callback.
+        :param result: value to pass to user's `on_done` callback.
         """
         if isinstance(result, BaseException):
             _LOG.error('AMQPConnector - reporting failure: %r', result)
@@ -324,10 +318,10 @@ class AMQPConnector:
         on_done(result)
 
     def _on_tcp_connection_timeout(self) -> None:
-        """Handle TCP connection timeout
+        """
+        Handle TCP connection timeout.
 
         Reports AMQPConnectorSocketConnectError with socket.timeout inside.
-
         """
         assert self._conn_params is not None
         self._tcp_timeout_ref = None
@@ -339,16 +333,14 @@ class AMQPConnector:
         self._report_completion_and_cleanup(error)
 
     def _on_overall_timeout(self) -> None:
-        """Handle overall TCP/[SSL]/AMQP connection attempt timeout by reporting
-        `Timeout` error to the client.
+        """
+        Handle overall TCP/[SSL]/AMQP connection attempt timeout by reporting `Timeout` error to the
+        client.
 
-        Reports AMQPConnectorSocketConnectError if timeout occurred during
-            socket TCP connection attempt.
-        Reports AMQPConnectorTransportSetupError if timeout occurred during
-            tramsport [SSL] setup attempt.
-        Reports AMQPConnectorAMQPHandshakeError if timeout occurred during
-            AMQP handshake.
-
+        Reports AMQPConnectorSocketConnectError if timeout occurred during     socket TCP connection
+        attempt. Reports AMQPConnectorTransportSetupError if timeout occurred during     tramsport
+        [SSL] setup attempt. Reports AMQPConnectorAMQPHandshakeError if timeout occurred during AMQP
+        handshake.
         """
         assert self._conn_params is not None
         self._stack_timeout_ref = None
@@ -385,14 +377,12 @@ class AMQPConnector:
         self._report_completion_and_cleanup(error)
 
     def _on_tcp_connection_done(self, exc: BaseException | None) -> None:
-        """Handle completion of asynchronous socket connection attempt.
+        """
+        Handle completion of asynchronous socket connection attempt.
 
-        Reports AMQPConnectorSocketConnectError if TCP socket connection
-            failed.
+        Reports AMQPConnectorSocketConnectError if TCP socket connection     failed.
 
-        :param exc: None on success; exception object on
-            failure
-
+        :param exc: None on success; exception object on failure
         """
         assert self._conn_params is not None
         assert self._nbio is not None
@@ -479,7 +469,8 @@ class AMQPConnector:
     def _on_amqp_handshake_done(self,
                                 connection: pika.connection.Connection,
                                 error: BaseException | None = None) -> None:
-        """Handle completion of AMQP connection handshake attempt.
+        """
+        Handle completion of AMQP connection handshake attempt.
 
         NOTE: we handle two types of callbacks - success with just connection
         arg as well as the open-error callback with connection and error
@@ -488,7 +479,6 @@ class AMQPConnector:
 
         :param connection: AMQP connection instance from the callback.
         :param error: None on success, otherwise failure
-
         """
         assert self._conn_params is not None
 
@@ -536,9 +526,7 @@ class AMQPConnector:
 class AbstractAMQPConnectionWorkflow(
         pika._utils.AbstractBase  # type: ignore[valid-type, misc]
 ):
-    """Interface for implementing a custom TCP/[SSL]/AMQP connection workflow.
-
-    """
+    """Interface for implementing a custom TCP/[SSL]/AMQP connection workflow."""
 
     def start(
         self, connection_configs: Sequence[pika.connection.Parameters],
@@ -546,8 +534,10 @@ class AbstractAMQPConnectionWorkflow(
         on_done: Callable[[pika.connection.Connection | AMQPConnectorException],
                           None]
     ) -> None:
-        """Asynchronously perform the workflow until success or all retries
-        are exhausted. Called by the adapter.
+        """
+        Asynchronously perform the workflow until success or all retries are exhausted.
+
+        Called by the adapter.
 
         :param connection_configs: A sequence of one or more
             `pika.connection.Parameters`-based objects. Will attempt to connect
@@ -572,8 +562,10 @@ class AbstractAMQPConnectionWorkflow(
         raise NotImplementedError
 
     def abort(self) -> None:
-        """Abort the workflow asynchronously. The completion callback will be
-        called with an instance of AMQPConnectionWorkflowAborted.
+        """
+        Abort the workflow asynchronously.
+
+        The completion callback will be called with an instance of AMQPConnectionWorkflowAborted.
 
         NOTE: we can't cancel/close synchronously because aborting pika
         Connection and its transport requires an asynchronous operation.
@@ -585,9 +577,9 @@ class AbstractAMQPConnectionWorkflow(
 
 
 class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
-    """Implements Pika's default workflow for performing multiple TCP/[SSL]/AMQP
-    connection attempts with timeouts and retries until one succeeds or all
-    attempts fail.
+    """
+    Implements Pika's default workflow for performing multiple TCP/[SSL]/AMQP connection attempts
+    with timeouts and retries until one succeeds or all attempts fail.
 
     The workflow:
         while not success and retries remain:
@@ -599,7 +591,6 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
                after the given retry pause. NOTE: failure of DNS resolution
                is equivalent to one cycle and will be retried after the pause
                if retries remain.
-
     """
 
     _SOCK_TYPE = socket.SOCK_STREAM
@@ -658,16 +649,15 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         self._state = self._STATE_INIT
 
     def set_io_services(self, nbio: nbio_interface.AbstractIOServices) -> None:
-        """Called by the conneciton adapter only on pika's
-        `AMQPConnectionWorkflow` instance to provide it the adapter-specific
-        `AbstractIOServices` object before calling the `start()` method.
+        """
+        Called by the conneciton adapter only on pika's `AMQPConnectionWorkflow` instance to provide
+        it the adapter-specific `AbstractIOServices` object before calling the `start()` method.
 
         NOTE: Custom workflow implementations should use the native I/O loop
         directly because `AbstractIOServices` is private to Pika
         implementation and its interface may change without notice.
 
         :param nbio:
-
         """
         self._nbio = nbio
 
@@ -677,7 +667,8 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         on_done: Callable[[pika.connection.Connection | AMQPConnectorException],
                           None]
     ) -> None:
-        """Override `AbstractAMQPConnectionWorkflow.start()`.
+        """
+        Override `AbstractAMQPConnectionWorkflow.start()`.
 
         NOTE: This implementation uses `connection_attempts` and `retry_delay`
         values from the last element of the given `connection_configs` sequence
@@ -729,9 +720,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
             0, functools.partial(self._start_new_cycle_async, first=True))
 
     def abort(self) -> None:
-        """Override `AbstractAMQPConnectionWorkflow.abort()`.
-
-        """
+        """Override `AbstractAMQPConnectionWorkflow.abort()`."""
         if self._state == self._STATE_INIT:
             raise AMQPConnectorWrongState('Cannot abort before starting.')
         if self._state == self._STATE_DONE:
@@ -757,10 +746,10 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
             self._connector.abort()
 
     def _close(self) -> None:
-        """Cancel asynchronous tasks and clean up to assist garbage collection.
+        """
+        Cancel asynchronous tasks and clean up to assist garbage collection.
 
         Transition to _STATE_DONE.
-
         """
         self._deactivate()
 
@@ -775,9 +764,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         self._state = self._STATE_DONE
 
     def _deactivate(self) -> None:
-        """Cancel asynchronous tasks.
-
-        """
+        """Cancel asynchronous tasks."""
         if self._task_ref is not None:
             self._task_ref.cancel()
             self._task_ref = None
@@ -785,7 +772,8 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
     def _report_completion_and_cleanup(
         self, result: (pika.connection.Connection | AMQPConnectorException)
     ) -> None:
-        """Clean up and invoke client's `on_done` callback.
+        """
+        Clean up and invoke client's `on_done` callback.
 
         :param result: value to pass to user's `on_done` callback.
         """
@@ -801,12 +789,13 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         on_done(result)
 
     def _start_new_cycle_async(self, first: bool) -> None:
-        """Start a new workflow cycle (if any more attempts are left) beginning
-        with the first Parameters object in self._connection_configs. If out of
-        attempts, report `AMQPConnectionWorkflowFailed`.
+        """
+        Start a new workflow cycle (if any more attempts are left) beginning with the first
+        Parameters object in self._connection_configs. If out of attempts, report
+        `AMQPConnectionWorkflowFailed`.
 
-        :param first: if True, don't delay; otherwise delay next attempt by
-            `self._retry_pause` seconds.
+        :param first: if True, don't delay; otherwise delay next attempt by `self._retry_pause`
+            seconds.
         """
         self._task_ref = None
 
@@ -833,9 +822,10 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
             0 if first else self._retry_pause, self._try_next_config_async)
 
     def _try_next_config_async(self) -> None:
-        """Attempt to connect using the next Parameters config. If there are no
-        more configs, start a new cycle.
+        """
+        Attempt to connect using the next Parameters config.
 
+        If there are no more configs, start a new cycle.
         """
         assert self._connection_configs is not None
         assert self._nbio is not None
@@ -867,10 +857,11 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
 
     def _on_getaddrinfo_async_done(
         self, addrinfos_or_exc: (list[ADDRESS_INFO] | BaseException)) -> None:
-        """Handles completion callback from asynchronous `getaddrinfo()`.
+        """
+        Handles completion callback from asynchronous `getaddrinfo()`.
 
-        :param addrinfos_or_exc: resolved address records
-            returned by `getaddrinfo()` or an exception object from failure.
+        :param addrinfos_or_exc: resolved address records returned by `getaddrinfo()` or an
+            exception object from failure.
         """
         assert self._connection_errors is not None
 
@@ -888,9 +879,10 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         self._try_next_resolved_address()
 
     def _try_next_resolved_address(self) -> None:
-        """Try connecting using next resolved address. If there aren't any left,
-        continue with next Parameters config.
+        """
+        Try connecting using next resolved address.
 
+        If there aren't any left, continue with next Parameters config.
         """
         assert self._addrinfo_iter is not None
         assert self._connector_factory is not None
@@ -917,11 +909,10 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
     def _on_connector_done(
         self,
         conn_or_exc: (pika.connection.Connection | BaseException)) -> None:
-        """Handle completion of connection attempt by `AMQPConnector`.
+        """
+        Handle completion of connection attempt by `AMQPConnector`.
 
-        :param conn_or_exc: See
-            `AMQPConnector.start()` for exception details.
-
+        :param conn_or_exc: See `AMQPConnector.start()` for exception details.
         """
         assert self._connection_errors is not None
         self._connector = None
@@ -931,8 +922,8 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
             self._connection_errors.append(conn_or_exc)
 
             if isinstance(conn_or_exc, AMQPConnectorAborted):
-                assert self._state == self._STATE_ABORTING, \
-                    f'Expected _STATE_ABORTING, but got {self._state!r}'
+                assert self._state == self._STATE_ABORTING, (
+                    f'Expected _STATE_ABORTING, but got {self._state!r}')
 
                 self._report_completion_and_cleanup(
                     AMQPConnectionWorkflowAborted())

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -1,7 +1,5 @@
-"""Utilities for implementing `nbio_interface.AbstractIOServices` for
-pika connection adapters.
+"""Utilities for implementing `nbio_interface.AbstractIOServices` for pika connection adapters."""
 
-"""
 from __future__ import annotations
 
 import collections
@@ -46,36 +44,36 @@ _log_exceptions = pika.diagnostic_utils.create_log_exception_decorator(_LOGGER)
 
 
 def check_callback_arg(callback: Any, name: str) -> None:
-    """Raise TypeError if callback is not callable
+    """
+    Raise TypeError if callback is not callable.
 
     :param callback: callback to check
     :param name: Name to include in exception text
     :raises TypeError:
-
+    :rtype: None
     """
     if not callable(callback):
         raise TypeError(f'{name} must be callable, but got {callback!r}')
 
 
 def check_fd_arg(fd: int) -> None:
-    """Raise TypeError if file descriptor is not an integer
+    """
+    Raise TypeError if file descriptor is not an integer.
 
     :param fd: file descriptor
     :raises TypeError:
-
+    :rtype: None
     """
     if not isinstance(fd, numbers.Integral):
         raise TypeError(f'Paramter must be a file descriptor, but got {fd!r}')
 
 
 def _retry_on_sigint(func):
-    """Function decorator for retrying on SIGINT.
-
-    """
+    """Function decorator for retrying on SIGINT."""
 
     @functools.wraps(func)
     def retry_sigint_wrap(*args, **kwargs):
-        """Wrapper for decorated function"""
+        """Wrapper for decorated function."""
         while True:
             try:
                 return func(*args, **kwargs)
@@ -106,6 +104,7 @@ class SocketConnectionMixin:
         :param sock: non-blocking socket to connect
         :param resolved_addr: resolved destination address/port two-tuple
         :param on_done: user callback called upon completion
+        :rtype: _AsyncServiceAsyncHandle
 
         """
         return _AsyncSocketConnector(nbio=cast(
@@ -141,6 +140,7 @@ class StreamingConnectionMixin:
         :param on_done: completion callback
         :param ssl_context: SSL context (optional)
         :param server_hostname: server hostname for SSL (optional)
+        :rtype: AbstractIOReference
 
         """
         try:
@@ -167,9 +167,7 @@ class StreamingConnectionMixin:
 
 
 class _AsyncServiceAsyncHandle(AbstractIOReference):
-    """This module's adaptation of `.nbio_interface.AbstractIOReference`
-
-    """
+    """This module's adaptation of `.nbio_interface.AbstractIOReference`"""
 
     def __init__(self, subject: Any) -> None:
         """
@@ -179,18 +177,21 @@ class _AsyncServiceAsyncHandle(AbstractIOReference):
         self._cancel = subject.cancel
 
     def cancel(self) -> bool:
-        """Cancel pending operation
+        """
+        Cancel pending operation.
 
         :returns: False if was already done or cancelled; True otherwise
-
+        :rtype: bool
         """
         return self._cancel()
 
 
 class _AsyncSocketConnector:
-    """Connects the given non-blocking socket asynchronously using
-    `.nbio_interface.AbstractFileDescriptorServices` and basic
-    `.nbio_interface.AbstractIOServices`. Used for implementing
+    """
+    Connects the given non-blocking socket asynchronously using
+    `.nbio_interface.AbstractFileDescriptorServices` and basic `.nbio_interface.AbstractIOServices`.
+
+    Used for implementing
     `.nbio_interface.AbstractIOServices.connect_socket()`.
     """
 
@@ -239,16 +240,16 @@ class _AsyncSocketConnector:
 
     @_log_exceptions
     def _cleanup(self) -> None:
-        """Remove socket watcher, if any
-
-        """
+        """Remove socket watcher, if any."""
         if self._watching_socket_events:
             self._watching_socket_events = False
             self._nbio.remove_writer(self._sock.fileno())
 
     def start(self) -> AbstractIOReference:
-        """Start asynchronous connection establishment.
+        """
+        Start asynchronous connection establishment.
 
+        :rtype: AbstractIOReference
         """
         assert self._state == self._STATE_NOT_STARTED, (
             '_AsyncSocketConnector.start(): expected _STATE_NOT_STARTED',
@@ -263,11 +264,11 @@ class _AsyncSocketConnector:
         return _AsyncServiceAsyncHandle(self)
 
     def cancel(self) -> bool:
-        """Cancel pending connection request without calling user's completion
-        callback.
+        """
+        Cancel pending connection request without calling user's completion callback.
 
         :returns: False if was already done or cancelled; True otherwise
-
+        :rtype: bool
         """
         if self._state == self._STATE_ACTIVE:
             self._state = self._STATE_CANCELED
@@ -283,11 +284,10 @@ class _AsyncSocketConnector:
 
     @_log_exceptions
     def _report_completion(self, result: BaseException | None) -> None:
-        """Advance to COMPLETED state, remove socket watcher, and invoke user's
-        completion callback.
+        """
+        Advance to COMPLETED state, remove socket watcher, and invoke user's completion callback.
 
         :param result: value to pass in user's callback
-
         """
         _LOGGER.debug('_AsyncSocketConnector._report_completion(%r); %s',
                       result, self._sock)
@@ -306,9 +306,8 @@ class _AsyncSocketConnector:
 
     @_log_exceptions
     def _start_async(self) -> None:
-        """Called as callback from I/O loop to kick-start the workflow, so it's
-        safe to call user's completion callback from here, if needed
-
+        """Called as callback from I/O loop to kick-start the workflow, so it's safe to call user's
+        completion callback from here, if needed.
         """
         if self._state != self._STATE_ACTIVE:
             # Must have been canceled by user before we were called
@@ -345,9 +344,10 @@ class _AsyncSocketConnector:
 
     @_log_exceptions
     def _on_writable(self) -> None:
-        """Called when socket connects or fails to. Check for predicament and
-        invoke user's completion callback.
+        """
+        Called when socket connects or fails to.
 
+        Check for predicament and invoke user's completion callback.
         """
         if self._state != self._STATE_ACTIVE:
             # This should never happen since we remove the watcher upon
@@ -373,12 +373,14 @@ class _AsyncSocketConnector:
 
 
 class _AsyncStreamConnector:
-    """Performs asynchronous SSL session establishment, if requested, on the
-    already-connected socket and links the streaming transport to protocol.
+    """
+    Performs asynchronous SSL session establishment, if requested, on the already-connected socket
+    and links the streaming transport to protocol.
+
     Used for implementing
     `.nbio_interface.AbstractIOServices.create_streaming_connection()`.
-
     """
+
     _STATE_NOT_STARTED = 0  # start() not called yet
     _STATE_ACTIVE = 1  # start() called and kicked off the workflow
     _STATE_CANCELED = 2  # workflow terminated by cancel() request
@@ -395,11 +397,10 @@ class _AsyncStreamConnector:
                             BaseException)], None]
     ) -> None:
         """
-        NOTE: We take ownership of the given socket upon successful completion
-        of the constructor.
+        NOTE: We take ownership of the given socket upon successful completion of the constructor.
 
-        See `AbstractIOServices.create_streaming_connection()` for detailed
-        documentation of the corresponding args.
+        See `AbstractIOServices.create_streaming_connection()` for detailed documentation of the
+        corresponding args.
 
         :param nbio:
         :param protocol_factory:
@@ -407,7 +408,6 @@ class _AsyncStreamConnector:
         :param ssl_context:
         :param server_hostname:
         :param on_done:
-
         """
         check_callback_arg(protocol_factory, 'protocol_factory')
         check_callback_arg(on_done, 'on_done')
@@ -449,7 +449,8 @@ class _AsyncStreamConnector:
 
     @_log_exceptions
     def _cleanup(self, close: bool) -> None:
-        """Cancel pending async operations, if any
+        """
+        Cancel pending async operations, if any.
 
         :param close: close the socket if true
         """
@@ -486,8 +487,10 @@ class _AsyncStreamConnector:
             self._on_done = None
 
     def start(self) -> AbstractIOReference:
-        """Kick off the workflow
+        """
+        Kick off the workflow.
 
+        :rtype: AbstractIOReference
         """
         _LOGGER.debug('_AsyncStreamConnector.start(); %s', self._sock)
 
@@ -505,11 +508,11 @@ class _AsyncStreamConnector:
         return _AsyncServiceAsyncHandle(self)
 
     def cancel(self) -> bool:
-        """Cancel pending connection request without calling user's completion
-        callback.
+        """
+        Cancel pending connection request without calling user's completion callback.
 
         :returns: False if was already done or cancelled; True otherwise
-
+        :rtype: bool
         """
         if self._state == self._STATE_ACTIVE:
             self._state = self._STATE_CANCELED
@@ -529,12 +532,12 @@ class _AsyncStreamConnector:
         (BaseException | tuple[nbio_interface.AbstractStreamTransport,
                                nbio_interface.AbstractStreamProtocol])
     ) -> None:
-        """Advance to COMPLETED state, cancel async operation(s), and invoke
-        user's completion callback.
+        """
+        Advance to COMPLETED state, cancel async operation(s), and invoke user's completion
+        callback.
 
-        :param result: value to pass in user's callback.
-            `tuple(transport, protocol)` on success, exception on error
-
+        :param result: value to pass in user's callback. `tuple(transport, protocol)` on success,
+            exception on error
         """
         _LOGGER.debug('_AsyncStreamConnector._report_completion(%r); %s',
                       result, self._sock)
@@ -562,9 +565,8 @@ class _AsyncStreamConnector:
 
     @_log_exceptions
     def _start_async(self) -> None:
-        """Called as callback from I/O loop to kick-start the workflow, so it's
-        safe to call user's completion callback from here if needed
-
+        """Called as callback from I/O loop to kick-start the workflow, so it's safe to call user's
+        completion callback from here if needed.
         """
         _LOGGER.debug('_AsyncStreamConnector._start_async(); %s', self._sock)
 
@@ -601,9 +603,8 @@ class _AsyncStreamConnector:
 
     @_log_exceptions
     def _linkup(self) -> None:
-        """Connection is ready: instantiate and link up transport and protocol,
-        and invoke user's completion callback.
-
+        """Connection is ready: instantiate and link up transport and protocol, and invoke user's
+        completion callback.
         """
         _LOGGER.debug('_AsyncStreamConnector._linkup()')
 
@@ -665,9 +666,7 @@ class _AsyncStreamConnector:
 
     @_log_exceptions
     def _do_ssl_handshake(self) -> None:
-        """Perform asynchronous SSL handshake on the already wrapped socket
-
-        """
+        """Perform asynchronous SSL handshake on the already wrapped socket."""
         _LOGGER.debug('_AsyncStreamConnector._do_ssl_handshake()')
 
         if self._state != self._STATE_ACTIVE:
@@ -730,9 +729,7 @@ class _AsyncStreamConnector:
 
 
 class _AsyncTransportBase(AbstractStreamTransport):
-    """Base class for `_AsyncPlaintextTransport` and `_AsyncSSLTransport`.
-
-    """
+    """Base class for `_AsyncPlaintextTransport` and `_AsyncSSLTransport`."""
 
     _STATE_ACTIVE = 1
     _STATE_FAILED = 2  # connection failed
@@ -745,9 +742,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
     _MAX_CONSUME_BYTES = 1024 * 100
 
     class RxEndOfFile(OSError):
-        """We raise this internally when EOF (empty read) is detected on input.
-
-        """
+        """We raise this internally when EOF (empty read) is detected on input."""
 
         def __init__(self) -> None:
             super().__init__(-1, 'End of input stream (EOF)')
@@ -779,9 +774,11 @@ class _AsyncTransportBase(AbstractStreamTransport):
         self._tx_buffered_byte_count = 0
 
     def abort(self) -> None:
-        """Close connection abruptly without waiting for pending I/O to
-        complete. Will invoke the corresponding protocol's `connection_lost()`
-        method asynchronously (not in context of the abort() call).
+        """
+        Close connection abruptly without waiting for pending I/O to complete.
+
+        Will invoke the corresponding protocol's `connection_lost()` method asynchronously (not in
+        context of the abort() call).
 
         :raises Exception: Exception-based exception on error
         """
@@ -791,8 +788,10 @@ class _AsyncTransportBase(AbstractStreamTransport):
         self._initiate_abort(None)
 
     def get_protocol(self) -> nbio_interface.AbstractStreamProtocol:
-        """Return the protocol linked to this transport.
+        """
+        Return the protocol linked to this transport.
 
+        :rtype: pika.adapters.utils.nbio_interface.AbstractStreamProtocol
         """
         assert self._protocol is not None
         return self._protocol
@@ -800,15 +799,16 @@ class _AsyncTransportBase(AbstractStreamTransport):
     def get_write_buffer_size(self) -> int:
         """
         :returns: Current size of output data buffered by the transport
+        :rtype: int
         """
         return self._tx_buffered_byte_count
 
     def _buffer_tx_data(self, data: bytes) -> None:
-        """Buffer the given data until it can be sent asynchronously.
+        """
+        Buffer the given data until it can be sent asynchronously.
 
         :param data:
         :raises ValueError: if called with empty data
-
         """
         if not data:
             _LOGGER.error('write() called with empty data: state=%s; %s',
@@ -825,20 +825,18 @@ class _AsyncTransportBase(AbstractStreamTransport):
         self._tx_buffered_byte_count += len(data)
 
     def _consume(self) -> None:
-        """Utility method for use by subclasses to ingest data from socket and
-        dispatch it to protocol's `data_received()` method socket-specific
-        "try again" exception, per-event data consumption limit is reached,
-        transport becomes inactive, or a fatal failure.
+        """
+        Utility method for use by subclasses to ingest data from socket and dispatch it to
+        protocol's `data_received()` method socket-specific "try again" exception, per-event data
+        consumption limit is reached, transport becomes inactive, or a fatal failure.
 
-        Consumes up to `self._MAX_CONSUME_BYTES` to prevent event starvation or
-        until state becomes inactive (e.g., `protocol.data_received()` callback
-        aborts the transport)
+        Consumes up to `self._MAX_CONSUME_BYTES` to prevent event starvation or until state becomes
+        inactive (e.g., `protocol.data_received()` callback aborts the transport)
 
-        :raises: Whatever the corresponding `sock.recv()` raises except the
-                 socket error with errno.EINTR
+        :raises: Whatever the corresponding `sock.recv()` raises except the socket error with
+            errno.EINTR
         :raises: Whatever the `protocol.data_received()` callback raises
         :raises _AsyncTransportBase.RxEndOfFile: upon shutdown of input stream
-
         """
         assert self._sock is not None
         assert self._protocol is not None
@@ -865,14 +863,14 @@ class _AsyncTransportBase(AbstractStreamTransport):
                 raise
 
     def _produce(self) -> None:
-        """Utility method for use by subclasses to emit data from tx_buffers.
-        This method sends chunks from `tx_buffers` until all chunks are
-        exhausted or sending is interrupted by an exception. Maintains integrity
-        of `self.tx_buffers`.
+        """
+        Utility method for use by subclasses to emit data from tx_buffers.
 
-        :raises: whatever the corresponding `sock.send()` raises except the
-                 socket error with errno.EINTR
+        This method sends chunks from `tx_buffers` until all chunks are exhausted or sending is
+        interrupted by an exception. Maintains integrity of `self.tx_buffers`.
 
+        :raises: whatever the corresponding `sock.send()` raises except the socket error with
+            errno.EINTR
         """
         while self._tx_buffers:
             num_bytes_sent = self._sigint_safe_send(self._sock,
@@ -893,14 +891,15 @@ class _AsyncTransportBase(AbstractStreamTransport):
     @_retry_on_sigint
     def _sigint_safe_recv(sock: socket.socket | ssl.SSLSocket,
                           max_bytes: int) -> bytes:
-        """Receive data from socket, retrying on SIGINT.
+        """
+        Receive data from socket, retrying on SIGINT.
 
         :param sock: stream or SSL socket
         :param max_bytes: maximum number of bytes to receive
         :returns: received data or empty bytes uppon end of file
-        :raises: whatever the corresponding `sock.recv()` raises except socket
-                 error with errno.EINTR
-
+        :rtype: bytes
+        :raises: whatever the corresponding `sock.recv()` raises except socket error with
+            errno.EINTR
         """
         return sock.recv(max_bytes)
 
@@ -908,22 +907,21 @@ class _AsyncTransportBase(AbstractStreamTransport):
     @_retry_on_sigint
     def _sigint_safe_send(sock: socket.socket | ssl.SSLSocket,
                           data: bytes) -> int:
-        """Send data to socket, retrying on SIGINT.
+        """
+        Send data to socket, retrying on SIGINT.
 
         :param sock: stream or SSL socket
         :param data: data bytes to send
         :returns: number of bytes actually sent
-        :raises: whatever the corresponding `sock.send()` raises except socket
-                 error with errno.EINTR
-
+        :rtype: int
+        :raises: whatever the corresponding `sock.send()` raises except socket error with
+            errno.EINTR
         """
         return sock.send(data)
 
     @_log_exceptions
     def _deactivate(self) -> None:
-        """Unregister the transport from I/O events
-
-        """
+        """Unregister the transport from I/O events."""
         if self._state == self._STATE_ACTIVE:
             _LOGGER.info('Deactivating transport: state=%s; %s', self._state,
                          self._sock)
@@ -935,9 +933,8 @@ class _AsyncTransportBase(AbstractStreamTransport):
 
     @_log_exceptions
     def _close_and_finalize(self) -> None:
-        """Close the transport's socket and unlink the transport it from
-        references to other assets (protocol, etc.)
-
+        """Close the transport's socket and unlink the transport it from references to other assets
+        (protocol, etc.)
         """
         if self._state != self._STATE_COMPLETED:
             _LOGGER.info('Closing transport socket and unlinking: state=%s; %s',
@@ -955,13 +952,13 @@ class _AsyncTransportBase(AbstractStreamTransport):
 
     @_log_exceptions
     def _initiate_abort(self, error: BaseException | None) -> None:
-        """Initiate asynchronous abort of the transport that concludes with a
-        call to the protocol's `connection_lost()` method. No flushing of
-        output buffers will take place.
+        """
+        Initiate asynchronous abort of the transport that concludes with a call to the protocol's
+        `connection_lost()` method. No flushing of output buffers will take place.
 
-        :param error: None if being canceled by user,
-            including via falsie return value from protocol.eof_received;
-            otherwise the exception corresponding to the the failed connection.
+        :param error: None if being canceled by user, including via falsie return value from
+            protocol.eof_received; otherwise the exception corresponding to the the failed
+            connection.
         """
         _LOGGER.info(
             '_AsyncTransportBase._initate_abort(): Initiating abrupt '
@@ -1010,13 +1007,13 @@ class _AsyncTransportBase(AbstractStreamTransport):
     @_log_exceptions
     def _connection_lost_notify_async(self,
                                       error: BaseException | None) -> None:
-        """Handle aborting of transport either due to socket error or user-
-        initiated `abort()` call. Must be called from an I/O loop callback owned
-        by us in order to avoid reentry into user code from user's API call into
-        the transport.
+        """
+        Handle aborting of transport either due to socket error or user- initiated `abort()` call.
+        Must be called from an I/O loop callback owned by us in order to avoid reentry into user
+        code from user's API call into the transport.
 
-        :param error: None if being canceled by user;
-            otherwise the exception corresponding to the the failed connection.
+        :param error: None if being canceled by user; otherwise the exception corresponding to the
+            the failed connection.
         """
         _LOGGER.debug('Concluding transport shutdown: state=%s; error=%r',
                       self._state, error)
@@ -1046,10 +1043,7 @@ class _AsyncTransportBase(AbstractStreamTransport):
 
 
 class _AsyncPlaintextTransport(_AsyncTransportBase):
-    """Implementation of `nbio_interface.AbstractStreamTransport` for a
-    plaintext connection.
-
-    """
+    """Implementation of `nbio_interface.AbstractStreamTransport` for a plaintext connection."""
 
     def __init__(
         self, sock: socket.socket | ssl.SSLSocket,
@@ -1075,11 +1069,11 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
         self._nbio.set_reader(self._sock.fileno(), self._on_socket_readable)
 
     def write(self, data: bytes) -> None:
-        """Buffer the given data until it can be sent asynchronously.
+        """
+        Buffer the given data until it can be sent asynchronously.
 
         :param data:
         :raises ValueError: if called with empty data
-
         """
         if self._state != self._STATE_ACTIVE:
             _LOGGER.debug(
@@ -1106,10 +1100,9 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
 
     @_log_exceptions
     def _on_socket_readable(self) -> None:
-        """Ingest data from socket and dispatch it to protocol until exception
-        occurs (typically EAGAIN or EWOULDBLOCK), per-event data consumption
-        limit is reached, transport becomes inactive, or failure.
-
+        """Ingest data from socket and dispatch it to protocol until exception occurs (typically
+        EAGAIN or EWOULDBLOCK), per-event data consumption limit is reached, transport becomes
+        inactive, or failure.
         """
         if self._state != self._STATE_ACTIVE:
             _LOGGER.debug(
@@ -1162,9 +1155,7 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
 
     @_log_exceptions
     def _on_socket_writable(self) -> None:
-        """Handle writable socket notification
-
-        """
+        """Handle writable socket notification."""
         if self._state != self._STATE_ACTIVE:
             _LOGGER.debug(
                 'Ignoring writability notification due to inactive '
@@ -1200,10 +1191,7 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
 
 
 class _AsyncSSLTransport(_AsyncTransportBase):
-    """Implementation of `.nbio_interface.AbstractStreamTransport` for an SSL
-    connection.
-
-    """
+    """Implementation of `.nbio_interface.AbstractStreamTransport` for an SSL connection."""
 
     def __init__(
         self, sock: ssl.SSLSocket,
@@ -1233,11 +1221,11 @@ class _AsyncSSLTransport(_AsyncTransportBase):
         self._nbio.add_callback_threadsafe(self._on_socket_readable)
 
     def write(self, data: bytes) -> None:
-        """Buffer the given data until it can be sent asynchronously.
+        """
+        Buffer the given data until it can be sent asynchronously.
 
         :param data:
         :raises ValueError: if called with empty data
-
         """
         if self._state != self._STATE_ACTIVE:
             _LOGGER.debug(
@@ -1265,9 +1253,7 @@ class _AsyncSSLTransport(_AsyncTransportBase):
 
     @_log_exceptions
     def _on_socket_readable(self) -> None:
-        """Handle readable socket indication
-
-        """
+        """Handle readable socket indication."""
         if self._state != self._STATE_ACTIVE:
             _LOGGER.debug(
                 'Ignoring readability notification due to inactive '
@@ -1287,9 +1273,7 @@ class _AsyncSSLTransport(_AsyncTransportBase):
 
     @_log_exceptions
     def _on_socket_writable(self) -> None:
-        """Handle writable socket notification
-
-        """
+        """Handle writable socket notification."""
         if self._state != self._STATE_ACTIVE:
             _LOGGER.debug(
                 'Ignoring writability notification due to inactive '
@@ -1309,15 +1293,14 @@ class _AsyncSSLTransport(_AsyncTransportBase):
 
     @_log_exceptions
     def _consume(self) -> None:
-        """[override] Ingest data from socket and dispatch it to protocol until
-        exception occurs (typically ssl.SSLError with
-        SSL_ERROR_WANT_READ/WRITE), per-event data consumption limit is reached,
-        transport becomes inactive, or failure.
+        """
+        [override] Ingest data from socket and dispatch it to protocol until exception occurs
+        (typically ssl.SSLError with SSL_ERROR_WANT_READ/WRITE), per-event data consumption limit is
+        reached, transport becomes inactive, or failure.
 
         Update consumer/producer registration.
 
-        :raises Exception: error that signals that connection needs to be
-            aborted
+        :raises Exception: error that signals that connection needs to be aborted
         """
         assert self._nbio is not None
         assert self._sock is not None
@@ -1385,15 +1368,13 @@ class _AsyncSSLTransport(_AsyncTransportBase):
 
     @_log_exceptions
     def _produce(self) -> None:
-        """[override] Emit data from tx_buffers all chunks are exhausted or
-        sending is interrupted by an exception (typically ssl.SSLError with
-        SSL_ERROR_WANT_READ/WRITE).
+        """
+        [override] Emit data from tx_buffers all chunks are exhausted or sending is interrupted by
+        an exception (typically ssl.SSLError with SSL_ERROR_WANT_READ/WRITE).
 
         Update consumer/producer registration.
 
-        :raises Exception: error that signals that connection needs to be
-            aborted
-
+        :raises Exception: error that signals that connection needs to be aborted
         """
         assert self._nbio is not None
         assert self._sock is not None

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -1,4 +1,5 @@
-"""Non-blocking I/O interface for pika connection adapters.
+"""
+Non-blocking I/O interface for pika connection adapters.
 
 I/O interface expected by `pika.adapters.base_connection.BaseConnection`
 
@@ -9,8 +10,8 @@ NOTE: This API is modeled after asyncio in python3 for a couple of reasons
 Furthermore, the API caters to the needs of pika core and lack of generalization
 is intentional for the sake of reducing complexity of the implementation and
 testing and lessening the maintenance burden.
-
 """
+
 from __future__ import annotations
 
 import abc
@@ -24,26 +25,25 @@ if TYPE_CHECKING:
 
 
 class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]  # yapf: disable
-    """Interface to I/O services required by `pika.adapters.BaseConnection` and
-    related utilities.
+    """
+    Interface to I/O services required by `pika.adapters.BaseConnection` and related utilities.
 
     NOTE: This is not a public API. Pika users should rely on the native I/O
     loop APIs (e.g., asyncio event loop, tornado ioloop, twisted reactor, etc.)
     that corresponds to the chosen Connection adapter.
-
     """
 
     @abc.abstractmethod
     def get_native_ioloop(self) -> Any:
-        """Returns the native I/O loop instance, such as Twisted reactor,
-        asyncio's or tornado's event loop
-
+        """Returns the native I/O loop instance, such as Twisted reactor, asyncio's or tornado's
+        event loop.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def close(self) -> None:
-        """Release IOLoop's resources.
+        """
+        Release IOLoop's resources.
 
         the `close()` method is intended to be called by Pika's own test
         code only after `start()` returns. After calling `close()`, no other
@@ -53,30 +53,32 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         be able to run I/O loops generically to test multiple Connection Adapter
         implementations. Pika users should use the native I/O loop's API
         instead.
-
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def run(self) -> None:
-        """Run the I/O loop. It will loop until requested to exit. See `stop()`.
+        """
+        Run the I/O loop.
 
-        NOTE: the outcome or restarting an instance that had been stopped is
-        UNDEFINED!
+        It will loop until requested to exit. See `stop()`.
+                NOTE: the outcome or restarting an instance that had been stopped is
+                UNDEFINED!
 
-        NOTE: This method is provided for Pika's own test scripts that need to
-        be able to run I/O loops generically to test multiple Connection Adapter
-        implementations (not all of the supported I/O Loop frameworks have
-        methods named start/stop). Pika users should use the native I/O loop's
-        API instead.
-
+                NOTE: This method is provided for Pika's own test scripts that need to
+                be able to run I/O loops generically to test multiple Connection Adapter
+                implementations (not all of the supported I/O Loop frameworks have
+                methods named start/stop). Pika users should use the native I/O loop's
+                API instead.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def stop(self) -> None:
-        """Request exit from the ioloop. The loop is NOT guaranteed to
-        stop before this method returns.
+        """
+        Request exit from the ioloop.
+
+        The loop is NOT guaranteed to stop before this method returns.
 
         NOTE: The outcome of calling `stop()` on a non-running instance is
         UNDEFINED!
@@ -91,14 +93,15 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         call it via `add_callback_threadsafe`; e.g.,
 
             `ioloop.add_callback_threadsafe(ioloop.stop)`
-
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def add_callback_threadsafe(self, callback: Callable[..., None]) -> None:
-        """Requests a call to the given function as soon as possible. It will be
-        called from this IOLoop's thread.
+        """
+        Requests a call to the given function as soon as possible.
+
+        It will be called from this IOLoop's thread.
 
         NOTE: This is the only thread-safe method offered by the IOLoop adapter.
               All other manipulations of the IOLoop adapter and objects governed
@@ -115,17 +118,16 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
     @abc.abstractmethod
     def call_later(self, delay: float,
                    callback: Callable[..., None]) -> AbstractTimerReference:
-        """Add the callback to the IOLoop timer to be called after delay seconds
-        from the time of call on best-effort basis. Returns a handle to the
-        timeout.
+        """
+        Add the callback to the IOLoop timer to be called after delay seconds from the time of call
+        on best-effort basis. Returns a handle to the timeout.
 
-        If two are scheduled for the same time, it's undefined which one will
-        be called first.
+        If two are scheduled for the same time, it's undefined which one will be called first.
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback method
         :returns: A handle that can be used to cancel the request.
-
+        :rtype: AbstractTimerReference
         """
         raise NotImplementedError
 
@@ -138,20 +140,21 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
                     socktype: int = 0,
                     proto: int = 0,
                     flags: int = 0) -> AbstractIOReference:
-        """Perform the equivalent of `socket.getaddrinfo()` asynchronously.
+        """
+        Perform the equivalent of `socket.getaddrinfo()` asynchronously.
 
         See `socket.getaddrinfo()` for the standard args.
 
         :param host: Hostname or IP address
         :param port: TCP port number
-        :param on_done: user callback that takes the return value of
-            `socket.getaddrinfo()` upon successful completion or exception upon
-            failure (check for `BaseException`) as its only arg. It will not be
-            called if the operation was cancelled.
+        :param on_done: user callback that takes the return value of `socket.getaddrinfo()` upon
+            successful completion or exception upon failure (check for `BaseException`) as its only
+            arg. It will not be called if the operation was cancelled.
         :param family: Socket address family (e.g. ``socket.AF_INET``)
         :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param proto: Protocol number (0 for default)
         :param flags: :func:`socket.getaddrinfo` flags
+        :rtype: AbstractIOReference
         """
         raise NotImplementedError
 
@@ -160,8 +163,9 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             self, sock: socket.socket, resolved_addr: tuple[str, int],
             on_done: Callable[[BaseException | None],
                               None]) -> AbstractIOReference:
-        """Perform the equivalent of `socket.connect()` on a previously-resolved
-        address asynchronously.
+        """
+        Perform the equivalent of `socket.connect()` on a previously-resolved address
+        asynchronously.
 
         IMPLEMENTATION NOTE: Pika's connection logic resolves the addresses
             prior to making socket connections, so we don't need to burden the
@@ -179,6 +183,7 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             completion or exception (check for `BaseException`) upon error as
             its only arg. It will not be called if the operation was cancelled.
 
+        :rtype: AbstractIOReference
         :raises ValueError: if host portion of `resolved_addr` is not an IP
             address or is inconsistent with the socket's address family as
             validated via `socket.inet_pton()`
@@ -195,8 +200,9 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
                               None],
             ssl_context: ssl.SSLContext | None = None,
             server_hostname: str | None = None) -> AbstractIOReference:
-        """Perform SSL session establishment, if requested, on the already-
-        connected socket and link the streaming transport/protocol pair.
+        """
+        Perform SSL session establishment, if requested, on the already- connected socket and link
+        the streaming transport/protocol pair.
 
         NOTE: This method takes ownership of the socket.
 
@@ -222,6 +228,7 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         :param server_hostname: For use during SSL session
             establishment to match against the target server's certificate. The
             value `None` disables this check (which is a huge security risk)
+        :rtype: AbstractIOReference
         """
         raise NotImplementedError
 
@@ -229,40 +236,43 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
 class AbstractFileDescriptorServices(
         pika._utils.AbstractBase  # type: ignore[valid-type, misc]
 ):
-    """Interface definition of common non-blocking file descriptor services
-    required by some utility implementations.
+    """
+    Interface definition of common non-blocking file descriptor services required by some utility
+    implementations.
 
     NOTE: This is not a public API. Pika users should rely on the native I/O
     loop APIs (e.g., asyncio event loop, tornado ioloop, twisted reactor, etc.)
     that corresponds to the chosen Connection adapter.
-
     """
 
     @abc.abstractmethod
     def set_reader(self, fd: int, on_readable: Callable[[], None]):
-        """Call the given callback when the file descriptor is readable.
+        """
+        Call the given callback when the file descriptor is readable.
+
         Replace prior reader, if any, for the given file descriptor.
 
         :param fd: file descriptor
-        :param on_readable: a callback taking no args to be notified
-            when fd becomes readable.
-
+        :param on_readable: a callback taking no args to be notified when fd becomes readable.
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def remove_reader(self, fd: int) -> bool:
-        """Stop watching the given file descriptor for readability
+        """
+        Stop watching the given file descriptor for readability.
 
         :param fd: file descriptor
         :returns: True if reader was removed; False if none was registered.
-
+        :rtype: bool
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_writer(self, fd: int, on_writable: Callable[[], None]) -> None:
-        """Call the given callback whenever the file descriptor is writable.
+        """
+        Call the given callback whenever the file descriptor is writable.
+
         Replace prior writer callback, if any, for the given file descriptor.
 
         IMPLEMENTATION NOTE: For portability, implementations of
@@ -277,17 +287,17 @@ class AbstractFileDescriptorServices(
         :param fd: file descriptor
         :param on_writable: a callback taking no args to be notified
             when fd becomes writable.
-
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def remove_writer(self, fd: int) -> bool:
-        """Stop watching the given file descriptor for writability
+        """
+        Stop watching the given file descriptor for writability.
 
         :param fd: file descriptor
         :returns: True if reader was removed; False if none was registered.
-
+        :rtype: bool
         """
         raise NotImplementedError
 
@@ -295,23 +305,28 @@ class AbstractFileDescriptorServices(
 class AbstractTimerReference(
         pika._utils.AbstractBase  # type: ignore[valid-type, misc]
 ):
-    """Reference to asynchronous operation"""
+    """Reference to asynchronous operation."""
 
     @abc.abstractmethod
     def cancel(self) -> None:
-        """Cancel callback. If already cancelled, has no affect.
+        """
+        Cancel callback.
+
+        If already cancelled, has no affect.
         """
         raise NotImplementedError
 
 
 class AbstractIOReference(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]  # yapf: disable
-    """Reference to asynchronous I/O operation"""
+    """Reference to asynchronous I/O operation."""
 
     @abc.abstractmethod
     def cancel(self) -> bool:
-        """Cancel pending operation
+        """
+        Cancel pending operation.
 
         :returns: False if was already done or cancelled; True otherwise
+        :rtype: bool
         """
         raise NotImplementedError
 
@@ -319,15 +334,17 @@ class AbstractIOReference(pika._utils.AbstractBase):  # type: ignore[valid-type,
 class AbstractStreamProtocol(
         pika._utils.AbstractBase  # type: ignore[valid-type, misc]
 ):
-    """Stream protocol interface. It's compatible with a subset of
-    `asyncio.protocols.Protocol` for compatibility with asyncio-based
-    `AbstractIOServices` implementation.
+    """
+    Stream protocol interface.
 
+    It's compatible with a subset of `asyncio.protocols.Protocol` for compatibility with asyncio-
+    based `AbstractIOServices` implementation.
     """
 
     @abc.abstractmethod
     def connection_made(self, transport: AbstractStreamTransport):
-        """Introduces transport to protocol after transport is connected.
+        """
+        Introduces transport to protocol after transport is connected.
 
         :param transport:
         :raises Exception: Exception-based exception on error
@@ -336,7 +353,8 @@ class AbstractStreamProtocol(
 
     @abc.abstractmethod
     def connection_lost(self, error: BaseException | None) -> None:
-        """Called upon loss or closing of connection.
+        """
+        Called upon loss or closing of connection.
 
         NOTE: `connection_made()` and `connection_lost()` are each called just
         once and in that order. All other callbacks are called between them.
@@ -352,19 +370,21 @@ class AbstractStreamProtocol(
 
     @abc.abstractmethod
     def eof_received(self) -> bool | None:
-        """Called after the remote peer shuts its write end of the connection.
+        """
+        Called after the remote peer shuts its write end of the connection.
 
-        :returns: A falsy value (including None) will cause the transport to
-            close itself, resulting in an eventual `connection_lost()` call
-            from the transport. If a truthy value is returned, it will be the
-            protocol's responsibility to close/abort the transport.
+        :returns: A falsy value (including None) will cause the transport to close itself, resulting
+            in an eventual `connection_lost()` call from the transport. If a truthy value is
+            returned, it will be the protocol's responsibility to close/abort the transport.
+        :rtype: falsy|truthy
         :raises Exception: Exception-based exception on error
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def data_received(self, data: bytes) -> None:
-        """Called to deliver incoming data to the protocol.
+        """
+        Called to deliver incoming data to the protocol.
 
         :param data: Non-empty data bytes.
         :raises Exception: Exception-based exception on error
@@ -393,17 +413,20 @@ class AbstractStreamProtocol(
 class AbstractStreamTransport(
         pika._utils.AbstractBase  # type: ignore[valid-type, misc]
 ):
-    """Stream transport interface. It's compatible with a subset of
-    `asyncio.transports.Transport` for compatibility with asyncio-based
-    `AbstractIOServices` implementation.
+    """
+    Stream transport interface.
 
+    It's compatible with a subset of `asyncio.transports.Transport` for compatibility with asyncio-
+    based `AbstractIOServices` implementation.
     """
 
     @abc.abstractmethod
     def abort(self) -> None:
-        """Close connection abruptly without waiting for pending I/O to
-        complete. Will invoke the corresponding protocol's `connection_lost()`
-        method asynchronously (not in context of the abort() call).
+        """
+        Close connection abruptly without waiting for pending I/O to complete.
+
+        Will invoke the corresponding protocol's `connection_lost()` method asynchronously (not in
+        context of the abort() call).
 
         :raises Exception: Exception-based exception on error
         """
@@ -411,15 +434,18 @@ class AbstractStreamTransport(
 
     @abc.abstractmethod
     def get_protocol(self) -> AbstractStreamProtocol:
-        """Return the protocol linked to this transport.
+        """
+        Return the protocol linked to this transport.
 
+        :rtype: AbstractStreamProtocol
         :raises Exception: Exception-based exception on error
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def write(self, data: bytes) -> None:
-        """Buffer the given data until it can be sent asynchronously.
+        """
+        Buffer the given data until it can be sent asynchronously.
 
         :param data:
         :raises ValueError: if called with empty data
@@ -431,6 +457,7 @@ class AbstractStreamTransport(
     def get_write_buffer_size(self) -> int:
         """
         :returns: Current size of output data buffered by the transport
+        :rtype: int
         """
         raise NotImplementedError
 

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -1,9 +1,7 @@
+"""Implementation of `nbio_interface.AbstractIOServices` on top of a selector-based I/O loop, such
+as tornado's and our home-grown select_connection's I/O loops.
 """
-Implementation of `nbio_interface.AbstractIOServices` on top of a
-selector-based I/O loop, such as tornado's and our home-grown
-select_connection's I/O loops.
 
-"""
 from __future__ import annotations
 
 import abc
@@ -19,7 +17,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class AbstractSelectorIOLoop:
-    """Selector-based I/O loop interface expected by
+    """
+    Selector-based I/O loop interface expected by
     `selector_ioloop_adapter.SelectorIOServicesAdapter`
 
     NOTE: this interface follows the corresponding methods and attributes
@@ -30,83 +29,84 @@ class AbstractSelectorIOLoop:
     @property
     @abc.abstractmethod
     def READ(self) -> int:
-        """The value of the I/O loop's READ flag; READ/WRITE/ERROR may be used
-        with bitwise operators as expected.
+        """
+        The value of the I/O loop's READ flag; READ/WRITE/ERROR may be used with bitwise operators
+        as expected.
 
         Implementation note: the implementations can simply replace these
         READ/WRITE/ERROR properties with class-level attributes
-
         """
 
     @property
     @abc.abstractmethod
     def WRITE(self) -> int:
-        """The value of the I/O loop's WRITE flag; READ/WRITE/ERROR may be used
-        with bitwise operators as expected
-
+        """The value of the I/O loop's WRITE flag; READ/WRITE/ERROR may be used with bitwise
+        operators as expected.
         """
 
     @property
     @abc.abstractmethod
     def ERROR(self) -> int:
-        """The value of the I/O loop's ERROR flag; READ/WRITE/ERROR may be used
-        with bitwise operators as expected
-
+        """The value of the I/O loop's ERROR flag; READ/WRITE/ERROR may be used with bitwise
+        operators as expected.
         """
 
     @abc.abstractmethod
     def close(self) -> None:
-        """Release IOLoop's resources.
+        """
+        Release IOLoop's resources.
 
-        the `close()` method is intended to be called by the application or test
-        code only after `start()` returns. After calling `close()`, no other
-        interaction with the closed instance of `IOLoop` should be performed.
-
+        the `close()` method is intended to be called by the application or test code only after
+        `start()` returns. After calling `close()`, no other interaction with the closed instance of
+        `IOLoop` should be performed.
         """
 
     @abc.abstractmethod
     def start(self) -> None:
-        """Run the I/O loop. It will loop until requested to exit. See `stop()`.
+        """
+        Run the I/O loop.
 
+        It will loop until requested to exit. See `stop()`.
         """
 
     @abc.abstractmethod
     def stop(self) -> None:
-        """Request exit from the ioloop. The loop is NOT guaranteed to
-        stop before this method returns.
+        """
+        Request exit from the ioloop.
 
-        To invoke `stop()` safely from a thread other than this IOLoop's thread,
-        call it via `add_callback_threadsafe`; e.g.,
+        The loop is NOT guaranteed to stop before this method returns.
 
-            `ioloop.add_callback(ioloop.stop)`
+        To invoke `stop()` safely from a thread other than this IOLoop's thread, call it via
+        `add_callback_threadsafe`; e.g.,
 
+        `ioloop.add_callback(ioloop.stop)`
         """
 
     @abc.abstractmethod
     def call_later(self, delay: float, callback: Callable[..., Any]) -> object:
-        """Add the callback to the IOLoop timer to be called after delay seconds
-        from the time of call on best-effort basis. Returns a handle to the
-        timeout.
+        """
+        Add the callback to the IOLoop timer to be called after delay seconds from the time of call
+        on best-effort basis. Returns a handle to the timeout.
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback method
-        :returns: handle to the created timeout that may be passed to
-            `remove_timeout()`
-
+        :returns: handle to the created timeout that may be passed to `remove_timeout()`
+        :rtype: object
         """
 
     @abc.abstractmethod
     def remove_timeout(self, timeout_handle: Any) -> None:
-        """Remove a timeout
+        """
+        Remove a timeout.
 
         :param timeout_handle: Handle of timeout to remove
-
         """
 
     @abc.abstractmethod
     def add_callback(self, callback: Callable[..., Any]) -> None:
-        """Requests a call to the given function as soon as possible in the
-        context of this IOLoop's thread.
+        """
+        Requests a call to the given function as soon as possible in the context of this IOLoop's
+        thread.
 
         NOTE: This is the only thread-safe method in IOLoop. All other
         manipulations of IOLoop must be performed from the IOLoop's thread.
@@ -116,36 +116,34 @@ class AbstractSelectorIOLoop:
         `ioloop.add_callback_threadsafe(ioloop.stop)`
 
         :param callback: The callback method
-
         """
 
     @abc.abstractmethod
     def add_handler(self, fd: int, handler: Callable[[int, int], None],
                     events: int) -> None:
-        """Start watching the given file descriptor for events
+        """
+        Start watching the given file descriptor for events.
 
         :param fd: The file descriptor
-        :param handler: When requested event(s) occur,
-            `handler(fd, events)` will be called.
+        :param handler: When requested event(s) occur, `handler(fd, events)` will be called.
         :param events: The event mask using READ, WRITE, ERROR.
-
         """
 
     @abc.abstractmethod
     def update_handler(self, fd: int, events: int) -> None:
-        """Changes the events we watch for
+        """
+        Changes the events we watch for.
 
         :param fd: The file descriptor
         :param events: The event mask using READ, WRITE, ERROR
-
         """
 
     @abc.abstractmethod
     def remove_handler(self, fd: int) -> None:
-        """Stop watching the given file descriptor for events
+        """
+        Stop watching the given file descriptor for events.
 
         :param fd: The file descriptor
-
         """
 
 
@@ -193,21 +191,15 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         return self._loop
 
     def close(self) -> None:
-        """Implement :py:meth:`.nbio_interface.AbstractIOServices.close()`.
-
-        """
+        """Implement :py:meth:`.nbio_interface.AbstractIOServices.close()`."""
         self._loop.close()
 
     def run(self) -> None:
-        """Implement :py:meth:`.nbio_interface.AbstractIOServices.run()`.
-
-        """
+        """Implement :py:meth:`.nbio_interface.AbstractIOServices.run()`."""
         self._loop.start()
 
     def stop(self) -> None:
-        """Implement :py:meth:`.nbio_interface.AbstractIOServices.stop()`.
-
-        """
+        """Implement :py:meth:`.nbio_interface.AbstractIOServices.stop()`."""
         self._loop.stop()
 
     def add_callback_threadsafe(self, callback) -> None:
@@ -218,7 +210,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         self._loop.add_callback(callback)
 
     def call_later(self, delay, callback: Callable[..., None]) -> _TimerHandle:
-        """Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
+        """
+        Implement :py:meth:`.nbio_interface.AbstractIOServices.call_later()`.
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback to call after delay seconds
@@ -233,7 +226,8 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
                     socktype: int = 0,
                     proto: int = 0,
                     flags: int = 0) -> nbio_interface.AbstractIOReference:
-        """Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
+        """
+        Implement :py:meth:`.nbio_interface.AbstractIOServices.getaddrinfo()`.
 
         :param host: Hostname or IP address
         :param port: TCP port number
@@ -385,15 +379,14 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         return True
 
     def _on_reader_writer_fd_events(self, fd: int, events: int) -> None:
-        """Handle indicated file descriptor events requested via `set_reader()`
-        and `set_writer()`.
+        """
+        Handle indicated file descriptor events requested via `set_reader()` and `set_writer()`.
 
         :param fd: file descriptor
-        :param events: event mask using native loop's READ/WRITE/ERROR. NOTE:
-            depending on the underlying poller mechanism, ERROR may be indicated
-            upon certain file description state even though we don't request it.
-            We ignore ERROR here since `set_reader()`/`set_writer()` don't
-            request for it.
+        :param events: event mask using native loop's READ/WRITE/ERROR. NOTE: depending on the
+            underlying poller mechanism, ERROR may be indicated upon certain file description state
+            even though we don't request it. We ignore ERROR here since
+            `set_reader()`/`set_writer()` don't request for it.
         """
         callbacks = self._watchers[fd]
 
@@ -423,26 +416,26 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
 
 class _FileDescriptorCallbacks:
-    """Holds reader and writer callbacks for a file descriptor"""
+    """Holds reader and writer callbacks for a file descriptor."""
 
     __slots__ = ('reader', 'writer')
 
     def __init__(self,
                  reader: Callable[[], None] | None = None,
                  writer: Callable[[], None] | None = None) -> None:
-        """Initialize file descriptor callbacks.
+        """
+        Initialize file descriptor callbacks.
 
         :param reader: Read callback.
         :param writer: Write callback.
+        :rtype: None
         """
         self.reader = reader
         self.writer = writer
 
 
 class _TimerHandle(nbio_interface.AbstractTimerReference):
-    """This module's adaptation of `nbio_interface.AbstractTimerReference`.
-
-    """
+    """This module's adaptation of `nbio_interface.AbstractTimerReference`."""
 
     def __init__(self, handle: object, loop: AbstractSelectorIOLoop) -> None:
         """
@@ -463,9 +456,7 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
 
 
 class _SelectorIOLoopIOHandle(nbio_interface.AbstractIOReference):
-    """This module's adaptation of `nbio_interface.AbstractIOReference`
-
-    """
+    """This module's adaptation of `nbio_interface.AbstractIOReference`"""
 
     def __init__(self, subject: Any) -> None:
         """
@@ -475,22 +466,25 @@ class _SelectorIOLoopIOHandle(nbio_interface.AbstractIOReference):
         self._cancel = subject.cancel
 
     def cancel(self) -> bool:
-        """Cancel pending operation
+        """
+        Cancel pending operation.
 
         :returns: False if was already done or cancelled; True otherwise
-
+        :rtype: bool
         """
         return self._cancel()
 
 
 class _AddressResolver:
-    """Performs getaddrinfo asynchronously using a thread, then reports result
-    via callback from the given I/O loop.
+    """
+    Performs getaddrinfo asynchronously using a thread, then reports result via callback from the
+    given I/O loop.
 
     NOTE: at this stage, we're using a thread per request, which may prove
     inefficient and even prohibitive if the app performs many of these
     operations concurrently.
     """
+
     NOT_STARTED = 0
     ACTIVE = 1
     CANCELED = 2
@@ -530,17 +524,16 @@ class _AddressResolver:
         self._threading_timer: threading.Timer | None = None
 
     def _cleanup(self) -> None:
-        """Release resources
-
-        """
+        """Release resources."""
         self._loop = None
         self._threading_timer = None
         self._on_done = None
 
     def start(self) -> _SelectorIOLoopIOHandle:
-        """Start asynchronous DNS lookup.
+        """
+        Start asynchronous DNS lookup.
 
-
+        :rtype: nbio_interface.AbstractIOReference
         """
         assert self._state == self.NOT_STARTED, self._state
 
@@ -551,10 +544,11 @@ class _AddressResolver:
         return _SelectorIOLoopIOHandle(self)
 
     def cancel(self) -> bool:
-        """Cancel the pending resolver
+        """
+        Cancel the pending resolver.
 
         :returns: False if was already done or cancelled; True otherwise
-
+        :rtype: bool
         """
         # Try to cancel, but no guarantees
         with self._mutex:
@@ -576,9 +570,8 @@ class _AddressResolver:
             return False
 
     def _resolve(self) -> None:
-        """Call `socket.getaddrinfo()` and return result via user's callback
-        function on the given I/O loop
-
+        """Call `socket.getaddrinfo()` and return result via user's callback function on the given
+        I/O loop.
         """
         try:
             result: Any = socket.getaddrinfo(host=self._host,
@@ -604,9 +597,8 @@ class _AddressResolver:
                     'in thread; host=%r', self._host)
 
     def _dispatch_result(self) -> None:
-        """This is called from the user's I/O loop to pass the result to the
-         user via the user's on_done callback
-
+        """This is called from the user's I/O loop to pass the result to the user via the user's
+        on_done callback.
         """
         if self._state == self.ACTIVE:
             self._state = self.COMPLETED

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -1,16 +1,13 @@
-"""Base classes that are extended by low level AMQP frames and higher level
-AMQP classes and methods.
-
+"""Base classes that are extended by low level AMQP frames and higher level AMQP classes and
+methods.
 """
 
 from __future__ import annotations
 
 
 class AMQPObject:
-    """Base object that is extended by AMQP low level frames and AMQP classes
-    and methods.
+    """Base object that is extended by AMQP low level frames and AMQP classes and methods."""
 
-    """
     NAME: str = 'AMQPObject'
     INDEX: int | None = None
 
@@ -30,57 +27,64 @@ class AMQPObject:
 
 
 class Class(AMQPObject):
-    """Is extended by AMQP classes"""
+    """Is extended by AMQP classes."""
+
     NAME: str = 'Unextended Class'
 
 
 class Method(AMQPObject):
-    """Is extended by AMQP methods"""
+    """Is extended by AMQP methods."""
+
     NAME: str = 'Unextended Method'
     synchronous: bool = False
 
     def _set_content(self, properties: Properties, body: bytes) -> None:
-        """If the method is a content frame, set the properties and body to
-        be carried as attributes of the class.
+        """
+        If the method is a content frame, set the properties and body to be carried as attributes of
+        the class.
 
         :param properties: AMQP Basic Properties
         :param body: The message body
-
         """
         self._properties = properties
         self._body = body
 
     def get_properties(self) -> Properties:
-        """Return the properties if they are set.
+        """
+        Return the properties if they are set.
 
-
+        :rtype: pika.frame.Properties
         """
         return self._properties
 
     def get_body(self) -> bytes:
-        """Return the message body if it is set.
+        """
+        Return the message body if it is set.
 
-
+        :rtype: bytes
         """
         return self._body
 
     def encode(self) -> list[bytes]:
-        """Encode the method into a binary format.
+        """
+        Encode the method into a binary format.
 
-
+        :rtype: list[bytes]
         """
         raise NotImplementedError("Subclasses must implement this method")
 
     def decode(self, encoded: bytes, offset: int = 0) -> Method:
-        """Decode the method from a binary format.
+        """
+        Decode the method from a binary format.
 
         :param encoded: The encoded method data
         :param offset: The offset to start decoding from
-
+        :rtype: Method
         """
         raise NotImplementedError("Subclasses must implement this method")
 
 
 class Properties(AMQPObject):
     """Class to encompass message properties (AMQP Basic.Properties)"""
+
     NAME: str = 'Unextended Properties'

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -1,7 +1,5 @@
-"""Callback management class, common area for keeping track of all callbacks in
-the Pika stack.
+"""Callback management class, common area for keeping track of all callbacks in the Pika stack."""
 
-"""
 from __future__ import annotations
 
 import functools
@@ -21,11 +19,11 @@ LOGGER = logging.getLogger(__name__)
 
 
 def name_or_value(value: AMQPValue) -> str:
-    """Will take Frame objects, classes, etc and attempt to return a valid
-    string identifier for them.
+    """
+    Will take Frame objects, classes, etc and attempt to return a valid string identifier for them.
 
     :param value: The value to sanitize
-
+    :rtype: str
     """
     # Is it subclass of AMQPObject
     if isinstance(value, type) and issubclass(value, amqp_object.AMQPObject):
@@ -44,9 +42,11 @@ def name_or_value(value: AMQPValue) -> str:
 
 
 def sanitize_prefix(function: _Callback) -> _Callback:
-    """Automatically call name_or_value on the prefix passed in.
+    """
+    Automatically call name_or_value on the prefix passed in.
 
     :param function: The function to wrap
+    :rtype: _Callback
     """
 
     @functools.wraps(function)
@@ -69,11 +69,11 @@ def sanitize_prefix(function: _Callback) -> _Callback:
 
 
 def check_for_prefix_and_key(function: _Callback) -> _Callback:
-    """Automatically return false if the key or prefix is not in the callbacks
-    for the instance.
+    """
+    Automatically return false if the key or prefix is not in the callbacks for the instance.
 
     :param function: Callback to validate
-
+    :rtype: _Callback
     """
 
     @functools.wraps(function)
@@ -103,12 +103,14 @@ def check_for_prefix_and_key(function: _Callback) -> _Callback:
 
 
 class CallbackManager:
-    """CallbackManager is a global callback system designed to be a single place
-    where Pika can manage callbacks and process them. It should be referenced
-    by the CallbackManager.instance() method instead of constructing new
-    instances of it.
-
     """
+    CallbackManager is a global callback system designed to be a single place where Pika can manage
+    callbacks and process them.
+
+    It should be referenced by the CallbackManager.instance() method instead of constructing new
+    instances of it.
+    """
+
     CALLS: str = 'calls'
     ARGUMENTS: str = 'arguments'
     DUPLICATE_WARNING: str = 'Duplicate callback found for "%s:%s"'
@@ -117,7 +119,7 @@ class CallbackManager:
     ONLY_CALLER: str = 'only'
 
     def __init__(self) -> None:
-        """Create an instance of the CallbackManager"""
+        """Create an instance of the CallbackManager."""
         self._stack: dict[_Prefix, dict[AMQPValue, list[dict[str, Any]]]] = {}
 
     @sanitize_prefix
@@ -128,22 +130,22 @@ class CallbackManager:
             one_shot: bool = True,
             only_caller: _Caller | None = None,
             arguments: dict[str, Any] | None = None) -> tuple[_Prefix, Any]:
-        """Add a callback to the stack for the specified key. If the call is
-        specified as one_shot, it will be removed after being fired
+        """
+        Add a callback to the stack for the specified key.
 
-        The prefix is usually the channel number but the class is generic
-        and prefix and key may be any value. If you pass in only_caller
-        CallbackManager will restrict processing of the callback to only
-        the calling function/object that you specify.
+        If the call is specified as one_shot, it will be removed after being fired
+
+        The prefix is usually the channel number but the class is generic and prefix and key may be
+        any value. If you pass in only_caller CallbackManager will restrict processing of the
+        callback to only the calling function/object that you specify.
 
         :param prefix: Categorize the callback
         :param key: The key for the callback
         :param callback: The callback to call
         :param one_shot: Remove this callback after it is called
-        :param only_caller: Only allow one_caller value to call the
-                                   event that fires the callback.
+        :param only_caller: Only allow one_caller value to call the event that fires the callback.
         :param arguments: Arguments to validate when processing
-
+        :rtype: tuple(prefix, key)
         """
         # Prep the stack
         if prefix not in self._stack:
@@ -179,11 +181,13 @@ class CallbackManager:
 
     @sanitize_prefix
     def cleanup(self, prefix: _Prefix) -> bool:
-        """Remove all callbacks from the stack by a prefix. Returns True
-        if keys were there to be removed
+        """
+        Remove all callbacks from the stack by a prefix.
+
+        Returns True if keys were there to be removed
 
         :param prefix: The prefix for keeping track of callbacks with
-
+        :rtype: bool
         """
         LOGGER.debug('Clearing out %r from the stack', prefix)
         if prefix not in self._stack or not self._stack[prefix]:
@@ -193,11 +197,11 @@ class CallbackManager:
 
     @sanitize_prefix
     def pending(self, prefix: _Prefix, key: AMQPValue) -> int | None:
-        """Return count of callbacks for a given prefix or key or None
+        """
+        Return count of callbacks for a given prefix or key or None.
 
         :param prefix: Categorize the callback
         :param key: The key for the callback
-
         """
         if prefix not in self._stack or key not in self._stack[prefix]:
             return None
@@ -207,17 +211,18 @@ class CallbackManager:
     @check_for_prefix_and_key
     def process(self, prefix: _Prefix, key: AMQPValue, caller: _Caller, *args:
                 Any, **keywords: Any) -> bool:
-        """Run through and process all the callbacks for the specified keys.
-        Caller should be specified at all times so that callbacks which
-        require a specific function to call CallbackManager.process will
-        not be processed.
+        """
+        Run through and process all the callbacks for the specified keys.
+
+        Caller should be specified at all times so that callbacks which require a specific function
+        to call CallbackManager.process will not be processed.
 
         :param prefix: Categorize the callback
         :param key: The key for the callback
         :param caller: Who is firing the event
         :param args: Any optional arguments
         :param keywords: Optional keyword arguments
-
+        :rtype: bool
         """
         LOGGER.debug('Processing %s:%s', prefix, key)
         if prefix not in self._stack or key not in self._stack[prefix]:
@@ -249,15 +254,16 @@ class CallbackManager:
                key: AMQPValue,
                callback_value: Callable[..., Any] | None = None,
                arguments: dict[str, Any] | None = None) -> bool:
-        """Remove a callback from the stack by prefix, key and optionally
-        the callback itself. If you only pass in prefix and key, all
-        callbacks for that prefix and key will be removed.
+        """
+        Remove a callback from the stack by prefix, key and optionally the callback itself.
+
+        If you only pass in prefix and key, all callbacks for that prefix and key will be removed.
 
         :param prefix: The prefix for keeping track of callbacks with
         :param key: The callback key
         :param callback_value: The method defined to call on callback
         :param arguments: Optional arguments to check
-
+        :rtype: bool
         """
         if callback_value:
             offsets_to_remove = []
@@ -282,24 +288,25 @@ class CallbackManager:
     @sanitize_prefix
     @check_for_prefix_and_key
     def remove_all(self, prefix: _Prefix, key: AMQPValue) -> None:
-        """Remove all callbacks for the specified prefix and key.
+        """
+        Remove all callbacks for the specified prefix and key.
 
         :param prefix: The prefix for keeping track of callbacks with
         :param key: The callback key
-
         """
         del self._stack[prefix][key]
         self._cleanup_callback_dict(prefix, key)
 
     def _arguments_match(self, callback_dict: dict[str, Any],
                          args: list[Any]) -> bool:
-        """Validate if the arguments passed in match the expected arguments in
-        the callback_dict. We expect this to be a frame passed in to *args for
-        process or passed in as a list from remove.
+        """
+        Validate if the arguments passed in match the expected arguments in the callback_dict.
+
+        We expect this to be a frame passed in to *args for process or passed in as a list from
+        remove.
 
         :param callback_dict: The callback dictionary to evaluate against
         :param args: The arguments passed in as a list
-
         """
         if callback_dict[self.ARGUMENTS] is None:
             return True
@@ -315,14 +322,14 @@ class CallbackManager:
     def _callback_dict(self, callback: Callable[..., Any], one_shot: bool,
                        only_caller: _Caller,
                        arguments: dict[str, Any] | None) -> dict[str, Any]:
-        """Return the callback dictionary.
+        """
+        Return the callback dictionary.
 
         :param callback: The callback to call
         :param one_shot: Remove this callback after it is called
-        :param only_caller: Only allow one_caller value to call the
-                                   event that fires the callback.
+        :param only_caller: Only allow one_caller value to call the event that fires the callback.
         :param arguments: arguments to attach to the callback dict
-
+        :rtype: dict
         """
         value = {
             self.CALLBACK: callback,
@@ -337,11 +344,11 @@ class CallbackManager:
     def _cleanup_callback_dict(self,
                                prefix: _Prefix,
                                key: AMQPValue | None = None) -> None:
-        """Remove empty dict nodes in the callback stack.
+        """
+        Remove empty dict nodes in the callback stack.
 
         :param prefix: The prefix for keeping track of callbacks with
         :param key: The callback key
-
         """
         if key and key in self._stack[prefix] and not self._stack[prefix][key]:
             del self._stack[prefix][key]
@@ -351,11 +358,12 @@ class CallbackManager:
     @staticmethod
     def _dict_arguments_match(value: dict[str, Any],
                               expectation: dict[str, Any]) -> bool:
-        """Checks an dict to see if it has attributes that meet the expectation.
+        """
+        Checks an dict to see if it has attributes that meet the expectation.
 
         :param value: The dict to evaluate
         :param expectation: The values to check against
-
+        :rtype: bool
         """
         LOGGER.debug('Comparing %r to %r', value, expectation)
         for key, expected in expectation.items():
@@ -367,12 +375,12 @@ class CallbackManager:
     @staticmethod
     def _obj_arguments_match(value: object, expectation: dict[str,
                                                               Any]) -> bool:
-        """Checks an object to see if it has attributes that meet the
-        expectation.
+        """
+        Checks an object to see if it has attributes that meet the expectation.
 
         :param value: The object to evaluate
         :param expectation: The values to check against
-
+        :rtype: bool
         """
         for key, expected in expectation.items():
             if not hasattr(value, key):
@@ -387,12 +395,13 @@ class CallbackManager:
 
     def _should_process_callback(self, callback_dict: dict[str, Any],
                                  caller: _Caller, args: list[Any]) -> bool:
-        """Returns True if the callback should be processed.
+        """
+        Returns True if the callback should be processed.
 
         :param callback_dict: The callback configuration
         :param caller: Who is firing the event
         :param args: Any optional arguments
-
+        :rtype: bool
         """
         if not self._arguments_match(callback_dict, args):
             LOGGER.debug('Arguments do not match for %r, %r', callback_dict,
@@ -404,13 +413,13 @@ class CallbackManager:
 
     def _use_one_shot_callback(self, prefix: _Prefix, key: AMQPValue,
                                callback_dict: dict[str, Any]) -> None:
-        """Process the one-shot callback, decrementing the use counter and
-        removing it from the stack if it's now been fully used.
+        """
+        Process the one-shot callback, decrementing the use counter and removing it from the stack
+        if it's now been fully used.
 
         :param prefix: The prefix for keeping track of callbacks with
         :param key: The callback key
         :param callback_dict: The callback dict to process
-
         """
         LOGGER.debug('Processing use of oneshot callback')
         callback_dict[self.CALLS] -= 1

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -1,6 +1,5 @@
-"""The Channel class provides a wrapper for interacting with RabbitMQ
-implementing the methods and behaviors for an AMQP Channel.
-
+"""The Channel class provides a wrapper for interacting with RabbitMQ implementing the methods and
+behaviors for an AMQP Channel.
 """
 
 from __future__ import annotations
@@ -63,11 +62,12 @@ _OnTxSelectCallback = Callable[[spec.Tx.SelectOk], None]
 
 
 class Channel:
-    """A Channel is the primary communication method for interacting with
-    RabbitMQ. It is recommended that you do not directly invoke the creation of
-    a channel object in your application code but rather construct a channel by
-    calling the active connection's channel() method.
+    """
+    A Channel is the primary communication method for interacting with RabbitMQ.
 
+    It is recommended that you do not directly invoke the creation of a channel object in your
+    application code but rather construct a channel by calling the active connection's channel()
+    method.
     """
 
     CLOSED = 0
@@ -86,14 +86,13 @@ class Channel:
 
     def __init__(self, connection: Connection, channel_number: int,
                  on_open_callback: _OnOpenCallback | None) -> None:
-        """Create a new instance of the Channel
+        """
+        Create a new instance of the Channel.
 
         :param connection: The connection
         :param channel_number: The channel number for this instance
-        :param on_open_callback: The callback to call on channel open.
-            The callback will be invoked with the `Channel` instance as its only
-            argument.
-
+        :param on_open_callback: The callback to call on channel open. The callback will be invoked
+            with the `Channel` instance as its only argument.
         """
         if not isinstance(channel_number, int):
             raise exceptions.InvalidChannelNumber(channel_number)
@@ -132,9 +131,10 @@ class Channel:
         self._cookie: object = None
 
     def __int__(self) -> int:
-        """Return the channel object as its channel number
+        """
+        Return the channel object as its channel number.
 
-
+        :rtype: int
         """
         return self.channel_number
 
@@ -145,69 +145,66 @@ class Channel:
                      callback: Callable[..., Any],
                      replies: Sequence[type[amqp_object.Method]],
                      one_shot: bool = True) -> None:
-        """Pass in a callback handler and a list replies from the
-        RabbitMQ broker which you'd like the callback notified of. Callbacks
-        should allow for the frame parameter to be passed in.
+        """
+        Pass in a callback handler and a list replies from the RabbitMQ broker which you'd like the
+        callback notified of. Callbacks should allow for the frame parameter to be passed in.
 
         :param callback: The callback to call
         :param replies: The replies to get a callback for
         :param one_shot: Only handle the first type callback
-
         """
         for reply in replies:
             self.callbacks.add(self.channel_number, reply, callback, one_shot)
 
     def add_on_cancel_callback(self, callback: _OnCancelCallback) -> None:
-        """Pass a callback function that will be called when the basic_cancel
-        is sent by the server. The callback function should receive a frame
-        parameter.
+        """
+        Pass a callback function that will be called when the basic_cancel is sent by the server.
+        The callback function should receive a frame parameter.
 
-        :param callback: The callback to call on Basic.Cancel from
-            broker
-
+        :param callback: The callback to call on Basic.Cancel from broker
         """
         self.callbacks.add(self.channel_number, spec.Basic.Cancel, callback,
                            False)
 
     def add_on_close_callback(self, callback: _OnCloseCallback) -> None:
-        """Pass a callback function that will be called when the channel is
-        closed. The callback function will receive the channel and an exception
-        describing why the channel was closed.
+        """
+        Pass a callback function that will be called when the channel is closed.
 
-        If the channel is closed by broker via Channel.Close, the callback will
-        receive `ChannelClosedByBroker` as the reason.
+        The callback function will receive the channel and an exception describing why the channel
+        was closed.
 
-        If graceful user-initiated channel closing completes successfully (
-        either directly of indirectly by closing a connection containing the
-        channel) and closing concludes gracefully without Channel.Close from the
-        broker and without loss of connection, the callback will receive
-        `ChannelClosedByClient` exception as reason.
+        If the channel is closed by broker via Channel.Close, the callback will receive
+        `ChannelClosedByBroker` as the reason.
 
-        If channel was closed due to loss of connection, the callback will
-        receive another exception type describing the failure.
+        If graceful user-initiated channel closing completes successfully ( either directly of
+        indirectly by closing a connection containing the channel) and closing concludes gracefully
+        without Channel.Close from the broker and without loss of connection, the callback will
+        receive `ChannelClosedByClient` exception as reason.
 
-        :param callback: The callback, having the signature:
-            callback(Channel, Exception reason)
+        If channel was closed due to loss of connection, the callback will receive another exception
+        type describing the failure.
 
+        :param callback: The callback, having the signature: callback(Channel, Exception reason)
         """
         self.callbacks.add(self.channel_number, '_on_channel_close', callback,
                            False, self)
 
     def add_on_flow_callback(self, callback: _OnFlowCallback) -> None:
-        """Pass a callback function that will be called when Channel.Flow is
-        called by the remote server. Note that newer versions of RabbitMQ
-        will not issue this but instead use TCP backpressure
+        """
+        Pass a callback function that will be called when Channel.Flow is called by the remote
+        server. Note that newer versions of RabbitMQ will not issue this but instead use TCP
+        backpressure.
 
         :param callback: The callback function
-
         """
         self._has_on_flow_callback = True
         self.callbacks.add(self.channel_number, spec.Channel.Flow, callback,
                            False)
 
     def add_on_return_callback(self, callback: _OnReturnCallback) -> None:
-        """Pass a callback function that will be called when basic_publish is
-        sent a message that has been rejected and returned by the server.
+        """
+        Pass a callback function that will be called when basic_publish is sent a message that has
+        been rejected and returned by the server.
 
         :param callback: The function to call, having the signature
                                 callback(channel, method, properties, body)
@@ -216,27 +213,23 @@ class Channel:
                                 - method: pika.spec.Basic.Return
                                 - properties: pika.spec.BasicProperties
                                 - body: bytes
-
         """
         self.callbacks.add(self.channel_number, '_on_return', callback, False)
 
     def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
-        """Acknowledge one or more messages. When sent by the client, this
-        method acknowledges one or more messages delivered via the Deliver or
-        Get-Ok methods. When sent by server, this method acknowledges one or
-        more messages published with the Publish method on a channel in
-        confirm mode. The acknowledgement can be for a single message or a
-        set of messages up to and including a specific message.
+        """
+        Acknowledge one or more messages.
+
+        When sent by the client, this method acknowledges one or more messages delivered via the
+        Deliver or Get-Ok methods. When sent by server, this method acknowledges one or more
+        messages published with the Publish method on a channel in confirm mode. The acknowledgement
+        can be for a single message or a set of messages up to and including a specific message.
 
         :param delivery_tag: int/long The server-assigned delivery tag
-        :param multiple: If set to True, the delivery tag is treated as
-                              "up to and including", so that multiple messages
-                              can be acknowledged with a single method. If set
-                              to False, the delivery tag refers to a single
-                              message. If the multiple field is 1, and the
-                              delivery tag is zero, this indicates
-                              acknowledgement of all outstanding messages.
-
+        :param multiple: If set to True, the delivery tag is treated as "up to and including", so
+            that multiple messages can be acknowledged with a single method. If set to False, the
+            delivery tag refers to a single message. If the multiple field is 1, and the delivery
+            tag is zero, this indicates acknowledgement of all outstanding messages.
         """
         self._raise_if_not_open()
         return self._send_method(spec.Basic.Ack(delivery_tag, multiple))
@@ -244,23 +237,21 @@ class Channel:
     def basic_cancel(self,
                      consumer_tag: str = '',
                      callback: _OnBasicCancelCallback | None = None) -> None:
-        """This method cancels a consumer. This does not affect already
-        delivered messages, but it does mean the server will not send any more
-        messages for that consumer. The client may receive an arbitrary number
-        of messages in between sending the cancel method and receiving the
-        cancel-ok reply. It may also be sent from the server to the client in
-        the event of the consumer being unexpectedly cancelled (i.e. cancelled
-        for any reason other than the server receiving the corresponding
-        basic.cancel from the client). This allows clients to be notified of
-        the loss of consumers due to events such as queue deletion.
+        """
+        This method cancels a consumer.
+
+        This does not affect already delivered messages, but it does mean the server will not send
+        any more messages for that consumer. The client may receive an arbitrary number of messages
+        in between sending the cancel method and receiving the cancel-ok reply. It may also be sent
+        from the server to the client in the event of the consumer being unexpectedly cancelled
+        (i.e. cancelled for any reason other than the server receiving the corresponding
+        basic.cancel from the client). This allows clients to be notified of the loss of consumers
+        due to events such as queue deletion.
 
         :param consumer_tag: Identifier for the consumer
-        :param callback: callback(pika.frame.Method) for method
-            Basic.CancelOk. If None, do not expect a Basic.CancelOk response,
-            otherwise, callback must be callable
-
+        :param callback: callback(pika.frame.Method) for method Basic.CancelOk. If None, do not
+            expect a Basic.CancelOk response, otherwise, callback must be callable
         :raises ValueError:
-
         """
         validators.require_string(consumer_tag, 'consumer_tag')
         self._raise_if_not_open()
@@ -309,10 +300,10 @@ class Channel:
                       consumer_tag: str | None = None,
                       arguments: dict[str, Any] | None = None,
                       callback: _OnBasicConsumeCallback | None = None) -> str:
-        """Sends the AMQP 0-9-1 command Basic.Consume to the broker and binds messages
-        for the consumer_tag to the consumer callback. If you do not pass in
-        a consumer_tag, one will be automatically generated for you. Returns
-        the consumer tag.
+        """
+        Sends the AMQP 0-9-1 command Basic.Consume to the broker and binds messages for the
+        consumer_tag to the consumer callback. If you do not pass in a consumer_tag, one will be
+        automatically generated for you. Returns the consumer tag.
 
         For more information on basic_consume, see:
         Tutorial 2 at https://www.rabbitmq.com/getstarted.html
@@ -338,8 +329,8 @@ class Channel:
         :param callback: callback(pika.frame.Method) for method
           Basic.ConsumeOk.
         :returns: Consumer tag which may be used to cancel the consumer.
+        :rtype: str
         :raises ValueError:
-
         """
         validators.require_string(queue, 'queue')
         validators.require_callback(on_message_callback)
@@ -375,12 +366,13 @@ class Channel:
         return consumer_tag
 
     def _generate_consumer_tag(self) -> str:
-        """Generate a consumer tag
+        """
+        Generate a consumer tag.
 
         NOTE: this protected method may be called by derived classes
 
         :returns: consumer tag
-
+        :rtype: str
         """
         return f'ctag{self.channel_number}.{uuid.uuid4().hex}'
 
@@ -388,8 +380,10 @@ class Channel:
                   queue: str,
                   callback: _OnBasicGetCallback,
                   auto_ack: bool = False) -> None:
-        """Get a single message from the AMQP broker. If you want to
-        be notified of Basic.GetEmpty, use the Channel.add_callback method
+        """
+        Get a single message from the AMQP broker.
+
+        If you want to be notified of Basic.GetEmpty, use the Channel.add_callback method
         adding your Basic.GetEmpty callback which should expect only one
         parameter, frame. Due to implementation details, this cannot be called
         a second time until the callback is executed.  For more information on
@@ -408,7 +402,6 @@ class Channel:
             - body: bytes
         :param auto_ack: Tell the broker to not expect a reply
         :raises ValueError:
-
         """
         validators.require_string(queue, 'queue')
         validators.require_callback(callback)
@@ -425,23 +418,20 @@ class Channel:
                    delivery_tag: int = 0,
                    multiple: bool = False,
                    requeue: bool = True) -> None:
-        """This method allows a client to reject one or more incoming messages.
-        It can be used to interrupt and cancel large incoming messages, or
-        return untreatable messages to their original queue.
+        """
+        This method allows a client to reject one or more incoming messages.
+
+        It can be used to interrupt and cancel large incoming messages, or return untreatable
+        messages to their original queue.
 
         :param delivery_tag: int/long The server-assigned delivery tag
-        :param multiple: If set to True, the delivery tag is treated as
-                              "up to and including", so that multiple messages
-                              can be acknowledged with a single method. If set
-                              to False, the delivery tag refers to a single
-                              message. If the multiple field is 1, and the
-                              delivery tag is zero, this indicates
-                              acknowledgement of all outstanding messages.
-        :param requeue: If requeue is true, the server will attempt to
-                             requeue the message. If requeue is false or the
-                             requeue attempt fails the messages are discarded or
-                             dead-lettered.
-
+        :param multiple: If set to True, the delivery tag is treated as "up to and including", so
+            that multiple messages can be acknowledged with a single method. If set to False, the
+            delivery tag refers to a single message. If the multiple field is 1, and the delivery
+            tag is zero, this indicates acknowledgement of all outstanding messages.
+        :param requeue: If requeue is true, the server will attempt to requeue the message. If
+            requeue is false or the requeue attempt fails the messages are discarded or dead-
+            lettered.
         """
         self._raise_if_not_open()
         return self._send_method(
@@ -453,7 +443,9 @@ class Channel:
                       body: bytes,
                       properties: spec.BasicProperties | None = None,
                       mandatory: bool = False) -> None:
-        """Publish to the channel with the given exchange, routing key and body.
+        """
+        Publish to the channel with the given exchange, routing key and body.
+
         For more information on basic_publish and what the parameters do, see:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#basic.publish
@@ -463,7 +455,6 @@ class Channel:
         :param body: The message body
         :param properties: Basic.properties
         :param mandatory: The mandatory flag
-
         """
         self._raise_if_not_open()
         body = as_bytes(body)
@@ -478,38 +469,29 @@ class Channel:
                   prefetch_count: int = 0,
                   global_qos: bool = False,
                   callback: _OnBasicQosCallback | None = None) -> None:
-        """Specify quality of service. This method requests a specific quality
-        of service. The client can request that messages be sent in advance
-        so that when the client finishes processing a message, the following
-        message is already held locally, rather than needing to be sent down
-        the channel. The QoS can be applied separately to each new consumer on
-        channel or shared across all consumers on the channel. Prefetching
-        gives a performance improvement.
+        """
+        Specify quality of service.
 
-        :param prefetch_size:  This field specifies the prefetch window
-                                   size. The server will send a message in
-                                   advance if it is equal to or smaller in size
-                                   than the available prefetch size (and also
-                                   falls into other prefetch limits). May be set
-                                   to zero, meaning "no specific limit",
-                                   although other prefetch limits may still
-                                   apply. The prefetch-size is ignored by
-                                   consumers who have enabled the no-ack option.
-        :param prefetch_count: Specifies a prefetch window in terms of whole
-                                   messages. This field may be used in
-                                   combination with the prefetch-size field; a
-                                   message will only be sent in advance if both
-                                   prefetch windows (and those at the channel
-                                   and connection level) allow it. The
-                                   prefetch-count is ignored by consumers who
-                                   have enabled the no-ack option.
-        :param global_qos:    Should the QoS be shared across all
-                                   consumers on the channel.
+        This method requests a specific quality of service. The client can request that messages be
+        sent in advance so that when the client finishes processing a message, the following message
+        is already held locally, rather than needing to be sent down the channel. The QoS can be
+        applied separately to each new consumer on channel or shared across all consumers on the
+        channel. Prefetching gives a performance improvement.
+
+        :param prefetch_size: This field specifies the prefetch window size. The server will send a
+            message in advance if it is equal to or smaller in size than the available prefetch size
+            (and also falls into other prefetch limits). May be set to zero, meaning "no specific
+            limit", although other prefetch limits may still apply. The prefetch-size is ignored by
+            consumers who have enabled the no-ack option.
+        :param prefetch_count: Specifies a prefetch window in terms of whole messages. This field
+            may be used in combination with the prefetch-size field; a message will only be sent in
+            advance if both prefetch windows (and those at the channel and connection level) allow
+            it. The prefetch-count is ignored by consumers who have enabled the no-ack option.
+        :param global_qos: Should the QoS be shared across all consumers on the channel.
         :param callback: The callback to call for Basic.QosOk response
-        :returns: ``None``. Method frame from the Basic.Qos-ok response is delivered
-            to ``callback`` when provided.
+        :returns:``None``. Method frame from the Basic.Qos-ok response is delivered to ``callback``
+            when provided.
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.rpc_completion_callback(callback)
@@ -520,17 +502,17 @@ class Channel:
             [spec.Basic.QosOk])
 
     def basic_reject(self, delivery_tag: int = 0, requeue: bool = True) -> None:
-        """Reject an incoming message. This method allows a client to reject a
-        message. It can be used to interrupt and cancel large incoming messages,
-        or return untreatable messages to their original queue.
+        """
+        Reject an incoming message.
+
+        This method allows a client to reject a message. It can be used to interrupt and cancel
+        large incoming messages, or return untreatable messages to their original queue.
 
         :param delivery_tag: int/long The server-assigned delivery tag
-        :param requeue: If requeue is true, the server will attempt to
-                             requeue the message. If requeue is false or the
-                             requeue attempt fails the messages are discarded or
-                             dead-lettered.
+        :param requeue: If requeue is true, the server will attempt to requeue the message. If
+            requeue is false or the requeue attempt fails the messages are discarded or dead-
+            lettered.
         :raises TypeError:
-
         """
         self._raise_if_not_open()
         if not isinstance(delivery_tag, int):
@@ -540,20 +522,17 @@ class Channel:
     def basic_recover(self,
                       requeue: bool = False,
                       callback: _OnBasicRecoverCallback | None = None) -> None:
-        """This method asks the server to redeliver all unacknowledged messages
-        on a specified channel. Zero or more messages may be redelivered. This
-        method replaces the asynchronous Recover.
+        """
+        This method asks the server to redeliver all unacknowledged messages on a specified channel.
+        Zero or more messages may be redelivered. This method replaces the asynchronous Recover.
 
-        :param requeue: If False, the message will be redelivered to the
-                             original recipient. If True, the server will
-                             attempt to requeue the message, potentially then
-                             delivering it to an alternative subscriber.
-        :param callback: callback(pika.frame.Method) for method
-            Basic.RecoverOk
-        :returns: ``None``. Method frame from the Basic.Recover-ok response is
-            delivered to ``callback`` when provided.
+        :param requeue: If False, the message will be redelivered to the original recipient. If
+            True, the server will attempt to requeue the message, potentially then delivering it to
+            an alternative subscriber.
+        :param callback: callback(pika.frame.Method) for method Basic.RecoverOk
+        :returns:``None``. Method frame from the Basic.Recover-ok response is delivered to
+            ``callback`` when provided.
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.rpc_completion_callback(callback)
@@ -563,16 +542,15 @@ class Channel:
     def close(self,
               reply_code: int = 0,
               reply_text: str = "Normal shutdown") -> None:
-        """Invoke a graceful shutdown of the channel with the AMQP Broker.
+        """
+        Invoke a graceful shutdown of the channel with the AMQP Broker.
 
-        If channel is OPENING, transition to CLOSING and suppress the incoming
-        Channel.OpenOk, if any.
+        If channel is OPENING, transition to CLOSING and suppress the incoming Channel.OpenOk, if
+        any.
 
         :param reply_code: The reason code to send to broker
         :param reply_text: The reason text to send to broker
-
         :raises ChannelWrongStateError: if channel is closed or closing
-
         """
         if self.is_closed or self.is_closing:
             # Whoever is calling `close` might expect the on-channel-close-cb
@@ -606,8 +584,10 @@ class Channel:
             self,
             ack_nack_callback: _OnAckNackCallback,
             callback: _OnConfirmDeliveryCallback | None = None) -> None:
-        """Turn on Confirm mode in the channel. Pass in a callback to be
-        notified by the Broker when a message has been confirmed as received or
+        """
+        Turn on Confirm mode in the channel.
+
+        Pass in a callback to be notified by the Broker when a message has been confirmed as received or
         rejected (Basic.Ack, Basic.Nack) from the broker to the publisher.
 
         For more information see:
@@ -620,7 +600,6 @@ class Channel:
         :param callback: callback(pika.frame.Method) for method
             Confirm.SelectOk
         :raises ValueError:
-
         """
         if not callable(ack_nack_callback):
             # confirm_deliver requires a callback; it's meaningless
@@ -647,9 +626,10 @@ class Channel:
 
     @property
     def consumer_tags(self) -> list[str]:
-        """Property method that returns a list of currently active consumers
+        """
+        Property method that returns a list of currently active consumers.
 
-
+        :rtype: list[str]
         """
         return list(self._consumers.keys())
 
@@ -659,18 +639,17 @@ class Channel:
                       routing_key: str = '',
                       arguments: dict[str, Any] | None = None,
                       callback: _OnExchangeBindCallback | None = None) -> None:
-        """Bind an exchange to another exchange.
+        """
+        Bind an exchange to another exchange.
 
         :param destination: The destination exchange to bind
         :param source: The source exchange to bind to
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
         :param callback: callback(pika.frame.Method) for method Exchange.BindOk
-        :returns: ``None``. Method frame from the Exchange.Bind-ok response is
-            delivered to ``callback`` when synchronous (no ok frame in nowait
-            mode).
+        :returns:``None``. Method frame from the Exchange.Bind-ok response is delivered to
+            ``callback`` when synchronous (no ok frame in nowait mode).
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.require_string(destination, 'destination')
@@ -691,9 +670,9 @@ class Channel:
             internal: bool = False,
             arguments: dict[str, Any] | None = None,
             callback: _OnExchangeDeclareCallback | None = None) -> None:
-        """This method creates an exchange if it does not already exist, and if
-        the exchange exists, verifies that it is of the correct and expected
-        class.
+        """
+        This method creates an exchange if it does not already exist, and if the exchange exists,
+        verifies that it is of the correct and expected class.
 
         If passive set, the server will reply with Declare-Ok if the exchange
         already exists with the same name, and raise an error if not and if the
@@ -714,7 +693,6 @@ class Channel:
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
         :raises ValueError:
-
         """
         validators.require_string(exchange, 'exchange')
         self._raise_if_not_open()
@@ -740,16 +718,15 @@ class Channel:
             exchange: str | None = None,
             if_unused: bool = False,
             callback: _OnExchangeDeleteCallback | None = None) -> None:
-        """Delete the exchange.
+        """
+        Delete the exchange.
 
         :param exchange: The exchange name
         :param if_unused: only delete if the exchange is unused
         :param callback: callback(pika.frame.Method) for method Exchange.DeleteOk
-        :returns: ``None``. Method frame from the Exchange.Delete-ok response is
-            delivered to ``callback`` when synchronous (no ok frame in nowait
-            mode).
+        :returns:``None``. Method frame from the Exchange.Delete-ok response is delivered to
+            ``callback`` when synchronous (no ok frame in nowait mode).
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         nowait = validators.rpc_completion_callback(callback)
@@ -764,18 +741,17 @@ class Channel:
             routing_key: str = '',
             arguments: dict[str, Any] | None = None,
             callback: _OnExchangeUnbindCallback | None = None) -> None:
-        """Unbind an exchange from another exchange.
+        """
+        Unbind an exchange from another exchange.
 
         :param destination: The destination exchange to unbind
         :param source: The source exchange to unbind from
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :param callback: callback(pika.frame.Method) for method Exchange.UnbindOk
-        :returns: ``None``. Method frame from the Exchange.Unbind-ok response is
-            delivered to ``callback`` when synchronous (no ok frame in nowait
-            mode).
+        :returns:``None``. Method frame from the Exchange.Unbind-ok response is delivered to
+            ``callback`` when synchronous (no ok frame in nowait mode).
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         nowait = validators.rpc_completion_callback(callback)
@@ -787,17 +763,18 @@ class Channel:
     def flow(self,
              active: bool,
              callback: _OnFlowCallback | None = None) -> None:
-        """Turn Channel flow control off and on. Pass a callback to be notified
-        of the response from the server. active is a bool. Callback should
-        expect a bool in response indicating channel flow state. For more
-        information, please reference:
+        """
+        Turn Channel flow control off and on.
+
+        Pass a callback to be notified of the response from the server. active is a bool. Callback
+        should expect a bool in response indicating channel flow state. For more information, please
+        reference:
 
         https://www.rabbitmq.com/amqp-0-9-1-reference.html#channel.flow
 
         :param active: Turn flow on or off
         :param callback: callback(bool) upon completion
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.rpc_completion_callback(callback)
@@ -807,39 +784,42 @@ class Channel:
 
     @property
     def is_closed(self) -> bool:
-        """Returns True if the channel is closed.
+        """
+        Returns True if the channel is closed.
 
-
+        :rtype: bool
         """
         return self._state == self.CLOSED
 
     @property
     def is_closing(self) -> bool:
-        """Returns True if client-initiated closing of the channel is in
-        progress.
+        """
+        Returns True if client-initiated closing of the channel is in progress.
 
-
+        :rtype: bool
         """
         return self._state == self.CLOSING
 
     @property
     def is_open(self) -> bool:
-        """Returns True if the channel is open.
+        """
+        Returns True if the channel is open.
 
-
+        :rtype: bool
         """
         return self._state == self.OPEN
 
     @property
     def is_opening(self) -> bool:
-        """Returns True if the channel is opening.
+        """
+        Returns True if the channel is opening.
 
-
+        :rtype: bool
         """
         return self._state == self.OPENING
 
     def open(self) -> None:
-        """Open the channel"""
+        """Open the channel."""
         self._set_state(self.OPENING)
         self._add_callbacks()
         self._rpc(spec.Channel.Open(), self._on_openok, [spec.Channel.OpenOk])
@@ -850,17 +830,17 @@ class Channel:
                    routing_key: str | None = None,
                    arguments: dict[str, Any] | None = None,
                    callback: _OnQueueBindCallback | None = None) -> None:
-        """Bind the queue to the specified exchange
+        """
+        Bind the queue to the specified exchange.
 
         :param queue: The queue to bind to the exchange
         :param exchange: The source exchange to bind to
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
         :param callback: callback(pika.frame.Method) for method Queue.BindOk
-        :returns: ``None``. Method frame from the Queue.Bind-ok response is delivered
-            to ``callback`` when synchronous (no ok frame in nowait mode).
+        :returns:``None``. Method frame from the Queue.Bind-ok response is delivered to ``callback``
+            when synchronous (no ok frame in nowait mode).
         :raises ValueError:
-
         """
         validators.require_string(queue, 'queue')
         validators.require_string(exchange, 'exchange')
@@ -881,8 +861,10 @@ class Channel:
                       auto_delete: bool = False,
                       arguments: dict[str, Any] | None = None,
                       callback: _OnQueueDeclareCallback | None = None) -> None:
-        """Declare queue, create if needed. This method creates or checks a
-        queue. When creating a new queue the client can specify various
+        """
+        Declare queue, create if needed.
+
+        This method creates or checks a queue. When creating a new queue the client can specify various
         properties that control the durability of the queue and its contents,
         and the level of sharing for the queue.
 
@@ -901,7 +883,6 @@ class Channel:
             delivered to ``callback`` when synchronous (no ok frame in nowait
             mode).
         :raises ValueError:
-
         """
         validators.require_string(queue, 'queue')
         self._raise_if_not_open()
@@ -924,17 +905,16 @@ class Channel:
                      if_unused: bool = False,
                      if_empty: bool = False,
                      callback: _OnQueueDeleteCallback | None = None) -> None:
-        """Delete a queue from the broker.
+        """
+        Delete a queue from the broker.
 
         :param queue: The queue to delete
         :param if_unused: only delete if it's unused
         :param if_empty: only delete if the queue is empty
         :param callback: callback(pika.frame.Method) for method Queue.DeleteOk
-        :returns: ``None``. Method frame from the Queue.Delete-ok response is
-            delivered to ``callback`` when synchronous (no ok frame in nowait
-            mode).
+        :returns:``None``. Method frame from the Queue.Delete-ok response is delivered to
+            ``callback`` when synchronous (no ok frame in nowait mode).
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.require_string(queue, 'queue')
@@ -947,15 +927,14 @@ class Channel:
     def queue_purge(self,
                     queue: str,
                     callback: _OnQueuePurgeCallback | None = None) -> None:
-        """Purge all of the messages from the specified queue
+        """
+        Purge all of the messages from the specified queue.
 
         :param queue: The queue to purge
         :param callback: callback(pika.frame.Method) for method Queue.PurgeOk
-        :returns: ``None``. Method frame from the Queue.Purge-ok response is
-            delivered to ``callback`` when synchronous (no ok frame in nowait
-            mode).
+        :returns:``None``. Method frame from the Queue.Purge-ok response is delivered to
+            ``callback`` when synchronous (no ok frame in nowait mode).
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.require_string(queue, 'queue')
@@ -969,17 +948,17 @@ class Channel:
                      routing_key: str | None = None,
                      arguments: dict[str, Any] | None = None,
                      callback: _OnQueueUnbindCallback | None = None) -> None:
-        """Unbind a queue from an exchange.
+        """
+        Unbind a queue from an exchange.
 
         :param queue: The queue to unbind from the exchange
         :param exchange: The source exchange to bind from
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :param callback: callback(pika.frame.Method) for method Queue.UnbindOk
-        :returns: ``None``. Method frame from the Queue.Unbind-ok response is
-            delivered to ``callback`` when provided.
+        :returns:``None``. Method frame from the Queue.Unbind-ok response is delivered to
+            ``callback`` when provided.
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.require_string(queue, 'queue')
@@ -991,13 +970,13 @@ class Channel:
             callback, [spec.Queue.UnbindOk])
 
     def tx_commit(self, callback: _OnTxCommitCallback | None = None) -> None:
-        """Commit a transaction
+        """
+        Commit a transaction.
 
         :param callback: callback(pika.frame.Method) for method Tx.CommitOk
-        :returns: ``None``. Method frame from the Tx.Commit-ok response is delivered
-            to ``callback`` when provided.
+        :returns:``None``. Method frame from the Tx.Commit-ok response is delivered to ``callback``
+            when provided.
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.rpc_completion_callback(callback)
@@ -1005,28 +984,29 @@ class Channel:
 
     def tx_rollback(self,
                     callback: _OnTxRollbackCallback | None = None) -> None:
-        """Rollback a transaction.
+        """
+        Rollback a transaction.
 
         :param callback: callback(pika.frame.Method) for method Tx.RollbackOk
-        :returns: ``None``. Method frame from the Tx.Rollback-ok response is delivered
-            to ``callback`` when provided.
+        :returns:``None``. Method frame from the Tx.Rollback-ok response is delivered to
+            ``callback`` when provided.
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.rpc_completion_callback(callback)
         return self._rpc(spec.Tx.Rollback(), callback, [spec.Tx.RollbackOk])
 
     def tx_select(self, callback: _OnTxSelectCallback | None = None) -> None:
-        """Select standard transaction mode. This method sets the channel to use
-        standard transactions. The client must use this method at least once on
-        a channel before using the Commit or Rollback methods.
+        """
+        Select standard transaction mode.
+
+        This method sets the channel to use standard transactions. The client must use this method
+        at least once on a channel before using the Commit or Rollback methods.
 
         :param callback: callback(pika.frame.Method) for method Tx.SelectOk
-        :returns: ``None``. Method frame from the Tx.Select-ok response is delivered
-            to ``callback`` when provided.
+        :returns:``None``. Method frame from the Tx.Select-ok response is delivered to ``callback``
+            when provided.
         :raises ValueError:
-
         """
         self._raise_if_not_open()
         validators.rpc_completion_callback(callback)
@@ -1035,9 +1015,8 @@ class Channel:
     # Internal methods
 
     def _add_callbacks(self) -> None:
-        """Callbacks that add the required behavior for a channel when
-        connecting and connected to a server.
-
+        """Callbacks that add the required behavior for a channel when connecting and connected to a
+        server.
         """
         # Add a callback for Basic.GetEmpty
         self.callbacks.add(self.channel_number, spec.Basic.GetEmpty,
@@ -1056,14 +1035,13 @@ class Channel:
                            self._on_close_from_broker, True)
 
     def _add_on_cleanup_callback(self, callback: Callable[..., Any]) -> None:
-        """For internal use only (e.g., Connection needs to remove closed
-        channels from its channel container). Pass a callback function that will
-        be called when the channel is being cleaned up after all channel-close
-        callbacks callbacks.
+        """
+        For internal use only (e.g., Connection needs to remove closed channels from its channel
+        container). Pass a callback function that will be called when the channel is being cleaned
+        up after all channel-close callbacks callbacks.
 
         :param callback: The callback to call, having the
             signature: callback(channel)
-
         """
         self.callbacks.add(self.channel_number,
                            self._ON_CHANNEL_CLEANUP_CB_KEY,
@@ -1080,36 +1058,35 @@ class Channel:
         self._cookie = None
 
     def _cleanup_consumer_ref(self, consumer_tag: str) -> None:
-        """Remove any references to the consumer tag in internal structures
-        for consumer state.
+        """
+        Remove any references to the consumer tag in internal structures for consumer state.
 
         :param consumer_tag: The consumer tag to cleanup
-
         """
         self._consumers_with_noack.discard(consumer_tag)
         self._consumers.pop(consumer_tag, None)
         self._cancelled.discard(consumer_tag)
 
     def _get_cookie(self) -> Any:
-        """Used by the wrapper implementation (e.g., `BlockingChannel`) to
-        retrieve the cookie that it set via `_set_cookie`
+        """
+        Used by the wrapper implementation (e.g., `BlockingChannel`) to retrieve the cookie that it
+        set via `_set_cookie`
 
         :returns: opaque cookie value that was set via `_set_cookie`
-
+        :rtype: object
         """
         return self._cookie
 
     def _handle_content_frame(self, frame_value: frame.Frame) -> None:
-        """This is invoked by the connection when frames that are not registered
-        with the CallbackManager have been found. This should only be the case
-        when the frames are related to content delivery.
+        """
+        This is invoked by the connection when frames that are not registered with the
+        CallbackManager have been found. This should only be the case when the frames are related to
+        content delivery.
 
-        The _content_assembler will be invoked which will return the fully
-        formed message in three parts when all of the body frames have been
-        received.
+        The _content_assembler will be invoked which will return the fully formed message in three
+        parts when all of the body frames have been received.
 
         :param frame_value: The frame to deliver
-
         """
         try:
             response = self._content_assembler.process(frame_value)
@@ -1126,11 +1103,10 @@ class Channel:
                 self._on_return(*response)
 
     def _on_cancel(self, method_frame: frame.Method) -> None:
-        """When the broker cancels a consumer, delete it from our internal
-        dictionary.
+        """
+        When the broker cancels a consumer, delete it from our internal dictionary.
 
         :param method_frame: The method frame received
-
         """
         if method_frame.method.consumer_tag in self._cancelled:
             # User-initiated cancel is waiting for Cancel-ok
@@ -1139,11 +1115,10 @@ class Channel:
         self._cleanup_consumer_ref(method_frame.method.consumer_tag)
 
     def _on_cancelok(self, method_frame: frame.Method) -> None:
-        """Called in response to a frame from the Broker when the
-         client sends Basic.Cancel
+        """
+        Called in response to a frame from the Broker when the client sends Basic.Cancel.
 
         :param method_frame: The method frame received
-
         """
         self._cleanup_consumer_ref(method_frame.method.consumer_tag)
 
@@ -1169,11 +1144,10 @@ class Channel:
             self._cleanup()
 
     def _on_close_from_broker(self, method_frame: frame.Method) -> None:
-        """Handle `Channel.Close` from broker.
+        """
+        Handle `Channel.Close` from broker.
 
-        :param method_frame: Method frame with Channel.Close
-            method
-
+        :param method_frame: Method frame with Channel.Close method
         """
         LOGGER.warning('Received remote Channel.Close (%s): %r on %s',
                        method_frame.method.reply_code,
@@ -1206,14 +1180,13 @@ class Channel:
             self._transition_to_closed()
 
     def _on_close_meta(self, reason: Exception | None) -> None:
-        """Handle meta-close request from either a remote Channel.Close from
-        the broker (when a pending Channel.Close method is queued for
-        execution) or a Connection's cleanup logic after sudden connection
-        loss. We use this opportunity to transition to CLOSED state, clean up
-        the channel, and dispatch the on-channel-closed callbacks.
+        """
+        Handle meta-close request from either a remote Channel.Close from the broker (when a pending
+        Channel.Close method is queued for execution) or a Connection's cleanup logic after sudden
+        connection loss. We use this opportunity to transition to CLOSED state, clean up the
+        channel, and dispatch the on-channel-closed callbacks.
 
         :param reason: Exception describing the reason for closing.
-
         """
         LOGGER.debug('Handling meta-close on %s: %r', self, reason)
 
@@ -1222,11 +1195,10 @@ class Channel:
             self._transition_to_closed()
 
     def _on_closeok(self, method_frame: frame.Method) -> None:
-        """Invoked when RabbitMQ replies to a Channel.Close method
+        """
+        Invoked when RabbitMQ replies to a Channel.Close method.
 
-        :param method_frame: Method frame with Channel.CloseOk
-            method
-
+        :param method_frame: Method frame with Channel.CloseOk method
         """
         LOGGER.info('Received %s on %s', method_frame.method, self)
 
@@ -1234,14 +1206,15 @@ class Channel:
 
     def _on_deliver(self, method_frame: frame.Method,
                     header_frame: frame.Header, body: bytes) -> None:
-        """Cope with reentrancy. If a particular consumer is still active when
-        another delivery appears for it, queue the deliveries up until it
-        finally exits.
+        """
+        Cope with reentrancy.
+
+        If a particular consumer is still active when another delivery appears for it, queue the
+        deliveries up until it finally exits.
 
         :param method_frame: The method frame received
         :param header_frame: The header frame received
         :param body: The body received
-
         """
         consumer_tag = method_frame.method.consumer_tag
 
@@ -1258,29 +1231,30 @@ class Channel:
                                       header_frame.properties, body)
 
     def _on_eventok(self, method_frame: frame.Method) -> None:
-        """Generic events that returned ok that may have internal callbacks.
-        We keep a list of what we've yet to implement so that we don't silently
-        drain events that we don't support.
+        """
+        Generic events that returned ok that may have internal callbacks.
+
+        We keep a list of what we've yet to implement so that we don't silently drain events that we
+        don't support.
 
         :param method_frame: The method frame received
-
         """
         LOGGER.debug('Discarding frame %r', method_frame)
 
     def _on_flow(self, _method_frame_unused: frame.Method) -> None:
-        """Called if the server sends a Channel.Flow frame.
+        """
+        Called if the server sends a Channel.Flow frame.
 
         :param _method_frame_unused: The Channel.Flow frame
-
         """
         if self._has_on_flow_callback is False:
             LOGGER.warning('Channel.Flow received from server')
 
     def _on_flowok(self, method_frame: frame.Method) -> None:
-        """Called in response to us asking the server to toggle on Channel.Flow
+        """
+        Called in response to us asking the server to toggle on Channel.Flow.
 
         :param method_frame: The method frame received
-
         """
         self.flow_active = method_frame.method.active
         if self._on_flowok_callback:
@@ -1290,10 +1264,10 @@ class Channel:
             LOGGER.warning('Channel.FlowOk received with no active callbacks')
 
     def _on_getempty(self, method_frame: frame.Method) -> None:
-        """When we receive an empty reply do nothing but log it
+        """
+        When we receive an empty reply do nothing but log it.
 
         :param method_frame: The method frame received
-
         """
         LOGGER.debug('Received Basic.GetEmpty: %r', method_frame)
         if self._on_getok_callback is not None:
@@ -1301,12 +1275,12 @@ class Channel:
 
     def _on_getok(self, method_frame: frame.Method, header_frame: frame.Header,
                   body: bytes) -> None:
-        """Called in reply to a Basic.Get when there is a message.
+        """
+        Called in reply to a Basic.Get when there is a message.
 
         :param method_frame: The method frame received
         :param header_frame: The header frame received
         :param body: The body received
-
         """
         if self._on_getok_callback is not None:
             callback = self._on_getok_callback
@@ -1316,17 +1290,15 @@ class Channel:
             LOGGER.error('Basic.GetOk received with no active callback')
 
     def _on_openok(self, method_frame: frame.Method) -> None:
-        """Called by our callback handler when we receive a Channel.OpenOk and
-        subsequently calls our _on_openok_callback which was passed into the
-        Channel constructor. The reason we do this is because we want to make
-        sure that the on_open_callback parameter passed into the Channel
+        """
+        Called by our callback handler when we receive a Channel.OpenOk and subsequently calls our
+        _on_openok_callback which was passed into the Channel constructor. The reason we do this is
+        because we want to make sure that the on_open_callback parameter passed into the Channel
         constructor is not the first callback we make.
 
-        Suppress the state transition and callback if channel is already in
-        CLOSING state.
+        Suppress the state transition and callback if channel is already in CLOSING state.
 
         :param method_frame: Channel.OpenOk frame
-
         """
         # Suppress OpenOk if the user or Connection.Close started closing it
         # before open completed.
@@ -1339,12 +1311,12 @@ class Channel:
 
     def _on_return(self, method_frame: frame.Method, header_frame: frame.Header,
                    body: bytes) -> None:
-        """Called if the server sends a Basic.Return frame.
+        """
+        Called if the server sends a Basic.Return frame.
 
         :param method_frame: The Basic.Return frame
         :param header_frame: The content header frame
         :param body: The message body
-
         """
         if not self.callbacks.process(self.channel_number, '_on_return', self,
                                       self, method_frame.method,
@@ -1353,21 +1325,22 @@ class Channel:
                          method_frame.method, header_frame.properties)
 
     def _on_selectok(self, method_frame: frame.Method) -> None:
-        """Called when the broker sends a Confirm.SelectOk frame
+        """
+        Called when the broker sends a Confirm.SelectOk frame.
 
         :param method_frame: The method frame received
-
         """
         LOGGER.debug("Confirm.SelectOk Received: %r", method_frame)
 
     def _on_synchronous_complete(self,
                                  _method_frame_unused: frame.Method) -> None:
-        """This is called when a synchronous command is completed. It will undo
-        the blocking state and send all the frames that stacked up while we
-        were in the blocking state.
+        """
+        This is called when a synchronous command is completed.
+
+        It will undo the blocking state and send all the frames that stacked up while we were in the
+        blocking state.
 
         :param _method_frame_unused: The method frame received
-
         """
         LOGGER.debug('%i blocked frames', len(self._blocked))
         self._blocking = None
@@ -1378,21 +1351,17 @@ class Channel:
             self._rpc(*self._blocked.popleft())
 
     def _drain_blocked_methods_on_remote_close(self) -> None:
-        """This is called when the broker sends a Channel.Close while the
-        client is in CLOSING state. This method checks the blocked method
-        queue for a pending client-initiated Channel.Close method and
-        ensures its callbacks are processed, but does not send the method
-        to the broker.
+        """
+        This is called when the broker sends a Channel.Close while the client is in CLOSING state.
+        This method checks the blocked method queue for a pending client-initiated Channel.Close
+        method and ensures its callbacks are processed, but does not send the method to the broker.
 
-        The broker may close the channel before responding to outstanding
-        in-transit synchronous methods, or even before these methods have been
-        sent to the broker. AMQP 0.9.1 obliges the server to drop all methods
-        arriving on a closed channel other than Channel.CloseOk and
-        Channel.Close. Since the response to a synchronous method that blocked
-        the channel never arrives, the channel never becomes unblocked, and the
-        Channel.Close, if any, in the blocked queue has no opportunity to be
-        sent, and thus its completion callback would never be called.
-
+        The broker may close the channel before responding to outstanding in-transit synchronous
+        methods, or even before these methods have been sent to the broker. AMQP 0.9.1 obliges the
+        server to drop all methods arriving on a closed channel other than Channel.CloseOk and
+        Channel.Close. Since the response to a synchronous method that blocked the channel never
+        arrives, the channel never becomes unblocked, and the Channel.Close, if any, in the blocked
+        queue has no opportunity to be sent, and thus its completion callback would never be called.
         """
         LOGGER.debug(
             'Draining %i blocked frames due to broker-requested Channel.Close',
@@ -1413,8 +1382,10 @@ class Channel:
         (Sequence[(type[amqp_object.Method] |
                    tuple[type[amqp_object.Method], dict[str, Any]])]) = None
     ) -> None:
-        """Make a synchronous channel RPC call for a synchronous method frame. If
-        the channel is already in the blocking state, then enqueue the request,
+        """
+        Make a synchronous channel RPC call for a synchronous method frame.
+
+        If the channel is already in the blocking state, then enqueue the request,
         but don't send it at this time; it will be eventually sent by
         `_on_synchronous_complete` after the prior blocking request receives a
         response. If the channel is not in the blocking state and
@@ -1428,7 +1399,6 @@ class Channel:
         :param callback: The callback for the RPC response
         :param acceptable_replies: A (possibly empty) sequence of
             replies this RPC call expects or None
-
         """
         assert method.synchronous, (
             f'Only synchronous-capable methods may be used with _rpc: {method!r}'
@@ -1492,11 +1462,11 @@ class Channel:
                                        arguments=arguments)
 
     def _raise_if_not_open(self) -> None:
-        """If channel is not in the OPEN state, raises ChannelWrongStateError
-        with `reply_code` and `reply_text` corresponding to current state.
+        """
+        If channel is not in the OPEN state, raises ChannelWrongStateError with `reply_code` and
+        `reply_text` corresponding to current state.
 
-        :raises exceptions.ChannelWrongStateError: if channel is not in OPEN
-            state.
+        :raises exceptions.ChannelWrongStateError: if channel is not in OPEN state.
         """
         if self._state == self.OPEN:
             return
@@ -1517,53 +1487,48 @@ class Channel:
             method: amqp_object.Method,
             content: None | (tuple[spec.BasicProperties, bytes]) = None
     ) -> None:
-        """Shortcut wrapper to send a method through our connection, passing in
-        the channel number
+        """
+        Shortcut wrapper to send a method through our connection, passing in the channel number.
 
         :param method: The method to send
-        :param content: If set, is a content frame, is tuple of
-                              properties and body.
-
+        :param content: If set, is a content frame, is tuple of properties and body.
         """
-
         self.connection._send_method(self.channel_number, method, content)
 
     def _set_cookie(self, cookie: object) -> None:
-        """Used by wrapper layer (e.g., `BlockingConnection`) to link the
-        channel implementation back to the proxy. See `_get_cookie`.
+        """
+        Used by wrapper layer (e.g., `BlockingConnection`) to link the channel implementation back
+        to the proxy. See `_get_cookie`.
 
-        :param cookie: an opaque value; typically a proxy channel implementation
-            instance (e.g., `BlockingChannel` instance)
+        :param cookie: an opaque value; typically a proxy channel implementation instance (e.g.,
+            `BlockingChannel` instance)
         """
         self._cookie = cookie
 
     def _set_state(self, connection_state: int) -> None:
-        """Set the channel connection state to the specified state value.
+        """
+        Set the channel connection state to the specified state value.
 
         :param connection_state: The connection_state value
-
         """
         self._state = connection_state
 
     def _on_unexpected_frame(self, frame_value: frame.Frame) -> None:
-        """Invoked when a frame is received that is not setup to be processed.
+        """
+        Invoked when a frame is received that is not setup to be processed.
 
         :param frame_value: The frame received
-
         """
         LOGGER.error('Unexpected frame: %r', frame_value)
 
 
 class ContentFrameAssembler:
-    """Handle content related frames, building a message and return the message
-    back in three parts upon receipt.
-
+    """Handle content related frames, building a message and return the message back in three parts
+    upon receipt.
     """
 
     def __init__(self) -> None:
-        """Create a new instance of the conent frame assembler.
-
-        """
+        """Create a new instance of the conent frame assembler."""
         self._method_frame: frame.Method | None = None
         self._header_frame: frame.Header | None = None
         self._seen_so_far = 0
@@ -1572,12 +1537,12 @@ class ContentFrameAssembler:
     def process(
         self, frame_value: frame.Frame
     ) -> tuple[frame.Method, frame.Header, bytes] | None:
-        """Invoked by the Channel object when passed frames that are not
-        setup in the rpc process and that don't have explicit reply types
-        defined. This includes Basic.Publish, Basic.GetOk and Basic.Return
+        """
+        Invoked by the Channel object when passed frames that are not setup in the rpc process and
+        that don't have explicit reply types defined. This includes Basic.Publish, Basic.GetOk and
+        Basic.Return.
 
         :param frame_value: The frame to process
-
         """
         if (isinstance(frame_value, frame.Method) and
                 spec.has_content(frame_value.method.INDEX)):
@@ -1593,9 +1558,10 @@ class ContentFrameAssembler:
         raise exceptions.UnexpectedFrameError(frame_value)
 
     def _finish(self) -> tuple[frame.Method, frame.Header, bytes]:
-        """Invoked when all of the message has been received
+        """
+        Invoked when all of the message has been received.
 
-
+        :rtype: tuple(pika.frame.Method, pika.frame.Header, bytes)
         """
         assert self._method_frame is not None
         assert self._header_frame is not None
@@ -1607,12 +1573,14 @@ class ContentFrameAssembler:
     def _handle_body_frame(
         self, body_frame: frame.Body
     ) -> tuple[frame.Method, frame.Header, bytes] | None:
-        """Receive body frames and append them to the stack. When the body size
-        matches, call the finish method.
+        """
+        Receive body frames and append them to the stack.
+
+        When the body size matches, call the finish method.
 
         :param body_frame: The body frame
         :raises: pika.exceptions.BodyTooLongError
-
+        :rtype: tuple(pika.frame.Method, pika.frame.Header, bytes)|None
         """
         self._seen_so_far += len(body_frame.fragment)
         self._body_fragments.append(body_frame.fragment)
@@ -1625,7 +1593,7 @@ class ContentFrameAssembler:
         return None
 
     def _reset(self) -> None:
-        """Reset the values for processing frames"""
+        """Reset the values for processing frames."""
         self._method_frame = None
         self._header_frame = None
         self._seen_so_far = 0

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1,4 +1,4 @@
-"""Core connection objects"""
+"""Core connection objects."""
 
 from __future__ import annotations
 
@@ -48,9 +48,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Parameters:
-    """Base connection parameters class definition
-
-    """
+    """Base connection parameters class definition."""
 
     # Declare slots to protect against accidental assignment of an invalid
     # attribute
@@ -140,9 +138,10 @@ class Parameters:
         self.tcp_options = self.DEFAULT_TCP_OPTIONS
 
     def __repr__(self) -> str:
-        """Represent the info about the instance.
+        """
+        Represent the info about the instance.
 
-
+        :rtype: str
         """
         return (
             f'<{self.__class__.__name__} host={self.host} port={self.port} virtual_host={self.virtual_host} ssl={bool(self.ssl_options)}>'
@@ -164,6 +163,7 @@ class Parameters:
         """
         :returns: blocked connection timeout. Defaults to
             `DEFAULT_BLOCKED_CONNECTION_TIMEOUT`.
+        :rtype: float|None
 
         """
         return self._blocked_connection_timeout
@@ -191,6 +191,7 @@ class Parameters:
         """
         :returns: max preferred number of channels. Defaults to
             `DEFAULT_CHANNEL_MAX`.
+        :rtype: int
 
         """
         return self._channel_max
@@ -216,6 +217,7 @@ class Parameters:
         :returns: client properties used to override the fields in the default
             client properties reported  to RabbitMQ via `Connection.StartOk`
             method. Defaults to `DEFAULT_CLIENT_PROPERTIES`.
+        :rtype: dict|None
 
         """
         return self._client_properties
@@ -241,6 +243,7 @@ class Parameters:
         """
         :returns: number of socket connection attempts. Defaults to
             `DEFAULT_CONNECTION_ATTEMPTS`. See also `retry_delay`.
+        :rtype: int
 
         """
         return self._connection_attempts
@@ -265,6 +268,7 @@ class Parameters:
     ) -> (pika.credentials.PlainCredentials |
           pika.credentials.ExternalCredentials):
         """
+        :rtype: one of the classes from `pika.credentials.VALID_TYPES`. Defaults
             to `DEFAULT_CREDENTIALS`.
 
         """
@@ -292,6 +296,7 @@ class Parameters:
         """
         :returns: desired maximum AMQP frame size to use. Defaults to
             `DEFAULT_FRAME_MAX`.
+        :rtype: int
 
         """
         return self._frame_max
@@ -322,6 +327,7 @@ class Parameters:
             connection tuning or callable which is invoked during connection tuning.
             None to accept broker's value. 0 turns heartbeat off. Defaults to
             `DEFAULT_HEARTBEAT_TIMEOUT`.
+        :rtype: int|callable|None
 
         """
         return self._heartbeat
@@ -351,6 +357,7 @@ class Parameters:
     def host(self) -> str:
         """
         :returns: hostname or ip address of broker. Defaults to `DEFAULT_HOST`.
+        :rtype: str
 
         """
         return self._host
@@ -369,6 +376,7 @@ class Parameters:
         """
         :returns: locale value to pass to broker; e.g., 'en_US'. Defaults to
             `DEFAULT_LOCALE`.
+        :rtype: str
 
         """
         return self._locale
@@ -387,6 +395,7 @@ class Parameters:
         """
         :returns: port number of broker's listening socket. Defaults to
             `DEFAULT_PORT`.
+        :rtype: int
 
         """
         return self._port
@@ -407,6 +416,7 @@ class Parameters:
         """
         :returns: interval between socket connection attempts; see also
             `connection_attempts`. Defaults to `DEFAULT_RETRY_DELAY`.
+        :rtype: float
 
         """
         return self._retry_delay
@@ -428,6 +438,7 @@ class Parameters:
         """
         :returns: socket connect timeout in seconds. Defaults to
             `DEFAULT_SOCKET_TIMEOUT`. The value None disables this timeout.
+        :rtype: float|None
 
         """
         return self._socket_timeout
@@ -456,6 +467,7 @@ class Parameters:
         :returns: full protocol stack TCP/[SSL]/AMQP bring-up timeout in
             seconds. Defaults to `DEFAULT_STACK_TIMEOUT`. The value None
             disables this timeout.
+        :rtype: float
 
         """
         return self._stack_timeout
@@ -484,6 +496,7 @@ class Parameters:
     def ssl_options(self) -> SSLOptions | None:
         """
         :returns: None for plaintext or `pika.SSLOptions` instance for SSL/TLS.
+        :rtype: `pika.SSLOptions`|None
         """
         return self._ssl_options
 
@@ -504,6 +517,7 @@ class Parameters:
         """
         :returns: rabbitmq virtual host name. Defaults to
             `DEFAULT_VIRTUAL_HOST`.
+        :rtype: str
 
         """
         return self._virtual_host
@@ -521,6 +535,7 @@ class Parameters:
     def tcp_options(self) -> dict[str, int] | None:
         """
         :returns: None or a dict of options to pass to the underlying socket
+        :rtype: dict|None
         """
         return self._tcp_options
 
@@ -538,14 +553,15 @@ class Parameters:
 
 
 class ConnectionParameters(Parameters):
-    """Connection parameters object that is passed into the connection adapter
-    upon construction."""
+    """Connection parameters object that is passed into the connection adapter upon construction."""
 
     # Protect against accidental assignment of an invalid attribute
     __slots__ = ()
 
     class _DEFAULT:
-        """Designates default parameter value; internal use"""
+        """Designates default parameter value; internal use."""
+
+        ...  # noqa: PIE790
 
     T = TypeVar('T')
     DefaultT = Union[T, Type[_DEFAULT]]
@@ -571,8 +587,10 @@ class ConnectionParameters(Parameters):
                  client_properties: DefaultT[dict[str, Any] | None] = _DEFAULT,
                  tcp_options: DefaultT[dict[str, Any] | None] = _DEFAULT,
                  **kwargs: Any) -> None:
-        """Create a new ConnectionParameters instance. See `Parameters` for
-        default values.
+        """
+        Create a new ConnectionParameters instance.
+
+        See `Parameters` for default values.
 
         :param host: Hostname or IP Address to connect to
         :param port: TCP port to connect to
@@ -734,10 +752,10 @@ class URLParameters(Parameters):
     _SETTER_PREFIX = '_set_url_'
 
     def __init__(self, url: str) -> None:
-        """Create a new URLParameters instance.
+        """
+        Create a new URLParameters instance.
 
         :param url: The URL value
-
         """
         super().__init__()
 
@@ -893,7 +911,8 @@ class URLParameters(Parameters):
         self.stack_timeout = stack_timeout
 
     def _set_url_ssl_options(self, value: str) -> None:
-        """Deserialize and apply the corresponding query string arg
+        """
+        Deserialize and apply the corresponding query string arg.
 
         :param value: Raw query-string value to deserialize
         """
@@ -949,10 +968,7 @@ class URLParameters(Parameters):
 
 
 class SSLOptions:
-    """Class used to provide parameters for optional fine grained control of SSL
-    socket wrapping.
-
-    """
+    """Class used to provide parameters for optional fine grained control of SSL socket wrapping."""
 
     # Protect against accidental assignment of an invalid attribute
     __slots__ = ('context', 'server_hostname')
@@ -974,10 +990,11 @@ class SSLOptions:
 
 
 class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
-    """This is the core class that implements communication with RabbitMQ. This
-    class should not be invoked directly but rather through the use of an
-    adapter such as SelectConnection or BlockingConnection.
+    """
+    This is the core class that implements communication with RabbitMQ.
 
+    This class should not be invoked directly but rather through the use of an adapter such as
+    SelectConnection or BlockingConnection.
     """
 
     ON_CONNECTION_CLOSED = '_on_connection_closed'
@@ -1009,9 +1026,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                  on_close_callback: None |
                  (Callable[[Connection, Exception], Any]) = None,
                  internal_connection_workflow: bool = True) -> None:
-        """Connection initialization expects an object that has implemented the
-         Parameters class and a callback function to notify when we have
-         successfully connected to the AMQP Broker.
+        """
+        Connection initialization expects an object that has implemented the Parameters class and a
+        callback function to notify when we have successfully connected to the AMQP Broker.
 
         Available Parameters classes are the ConnectionParameters class and
         URLParameters class.
@@ -1033,7 +1050,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         :param internal_connection_workflow: True for autonomous connection
             establishment which is default; False for externally-managed
             connection workflow via the `create_connection()` factory.
-
         """
         self.connection_state: int = self.CONNECTION_CLOSED
 
@@ -1109,10 +1125,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             LOGGER.debug('Using external connection workflow.')
 
     def _init_connection_state(self) -> None:
-        """Initialize or reset all of the internal state variables for a given
-        connection. On disconnect or reconnect all of the state needs to
-        be wiped.
+        """
+        Initialize or reset all of the internal state variables for a given connection.
 
+        On disconnect or reconnect all of the state needs to be wiped.
         """
         # TODO: probably don't need the state recovery logic since we don't
         #       test re-connection sufficiently (if at all), and users should
@@ -1165,15 +1181,16 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def add_on_close_callback(
             self, callback: Callable[[Connection, Exception], Any]) -> None:
-        """Add a callback notification when the connection has closed. The
-        callback will be passed the connection and an exception instance. The
-        exception will either be an instance of `exceptions.ConnectionClosed` if
-        a fully-open connection was closed by user or broker or exception of
-        another type that describes the cause of connection closure/failure.
+        """
+        Add a callback notification when the connection has closed.
+
+        The callback will be passed the connection and an exception instance. The exception will
+        either be an instance of `exceptions.ConnectionClosed` if a fully-open connection was closed
+        by user or broker or exception of another type that describes the cause of connection
+        closure/failure.
 
         :param callback: Callback to call on close, having the signature:
             callback(pika.connection.Connection, exception)
-
         """
         validators.require_callback(callback)
         self.callbacks.add(0, self.ON_CONNECTION_CLOSED, callback, False)
@@ -1229,11 +1246,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def add_on_open_callback(self, callback: Callable[[Connection],
                                                       Any]) -> None:
-        """Add a callback notification when the connection has opened. The
-        callback will be passed the connection instance as its only arg.
+        """
+        Add a callback notification when the connection has opened.
+
+        The callback will be passed the connection instance as its only arg.
 
         :param callback: Callback to call when open
-
         """
         validators.require_callback(callback)
         self.callbacks.add(0, self.ON_CONNECTION_OPEN_OK, callback, False)
@@ -1242,15 +1260,15 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                    callback: Callable[
                                        [Connection, BaseException | None], Any],
                                    remove_default: bool = True) -> None:
-        """Add a callback notification when the connection can not be opened.
+        """
+        Add a callback notification when the connection can not be opened.
 
-        The callback method should accept the connection instance that could not
-        connect, and either a string or an exception as its second arg.
+        The callback method should accept the connection instance that could not connect, and either
+        a string or an exception as its second arg.
 
-        :param callback: Callback to call when can't connect, having
-            the signature _(Connection, Exception)
+        :param callback: Callback to call when can't connect, having the signature _(Connection,
+            Exception)
         :param remove_default: Remove default exception raising callback
-
         """
         validators.require_callback(callback)
         if remove_default:
@@ -1263,17 +1281,15 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             channel_number: int | None = None,
             on_open_callback: None | (Callable[[Channel], Any]) = None
     ) -> Channel:
-        """Create a new channel with the next available channel number or pass
-        in a channel number to use. Must be non-zero if you would like to
-        specify but it is recommended that you let Pika manage the channel
-        numbers.
+        """
+        Create a new channel with the next available channel number or pass in a channel number to
+        use. Must be non-zero if you would like to specify but it is recommended that you let Pika
+        manage the channel numbers.
 
-        :param channel_number: The channel number to use, defaults to the
-                                   next available.
-        :param on_open_callback: The callback when the channel is
-            opened.  The callback will be invoked with the `Channel` instance
-            as its only argument.
-
+        :param channel_number: The channel number to use, defaults to the next available.
+        :param on_open_callback: The callback when the channel is opened. The callback will be
+            invoked with the `Channel` instance as its only argument.
+        :rtype: pika.channel.Channel
         """
         if not self.is_open:
             raise exceptions.ConnectionWrongStateError(
@@ -1322,16 +1338,16 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def close(self,
               reply_code: int = 200,
               reply_text: str = 'Normal shutdown') -> None:
-        """Disconnect from RabbitMQ. If there are any open channels, it will
-        attempt to close them prior to fully disconnecting. Channels which
-        have active consumers will attempt to send a Basic.Cancel to RabbitMQ
-        to cleanly stop the delivery of messages prior to closing the channel.
+        """
+        Disconnect from RabbitMQ.
+
+        If there are any open channels, it will attempt to close them prior to fully disconnecting.
+        Channels which have active consumers will attempt to send a Basic.Cancel to RabbitMQ to
+        cleanly stop the delivery of messages prior to closing the channel.
 
         :param reply_code: The code number for the close
         :param reply_text: The text reason for the close
-
-        :raises pika.exceptions.ConnectionWrongStateError: if connection is
-            closed or closing.
+        :raises pika.exceptions.ConnectionWrongStateError: if connection is closed or closing.
         """
         if self.is_closing or self.is_closed:
             msg = (
@@ -1388,24 +1404,19 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @property
     def is_closed(self) -> bool:
-        """
-        Returns a boolean reporting the current connection state.
-        """
+        """Returns a boolean reporting the current connection state."""
         return self.connection_state == self.CONNECTION_CLOSED
 
     @property
     def is_closing(self) -> bool:
-        """
-        Returns True if connection is in the process of closing due to
-        client-initiated `close` request, but closing is not yet complete.
+        """Returns True if connection is in the process of closing due to client-initiated `close`
+        request, but closing is not yet complete.
         """
         return self.connection_state == self.CONNECTION_CLOSING
 
     @property
     def is_open(self) -> bool:
-        """
-        Returns a boolean reporting the current connection state.
-        """
+        """Returns a boolean reporting the current connection state."""
         return self.connection_state == self.CONNECTION_OPEN
 
     #
@@ -1414,9 +1425,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @property
     def basic_nack(self) -> bool:
-        """Specifies if the server supports basic.nack on the active connection.
+        """
+        Specifies if the server supports basic.nack on the active connection.
 
-
+        :rtype: bool
         """
         if self.server_capabilities is None:
             return False
@@ -1424,10 +1436,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @property
     def consumer_cancel_notify(self) -> bool:
-        """Specifies if the server supports consumer cancel notification on the
-        active connection.
+        """
+        Specifies if the server supports consumer cancel notification on the active connection.
 
-
+        :rtype: bool
         """
         if self.server_capabilities is None:
             return False
@@ -1435,10 +1447,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @property
     def exchange_exchange_bindings(self) -> bool:
-        """Specifies if the active connection supports exchange to exchange
-        bindings.
+        """
+        Specifies if the active connection supports exchange to exchange bindings.
 
-
+        :rtype: bool
         """
         if self.server_capabilities is None:
             return False
@@ -1446,9 +1458,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @property
     def publisher_confirms(self) -> bool:
-        """Specifies if the active connection can use publisher confirmations.
+        """
+        Specifies if the active connection can use publisher confirmations.
 
-
+        :rtype: bool
         """
         if self.server_capabilities is None:
             return False
@@ -1457,39 +1470,38 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     @abc.abstractmethod
     def _adapter_call_later(self, delay: int | float,
                             callback: Callable[[], Any]) -> object:
-        """Adapters should override to call the callback after the
-        specified number of seconds have elapsed, using a timer, or a
-        thread, or similar.
+        """
+        Adapters should override to call the callback after the specified number of seconds have
+        elapsed, using a timer, or a thread, or similar.
 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback will be called without args.
-        :returns: Handle that can be passed to `_adapter_remove_timeout()` to
-            cancel the callback.
-
+        :returns: Handle that can be passed to `_adapter_remove_timeout()` to cancel the callback.
+        :rtype: object
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def _adapter_remove_timeout(self, timeout_id: object) -> None:
-        """Adapters should override: Remove a timeout
+        """
+        Adapters should override: Remove a timeout.
 
         :param timeout_id: The timeout handle to remove
-
         """
         raise NotImplementedError
 
     @abc.abstractmethod
     def _adapter_add_callback_threadsafe(self, callback: Callable[...,
                                                                   Any]) -> None:
-        """Requests a call to the given function as soon as possible in the
-        context of this connection's IOLoop thread.
+        """
+        Requests a call to the given function as soon as possible in the context of this
+        connection's IOLoop thread.
 
         NOTE: This is the only thread-safe method offered by the connection. All
          other manipulations of the connection must be performed from the
          connection's thread.
 
         :param callback: The callback method; must be callable.
-
         """
         raise NotImplementedError
 
@@ -1498,13 +1510,13 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     #
     @abc.abstractmethod
     def _adapter_connect_stream(self) -> None:
-        """Subclasses should override to initiate stream connection
-        workflow asynchronously. Upon failed or aborted completion, they must
-        invoke `Connection._on_stream_terminated()`.
+        """
+        Subclasses should override to initiate stream connection workflow asynchronously.
+
+        Upon failed or aborted completion, they must invoke `Connection._on_stream_terminated()`.
 
         NOTE: On success, the stack will be up already, so there is no
               corresponding callback.
-
         """
         raise NotImplementedError
 
@@ -1520,23 +1532,21 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @abc.abstractmethod
     def _adapter_emit_data(self, data: bytes) -> None:
-        """Take ownership of data and send it to AMQP server as soon as
-        possible.
+        """
+        Take ownership of data and send it to AMQP server as soon as possible.
 
         Subclasses must override this
 
         :param data:
-
         """
         raise NotImplementedError
 
     def _add_channel_callbacks(self, channel_number: int) -> None:
-        """Add the appropriate callbacks for the specified channel number.
+        """
+        Add the appropriate callbacks for the specified channel number.
 
         :param channel_number: The channel number for the callbacks
-
         """
-
         # This permits us to garbage-collect our reference to the channel
         # regardless of whether it was closed by client or broker, and do so
         # after all channel-close callbacks.
@@ -1544,10 +1554,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self._on_channel_cleanup)
 
     def _add_connection_start_callback(self) -> None:
-        """Add a callback for when a Connection.Start frame is received from
-        the broker.
-
-        """
+        """Add a callback for when a Connection.Start frame is received from the broker."""
         self.callbacks.add(0, spec.Connection.Start, self._on_connection_start)
 
     def _add_connection_tune_callback(self) -> None:
@@ -1556,12 +1563,11 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _check_for_protocol_mismatch(
             self, value: frame.Method[spec.Connection.Start]) -> None:
-        """Invoked when starting a connection to make sure it's a supported
-        protocol.
+        """
+        Invoked when starting a connection to make sure it's a supported protocol.
 
         :param value: The frame to check
         :raises ProtocolVersionMismatch:
-
         """
         if ((value.method.version_major, value.method.version_minor)
                 != spec.PROTOCOL_VERSION[0:2]):
@@ -1570,9 +1576,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     @property
     def _client_properties(self) -> dict[str, Any]:
-        """Return the client properties dictionary.
+        """
+        Return the client properties dictionary.
 
-
+        :rtype: dict
         """
         properties = {
             'product': PRODUCT,
@@ -1595,12 +1602,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         return properties
 
     def _close_channels(self, reply_code: int, reply_text: str) -> None:
-        """Initiate graceful closing of channels that are in OPEN or OPENING
-        states, passing reply_code and reply_text.
+        """
+        Initiate graceful closing of channels that are in OPEN or OPENING states, passing reply_code
+        and reply_text.
 
         :param reply_code: The code for why the channels are being closed
         :param reply_text: The text reason for why the channels are closing
-
         """
         assert self.is_open, str(self)
 
@@ -1612,24 +1619,23 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _create_channel(
             self, channel_number: int,
             on_open_callback: Callable[[Channel], Any] | None) -> Channel:
-        """Create a new channel using the specified channel number and calling
-        back the method specified by on_open_callback
+        """
+        Create a new channel using the specified channel number and calling back the method
+        specified by on_open_callback.
 
         :param channel_number: The channel number to use
-        :param on_open_callback: The callback when the channel is
-            opened.  The callback will be invoked with the `Channel` instance
-            as its only argument.
-
+        :param on_open_callback: The callback when the channel is opened. The callback will be
+            invoked with the `Channel` instance as its only argument.
         """
         LOGGER.debug('Creating channel %s', channel_number)
         return pika.channel.Channel(self, channel_number, on_open_callback)
 
     def _create_heartbeat_checker(
             self) -> pika.heartbeat.HeartbeatChecker | None:
-        """Create a heartbeat checker instance if there is a heartbeat interval
-        set.
+        """
+        Create a heartbeat checker instance if there is a heartbeat interval set.
 
-
+        :rtype: pika.heartbeat.Heartbeat|None
         """
         if isinstance(self.params.heartbeat, int) and self.params.heartbeat > 0:
             LOGGER.debug('Creating a HeartbeatChecker: %r',
@@ -1639,18 +1645,16 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         return None
 
     def _remove_heartbeat(self) -> None:
-        """Stop the heartbeat checker if it exists
-
-        """
+        """Stop the heartbeat checker if it exists."""
         if self._heartbeat_checker:
             self._heartbeat_checker.stop()
             self._heartbeat_checker = None
 
     def _deliver_frame_to_channel(self, value: frame.Frame) -> None:
-        """Deliver the frame to the channel specified in the frame.
+        """
+        Deliver the frame to the channel specified in the frame.
 
         :param value: The frame to deliver
-
         """
         if value.channel_number not in self._channels:
             # This should never happen and would constitute breach of the
@@ -1668,9 +1672,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self.close()
 
     def _get_body_frame_max_length(self) -> int:
-        """Calculate the maximum amount of bytes that can be in a body frame.
+        """
+        Calculate the maximum amount of bytes that can be in a body frame.
 
-
+        :rtype: int
         """
         return (self.params.frame_max - spec.FRAME_HEADER_SIZE -
                 spec.FRAME_END_SIZE)
@@ -1678,10 +1683,11 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _get_credentials(
         self, method_frame: frame.Method[spec.Connection.Start]
     ) -> tuple[str, bytes | None]:
-        """Get credentials for authentication.
+        """
+        Get credentials for authentication.
 
         :param method_frame: The Connection.Start frame
-
+        :rtype: tuple(str, bytes|None)
         """
         (auth_type,
          response) = self.params.credentials.response_for(method_frame.method)
@@ -1692,33 +1698,37 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _has_pending_callbacks(
             self, value: frame.Method[amqp_object.Method]) -> int | None:
-        """Return true if there are any callbacks pending for the specified
-        frame.
+        """
+        Return true if there are any callbacks pending for the specified frame.
 
         :param value: The frame to check
-
+        :rtype: int|None
         """
         return self.callbacks.pending(value.channel_number, value.method)
 
     def _is_method_frame(self, value: frame.Frame) -> bool:
-        """Returns true if the frame is a method frame.
+        """
+        Returns true if the frame is a method frame.
 
         :param value: The frame to evaluate
-
+        :rtype: bool
         """
         return isinstance(value, frame.Method)
 
     def _is_protocol_header_frame(self, value: frame.Frame) -> bool:
-        """Returns True if it's a protocol header frame.
+        """
+        Returns True if it's a protocol header frame.
 
         :param value: Frame to inspect
+        :rtype: bool
         """
         return isinstance(value, frame.ProtocolHeader)
 
     def _next_channel_number(self) -> int:
-        """Return the next available channel number or raise an exception.
+        """
+        Return the next available channel number or raise an exception.
 
-
+        :rtype: int
         """
         limit = self.params.channel_max or pika.channel.MAX_CHANNELS
         if len(self._channels) >= limit:
@@ -1730,12 +1740,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         return len(self._channels) + 1
 
     def _on_channel_cleanup(self, channel: Channel) -> None:
-        """Remove the channel from the dict of channels when Channel.CloseOk is
-        sent. If connection is closing and no more channels remain, proceed to
-        `_on_close_ready`.
+        """
+        Remove the channel from the dict of channels when Channel.CloseOk is sent.
+
+        If connection is closing and no more channels remain, proceed to `_on_close_ready`.
 
         :param channel: channel instance
-
         """
         try:
             del self._channels[channel.channel_number]
@@ -1760,10 +1770,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                         'channels: %r', channels_not_in_closing_state)
 
     def _on_close_ready(self) -> None:
-        """Called when the Connection is in a state that it can close after
-        a close has been requested by client. This happens after all of the
-        channels are closed that were open when the close request was made.
+        """
+        Called when the Connection is in a state that it can close after a close has been requested
+        by client.
 
+        This happens after all of the channels are closed that were open when the close request was
+        made.
         """
         if self.is_closed:
             LOGGER.warning('_on_close_ready invoked when already closed')
@@ -1774,9 +1786,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                     self._error.reply_text)
 
     def _on_stream_connected(self) -> None:
-        """Invoked when the socket is connected and it's time to start speaking
-        AMQP with the broker.
-
+        """Invoked when the socket is connected and it's time to start speaking AMQP with the
+        broker.
         """
         self._set_connection_state(self.CONNECTION_PROTOCOL)
 
@@ -1784,9 +1795,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._send_frame(frame.ProtocolHeader())
 
     def _on_blocked_connection_timeout(self) -> None:
-        """ Called when the "connection blocked timeout" expires. When this
-        happens, we tear down the connection
+        """
+        Called when the "connection blocked timeout" expires.
 
+        When this happens, we tear down the connection
         """
         self._blocked_conn_timer = None
         self._terminate_stream(
@@ -1796,11 +1808,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _on_connection_blocked(
             self, _connection: Connection,
             method_frame: frame.Method[spec.Connection.Blocked]) -> None:
-        """Handle Connection.Blocked notification from RabbitMQ broker
+        """
+        Handle Connection.Blocked notification from RabbitMQ broker.
 
         :param _connection: The connection instance (unused)
-        :param method_frame: method frame having `method`
-            member of type `pika.spec.Connection.Blocked`
+        :param method_frame: method frame having `method` member of type
+            `pika.spec.Connection.Blocked`
         """
         LOGGER.warning('Received %s from broker', method_frame)
 
@@ -1819,11 +1832,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _on_connection_unblocked(
             self, _connection: Connection,
             method_frame: frame.Method[spec.Connection.Unblocked]) -> None:
-        """Handle Connection.Unblocked notification from RabbitMQ broker
+        """
+        Handle Connection.Unblocked notification from RabbitMQ broker.
 
         :param _connection: The connection instance (unused)
-        :param method_frame: method frame having `method`
-            member of type `pika.spec.Connection.Blocked`
+        :param method_frame: method frame having `method` member of type
+            `pika.spec.Connection.Blocked`
         """
         LOGGER.info('Received %s from broker', method_frame)
 
@@ -1838,11 +1852,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _on_connection_close_from_broker(
             self, method_frame: frame.Method[spec.Connection.Close]) -> None:
-        """Called when the connection is closed remotely via Connection.Close
-        frame from broker.
+        """
+        Called when the connection is closed remotely via Connection.Close frame from broker.
 
         :param method_frame: The Connection.Close frame
-
         """
         LOGGER.debug('_on_connection_close_from_broker: frame=%s', method_frame)
 
@@ -1855,10 +1868,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _on_connection_close_ok(
             self, method_frame: frame.Method[spec.Connection.CloseOk]) -> None:
-        """Called when Connection.CloseOk is received from remote.
+        """
+        Called when Connection.CloseOk is received from remote.
 
         :param method_frame: The Connection.CloseOk frame
-
         """
         LOGGER.debug('_on_connection_close_ok: frame=%s', method_frame)
 
@@ -1866,8 +1879,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _default_on_connection_error(self, _connection_unused: Connection,
                                      error: Exception) -> None:
-        """Default behavior when the connecting connection cannot connect and
-        user didn't supply own `on_connection_error` callback.
+        """
+        Default behavior when the connecting connection cannot connect and user didn't supply own
+        `on_connection_error` callback.
 
         :param _connection_unused: The connection instance (unused)
         :param error: The exception that caused the failure
@@ -1878,9 +1892,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _on_connection_open_ok(
             self, method_frame: frame.Method[spec.Connection.OpenOk]) -> None:
         """
-        This is called once we have tuned the connection with the server and
-        called the Connection.Open on the server and it has replied with
-        Connection.Ok.
+        This is called once we have tuned the connection with the server and called the
+        Connection.Open on the server and it has replied with Connection.Ok.
+
         :param method_frame: Server response frame
         """
         self._opened = True
@@ -1895,12 +1909,11 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _on_connection_start(
             self, method_frame: frame.Method[spec.Connection.Start]) -> None:
-        """This is called as a callback once we have received a Connection.Start
-        from the server.
+        """
+        This is called as a callback once we have received a Connection.Start from the server.
 
         :param method_frame: The frame received
         :raises UnexpectedFrameError:
-
         """
         self._set_connection_state(self.CONNECTION_START)
 
@@ -1918,13 +1931,15 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     @staticmethod
     def _negotiate_integer_value(client_value: int | None,
                                  server_value: int | None) -> int:
-        """Negotiates two values. If either of them is 0 or None,
-        returns the other one. If both are positive integers, returns the
-        smallest one.
+        """
+        Negotiates two values.
+
+        If either of them is 0 or None, returns the other one. If both are positive integers,
+        returns the smallest one.
 
         :param client_value: The client value
         :param server_value: The server value
-
+        :rtype: int
         """
         if client_value is None:
             client_value = 0
@@ -1943,7 +1958,8 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     @staticmethod
     def _tune_heartbeat_timeout(client_value: int | None,
                                 server_value: int) -> int:
-        """ Determine heartbeat timeout per AMQP 0-9-1 rules
+        """
+        Determine heartbeat timeout per AMQP 0-9-1 rules.
 
         Per https://www.rabbitmq.com/resources/specs/amqp0-9-1.pdf,
 
@@ -1960,6 +1976,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             broker; 0 (zero) to disable heartbeat.
 
         :returns: the value of the heartbeat timeout to use and return to broker
+        :rtype: int
         """
         if client_value is None:
             # Accept server's limit
@@ -1971,13 +1988,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _on_connection_tune(
             self, method_frame: frame.Method[spec.Connection.Tune]) -> None:
-        """Once the Broker sends back a Connection.Tune, we will set our tuning
-        variables that have been returned to us and kick off the Heartbeat
-        monitor if required, send our TuneOk and then the Connection. Open rpc
-        call on channel 0.
+        """
+        Once the Broker sends back a Connection.Tune, we will set our tuning variables that have
+        been returned to us and kick off the Heartbeat monitor if required, send our TuneOk and then
+        the Connection. Open rpc call on channel 0.
 
         :param method_frame: The frame received
-
         """
         self._set_connection_state(self.CONNECTION_TUNE)
 
@@ -2016,11 +2032,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._send_connection_open()
 
     def _on_data_available(self, data_in: bytes) -> None:
-        """This is called by our Adapter, passing in the data from the socket.
+        """
+        This is called by our Adapter, passing in the data from the socket.
+
         As long as we have buffer try and map out frame data.
 
         :param data_in: The data that is available to read
-
         """
         self._frame_buffer += data_in
 
@@ -2032,8 +2049,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self._process_frame(frame_value)
 
     def _terminate_stream(self, error: Exception | None) -> None:
-        """Deactivate heartbeat instance if activated already, and initiate
-        termination of the stream (TCP) connection asynchronously.
+        """
+        Deactivate heartbeat instance if activated already, and initiate termination of the stream
+        (TCP) connection asynchronously.
 
         When connection terminates, the appropriate user callback will be
         invoked with the given error: "on open error" or "on connection closed".
@@ -2041,10 +2059,9 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         :param error: Exception (or None) describing the reason
             for termination; None for normal closing, such as upon receipt of
             Connection.CloseOk.
-
         """
-        assert isinstance(error, (type(None), Exception)), \
-            f'error arg is neither None nor instance of Exception: {error!r}.'
+        assert isinstance(error, (type(None), Exception)), (
+            f'error arg is neither None nor instance of Exception: {error!r}.')
 
         if error is not None:
             # Save the exception for user callback once the stream closes
@@ -2061,16 +2078,15 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._adapter_disconnect_stream()
 
     def _on_stream_terminated(self, error: Exception | None) -> None:
-        """Handle termination of stack (including TCP layer) or failure to
-        establish the stack. Notify registered ON_CONNECTION_ERROR or
-        ON_CONNECTION_CLOSED callbacks, depending on whether the connection
-        was opening or open.
+        """
+        Handle termination of stack (including TCP layer) or failure to establish the stack.
 
-        :param error: Exception (or None). None means that the transport was aborted
-            internally and exception in `self._error` represents the cause.
-            Otherwise it's an exception object that describes the unexpected
-            loss of connection.
+        Notify registered ON_CONNECTION_ERROR or ON_CONNECTION_CLOSED callbacks, depending on
+        whether the connection was opening or open.
 
+        :param error: Exception (or None). None means that the transport was aborted internally and
+            exception in `self._error` represents the cause. Otherwise it's an exception object that
+            describes the unexpected loss of connection.
         """
         LOGGER.info(
             'AMQP stack terminated, failed to connect, or aborted: '
@@ -2150,11 +2166,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._init_connection_state()
 
     def _process_callbacks(self, frame_value: frame.Frame) -> bool:
-        """Process the callbacks for the frame if the frame is a method frame
-        and if it has any callbacks pending.
+        """
+        Process the callbacks for the frame if the frame is a method frame and if it has any
+        callbacks pending.
 
         :param frame_value: The frame to process
-
+        :rtype: bool
         """
         if (self._is_method_frame(frame_value) and
                 self._has_pending_callbacks(cast(frame.Method, frame_value))):
@@ -2168,10 +2185,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _process_frame(
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:
-        """Process an inbound frame from the socket.
+        """
+        Process an inbound frame from the socket.
 
         :param frame_value: The frame to process
-
         """
         # Will receive a frame type of -1 if protocol version mismatch
         if frame_value.frame_type < 0:
@@ -2202,21 +2219,22 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _read_frame(
             self) -> tuple[int, frame.Frame | frame.ProtocolHeader | None]:
-        """Try and read from the frame buffer and decode a frame.
+        """
+        Try and read from the frame buffer and decode a frame.
 
+        :rtype tuple: (int, pika.frame.Frame)
         """
         return frame.decode_frame(self._frame_buffer)
 
     def _remove_callbacks(
             self, channel_number: int,
             method_classes: Sequence[type[amqp_object.Method]]) -> None:
-        """Remove the callbacks for the specified channel number and list of
-        method frames.
+        """
+        Remove the callbacks for the specified channel number and list of method frames.
 
         :param channel_number: The channel number to remove the callback on
-        :param method_classes: The method classes (derived from
-            `pika.amqp_object.Method`) for the callbacks
-
+        :param method_classes: The method classes (derived from `pika.amqp_object.Method`) for the
+            callbacks
         """
         for method_cls in method_classes:
             self.callbacks.remove(str(channel_number), method_cls)
@@ -2228,15 +2246,16 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         callback: Callable[..., Any] | None = None,
         acceptable_replies: None | (Sequence[type[amqp_object.Method]]) = None
     ) -> None:
-        """Make an RPC call for the given callback, channel number and method.
-        acceptable_replies lists out what responses we'll process from the
-        server with the specified callback.
+        """
+        Make an RPC call for the given callback, channel number and method.
+
+        acceptable_replies lists out what responses we'll process from the server with the specified
+        callback.
 
         :param channel_number: The channel number for the RPC call
         :param method: The method frame to call
         :param callback: The callback for the RPC response
         :param acceptable_replies: The replies this RPC call expects
-
         """
         # Validate that acceptable_replies is a list or None
         if acceptable_replies and not isinstance(acceptable_replies, list):
@@ -2253,28 +2272,28 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._send_method(channel_number, method)
 
     def _send_connection_close(self, reply_code: int, reply_text: str) -> None:
-        """Send a Connection.Close method frame.
+        """
+        Send a Connection.Close method frame.
 
         :param reply_code: The reason for the close
         :param reply_text: The text reason for the close
-
         """
         self._rpc(0, spec.Connection.Close(reply_code, reply_text, 0, 0),
                   self._on_connection_close_ok, [spec.Connection.CloseOk])
 
     def _send_connection_open(self) -> None:
-        """Send a Connection.Open frame"""
+        """Send a Connection.Open frame."""
         self._rpc(0, spec.Connection.Open(self.params.virtual_host,
                                           insist=True),
                   self._on_connection_open_ok, [spec.Connection.OpenOk])
 
     def _send_connection_start_ok(self, authentication_type: str,
                                   response: bytes | None) -> None:
-        """Send a Connection.StartOk frame
+        """
+        Send a Connection.StartOk frame.
 
         :param authentication_type: The auth type value
         :param response: The encoded value to send
-
         """
         self._send_method(
             0,
@@ -2283,7 +2302,7 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                     self.params.locale))
 
     def _send_connection_tune_ok(self) -> None:
-        """Send a Connection.TuneOk frame"""
+        """Send a Connection.TuneOk frame."""
         self._send_method(
             0,
             spec.Connection.TuneOk(self.params.channel_max,
@@ -2292,12 +2311,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _send_frame(
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:
-        """This appends the fully generated frame to send to the broker to the
-        output buffer which will be then sent via the connection adapter.
+        """
+        This appends the fully generated frame to send to the broker to the output buffer which will
+        be then sent via the connection adapter.
 
         :param frame_value: The frame to write
         :raises exceptions.ConnectionClosed:
-
         """
         if self.is_closed:
             LOGGER.error('Attempted to send frame when closed')
@@ -2313,13 +2332,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             method: amqp_object.Method,
             content: None | (tuple[spec.BasicProperties, bytes]) = None
     ) -> None:
-        """Constructs a RPC method frame and then sends it to the broker.
+        """
+        Constructs a RPC method frame and then sends it to the broker.
 
         :param channel_number: The channel number for the frame
         :param method: The method to send
-        :param content: If set, is a content frame, is tuple of
-                              properties and body.
-
+        :param content: If set, is a content frame, is tuple of properties and body.
         """
         if content:
             self._send_message(channel_number, method, content)
@@ -2329,13 +2347,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _send_message(self, channel_number: int,
                       method_frame: amqp_object.Method,
                       content: tuple[spec.BasicProperties, bytes]) -> None:
-        """Publish a message.
+        """
+        Publish a message.
 
         :param channel_number: The channel number for the frame
         :param method_frame: The method frame to send
-        :param content: A content frame, which is tuple of properties and
-                              body.
-
+        :param content: A content frame, which is tuple of properties and body.
         """
         length = len(content[1])
         marshaled_body_frames = []
@@ -2360,10 +2377,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         self._output_marshaled_frames(marshaled_body_frames)
 
     def _set_connection_state(self, connection_state: int) -> None:
-        """Set the connection state.
+        """
+        Set the connection state.
 
         :param connection_state: The connection state to set
-
         """
         LOGGER.debug('New Connection state: %s (prev=%s)',
                      self._STATE_NAMES[connection_state],
@@ -2373,10 +2390,10 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
     def _set_server_information(
             self, method_frame: frame.Method[spec.Connection.Start]) -> None:
-        """Set the server properties and capabilities
+        """
+        Set the server properties and capabilities.
 
         :param method_frame: The Connection.Start frame
-
         """
         self.server_properties = method_frame.method.server_properties  # pyright: ignore[reportAttributeAccessIssue]
         self.server_capabilities = self.server_properties.get(  # pyright: ignore[reportOptionalMemberAccess]
@@ -2386,22 +2403,21 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                 'capabilities']  # pyright: ignore[reportOptionalSubscript]
 
     def _trim_frame_buffer(self, byte_count: int) -> None:
-        """Trim the leading N bytes off the frame buffer and increment the
-        counter that keeps track of how many bytes have been read/used from the
-        socket.
+        """
+        Trim the leading N bytes off the frame buffer and increment the counter that keeps track of
+        how many bytes have been read/used from the socket.
 
         :param byte_count: The number of bytes consumed
-
         """
         self._frame_buffer = self._frame_buffer[byte_count:]
         self.bytes_received += byte_count
 
     def _output_marshaled_frames(self,
                                  marshaled_frames: Sequence[bytes]) -> None:
-        """Output list of marshaled frames to buffer and update stats
+        """
+        Output list of marshaled frames to buffer and update stats.
 
         :param marshaled_frames: A list of frames marshaled to bytes
-
         """
         for marshaled_frame in marshaled_frames:
             self.bytes_sent += len(marshaled_frame)

--- a/pika/credentials.py
+++ b/pika/credentials.py
@@ -1,21 +1,21 @@
-"""The credentials classes are used to encapsulate all authentication
-information for the :class:`~pika.connection.ConnectionParameters` class.
-
-The :class:`~pika.credentials.PlainCredentials` class returns the properly
-formatted username and password to the :class:`~pika.connection.Connection`.
-
-To authenticate with Pika, create a :class:`~pika.credentials.PlainCredentials`
-object passing in the username and password and pass it as the credentials
-argument value to the :class:`~pika.connection.ConnectionParameters` object.
-
-If you are using :class:`~pika.connection.URLParameters` you do not need a
-credentials object, one will automatically be created for you.
-
-If you are looking to implement SSL certificate style authentication, you would
-extend the :class:`~pika.credentials.ExternalCredentials` class implementing
-the required behavior.
-
 """
+The credentials classes are used to encapsulate all authentication information for the
+:class:`~pika.connection.ConnectionParameters` class.
+
+The :class:`~pika.credentials.PlainCredentials` class returns the properly formatted username and
+password to the :class:`~pika.connection.Connection`.
+
+To authenticate with Pika, create a :class:`~pika.credentials.PlainCredentials` object passing in
+the username and password and pass it as the credentials argument value to the
+:class:`~pika.connection.ConnectionParameters` object.
+
+If you are using :class:`~pika.connection.URLParameters` you do not need a credentials object, one
+will automatically be created for you.
+
+If you are looking to implement SSL certificate style authentication, you would extend the
+:class:`~pika.credentials.ExternalCredentials` class implementing the required behavior.
+"""
+
 from __future__ import annotations
 
 import logging
@@ -30,32 +30,32 @@ LOGGER = logging.getLogger(__name__)
 
 
 class PlainCredentials:
-    """A credentials object for the default authentication methodology with
-    RabbitMQ.
+    """
+    A credentials object for the default authentication methodology with RabbitMQ.
 
-    If you do not pass in credentials to the ConnectionParameters object, it
-    will create credentials for 'guest' with the password of 'guest'.
+    If you do not pass in credentials to the ConnectionParameters object, it will create credentials
+    for 'guest' with the password of 'guest'.
 
-    If you pass True to erase_on_connect the credentials will not be stored
-    in memory after the Connection attempt has been made.
+    If you pass True to erase_on_connect the credentials will not be stored in memory after the
+    Connection attempt has been made.
 
     :param username: The username to authenticate with
     :param password: The password to authenticate with
     :param erase_on_connect: erase credentials on connect.
-
     """
+
     TYPE = 'PLAIN'
 
     def __init__(self,
                  username: str,
                  password: str,
                  erase_on_connect: bool = False) -> None:
-        """Create a new instance of PlainCredentials
+        """
+        Create a new instance of PlainCredentials.
 
         :param username: The username to authenticate with
         :param password: The password to authenticate with
         :param erase_on_connect: erase credentials on connect.
-
         """
         self.username: str | None = username
         self.password: str | None = password
@@ -76,19 +76,20 @@ class PlainCredentials:
 
     def response_for(
             self, start: Connection.Start) -> tuple[str | None, bytes | None]:
-        """Validate that this type of authentication is supported
+        """
+        Validate that this type of authentication is supported.
 
         :param start: Connection.Start method
-
+        :rtype: tuple(str|None, bytes|None)
         """
-        if as_bytes(PlainCredentials.TYPE) not in\
-                as_bytes(start.mechanisms).split():
+        if as_bytes(PlainCredentials.TYPE) not in as_bytes(
+                start.mechanisms).split():
             return None, None
         return (PlainCredentials.TYPE, b'\0' + as_bytes(self.username or '') +
                 b'\0' + as_bytes(self.password or ''))
 
     def erase_credentials(self) -> None:
-        """Called by Connection when it no longer needs the credentials"""
+        """Called by Connection when it no longer needs the credentials."""
         if self.erase_on_connect:
             LOGGER.info("Erasing stored credential values")
             self.username = None
@@ -96,14 +97,14 @@ class PlainCredentials:
 
 
 class ExternalCredentials:
-    """The ExternalCredentials class allows the connection to use EXTERNAL
-    authentication, generally with a client SSL certificate.
-
+    """The ExternalCredentials class allows the connection to use EXTERNAL authentication, generally
+    with a client SSL certificate.
     """
+
     TYPE = 'EXTERNAL'
 
     def __init__(self) -> None:
-        """Create a new instance of ExternalCredentials"""
+        """Create a new instance of ExternalCredentials."""
         self.erase_on_connect = False
 
     def __eq__(self, other) -> bool:
@@ -119,18 +120,19 @@ class ExternalCredentials:
 
     def response_for(
             self, start: Connection.Start) -> tuple[str | None, bytes | None]:
-        """Validate that this type of authentication is supported
+        """
+        Validate that this type of authentication is supported.
 
         :param start: Connection.Start method
-
+        :rtype: tuple(str|None, bytes|None)
         """
-        if as_bytes(ExternalCredentials.TYPE) not in\
-                as_bytes(start.mechanisms).split():
+        if as_bytes(ExternalCredentials.TYPE) not in as_bytes(
+                start.mechanisms).split():
             return None, None
         return ExternalCredentials.TYPE, b''
 
     def erase_credentials(self) -> None:
-        """Called by Connection when it no longer needs the credentials"""
+        """Called by Connection when it no longer needs the credentials."""
         LOGGER.debug('Not supported by this Credentials type')
 
 

--- a/pika/data.py
+++ b/pika/data.py
@@ -1,4 +1,5 @@
-"""AMQP Table Encoding/Decoding"""
+"""AMQP Table Encoding/Decoding."""
+
 from __future__ import annotations
 
 import calendar
@@ -12,12 +13,13 @@ from pika._utils import as_bytes
 
 
 def encode_short_string(pieces: list[bytes], value: str) -> int:
-    """Encode a string value as short string and append it to pieces list
-    returning the size of the encoded value.
+    """
+    Encode a string value as short string and append it to pieces list returning the size of the
+    encoded value.
 
     :param pieces: Already encoded values
     :param value: String value to encode
-
+    :rtype: int
     """
     encoded_value = as_bytes(value)
     length = len(encoded_value)
@@ -42,11 +44,13 @@ def encode_short_string(pieces: list[bytes], value: str) -> int:
 
 
 def decode_short_string(encoded: bytes, offset: int) -> tuple[str | bytes, int]:
-    """Decode a short string value from ``encoded`` data at ``offset``.
+    """
+    Decode a short string value from ``encoded`` data at ``offset``.
 
     :param encoded: encoded data
     :param offset: starting offset in the encoded data
     :returns: tuple of (decoded value, new offset)
+    :rtype: tuple[Union[str, bytes], int]
     """
     length = struct.unpack_from('B', encoded, offset)[0]
     offset += 1
@@ -60,12 +64,12 @@ def decode_short_string(encoded: bytes, offset: int) -> tuple[str | bytes, int]:
 
 
 def encode_table(pieces: list[bytes], table: dict[str, Any] | None) -> int:
-    """Encode a dict as an AMQP table appending the encded table to the
-    pieces list passed in.
+    """
+    Encode a dict as an AMQP table appending the encded table to the pieces list passed in.
 
     :param pieces: Already encoded frame pieces
     :param table: The dict to encode
-
+    :rtype: int
     """
     table = table or {}
     length_index = len(pieces)
@@ -81,14 +85,14 @@ def encode_table(pieces: list[bytes], table: dict[str, Any] | None) -> int:
 
 
 def encode_value(pieces: list[bytes], value: Any) -> int:
-    """Encode the value passed in and append it to the pieces list returning
-    the the size of the encoded value.
+    """
+    Encode the value passed in and append it to the pieces list returning the the size of the
+    encoded value.
 
     :param pieces: Already encoded values
     :param value: The value to encode
-
+    :rtype: int
     """
-
     if isinstance(value, str):
         value = as_bytes(value)
         pieces.append(struct.pack('>cI', b'S', len(value)))
@@ -143,12 +147,13 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
 
 def decode_table(encoded: bytes,
                  offset: int) -> tuple[dict[str | bytes, Any], int]:
-    """Decode the AMQP table passed in from the encoded value returning the
-    decoded result and the number of bytes read plus the offset.
+    """
+    Decode the AMQP table passed in from the encoded value returning the decoded result and the
+    number of bytes read plus the offset.
 
     :param encoded: The binary encoded data to decode
     :param offset: The starting byte offset
-
+    :rtype: tuple
     """
     result = {}
     tablesize = struct.unpack_from('>I', encoded, offset)[0]
@@ -162,13 +167,14 @@ def decode_table(encoded: bytes,
 
 
 def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
-    """Decode the value passed in returning the decoded value and the number
-    of bytes read in addition to the starting offset.
+    """
+    Decode the value passed in returning the decoded value and the number of bytes read in addition
+    to the starting offset.
 
     :param encoded: The binary encoded data to decode
     :param offset: The starting byte offset
+    :rtype: tuple
     :raises: pika.exceptions.InvalidFieldTypeException
-
     """
     # Slice to get bytes
     kind = encoded[offset:offset + 1]

--- a/pika/delivery_mode.py
+++ b/pika/delivery_mode.py
@@ -2,7 +2,8 @@ from enum import IntEnum
 
 
 class DeliveryMode(IntEnum):
-    """Enum for specifying the message delivery mode.
+    """
+    Enum for specifying the message delivery mode.
 
     Inherits from :class:`enum.IntEnum` so members are usable wherever an
     integer is expected, including the wire encoder for

--- a/pika/diagnostic_utils.py
+++ b/pika/diagnostic_utils.py
@@ -1,6 +1,4 @@
-"""
-Diagnostic utilities
-"""
+"""Diagnostic utilities."""
 
 from __future__ import annotations
 
@@ -38,7 +36,8 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
     """
 
     def log_exception(func: F) -> F:
-        """The decorator returned by the parent function
+        """
+        The decorator returned by the parent function.
 
         :param func: function to be wrapped
         :returns: the function wrapper
@@ -46,10 +45,11 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
 
         @functools.wraps(func)
         def log_exception_func_wrap(*args: Any, **kwargs: Any) -> Any:
-            """The wrapper function returned by the decorator. Invokes the
-            function with the given args/kwargs and returns the function's
-            return value. If the function exits with an exception, logs the
-            exception traceback and re-raises the
+            """
+            The wrapper function returned by the decorator.
+
+            Invokes the function with the given args/kwargs and returns the function's return value.
+            If the function exits with an exception, logs the exception traceback and re-raises the
 
             :param args: positional args passed to wrapped function
             :param kwargs: keyword args passed to wrapped function

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -1,4 +1,4 @@
-"""Pika specific exceptions"""
+"""Pika specific exceptions."""
 
 from __future__ import annotations
 
@@ -98,16 +98,12 @@ class ConnectionClosed(AMQPConnectionError):
 
     @property
     def reply_code(self) -> int:
-        """ NEW in v1.0.0
-
-        """
+        """NEW in v1.0.0 :rtype: int."""
         return self.args[0]
 
     @property
     def reply_text(self) -> str:
-        """ NEW in v1.0.0
-
-        """
+        """NEW in v1.0.0 :rtype: str."""
         return self.args[1]
 
 
@@ -138,9 +134,7 @@ class ChannelWrongStateError(AMQPChannelError):
 
 
 class ChannelClosed(AMQPChannelError):
-    """The channel closed by client or by broker
-
-    """
+    """The channel closed by client or by broker."""
 
     def __init__(self, reply_code: int, reply_text: str) -> None:
         """
@@ -161,32 +155,28 @@ class ChannelClosed(AMQPChannelError):
 
     @property
     def reply_code(self) -> int:
-        """ NEW in v1.0.0
-
-        """
+        """NEW in v1.0.0 :rtype: int."""
         return self.args[0]
 
     @property
     def reply_text(self) -> str:
-        """ NEW in v1.0.0
-
-        """
+        """NEW in v1.0.0 :rtype: str."""
         return self.args[1]
 
 
 class ChannelClosedByBroker(ChannelClosed):
-    """`Channel.Close` from broker; may be passed as reason to channel's
-    on-closed callback of non-blocking connection adapters or raised by
-    `BlockingConnection`.
+    """
+    `Channel.Close` from broker; may be passed as reason to channel's on-closed callback of non-
+    blocking connection adapters or raised by `BlockingConnection`.
 
     NEW in v1.0.0
     """
 
 
 class ChannelClosedByClient(ChannelClosed):
-    """Channel closed by client upon receipt of `Channel.CloseOk`; may be passed
-    as reason to channel's on-closed callback of non-blocking connection
-    adapters, but not raised by `BlockingConnection`.
+    """
+    Channel closed by client upon receipt of `Channel.CloseOk`; may be passed as reason to channel's
+    on-closed callback of non-blocking connection adapters, but not raised by `BlockingConnection`.
 
     NEW in v1.0.0
     """
@@ -207,14 +197,13 @@ class ConsumerCancelled(AMQPChannelError):
 
 
 class UnroutableError(AMQPChannelError):
-    """Exception containing one or more unroutable messages returned by broker
-    via Basic.Return.
+    """
+    Exception containing one or more unroutable messages returned by broker via Basic.Return.
 
     Used by BlockingChannel.
 
-    In publisher-acknowledgements mode, this is raised upon receipt of Basic.Ack
-    from broker; in the event of Basic.Nack from broker, `NackError` is raised
-    instead
+    In publisher-acknowledgements mode, this is raised upon receipt of Basic.Ack from broker; in the
+    event of Basic.Nack from broker, `NackError` is raised instead
     """
 
     def __init__(self, messages: Sequence[ReturnedMessage]) -> None:
@@ -230,8 +219,9 @@ class UnroutableError(AMQPChannelError):
 
 
 class NackError(AMQPChannelError):
-    """This exception is raised when a message published in
-    publisher-acknowledgements mode is Nack'ed by the broker.
+    """
+    This exception is raised when a message published in publisher-acknowledgements mode is Nack'ed
+    by the broker.
 
     Used by BlockingChannel.
     """
@@ -309,11 +299,10 @@ class ChannelError(Exception):
 
 
 class ReentrancyError(Exception):
-    """The requested operation would result in unsupported recursion or
-    reentrancy.
+    """
+    The requested operation would result in unsupported recursion or reentrancy.
 
     Used by BlockingConnection/BlockingChannel
-
     """
 
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -1,4 +1,5 @@
 """Frame objects that do the frame demarshaling and marshaling."""
+
 from __future__ import annotations
 
 import logging
@@ -13,63 +14,71 @@ _MethodT = TypeVar('_MethodT', bound=amqp_object.Method)
 
 
 class Frame(amqp_object.AMQPObject):
-    """Base Frame object mapping. Defines a behavior for all child classes for
-    assignment of core attributes and implementation of the a core _marshal
-    method which child classes use to create the binary AMQP frame.
-
     """
+    Base Frame object mapping.
+
+    Defines a behavior for all child classes for assignment of core attributes and implementation of
+    the a core _marshal method which child classes use to create the binary AMQP frame.
+    """
+
     NAME = 'Frame'
 
     def __init__(self, frame_type: int, channel_number: int) -> None:
-        """Create a new instance of a frame
+        """
+        Create a new instance of a frame.
 
         :param frame_type: The frame type
         :param channel_number: The channel number for the frame
-
         """
         self.frame_type = frame_type
         self.channel_number = channel_number
 
     def _marshal(self, pieces: list[bytes]) -> bytes:
-        """Create the full AMQP wire protocol frame data representation
+        """
+        Create the full AMQP wire protocol frame data representation.
 
         :param pieces: Encoded AMQP frame fragments to assemble
-
+        :rtype: bytes
         """
         payload = b''.join(pieces)
         return struct.pack('>BHI', self.frame_type, self.channel_number,
                            len(payload)) + payload + bytes((spec.FRAME_END,))
 
     def marshal(self) -> bytes:
-        """To be ended by child classes
+        """
+        To be ended by child classes.
 
         :raises NotImplementedError
-
+        :rtype: bytes
         """
         raise NotImplementedError
 
 
 class Method(Frame, Generic[_MethodT]):
-    """Base Method frame object mapping. AMQP method frames are mapped on top
-    of this class for creating or accessing their data and attributes.
-
     """
+    Base Method frame object mapping.
+
+    AMQP method frames are mapped on top of this class for creating or accessing their data and
+    attributes.
+    """
+
     NAME = 'METHOD'
 
     def __init__(self, channel_number: int, method: _MethodT) -> None:
-        """Create a new instance of a frame
+        """
+        Create a new instance of a frame.
 
         :param channel_number: The channel number for the frame
         :param method: The AMQP Class.Method
-
         """
         Frame.__init__(self, spec.FRAME_METHOD, channel_number)
         self.method = method
 
     def marshal(self) -> bytes:
-        """Return the AMQP binary encoded value of the frame
+        """
+        Return the AMQP binary encoded value of the frame.
 
-
+        :rtype: bytes
         """
         pieces = self.method.encode()
         pieces.insert(0, struct.pack('>I', self.method.INDEX))
@@ -77,29 +86,33 @@ class Method(Frame, Generic[_MethodT]):
 
 
 class Header(Frame):
-    """Header frame object mapping. AMQP content header frames are mapped
-    on top of this class for creating or accessing their data and attributes.
-
     """
+    Header frame object mapping.
+
+    AMQP content header frames are mapped on top of this class for creating or accessing their data
+    and attributes.
+    """
+
     NAME = 'Header'
 
     def __init__(self, channel_number: int, body_size: int,
                  props: spec.BasicProperties) -> None:
-        """Create a new instance of a AMQP ContentHeader object
+        """
+        Create a new instance of a AMQP ContentHeader object.
 
         :param channel_number: The channel number for the frame
         :param body_size: The number of bytes for the body
         :param props: Basic.Properties object
-
         """
         Frame.__init__(self, spec.FRAME_HEADER, channel_number)
         self.body_size = body_size
         self.properties = props
 
     def marshal(self) -> bytes:
-        """Return the AMQP binary encoded value of the frame
+        """
+        Return the AMQP binary encoded value of the frame.
 
-
+        :rtype: bytes
         """
         pieces = self.properties.encode()
         pieces.insert(
@@ -108,10 +121,13 @@ class Header(Frame):
 
 
 class Body(Frame):
-    """Body frame object mapping class. AMQP content body frames are mapped on
-    to this base class for getting/setting of attributes/data.
-
     """
+    Body frame object mapping class.
+
+    AMQP content body frames are mapped on to this base class for getting/setting of
+    attributes/data.
+    """
+
     NAME = 'Body'
 
     def __init__(self, channel_number: int, fragment: bytes) -> None:
@@ -123,51 +139,54 @@ class Body(Frame):
         self.fragment = fragment
 
     def marshal(self) -> bytes:
-        """Return the AMQP binary encoded value of the frame
+        """
+        Return the AMQP binary encoded value of the frame.
 
-
+        :rtype: bytes
         """
         return self._marshal([self.fragment])
 
 
 class Heartbeat(Frame):
-    """Heartbeat frame object mapping class. AMQP Heartbeat frames are mapped
-    on to this class for a common access structure to the attributes/data
-    values.
-
     """
+    Heartbeat frame object mapping class.
+
+    AMQP Heartbeat frames are mapped on to this class for a common access structure to the
+    attributes/data values.
+    """
+
     NAME = 'Heartbeat'
 
     def __init__(self) -> None:
-        """Create a new instance of the Heartbeat frame"""
+        """Create a new instance of the Heartbeat frame."""
         Frame.__init__(self, spec.FRAME_HEARTBEAT, 0)
 
     def marshal(self) -> bytes:
-        """Return the AMQP binary encoded value of the frame
+        """
+        Return the AMQP binary encoded value of the frame.
 
-
+        :rtype: bytes
         """
         return self._marshal([])
 
 
 class ProtocolHeader(amqp_object.AMQPObject):
-    """AMQP Protocol header frame class which provides a pythonic interface
-    for creating AMQP Protocol headers
-
+    """AMQP Protocol header frame class which provides a pythonic interface for creating AMQP
+    Protocol headers.
     """
+
     NAME = 'ProtocolHeader'
 
     def __init__(self,
                  major: int | None = None,
                  minor: int | None = None,
                  revision: int | None = None) -> None:
-        """Construct a Protocol Header frame object for the specified AMQP
-        version
+        """
+        Construct a Protocol Header frame object for the specified AMQP version.
 
         :param major: Major version number
         :param minor: Minor version number
         :param revision: Revision
-
         """
         self.frame_type = -1
         self.major = major or spec.PROTOCOL_VERSION[0]
@@ -175,22 +194,24 @@ class ProtocolHeader(amqp_object.AMQPObject):
         self.revision = revision or spec.PROTOCOL_VERSION[2]
 
     def marshal(self) -> bytes:
-        """Return the full AMQP wire protocol frame data representation of the
-        ProtocolHeader frame
+        """
+        Return the full AMQP wire protocol frame data representation of the ProtocolHeader frame.
 
-
+        :rtype: bytes
         """
         return b'AMQP' + struct.pack('BBBB', 0, self.major, self.minor,
                                      self.revision)
 
 
 def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
-    """Receives raw socket data and attempts to turn it into a frame.
+    """
+    Receives raw socket data and attempts to turn it into a frame.
+
     Returns the number of bytes consumed from the stream and the frame.
 
     :param data_in: The raw data stream
+    :rtype: tuple(int, Frame|ProtocolHeader)
     :raises: pika.exceptions.InvalidFrameError
-
     """
     # Look to see if it's a protocol header frame
     try:

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -1,4 +1,5 @@
-"""Handle AMQP Heartbeats"""
+"""Handle AMQP Heartbeats."""
+
 import logging
 
 import pika.exceptions
@@ -8,31 +9,31 @@ LOGGER = logging.getLogger(__name__)
 
 
 class HeartbeatChecker:
-    """Sends heartbeats to the broker. The provided timeout is used to
-    determine if the connection is stale - no received heartbeats or
+    """
+    Sends heartbeats to the broker.
+
+    The provided timeout is used to determine if the connection is stale - no received heartbeats or
     other activity will close the connection. See the parameter list for more
     details.
-
     """
+
     _STALE_CONNECTION = "No activity or too many missed heartbeats in the last %i seconds"
 
     def __init__(self, connection, timeout) -> None:
-        """Create an object that will check for activity on the provided
-        connection as well as receive heartbeat frames from the broker. The
-        timeout parameter defines a window within which this activity must
-        happen. If not, the connection is considered dead and closed.
+        """
+        Create an object that will check for activity on the provided connection as well as receive
+        heartbeat frames from the broker. The timeout parameter defines a window within which this
+        activity must happen. If not, the connection is considered dead and closed.
 
-        The value must be >= 1. The value passed for timeout is also used to
-        calculate an interval at which a heartbeat frame is sent to the broker.
-        The interval is equal to the timeout value divided by two.
+        The value must be >= 1. The value passed for timeout is also used to calculate an interval
+        at which a heartbeat frame is sent to the broker. The interval is equal to the timeout value
+        divided by two.
 
         :param connection: Connection object
-        :param timeout: Connection idle timeout. If no activity occurs on the
-                            connection nor heartbeat frames received during the
-                            timeout window the connection will be closed. The
-                            interval used to send heartbeats is calculated from
-                            this value by dividing it by two.
-
+        :param timeout: Connection idle timeout. If no activity occurs on the connection nor
+            heartbeat frames received during the timeout window the connection will be closed. The
+            interval used to send heartbeats is calculated from this value by dividing it by two.
+        :rtype: None
         """
         if timeout < 1:
             raise ValueError(f'timeout must >= 1, but got {timeout!r}')
@@ -82,39 +83,40 @@ class HeartbeatChecker:
 
     @property
     def bytes_received_on_connection(self) -> int:
-        """Return the number of bytes received by the connection bytes object.
+        """
+        Return the number of bytes received by the connection bytes object.
 
-
+        :rtype: int
         """
         return self._connection.bytes_received
 
     @property
     def connection_is_idle(self) -> bool:
-        """Returns true if the byte count hasn't changed in enough intervals
-        to trip the max idle threshold.
+        """
+        Returns true if the byte count hasn't changed in enough intervals to trip the max idle
+        threshold.
 
-
+        :rtype: bool
         """
         return self._idle_byte_intervals > 0
 
     def received(self) -> None:
-        """Called when a heartbeat is received"""
+        """Called when a heartbeat is received."""
         LOGGER.debug('Received heartbeat frame')
         self._heartbeat_frames_received += 1
 
     def _send_heartbeat(self) -> None:
-        """Invoked by a timer to send a heartbeat when we need to.
-
-        """
+        """Invoked by a timer to send a heartbeat when we need to."""
         LOGGER.debug('Sending heartbeat frame')
         self._send_heartbeat_frame()
         self._start_send_timer()
 
     def _check_heartbeat(self) -> None:
-        """Invoked by a timer to check for broker heartbeats. Checks to see
-        if we've missed any heartbeats and disconnect our connection if it's
-        been idle too long.
+        """
+        Invoked by a timer to check for broker heartbeats.
 
+        Checks to see if we've missed any heartbeats and disconnect our connection if it's been idle
+        too long.
         """
         if self._has_received_data:
             self._idle_byte_intervals = 0
@@ -134,7 +136,7 @@ class HeartbeatChecker:
         self._start_check_timer()
 
     def stop(self) -> None:
-        """Stop the heartbeat checker"""
+        """Stop the heartbeat checker."""
         if self._send_timer:
             LOGGER.debug('Removing timer for next heartbeat send interval')
             self._connection._adapter_remove_timeout(self._send_timer)
@@ -158,24 +160,24 @@ class HeartbeatChecker:
 
     @property
     def _has_received_data(self) -> bool:
-        """Returns True if the connection has received data.
+        """
+        Returns True if the connection has received data.
 
-
+        :rtype: bool
         """
         return self._bytes_received != self.bytes_received_on_connection
 
     @staticmethod
     def _new_heartbeat_frame() -> frame.Heartbeat:
-        """Return a new heartbeat frame.
+        """
+        Return a new heartbeat frame.
 
-
+        :rtype: pika.frame.Heartbeat
         """
         return frame.Heartbeat()
 
     def _send_heartbeat_frame(self) -> None:
-        """Send a heartbeat frame on the connection.
-
-        """
+        """Send a heartbeat frame on the connection."""
         LOGGER.debug('Sending heartbeat frame')
         self._connection._send_frame(self._new_heartbeat_frame())
         self._heartbeat_frames_sent += 1
@@ -197,9 +199,8 @@ class HeartbeatChecker:
             self._check_interval, self._check_heartbeat)
 
     def _update_counters(self) -> None:
-        """Update the internal counters for bytes sent and received and the
-        number of frames received
-
+        """Update the internal counters for bytes sent and received and the number of frames
+        received.
         """
         self._bytes_sent = self._connection.bytes_sent
         self._bytes_received = self._connection.bytes_received

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -1,12 +1,11 @@
-"""
-Common validation functions
-"""
+"""Common validation functions."""
+
 from typing import Any, Callable, Optional
 
 
 def require_string(value: Any, value_name: str) -> None:
-    """Require that value is a string
-
+    """
+    Require that value is a string.
 
     :param value: The value to validate
     :param value_name: Human-readable name of the value, used in error messages
@@ -18,8 +17,8 @@ def require_string(value: Any, value_name: str) -> None:
 
 def require_callback(callback: Callable[..., Any],
                      callback_name: str = 'callback') -> None:
-    """Require that callback is callable and is not None
-
+    """
+    Require that callback is callable and is not None.
 
     :param callback: The callback to validate
     :param callback_name: Human-readable name of the callback, used in error messages
@@ -31,12 +30,12 @@ def require_callback(callback: Callable[..., Any],
 
 
 def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
-    """Verify callback is callable if not None
+    """
+    Verify callback is callable if not None.
 
     :param callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     :returns: boolean indicating nowait
     :raises: TypeError
-
     """
     if callback is None:
         # No callback means we will not expect a response
@@ -50,8 +49,10 @@ def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
 
 
 def zero_or_greater(name: str, value: int) -> None:
-    """Verify that value is zero or greater. If not, 'name'
-    will be used in error message
+    """
+    Verify that value is zero or greater.
+
+    If not, 'name' will be used in error message
 
     :param name: value name to use in error message
     :param value: value to check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,10 +102,18 @@ packages = ["pika", "pika.adapters", "pika.adapters.utils"]
 [tool.setuptools.package-data]
 "*" = ["LICENSE", "README.md"]
 
+[tool.docformatter]
+wrap-summaries = 100
+wrap-descriptions = 100
+pre-summary-newline = true
+close-quotes-on-newline = true
+force-one-line-summary = false
+
 [tool.hatch.envs.default]
 dependencies = [
     "coverage",
     "codecov",
+    "docformatter",
     "gevent",
     "pytest>=7.0.0",
     "pytest-cov",
@@ -123,6 +131,8 @@ fmt = "yapf --in-place --style google --recursive --exclude 'pika/spec.py' pika/
 fmt-check = "yapf --diff --style google --recursive --exclude 'pika/spec.py' pika/ tests/ examples/ utils/"
 lint = "ruff check pika/ tests/ examples/ utils/ --fix"
 lint-check = "ruff check pika/ tests/ examples/ utils/"
+docfmt = "docformatter --in-place --recursive pika/ tests/ examples/ utils/ --exclude pika/spec.py"
+docfmt-check = "docformatter --check --diff --recursive pika/ tests/ examples/ utils/ --exclude pika/spec.py"
 typecheck = "python -m mypy"
 unit = "pytest -n auto --dist=loadscope tests/unit/ {args}"
 test = "pytest -n auto --dist=loadscope {args}"

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -202,7 +202,7 @@ class TestCreateConnectionViaCustomConnectionWorkflow(AsyncTestCase,
                                      'AMQPConnectionWorkflow.')
 
             def _report_completion_and_cleanup(self, result):
-                """Override implementation to tag the presumed connection"""
+                """Override implementation to tag the presumed connection."""
                 result.i_was_here = MyWorkflow
                 super()._report_completion_and_cleanup(result)
 
@@ -911,7 +911,7 @@ class TestBlockedConnectionTimesOut(AsyncTestCase, AsyncAdapters):
                 spec.Connection.Blocked('Testing blocked connection timeout')))
 
     def on_closed(self, connection, error):
-        """called when the connection has finished closing"""
+        """Called when the connection has finished closing."""
         self.on_closed_error = error
         self.stop()  # acknowledge that closed connection is expected
         super().on_closed(connection, error)
@@ -951,7 +951,7 @@ class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):
         self.stop()
 
     def on_closed(self, connection, error):
-        """called when the connection has finished closing"""
+        """Called when the connection has finished closing."""
         self.on_closed_error = error
         super().on_closed(connection, error)
 
@@ -1047,8 +1047,8 @@ class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Test ioloop.stop() before ioloop starts causes ioloop to exit quickly."
 
     def _run_ioloop(self, *args, **kwargs):
-        """We intercept this method from AsyncTestCase in order to call
-        ioloop.stop() before AsyncTestCase starts the ioloop.
+        """We intercept this method from AsyncTestCase in order to call ioloop.stop() before
+        AsyncTestCase starts the ioloop.
         """
         # Request ioloop to stop before it starts
         my_start_time = time_now()

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1,4 +1,5 @@
-"""blocking adapter test"""
+"""Blocking adapter test."""
+
 import functools
 import logging
 import socket
@@ -57,8 +58,9 @@ class BlockingTestCaseBase(unittest.TestCase):
         return connection
 
     def _instrument_io_loop_exception_leak_detection(self, connection):
-        """Instrument the given connection to detect and fail test when
-        an exception is leaked through the I/O loop
+        """
+        Instrument the given connection to detect and fail test when an exception is leaked through
+        the I/O loop.
 
         NOTE: BlockingConnection's underlying asynchronous connection adapter
         (SelectConnection) uses callbacks to communicate with its user (
@@ -99,7 +101,7 @@ class BlockingTestCaseBase(unittest.TestCase):
                         real_process_timeouts)
 
     def _on_test_timeout(self):
-        """Called when test times out"""
+        """Called when test times out."""
         LOGGER.info('%s TIMED OUT (%s)', datetime.now(timezone.utc), self)
         self.fail('Test timed out')
 
@@ -113,7 +115,7 @@ class BlockingTestCaseBase(unittest.TestCase):
 class TestCreateAndCloseConnection(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: Create and close connection"""
+        """BlockingConnection: Create and close connection."""
         connection = self._connect()
         self.assertIsInstance(connection, pika.BlockingConnection)
         self.assertTrue(connection.is_open)
@@ -129,9 +131,7 @@ class TestCreateAndCloseConnection(BlockingTestCaseBase):
 class TestCreateConnectionWithNoneSocketAndStackTimeouts(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection: create a connection with socket and stack timeouts both None
-
-        """
+        """BlockingConnection: create a connection with socket and stack timeouts both None."""
         params = pika.URLParameters(DEFAULT_URL)
         params.socket_timeout = None
         params.stack_timeout = None
@@ -143,9 +143,7 @@ class TestCreateConnectionWithNoneSocketAndStackTimeouts(BlockingTestCaseBase):
 class TestCreateConnectionFromTwoConfigsFirstUnreachable(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection: create a connection from two configs, first unreachable
-
-        """
+        """BlockingConnection: create a connection from two configs, first unreachable."""
         # Reserve a port for use in connect
         sock = socket.socket()
         self.addCleanup(sock.close)
@@ -167,9 +165,8 @@ class TestCreateConnectionFromTwoConfigsFirstUnreachable(BlockingTestCaseBase):
 class TestCreateConnectionFromTwoUnreachableConfigs(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection: creating a connection from two unreachable \
-        configs raises AMQPConnectionError
-
+        r"""BlockingConnection: creating a connection from two unreachable \ configs raises
+        AMQPConnectionError.
         """
         # Reserve a port for use in connect
         sock = socket.socket()
@@ -190,7 +187,7 @@ class TestCreateConnectionFromTwoUnreachableConfigs(BlockingTestCaseBase):
 class TestMultiCloseConnectionRaisesWrongState(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: Close connection twice raises ConnectionWrongStateError"""
+        """BlockingConnection: Close connection twice raises ConnectionWrongStateError."""
         connection = self._connect()
         self.assertIsInstance(connection, pika.BlockingConnection)
         self.assertTrue(connection.is_open)
@@ -209,7 +206,7 @@ class TestMultiCloseConnectionRaisesWrongState(BlockingTestCaseBase):
 class TestConnectionContextManagerClosesConnection(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: connection context manager closes connection"""
+        """BlockingConnection: connection context manager closes connection."""
         with self._connect() as connection:
             self.assertIsInstance(connection, pika.BlockingConnection)
             self.assertTrue(connection.is_open)
@@ -221,7 +218,7 @@ class TestConnectionContextManagerExitSurvivesClosedConnection(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: connection context manager exit survives closed connection"""
+        """BlockingConnection: connection context manager exit survives closed connection."""
         with self._connect() as connection:
             self.assertTrue(connection.is_open)
             connection.close()
@@ -234,7 +231,9 @@ class TestConnectionContextManagerClosesConnectionAndPassesOriginalException(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: connection context manager closes connection and passes original exception"""
+        """BlockingConnection: connection context manager closes connection and passes original
+        exception.
+        """
 
         class MyException(Exception):
             pass
@@ -252,7 +251,9 @@ class TestConnectionContextManagerClosesConnectionAndPassesSystemException(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: connection context manager closes connection and passes system exception"""
+        """BlockingConnection: connection context manager closes connection and passes system
+        exception.
+        """
         with self.assertRaises(SystemExit):
             with self._connect() as connection:
                 self.assertTrue(connection.is_open)
@@ -332,7 +333,7 @@ class TestUpdateSecretExpectsStrings(BlockingTestCaseBase):
 class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: ConnectionClosed raised when creating exchange with invalid type"""
+        """BlockingConnection: ConnectionClosed raised when creating exchange with invalid type."""
         # This test exploits behavior specific to RabbitMQ whereby the broker
         # closes the connection if an attempt is made to declare an exchange
         # with an invalid exchange type
@@ -352,7 +353,7 @@ class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
 class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: Create and close connection with channel and consumer"""
+        """BlockingConnection: Create and close connection with channel and consumer."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -389,8 +390,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
 class TestUsingInvalidQueueArgument(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection raises expected exception when invalid queue parameter is used
-        """
+        """BlockingConnection raises expected exception when invalid queue parameter is used."""
         connection = self._connect()
         ch = connection.channel()
         with self.assertRaises(TypeError):
@@ -400,8 +400,7 @@ class TestUsingInvalidQueueArgument(BlockingTestCaseBase):
 class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection resets properly on TCP/IP drop during channel()
-        """
+        """BlockingConnection resets properly on TCP/IP drop during channel()"""
         with ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
                                         DEFAULT_PARAMS.port),
                            local_linger_args=(1, 0)) as fwd:
@@ -423,8 +422,7 @@ class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
 class TestNoAccessToConnectionAfterConnectionLost(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection no access file descriptor after StreamLostError
-        """
+        """BlockingConnection no access file descriptor after StreamLostError."""
         with ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
                                         DEFAULT_PARAMS.port),
                            local_linger_args=(1, 0)) as fwd:
@@ -450,9 +448,7 @@ class TestNoAccessToConnectionAfterConnectionLost(BlockingTestCaseBase):
 class TestConnectWithDownedBroker(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection to downed broker results in AMQPConnectionError
-
-        """
+        """BlockingConnection to downed broker results in AMQPConnectionError."""
         # Reserve a port for use in connect
         sock = socket.socket()
         self.addCleanup(sock.close)
@@ -471,8 +467,7 @@ class TestConnectWithDownedBroker(BlockingTestCaseBase):
 class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection TCP/IP connection loss in CONNECTION_START
-        """
+        """BlockingConnection TCP/IP connection loss in CONNECTION_START."""
         fwd = ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
                                          DEFAULT_PARAMS.port),
                             local_linger_args=(1, 0))
@@ -495,8 +490,7 @@ class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
 class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection TCP/IP connection loss in CONNECTION_TUNE
-        """
+        """BlockingConnection TCP/IP connection loss in CONNECTION_TUNE."""
         fwd = ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
                                          DEFAULT_PARAMS.port),
                             local_linger_args=(1, 0))
@@ -518,8 +512,7 @@ class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
 class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
 
     def test(self):
-        """ BlockingConnection TCP/IP connection loss in CONNECTION_PROTOCOL
-        """
+        """BlockingConnection TCP/IP connection loss in CONNECTION_PROTOCOL."""
         fwd = ForwardServer(remote_addr=(DEFAULT_PARAMS.host,
                                          DEFAULT_PARAMS.port),
                             local_linger_args=(1, 0))
@@ -542,7 +535,7 @@ class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
 class TestProcessDataEvents(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.process_data_events"""
+        """BlockingConnection.process_data_events."""
         connection = self._connect()
 
         # Try with time_limit=0
@@ -562,7 +555,7 @@ class TestProcessDataEvents(BlockingTestCaseBase):
 class TestConnectionRegisterForBlockAndUnblock(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection register for Connection.Blocked/Unblocked"""
+        """BlockingConnection register for Connection.Blocked/Unblocked."""
         connection = self._connect()
 
         # NOTE: I haven't figured out yet how to coerce RabbitMQ to emit
@@ -599,7 +592,7 @@ class TestConnectionRegisterForBlockAndUnblock(BlockingTestCaseBase):
 class TestBlockedConnectionTimeout(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection Connection.Blocked timeout """
+        """BlockingConnection Connection.Blocked timeout."""
         url = DEFAULT_URL + '&blocked_connection_timeout=0.001'
         conn = self._connect(url=url)
 
@@ -623,7 +616,7 @@ class TestBlockedConnectionTimeout(BlockingTestCaseBase):
 class TestAddCallbackThreadsafeFromSameThread(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.add_callback_threadsafe from same thread"""
+        """BlockingConnection.add_callback_threadsafe from same thread."""
         connection = self._connect()
 
         # Test timer completion
@@ -642,7 +635,7 @@ class TestAddCallbackThreadsafeFromSameThread(BlockingTestCaseBase):
 class TestAddCallbackThreadsafeFromAnotherThread(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.add_callback_threadsafe from another thread"""
+        """BlockingConnection.add_callback_threadsafe from another thread."""
         connection = self._connect()
 
         # Test timer completion
@@ -666,7 +659,9 @@ class TestAddCallbackThreadsafeOnClosedConnectionRaisesWrongState(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.add_callback_threadsafe on closed connection raises ConnectionWrongStateError"""
+        """BlockingConnection.add_callback_threadsafe on closed connection raises
+        ConnectionWrongStateError.
+        """
         connection = self._connect()
         connection.close()
 
@@ -677,7 +672,7 @@ class TestAddCallbackThreadsafeOnClosedConnectionRaisesWrongState(
 class TestAddTimeoutRemoveTimeout(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.call_later and remove_timeout"""
+        """BlockingConnection.call_later and remove_timeout."""
         connection = self._connect()
 
         # Test timer completion
@@ -712,7 +707,7 @@ class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection viability of multiple timeouts with same deadline and callback"""
+        """BlockingConnection viability of multiple timeouts with same deadline and callback."""
         connection = self._connect()
 
         rx_callback = []
@@ -738,7 +733,7 @@ class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(
 class TestRemoveTimeoutFromTimeoutCallback(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.remove_timeout from timeout callback"""
+        """BlockingConnection.remove_timeout from timeout callback."""
         connection = self._connect()
 
         # Test timer completion
@@ -762,7 +757,7 @@ class TestRemoveTimeoutFromTimeoutCallback(BlockingTestCaseBase):
 class TestSleep(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.sleep"""
+        """BlockingConnection.sleep."""
         connection = self._connect()
 
         # Try with duration=0
@@ -782,7 +777,7 @@ class TestSleep(BlockingTestCaseBase):
 class TestConnectionProperties(BlockingTestCaseBase):
 
     def test(self):
-        """Test BlockingConnection properties"""
+        """Test BlockingConnection properties."""
         connection = self._connect()
 
         self.assertTrue(connection.is_open)
@@ -803,7 +798,7 @@ class TestConnectionProperties(BlockingTestCaseBase):
 class TestCreateAndCloseChannel(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: Create and close channel"""
+        """BlockingChannel: Create and close channel."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -822,7 +817,7 @@ class TestCreateAndCloseChannel(BlockingTestCaseBase):
 class TestExchangeDeclareAndDelete(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: Test exchange_declare and exchange_delete"""
+        """BlockingChannel: Test exchange_declare and exchange_delete."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -853,7 +848,7 @@ class TestExchangeDeclareAndDelete(BlockingTestCaseBase):
 class TestExchangeBindAndUnbind(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: Test exchange_bind and exchange_unbind"""
+        """BlockingChannel: Test exchange_bind and exchange_unbind."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -915,7 +910,7 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
 class TestQueueDeclareAndDelete(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: Test queue_declare and queue_delete"""
+        """BlockingChannel: Test queue_declare and queue_delete."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -946,7 +941,7 @@ class TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: ChannelClosed raised when passive-declaring unknown queue"""
+        """BlockingChannel: ChannelClosed raised when passive-declaring unknown queue."""
         connection = self._connect()
         ch = connection.channel()
 
@@ -963,7 +958,7 @@ class TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed(
 class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: Test queue_bind and queue_unbind"""
+        """BlockingChannel: Test queue_bind and queue_unbind."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1033,7 +1028,7 @@ class TestBasicGet(BlockingTestCaseBase):
         LOGGER.info('%s TEARING DOWN (%s)', datetime.now(timezone.utc), self)
 
     def test(self):
-        """BlockingChannel.basic_get"""
+        """BlockingChannel.basic_get."""
         LOGGER.info('%s STARTED (%s)', datetime.now(timezone.utc), self)
 
         connection = self._connect()
@@ -1097,7 +1092,7 @@ class TestBasicGet(BlockingTestCaseBase):
 class TestBasicReject(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_reject"""
+        """BlockingChannel.basic_reject."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1144,7 +1139,7 @@ class TestBasicReject(BlockingTestCaseBase):
 class TestBasicRejectNoRequeue(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_reject with requeue=False"""
+        """BlockingChannel.basic_reject with requeue=False."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1188,7 +1183,7 @@ class TestBasicRejectNoRequeue(BlockingTestCaseBase):
 class TestBasicNack(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_nack single message"""
+        """BlockingChannel.basic_nack single message."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1235,7 +1230,7 @@ class TestBasicNack(BlockingTestCaseBase):
 class TestBasicNackNoRequeue(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_nack with requeue=False"""
+        """BlockingChannel.basic_nack with requeue=False."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1279,7 +1274,7 @@ class TestBasicNackNoRequeue(BlockingTestCaseBase):
 class TestBasicNackMultiple(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_nack multiple messages"""
+        """BlockingChannel.basic_nack multiple messages."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1327,7 +1322,8 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
 class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_recover with requeue=True.
+        """
+        BlockingChannel.basic_recover with requeue=True.
 
         NOTE: the requeue=False option is not supported by RabbitMQ broker as
         of this writing (using RabbitMQ 3.5.1)
@@ -1383,7 +1379,7 @@ class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
 class TestTxCommit(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.tx_commit"""
+        """BlockingChannel.tx_commit."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1421,7 +1417,7 @@ class TestTxCommit(BlockingTestCaseBase):
 class TestTxRollback(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.tx_commit"""
+        """BlockingChannel.tx_commit."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1456,7 +1452,7 @@ class TestTxRollback(BlockingTestCaseBase):
 class TestBasicConsumeFromUnknownQueueRaisesChannelClosed(BlockingTestCaseBase):
 
     def test(self):
-        """ChannelClosed raised when consuming from unknown queue"""
+        """ChannelClosed raised when consuming from unknown queue."""
         connection = self._connect()
         ch = connection.channel()
 
@@ -1472,7 +1468,7 @@ class TestBasicConsumeFromUnknownQueueRaisesChannelClosed(BlockingTestCaseBase):
 class TestPublishAndBasicPublishWithPubacksUnroutable(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.publish amd basic_publish unroutable message with pubacks"""
+        """BlockingChannel.publish amd basic_publish unroutable message with pubacks."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1515,7 +1511,7 @@ class TestPublishAndBasicPublishWithPubacksUnroutable(BlockingTestCaseBase):
 class TestConfirmDeliveryAfterUnroutableMessage(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.confirm_delivery following unroutable message"""
+        """BlockingChannel.confirm_delivery following unroutable message."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1572,7 +1568,7 @@ class TestConfirmDeliveryAfterUnroutableMessage(BlockingTestCaseBase):
 class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: unroutable messages is returned in non-puback mode"""
+        """BlockingChannel: unroutable messages is returned in non-puback mode."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1640,7 +1636,7 @@ class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
 class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: unroutable messages is returned in puback mode"""
+        """BlockingChannel: unroutable messages is returned in puback mode."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1720,7 +1716,7 @@ class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
 class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_publish msg delivered despite pending unroutable message"""
+        """BlockingChannel.basic_publish msg delivered despite pending unroutable message."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -1790,8 +1786,8 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
 class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_publish, publish, basic_consume, QoS, \
-        Basic.Cancel from broker
+        r"""BlockingChannel.basic_publish, publish, basic_consume, QoS, \ Basic.Cancel from
+        broker.
         """
         connection = self._connect()
 
@@ -1925,8 +1921,8 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
 class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_consume with ack from another thread and \
-        requesting basic_ack via add_callback_threadsafe
+        r"""BlockingChannel.basic_consume with ack from another thread and \ requesting basic_ack
+        via add_callback_threadsafe.
         """
         # This test simulates processing of a message on another thread and
         # then requesting an ACK to be dispatched on the connection's thread
@@ -2017,8 +2013,8 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
 class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.consume and requesting basic_ack from another \
-        thread via add_callback_threadsafe
+        r"""BlockingChannel.consume and requesting basic_ack from another \ thread via
+        add_callback_threadsafe.
         """
         connection = self._connect()
 
@@ -2101,8 +2097,7 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
 class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel: two basic_consume consumers on same channel
-        """
+        """BlockingChannel: two basic_consume consumers on same channel."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2204,7 +2199,7 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
 class TestBasicCancelPurgesPendingConsumerCancellationEvt(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_cancel purges pending _ConsumerCancellationEvt"""
+        """BlockingChannel.basic_cancel purges pending _ConsumerCancellationEvt."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2255,7 +2250,7 @@ class TestBasicCancelPurgesPendingConsumerCancellationEvt(BlockingTestCaseBase):
 class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_publish without pubacks"""
+        """BlockingChannel.basic_publish without pubacks."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2370,8 +2365,7 @@ class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
 class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.basic_publish from basic_consume callback
-        """
+        """BlockingChannel.basic_publish from basic_consume callback."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2421,8 +2415,7 @@ class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
 class TestStopConsumingFromBasicConsumeCallback(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.stop_consuming from basic_consume callback
-        """
+        """BlockingChannel.stop_consuming from basic_consume callback."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2476,8 +2469,7 @@ class TestStopConsumingFromBasicConsumeCallback(BlockingTestCaseBase):
 class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.close from basic_consume callback
-        """
+        """BlockingChannel.close from basic_consume callback."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2528,8 +2520,7 @@ class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
 class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection.close from basic_consume callback
-        """
+        """BlockingConnection.close from basic_consume callback."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2583,8 +2574,7 @@ class TestStartConsumingRaisesChannelClosedOnSameChannelFailure(
         BlockingTestCaseBase):
 
     def test(self):
-        """start_consuming() exits with ChannelClosed exception on same channel failure
-        """
+        """start_consuming() exits with ChannelClosed exception on same channel failure."""
         connection = self._connect()
 
         # Fail test if exception leaks back ito I/O loop
@@ -2618,8 +2608,7 @@ class TestStartConsumingRaisesChannelClosedOnSameChannelFailure(
 class TestStartConsumingReturnsAfterCancelFromBroker(BlockingTestCaseBase):
 
     def test(self):
-        """start_consuming() returns after Cancel from broker
-        """
+        """start_consuming() returns after Cancel from broker."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2650,7 +2639,7 @@ class TestStartConsumingReturnsAfterCancelFromBroker(BlockingTestCaseBase):
 class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel.publish/consume huge message"""
+        """BlockingChannel.publish/consume huge message."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2698,7 +2687,7 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
 class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel non-pub-ack publish/consume many messages"""
+        """BlockingChannel non-pub-ack publish/consume many messages."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2755,7 +2744,7 @@ class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
 class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel user cancels non-ackable consumer via basic_cancel"""
+        """BlockingChannel user cancels non-ackable consumer via basic_cancel."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2813,7 +2802,7 @@ class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
 class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel user cancels ackable consumer via basic_cancel"""
+        """BlockingChannel user cancels ackable consumer via basic_cancel."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2866,7 +2855,7 @@ class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
 class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel unacked message restored to q on channel close """
+        """BlockingChannel unacked message restored to q on channel close."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2915,7 +2904,7 @@ class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel unacked message restored to q on channel close """
+        """BlockingChannel unacked message restored to q on channel close."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2963,7 +2952,7 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
 class TestConsumeGeneratorInactivityTimeout(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel consume returns 3-tuple of None values on inactivity timeout """
+        """BlockingChannel consume returns 3-tuple of None values on inactivity timeout."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -2985,7 +2974,7 @@ class TestConsumeGeneratorInactivityTimeout(BlockingTestCaseBase):
 class TestConsumeGeneratorInterruptedByCancelFromBroker(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel consume generator is interrupted broker's Cancel """
+        """BlockingChannel consume generator is interrupted broker's Cancel."""
         connection = self._connect()
 
         self.assertTrue(connection.consumer_cancel_notify_supported)
@@ -3012,7 +3001,7 @@ class TestConsumeGeneratorCancelEncountersCancelFromBroker(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel consume generator cancel called when broker's Cancel is enqueued """
+        """BlockingChannel consume generator cancel called when broker's Cancel is enqueued."""
         connection = self._connect()
 
         self.assertTrue(connection.consumer_cancel_notify_supported)
@@ -3048,8 +3037,7 @@ class TestConsumeGeneratorPassesChannelClosedOnSameChannelFailure(
         BlockingTestCaseBase):
 
     def test(self):
-        """consume() exits with ChannelClosed exception on same channel failure
-        """
+        """Consume() exits with ChannelClosed exception on same channel failure."""
         connection = self._connect()
 
         # Fail test if exception leaks back ito I/O loop
@@ -3078,7 +3066,7 @@ class TestConsumeGeneratorPassesChannelClosedOnSameChannelFailure(
 class TestChannelFlow(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingChannel Channel.Flow activate and deactivate """
+        """BlockingChannel Channel.Flow activate and deactivate."""
         connection = self._connect()
 
         ch = connection.channel()
@@ -3112,7 +3100,7 @@ class TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: Declaring queue on closed channel raises ChannelWrongStateError"""
+        """BlockingConnection: Declaring queue on closed channel raises ChannelWrongStateError."""
         q_name = (
             'TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel_q' +
             uuid.uuid1().hex)
@@ -3126,7 +3114,7 @@ class TestChannelRaisesWrongStateWhenDeclaringQueueOnClosedChannel(
 class TestChannelRaisesWrongStateWhenClosingClosedChannel(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: Closing closed channel raises ChannelWrongStateError"""
+        """BlockingConnection: Closing closed channel raises ChannelWrongStateError."""
         channel = self._connect().channel()
         channel.close()
         with self.assertRaises(pika.exceptions.ChannelWrongStateError):
@@ -3136,7 +3124,7 @@ class TestChannelRaisesWrongStateWhenClosingClosedChannel(BlockingTestCaseBase):
 class TestChannelContextManagerClosesChannel(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: chanel context manager exit survives closed channel"""
+        """BlockingConnection: chanel context manager exit survives closed channel."""
         with self._connect().channel() as channel:
             self.assertTrue(channel.is_open)
 
@@ -3146,7 +3134,7 @@ class TestChannelContextManagerClosesChannel(BlockingTestCaseBase):
 class TestChannelContextManagerExitSurvivesClosedChannel(BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: chanel context manager exit survives closed channel"""
+        """BlockingConnection: chanel context manager exit survives closed channel."""
         with self._connect().channel() as channel:
             self.assertTrue(channel.is_open)
             channel.close()
@@ -3159,8 +3147,9 @@ class TestChannelContextManagerDoesNotSuppressChannelClosedByBroker(
         BlockingTestCaseBase):
 
     def test(self):
-        """BlockingConnection: chanel context manager doesn't suppress ChannelClosedByBroker exception"""
-
+        """BlockingConnection: chanel context manager doesn't suppress ChannelClosedByBroker
+        exception.
+        """
         exg_name = (
             "TestChannelContextManagerDoesNotSuppressChannelClosedByBroker" +
             uuid.uuid1().hex)

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -1,7 +1,4 @@
-"""
-Tests of nbio_interface.AbstractIOServices adaptations
-
-"""
+"""Tests of nbio_interface.AbstractIOServices adaptations."""
 
 import collections
 import errno
@@ -20,27 +17,22 @@ class AsyncServicesTestBase(unittest.TestCase):
 
     @property
     def logger(self):
-        """Return the logger for tests to use
-
-        """
+        """Return the logger for tests to use."""
         return logging.getLogger(self.__class__.__module__ + '.' +
                                  self.__class__.__name__)
 
     def create_nonblocking_tcp_socket(self):
-        """Create a TCP stream socket and schedule cleanup to close it
-
-        """
+        """Create a TCP stream socket and schedule cleanup to close it."""
         sock = socket.socket()
         sock.setblocking(False)
         self.addCleanup(sock.close)
         return sock
 
     def create_nonblocking_socketpair(self):
-        """Creates a non-blocking socket pair and schedules cleanup to close
-        them
+        """
+        Creates a non-blocking socket pair and schedules cleanup to close them.
 
         :returns: two-tuple of connected non-blocking sockets
-
         """
         pair = pika._utils.nonblocking_socketpair()
         self.addCleanup(pair[0].close)
@@ -48,11 +40,10 @@ class AsyncServicesTestBase(unittest.TestCase):
         return pair
 
     def create_blocking_socketpair(self):
-        """Creates a blocking socket pair and schedules cleanup to close
-        them
+        """
+        Creates a blocking socket pair and schedules cleanup to close them.
 
         :returns: two-tuple of connected non-blocking sockets
-
         """
         pair = self.create_nonblocking_socketpair()
         pair[0].setblocking(True)
@@ -61,9 +52,8 @@ class AsyncServicesTestBase(unittest.TestCase):
 
     @staticmethod
     def safe_connect_nonblocking_socket(sock, addr_pair):
-        """Initiate socket connection, suppressing EINPROGRESS/EWOULDBLOCK
-        :param socket.socket sock
-        :param addr_pair: two tuple of address string and port integer
+        """Initiate socket connection, suppressing EINPROGRESS/EWOULDBLOCK :param socket.socket sock
+        :param addr_pair: two tuple of address string and port integer.
         """
         try:
             sock.connect(addr_pair)
@@ -192,8 +182,9 @@ class SocketWatcherTestBase(AsyncServicesTestBase):
                                              ['readable', 'writable'])
 
     def _check_socket_watchers_fired(self, sock, expected):
-        """Registers reader and writer for the given socket, runs the event loop
-        until either one fires and asserts against expectation.
+        """
+        Registers reader and writer for the given socket, runs the event loop until either one fires
+        and asserts against expectation.
 
         :param AsyncServicesTestBase | IOServicesTestStubs self:
         :param socket.socket sock:
@@ -570,11 +561,10 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
         """
         :param IOServicesTestStubs | SocketConnectorTestBase self:
 
-        :return: two-tuple (lsock, csock), where lscok is the listening sock and
-            csock is the socket that's can be connected to the listening socket.
+        :return: two-tuple (lsock, csock), where lscok is the listening sock and csock is the socket
+            that's can be connected to the listening socket.
         :rtype: tuple
         """
-
         # Create listener
         lsock = socket.socket(family, socket.SOCK_STREAM)
         self.addCleanup(lsock.close)
@@ -593,9 +583,7 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
         return lsock, csock
 
     def check_successful_connect(self, family):
-        """
-        :param IOServicesTestStubs | SocketConnectorTestBase self:
-        """
+        """:param IOServicesTestStubs | SocketConnectorTestBase self:"""
         # provided by IOServicesTestStubs mixin
         nbio = self.create_nbio()
 
@@ -617,9 +605,7 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
         self.assertEqual(connect_ref.cancel(), False)
 
     def check_failed_connect(self, family):
-        """
-        :param IOServicesTestStubs | SocketConnectorTestBase self:
-        """
+        """:param IOServicesTestStubs | SocketConnectorTestBase self:"""
         # provided by IOServicesTestStubs mixin
         nbio = self.create_nbio()
 
@@ -648,9 +634,7 @@ class SocketConnectorTestBase(AsyncServicesTestBase):
         self.assertEqual(connect_ref.cancel(), False)
 
     def check_cancel_connect(self, family):
-        """
-        :param IOServicesTestStubs | SocketConnectorTestBase self:
-        """
+        """:param IOServicesTestStubs | SocketConnectorTestBase self:"""
         # provided by IOServicesTestStubs mixin
         nbio = self.create_nbio()
 
@@ -695,13 +679,14 @@ class TestConnectSocketToDisconnectedPeer(SocketConnectorTestBase,
                                           IOServicesTestStubs):
 
     def start(self):
-        """Differs from `TestConnectSocketIPV4Fail` in that this test attempts
-        to connect to the address of a socket whose peer had disconnected from
-        it. `TestConnectSocketIPv4Fail` attempts to connect to a closed socket
-        that was previously listening. We want to see what happens in this case
-        because we're seeing strange behavior in TestConnectSocketIPv4Fail when
-        testing with Twisted on Linux, such that the reactor calls the
-        descriptors's `connectionLost()` method, but not its `write()` method.
+        """
+        Differs from `TestConnectSocketIPV4Fail` in that this test attempts to connect to the
+        address of a socket whose peer had disconnected from it.
+
+        `TestConnectSocketIPv4Fail` attempts to connect to a closed socket that was previously
+        listening. We want to see what happens in this case because we're seeing strange behavior in
+        TestConnectSocketIPv4Fail when testing with Twisted on Linux, such that the reactor calls
+        the descriptors's `connectionLost()` method, but not its `write()` method.
         """
         nbio = self.create_nbio()
 
@@ -1030,33 +1015,30 @@ class TestStreamConnectorEOFReceived(StreamingTestBase, IOServicesTestStubs):
 
 
 class TestStreamConnectorProtocolInterfaceFailsBase(StreamingTestBase):
-    """Base test class for streaming protocol method fails"""
+    """Base test class for streaming protocol method fails."""
 
-    def linkup_streaming_connection(
-            self,
-            nbio,
-            sock,
-            on_create_done,
-            proto_constructor_exc=None,
-            proto_connection_made_exc=None,
-            proto_eof_received_exc=None,
-            proto_data_received_exc=None) -> nbio_interface.AbstractIOReference:
-        """Links up transport and protocol. On protocol.connection_lost(),
-        requests stop of ioloop.
+    def linkup_streaming_connection(self,
+                                    nbio,
+                                    sock,
+                                    on_create_done,
+                                    proto_constructor_exc=None,
+                                    proto_connection_made_exc=None,
+                                    proto_eof_received_exc=None,
+                                    proto_data_received_exc=None):
+        """
+        Links up transport and protocol.
+
+        On protocol.connection_lost(), requests stop of ioloop.
 
         :param nbio_interface.AbstractIOServices nbio:
         :param socket.socket sock: connected socket
-        :param on_create_done: `create_streaming_connection()` completion
-            function.
+        :param on_create_done:`create_streaming_connection()` completion function.
         :param proto_constructor_exc: None or exception to raise in constructor
-        :param proto_connection_made_exc: None or exception to raise in
-            `connection_made()`
-        :param proto_eof_received_exc:  None or exception to raise in
-            `eof_received()`
-        :param proto_data_received_exc:  None or exception to raise in
-            `data_received()`
+        :param proto_connection_made_exc: None or exception to raise in `connection_made()`
+        :param proto_eof_received_exc: None or exception to raise in `eof_received()`
+        :param proto_data_received_exc: None or exception to raise in `data_received()`
         :return: return value of `create_streaming_connection()`
-
+        :rtype: nbio_interface.AbstractIOReference
         """
         logger = self.logger
 

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -1,4 +1,5 @@
-"""Integration tests for ThreadSafeConnection and ThreadSafeChannel.
+"""
+Integration tests for ThreadSafeConnection and ThreadSafeChannel.
 
 These tests require a RabbitMQ broker listening on 127.0.0.1:5672 with the
 default guest/guest credentials.  They will fail, not skip, if the broker is
@@ -7,6 +8,7 @@ unreachable - consistent with the rest of the acceptance suite.
 Each test covers a scenario that unit tests with mocks cannot: real socket I/O,
 real AMQP frame exchange, and real concurrent threads.
 """
+
 import threading
 import unittest
 import uuid
@@ -89,10 +91,11 @@ class TestBasicLifecycle(ThreadSafeTestCaseBase):
 
 
 class TestConcurrentPublishing(ThreadSafeTestCaseBase):
-    """N threads publish simultaneously; all messages must reach the broker.
+    """
+    N threads publish simultaneously; all messages must reach the broker.
 
-    This is the core regression test for the original _tx_buffers race
-    (IndexError: pop from empty deque, issues #1144 and #511).
+    This is the core regression test for the original _tx_buffers race (IndexError: pop from empty
+    deque, issues #1144 and #511).
     """
 
     def test(self):
@@ -137,10 +140,11 @@ class TestConcurrentPublishing(ThreadSafeTestCaseBase):
 
 
 class TestConcurrentPublishAndConsume(ThreadSafeTestCaseBase):
-    """Producer threads and a consumer coexist; every message is acked.
+    """
+    Producer threads and a consumer coexist; every message is acked.
 
-    Exercises basic_qos, basic_consume, and basic_ack (from the IOLoop
-    thread inside the delivery callback).
+    Exercises basic_qos, basic_consume, and basic_ack (from the IOLoop thread inside the delivery
+    callback).
     """
 
     def test(self):
@@ -204,7 +208,8 @@ class TestConcurrentPublishAndConsume(ThreadSafeTestCaseBase):
 
 
 class TestBrokerDropBlockedInChannel(ThreadSafeTestCaseBase):
-    """A thread blocked in channel() must unblock when the broker drops.
+    """
+    A thread blocked in channel() must unblock when the broker drops.
 
     Before the _blocking_waiters escape hatch, this would hang forever.
     """
@@ -261,10 +266,11 @@ class TestBrokerDropBlockedInChannel(ThreadSafeTestCaseBase):
 
 
 class TestBrokerDropBlockedInQueueDeclare(ThreadSafeTestCaseBase):
-    """A thread blocked in queue_declare() must unblock when the broker drops.
+    """
+    A thread blocked in queue_declare() must unblock when the broker drops.
 
-    Exercises the _blocking_waiters escape hatch added to queue_declare()
-    in the re-review architectural fix.
+    Exercises the _blocking_waiters escape hatch added to queue_declare() in the re-review
+    architectural fix.
     """
 
     def test(self):
@@ -321,12 +327,12 @@ class TestBrokerDropBlockedInQueueDeclare(ThreadSafeTestCaseBase):
 
 
 class TestConcurrentClose(ThreadSafeTestCaseBase):
-    """close() called from multiple threads simultaneously must not crash or hang.
+    """
+    Close() called from multiple threads simultaneously must not crash or hang.
 
-    Before _safe_close and the _closed_reason guard, one of the racing
-    close() calls could schedule connection.close() when the connection was
-    already closing, raising ConnectionWrongStateError inside the IOLoop and
-    killing the IOLoop thread.
+    Before _safe_close and the _closed_reason guard, one of the racing close() calls could schedule
+    connection.close() when the connection was already closing, raising ConnectionWrongStateError
+    inside the IOLoop and killing the IOLoop thread.
     """
 
     def test(self):

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -1,4 +1,5 @@
-"""twisted adapter test"""
+"""Twisted adapter test."""
+
 import functools
 import unittest
 from unittest import mock
@@ -28,17 +29,19 @@ from pika.frame import Method
 
 
 class TestCase(unittest.TestCase):
-    """Imported from twisted.trial.unittest.TestCase
+    """
+    Imported from twisted.trial.unittest.TestCase.
 
-    We only want the assertFailure implementation, using the class directly
-    hides some assertion errors.
+    We only want the assertFailure implementation, using the class directly hides some assertion
+    errors.
     """
 
     def assertFailure(self, d, *expectedFailures):
         """
         Fail if C{deferred} does not errback with one of C{expectedFailures}.
-        Returns the original Deferred with callbacks added. You will need
-        to return this Deferred from your test case.
+
+        Returns the original Deferred with callbacks added. You will need to return this Deferred
+        from your test case.
         """
 
         def _cb(ignore):

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -1,7 +1,4 @@
-"""Base test classes for async_adapter_tests.py
-
-"""
-from __future__ import annotations
+"""Base test classes for async_adapter_tests.py."""
 
 import functools
 import logging
@@ -29,14 +26,12 @@ run_test_in_thread_with_timeout = create_run_in_thread_decorator(TEST_TIMEOUT *
 
 
 def make_stop_on_error_with_self(the_self=None):
-    """Create a decorator that stops test if the decorated method exits
-    with exception and causes the test to fail by re-raising that exception
-    after ioloop exits.
+    """
+    Create a decorator that stops test if the decorated method exits with exception and causes the
+    test to fail by re-raising that exception after ioloop exits.
 
-    :param None | AsyncTestCase the_self: if None, will use the first arg of
-        decorated method if it is an instance of AsyncTestCase, raising
-        exception otherwise.
-
+    :param None | AsyncTestCase the_self: if None, will use the first arg of     decorated method if
+    it is an instance of AsyncTestCase, raising     exception otherwise.
     """
 
     def stop_on_error_with_self_decorator(fun):
@@ -89,19 +84,30 @@ class AsyncTestCase(unittest.TestCase):
         self._public_stop_error_in = None  # exception passed to our stop()
         super().setUp()
 
-    def new_connection_params(
-            self) -> pika.ConnectionParameters | pika.URLParameters:
+    def new_connection_params(self):
+        """
+        :rtype: pika.ConnectionParameters
+
+        """
         if enable_tls():
             return self._new_tls_connection_params()
         return self._new_plaintext_connection_params()
 
-    def _new_tls_connection_params(self) -> pika.URLParameters:
+    def _new_tls_connection_params(self):
+        """
+        :rtype: pika.ConnectionParameters
+
+        """
         self.logger.info('testing using TLS/SSL connection to port 5671')
         url = 'amqps://localhost:5671/%2F?ssl_options=%7B%27ca_certs%27%3A%27tests%2Fcerts%2Fca_certificate.pem%27%2C%27keyfile%27%3A%27tests%2Fcerts%2Fclient_key.pem%27%2C%27certfile%27%3A%27tests%2Fcerts%2Fclient_certificate.pem%27%7D'
         return pika.URLParameters(url)
 
     @staticmethod
-    def _new_plaintext_connection_params() -> pika.ConnectionParameters:
+    def _new_plaintext_connection_params():
+        """
+        :rtype: pika.ConnectionParameters
+
+        """
         return pika.ConnectionParameters(host='127.0.0.1', port=5672)
 
     def tearDown(self):
@@ -114,7 +120,7 @@ class AsyncTestCase(unittest.TestCase):
         return method_desc
 
     def begin(self, channel):
-        """Extend to start the actual tests on the channel"""
+        """Extend to start the actual tests on the channel."""
         self.fail("AsyncTestCase.begin_test not extended")
 
     def start(self, adapter, ioloop_factory):
@@ -145,17 +151,18 @@ class AsyncTestCase(unittest.TestCase):
             self.connection = None
 
     def stop_ioloop_only(self):
-        """Request stopping of the connection's ioloop to end the test without
-        closing the connection
+        """Request stopping of the connection's ioloop to end the test without closing the
+        connection.
         """
         self._safe_remove_test_timeout()
         self.connection._nbio.stop()
 
     def stop(self, error=None):
-        """close the connection and stop the ioloop
+        """
+        Close the connection and stop the ioloop.
 
-        :param None | Exception error: if not None, will raise the given
-            exception after ioloop exits.
+        :param None | Exception error: if not None, will raise the given     exception after ioloop
+        exits.
         """
         if error is not None:
             if self._public_stop_error_in is None:
@@ -194,7 +201,7 @@ class AsyncTestCase(unittest.TestCase):
             self.connection._nbio.stop()
 
     def on_closed(self, connection, error):
-        """called when the connection has finished closing"""
+        """Called when the connection has finished closing."""
         self.logger.info('on_closed: %r %r', connection, error)
         self._conn_closed_reason = error
         self._stop()
@@ -213,7 +220,7 @@ class AsyncTestCase(unittest.TestCase):
         self.begin(channel)
 
     def on_timeout(self):
-        """called when stuck waiting for connection to close"""
+        """Called when stuck waiting for connection to close."""
         self.logger.error('%s timed out; on_timeout called at %s', self,
                           datetime.now(timezone.utc))
         self.timeout = None  # the dispatcher should have removed it
@@ -285,14 +292,13 @@ class AsyncAdapters:
 
     @run_test_in_thread_with_timeout
     def test_with_select_default(self):
-        """SelectConnection:DefaultPoller"""
+        """SelectConnection:DefaultPoller."""
         with mock.patch.multiple(select_connection, SELECT_TYPE=None):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
     @run_test_in_thread_with_timeout
     def test_with_select_select(self):
-        """SelectConnection:select"""
-
+        """SelectConnection:select."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='select'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
@@ -301,31 +307,28 @@ class AsyncAdapters:
         "poll not supported")
     @run_test_in_thread_with_timeout
     def test_with_select_poll(self):
-        """SelectConnection:poll"""
-
+        """SelectConnection:poll."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='poll'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
     @unittest.skipIf(not hasattr(select, 'epoll'), "epoll not supported")
     @run_test_in_thread_with_timeout
     def test_with_select_epoll(self):
-        """SelectConnection:epoll"""
-
+        """SelectConnection:epoll."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='epoll'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
     @unittest.skipIf(not hasattr(select, 'kqueue'), "kqueue not supported")
     @run_test_in_thread_with_timeout
     def test_with_select_kqueue(self):
-        """SelectConnection:kqueue"""
-
+        """SelectConnection:kqueue."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='kqueue'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
     @unittest.skipIf(pika._utils.ON_WINDOWS, "Windows not supported")
     @run_test_in_thread_with_timeout
     def test_with_gevent(self):
-        """GeventConnection"""
+        """GeventConnection."""
         import gevent
 
         from pika.adapters.gevent_connection import GeventConnection, _GeventSelectorIOLoop
@@ -337,7 +340,7 @@ class AsyncAdapters:
 
     @run_test_in_thread_with_timeout
     def test_with_tornado(self):
-        """TornadoConnection"""
+        """TornadoConnection."""
         import tornado.ioloop
 
         from pika.adapters.tornado_connection import TornadoConnection
@@ -346,7 +349,7 @@ class AsyncAdapters:
 
     @run_test_in_thread_with_timeout
     def test_with_asyncio(self):
-        """AsyncioConnection"""
+        """AsyncioConnection."""
         import asyncio
 
         from pika.adapters.asyncio_connection import AsyncioConnection

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -18,12 +18,12 @@ import pika._utils
 
 
 def buffer(object_, offset, size):
-    """array etc. have the buffer protocol"""
+    """Array etc. have the buffer protocol."""
     return object_[offset:offset + size]
 
 
 def _trace(fmt, *args):
-    """Format and output the text to stderr"""
+    """Format and output the text to stderr."""
     print((fmt % args) + "\n", end="", file=sys.stderr)
 
 
@@ -125,12 +125,13 @@ class ForwardServer:
 
     @property
     def running(self):
-        """Property: True if ForwardServer is active"""
+        """Property: True if ForwardServer is active."""
         return self._subproc is not None
 
     @property
     def server_address_family(self):
-        """Property: Get listening socket's address family
+        """
+        Property: Get listening socket's address family.
 
         NOTE: undefined before server starts and after it shuts down
         """
@@ -140,8 +141,9 @@ class ForwardServer:
 
     @property
     def server_address(self):
-        """ Property: Get listening socket's address; the returned value
-        depends on the listening socket's address family
+        """
+        Property: Get listening socket's address; the returned value depends on the listening
+        socket's address family.
 
         NOTE: undefined before server starts and after it shuts down
         """
@@ -150,19 +152,21 @@ class ForwardServer:
         return self._server_addr
 
     def __enter__(self):
-        """ Context manager entry. Starts the forwarding server
+        """
+        Context manager entry.
 
-        :returns: self
+        Starts the forwarding server
+                :returns: self
         """
         return self.start()
 
     def __exit__(self, *args):
-        """ Context manager exit; stops the forwarding server
-        """
+        """Context manager exit; stops the forwarding server."""
         self.stop()
 
     def start(self):
-        """ Start the server
+        """
+        Start the server.
 
         NOTE: The context manager is the recommended way to use
         ForwardServer. start()/stop() are alternatives to the context manager
@@ -211,7 +215,8 @@ class ForwardServer:
         return self
 
     def stop(self):
-        """Stop the server
+        """
+        Stop the server.
 
         NOTE: The context manager is the recommended way to use
         ForwardServer. start()/stop() are alternatives to the context manager
@@ -241,7 +246,8 @@ class ForwardServer:
 def _run_server(local_addr, local_addr_family, local_socket_type,
                 local_linger_args, remote_addr, remote_addr_family,
                 remote_socket_type, queue):
-    """ Run the server; executed in the subprocess
+    """
+    Run the server; executed in the subprocess.
 
     :param local_addr: listening address
     :param local_addr_family: listening address family; one of socket.AF_*
@@ -269,7 +275,7 @@ def _run_server(local_addr, local_addr_family, local_socket_type,
     # isn't derived from `object`, which prevents `super` from working properly
     class _ThreadedTCPServer(socketserver.ThreadingMixIn,
                              socketserver.TCPServer):
-        """Threaded streaming server for forwarding"""
+        """Threaded streaming server for forwarding."""
 
         # Override TCPServer's class members
         address_family = local_addr_family
@@ -302,8 +308,10 @@ def _run_server(local_addr, local_addr_family, local_socket_type,
 # NOTE: we add `object` to the base classes because `StreamRequestHandler` isn't
 # derived from `object`, which prevents `super` from working properly
 class _TCPHandler(socketserver.StreamRequestHandler):
-    """TCP/IP session handler instantiated by TCPServer upon incoming
-    connection. Implements forwarding/echo of the incoming connection.
+    """
+    TCP/IP session handler instantiated by TCPServer upon incoming connection.
+
+    Implements forwarding/echo of the incoming connection.
     """
 
     _SOCK_RX_BUF_SIZE = 16 * 1024
@@ -337,7 +345,7 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                          server=server)
 
     def handle(self):
-        """Connect to remote and forward data between local and remote"""
+        """Connect to remote and forward data between local and remote."""
         local_sock = self.connection
 
         if self._local_linger_args is not None:
@@ -359,8 +367,8 @@ class _TCPHandler(socketserver.StreamRequestHandler):
             # Echo set-up
             # NOTE: Use pika._utils.nonblocking_socketpair() since
             # socket.socketpair() isn't available on Windows under python 2 yet.
-            remote_dest_sock, remote_src_sock = \
-                    pika._utils.nonblocking_socketpair()
+            remote_dest_sock, remote_src_sock = pika._utils.nonblocking_socketpair(
+            )
             # We rely on blocking I/O
             remote_dest_sock.setblocking(True)
             remote_src_sock.setblocking(True)
@@ -392,7 +400,7 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                     remote_src_sock.close()
 
     def _forward(self, src_sock, dest_sock):
-        """Forward from src_sock to dest_sock"""
+        """Forward from src_sock to dest_sock."""
         src_peername = src_sock.getpeername()
 
         _trace("%s forwarding from %s to %s", datetime.now(timezone.utc),
@@ -464,18 +472,14 @@ class _TCPHandler(socketserver.StreamRequestHandler):
 
 
 def echo(port=0):
-    """ This function implements a simple echo server for testing the
-    Forwarder class.
+    """
+    This function implements a simple echo server for testing the Forwarder class.
 
-    :param int port: port number on which to listen
-
-    We run this function and it prints out the listening socket binding.
-    Then, we run Forwarder and point it at this echo "server".
-    Then, we run telnet and point it at forwarder and see if whatever we
-    type gets echoed back to us.
-
-    This function waits for the client to connect and exits after the client
-    closes the connection
+    :param int port: port number on which to listen We run this function and it prints out the
+        listening socket binding. Then, we run Forwarder and point it at this echo "server". Then,
+        we run telnet and point it at forwarder and see if whatever we type gets echoed back to us.
+        This function waits for the client to connect and exits after the client closes the
+        connection
     """
     lsock = socket.socket()
     lsock.bind(("", port))
@@ -505,8 +509,7 @@ def echo(port=0):
 
 
 def _safe_shutdown_socket(sock, how=socket.SHUT_RDWR):
-    """ Shutdown a socket, suppressing ENOTCONN
-    """
+    """Shutdown a socket, suppressing ENOTCONN."""
     try:
         sock.shutdown(how)
     except pika._utils.SOCKET_ERROR as exc:

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -1,4 +1,4 @@
-"""Acceptance test utils"""
+"""Acceptance test utils."""
 
 import functools
 import logging
@@ -9,9 +9,9 @@ import pika._utils
 
 
 def retry_assertion(timeout_sec, retry_interval_sec=0.1):
-    """Creates a decorator that retries the decorated function or
-    method only upon `AssertionError` exception at the given retry interval
-    not to exceed the overall given timeout.
+    """
+    Creates a decorator that retries the decorated function or method only upon `AssertionError`
+    exception at the given retry interval not to exceed the overall given timeout.
 
     :param float timeout_sec: overall timeout in seconds
     :param float retry_interval_sec: amount of time to sleep
@@ -31,12 +31,11 @@ def retry_assertion(timeout_sec, retry_interval_sec=0.1):
     """
 
     def retry_assertion_decorator(func):
-        """Decorator"""
+        """Decorator."""
 
         @functools.wraps(func)
         def retry_assertion_wrap(*args, **kwargs):
-            """The wrapper"""
-
+            """The wrapper."""
             num_attempts = 0
             start_time = pika._utils.time_now()
 

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -22,15 +22,11 @@ class TestGetNativeIOLoop(unittest.TestCase,
 
 """
 
-from pika.adapters.utils import nbio_interface
 from tests.wrappers.threaded_test_wrapper import run_in_thread_with_timeout
 
 
 class IOServicesTestStubs:
-    """Provides a stub test method for each combination of parameters we wish to
-    test
-
-    """
+    """Provides a stub test method for each combination of parameters we wish to test."""
 
     # Overridden by framework-specific test methods
     _nbio_factory = None
@@ -38,32 +34,35 @@ class IOServicesTestStubs:
     _use_ssl = None
 
     def start(self):
-        """Subclasses must override to run the test. This method is called
-        from a thread.
+        """
+        Subclasses must override to run the test.
 
+        This method is called from a thread.
         """
         raise NotImplementedError
 
-    def create_nbio(self) -> nbio_interface.AbstractIOServices:
-        """Create the configured AbstractIOServices adaptation and schedule
-        it to be closed automatically when the test terminates.
+    def create_nbio(self):
+        """
+        Create the configured AbstractIOServices adaptation and schedule it to be closed
+        automatically when the test terminates.
 
         :param unittest.TestCase self:
-
+        :rtype: pika.adapters.utils.nbio_interface.AbstractIOServices
         """
         nbio = self._nbio_factory()
         self.addCleanup(nbio.close)
         return nbio
 
     def _run_start(self, nbio_factory, native_loop, use_ssl=False):
-        """Called by framework-specific test stubs to initialize test paramters
-        and execute the `self.start()` method.
+        """
+        Called by framework-specific test stubs to initialize test paramters and execute the
+        `self.start()` method.
 
-        :param nbio_interface.AbstractIOServices _() nbio_factory: function
-            to call to create an instance of `AbstractIOServices` adaptation.
+        :param nbio_interface.AbstractIOServices _() nbio_factory: function to call to create an
+            instance of `AbstractIOServices` adaptation.
         :param native_loop: native loop implementation instance
-        :param bool use_ssl: Whether to test with SSL instead of Plaintext
-            transport. Defaults to Plaintext.
+        :param bool use_ssl: Whether to test with SSL instead of Plaintext transport. Defaults to
+            Plaintext.
         """
         self._nbio_factory = nbio_factory
         self._native_loop = native_loop

--- a/tests/unit/asyncio_connection_tests.py
+++ b/tests/unit/asyncio_connection_tests.py
@@ -1,6 +1,4 @@
-"""
-Tests for pika.adapters.asyncio_connection
-"""
+"""Tests for pika.adapters.asyncio_connection."""
 
 import asyncio
 import threading

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -1,7 +1,4 @@
-"""
-Tests for pika.base_connection.BaseConnection
-
-"""
+"""Tests for pika.base_connection.BaseConnection."""
 
 import socket
 import unittest
@@ -19,9 +16,8 @@ except AttributeError:
 
 
 class ConstructibleBaseConnection(base_connection.BaseConnection):
-    """Adds dummy overrides for `BaseConnection`'s abstract methods so
-    that we can instantiate and test it.
-
+    """Adds dummy overrides for `BaseConnection`'s abstract methods so that we can instantiate and
+    test it.
     """
 
     @classmethod

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.adapters.blocking_connection.BlockingChannel
+"""Tests for pika.adapters.blocking_connection.BlockingChannel."""
 
-"""
 import unittest
 from collections import deque
 from unittest import mock

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.adapters.blocking_connection.BlockingConnection
+"""Tests for pika.adapters.blocking_connection.BlockingConnection."""
 
-"""
 import sys
 import unittest
 from unittest import mock
@@ -30,7 +28,7 @@ class SelectConnectionTemplate(
 
 
 class BlockingConnectionTests(unittest.TestCase):
-    """TODO: test properties"""
+    """TODO: test properties."""
 
     @patch.object(blocking_connection.select_connection,
                   'SelectConnection',

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.callback
+"""Tests for pika.callback."""
 
-"""
 from __future__ import annotations
 
 import logging

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1,6 +1,5 @@
-"""
-Tests for pika.channel.Channel
-"""
+"""Tests for pika.channel.Channel."""
+
 import collections
 import logging
 import sys
@@ -12,10 +11,13 @@ from pika import channel, connection, exceptions, frame, spec
 
 
 class ConnectionTemplate(connection.Connection):
-    """Template for using as mock spec_set for the pika Connection class. It
-    defines members accessed by the code under test that would be defined in
-    the base class's constructor.
     """
+    Template for using as mock spec_set for the pika Connection class.
+
+    It defines members accessed by the code under test that would be defined in the base class's
+    constructor.
+    """
+
     callbacks = None
 
     _adapter_connect_stream = connection.Connection._adapter_connect_stream

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -1,8 +1,7 @@
-"""
-Test `pika.connection.Parameters`, `pika.connection.ConnectionParameters`, and
+"""Test `pika.connection.Parameters`, `pika.connection.ConnectionParameters`, and
 `pika.connection.URLParameters`
-
 """
+
 import copy
 import ssl
 import unittest
@@ -87,11 +86,11 @@ class ParametersTestsBase(unittest.TestCase):
         return defaults
 
     def assert_default_parameter_values(self, params):
-        """Assert that the given parameters object has the default parameter
-        values.
+        """
+        Assert that the given parameters object has the default parameter values.
 
-        :param pika.connection.Parameters params: Verify that the given params
-            instance has all default property values
+        :param pika.connection.Parameters params: Verify that the given params instance has all
+            default property values
         """
         for name, expected_value in self.get_default_properties().items():
             value = getattr(params, name)
@@ -498,7 +497,7 @@ class ConnectionParametersTests(ParametersTestsBase):
         self.assertIsNone(params.socket_timeout)
 
     def test_good_connection_parameters(self):
-        """make sure connection kwargs get set correctly"""
+        """Make sure connection kwargs get set correctly."""
         kwargs = {
             'blocked_connection_timeout': 10.5,
             'channel_max': 3,
@@ -549,7 +548,7 @@ class ConnectionParametersTests(ParametersTestsBase):
         self.assertIs(parameters.heartbeat, heartbeat_callback)
 
     def test_bad_type_connection_parameters(self):
-        """test connection kwargs type checks throw errors for bad input"""
+        """Test connection kwargs type checks throw errors for bad input."""
         kwargs = {
             'host': 'https://www.test.com',
             'port': 5678,
@@ -637,9 +636,10 @@ class URLParametersTests(ParametersTestsBase):
 
     def test_ssl_default_protocol_version_fallback(self):
         """
-        This test does not set protocol_version option in ssl_options. Instead,
-        it relies on connection.URLParameters class to setup the default, and
-        then it asserts the protocol is what we expected (auto or TLSv1_2)
+        This test does not set protocol_version option in ssl_options.
+
+        Instead, it relies on connection.URLParameters class to setup the default, and then it
+        asserts the protocol is what we expected (auto or TLSv1_2)
         """
         params = connection.URLParameters(
             'amqps://foo.bar/some-vhost?ssl_options=%7B%27ca_certs%27%3A%27tests%2Fcerts%2Fca_certificate.pem%27%7D'
@@ -655,7 +655,7 @@ class URLParametersTests(ParametersTestsBase):
         self.assertEqual(params.port, params.DEFAULT_PORT)
 
     def test_good_parameters(self):
-        """test for the different query stings checked by process url"""
+        """Test for the different query stings checked by process url."""
         query_args = {
             'blocked_connection_timeout': 10.5,
             'channel_max': 3,

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -1,7 +1,4 @@
-"""
-Tests for pika.connection.Connection
-
-"""
+"""Tests for pika.connection.Connection."""
 
 import platform
 import random
@@ -13,13 +10,12 @@ from pika import channel, connection, credentials, exceptions, frame, spec
 
 
 def dummy_callback():
-    """Callback method to use in tests"""
+    """Callback method to use in tests."""
 
 
 class ConstructibleConnection(connection.Connection):
-    """Adds dummy overrides for `Connection`'s abstract methods so
-    that we can instantiate and test it.
-
+    """Adds dummy overrides for `Connection`'s abstract methods so that we can instantiate and test
+    it.
     """
 
     def _adapter_connect_stream(self):
@@ -124,7 +120,7 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.connection.Connection._send_method')
     def test_update_secret_sends_method(self, send_method):
-        """make sure it sends the update secret method"""
+        """Make sure it sends the update secret method."""
         new_secret = mock.Mock()
         reason = mock.Mock()
         self.connection.connection_state = self.connection.CONNECTION_OPEN
@@ -134,7 +130,7 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.connection.Connection._send_method')
     def test_update_secret_adds_callback_on_update_secret_ok(self, send_method):
-        """make sure the on update secret ok callback is added"""
+        """Make sure the on update secret ok callback is added."""
         self.connection.connection_state = self.connection.CONNECTION_OPEN
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
         new_secret = mock.Mock()
@@ -158,10 +154,7 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.connection.Connection._on_close_ready')
     def test_on_channel_cleanup_with_closing_channels(self, on_close_ready):
-        """if connection is closing but closing channels remain, do not call \
-        _on_close_ready
-
-        """
+        r"""If connection is closing but closing channels remain, do not call \ _on_close_ready."""
         self.channel.is_open = False
         self.channel.is_closing = True
         self.channel.is_closed = False
@@ -194,13 +187,13 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.connection.Connection._on_close_ready')
     def test_on_channel_cleanup_non_closing_state(self, on_close_ready):
-        """if connection isn't closing _on_close_ready should not be called"""
+        """If connection isn't closing _on_close_ready should not be called."""
         self.connection._on_channel_cleanup(mock.Mock())
         self.assertFalse(on_close_ready.called,
                          '_on_close_ready should not have been called')
 
     def test_on_stream_terminated_cleans_up(self):
-        """_on_stream_terminated cleans up heartbeat, adapter, and channels"""
+        """_on_stream_terminated cleans up heartbeat, adapter, and channels."""
         heartbeat = mock.Mock()
         self.connection._heartbeat_checker = heartbeat
         self.connection._adapter_disconnect_stream = mock.Mock()
@@ -215,7 +208,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertTrue(self.connection.is_closed)
 
     def test_on_stream_terminated_invokes_connection_closed_callback(self):
-        """_on_stream_terminated invokes `Connection.ON_CONNECTION_CLOSED` callbacks"""
+        """_on_stream_terminated invokes `Connection.ON_CONNECTION_CLOSED` callbacks."""
         self.connection.callbacks.process = mock.Mock(
             wraps=self.connection.callbacks.process)
 
@@ -234,8 +227,9 @@ class ConnectionTests(unittest.TestCase):
 
     def test_on_stream_terminated_invokes_protocol_on_connection_error_and_closed(
             self):
-        """_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \
-        `IncompatibleProtocolError` and `ON_CONNECTION_CLOSED` callbacks"""
+        r"""_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \ `IncompatibleProtocolError`
+        and `ON_CONNECTION_CLOSED` callbacks.
+        """
         with mock.patch.object(self.connection.callbacks, 'process'):
 
             self.connection._adapter_disconnect_stream = mock.Mock()
@@ -259,8 +253,9 @@ class ConnectionTests(unittest.TestCase):
 
     def test_on_stream_terminated_invokes_auth_on_connection_error_and_closed(
             self):
-        """_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \
-        `ProbableAuthenticationError` and `ON_CONNECTION_CLOSED` callbacks"""
+        r"""_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \ `ProbableAuthenticationError`
+        and `ON_CONNECTION_CLOSED` callbacks.
+        """
         with mock.patch.object(self.connection.callbacks, 'process'):
 
             self.connection._adapter_disconnect_stream = mock.Mock()
@@ -285,8 +280,9 @@ class ConnectionTests(unittest.TestCase):
 
     def test_on_stream_terminated_invokes_access_denied_on_connection_error_and_closed(
             self):
-        """_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \
-        `ProbableAccessDeniedError` and `ON_CONNECTION_CLOSED` callbacks"""
+        r"""_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \ `ProbableAccessDeniedError`
+        and `ON_CONNECTION_CLOSED` callbacks.
+        """
         with mock.patch.object(self.connection.callbacks, 'process'):
 
             self.connection._adapter_disconnect_stream = mock.Mock()
@@ -310,7 +306,7 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.connection.Connection._adapter_connect_stream')
     def test_new_conn_should_use_first_channel(self, connect):
-        """_next_channel_number in new conn should always be 1"""
+        """_next_channel_number in new conn should always be 1."""
         with mock.patch.object(ConstructibleConnection,
                                '_adapter_connect_stream'):
             conn = ConstructibleConnection()
@@ -318,7 +314,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(1, conn._next_channel_number())
 
     def test_next_channel_number_returns_lowest_unused(self):
-        """_next_channel_number must return lowest available channel number"""
+        """_next_channel_number must return lowest available channel number."""
         for channel_num in range(1, 50):
             self.connection._channels[channel_num] = True
         expectation = random.randint(5, 49)
@@ -326,7 +322,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(self.connection._next_channel_number(), expectation)
 
     def test_add_callbacks(self):
-        """make sure the callback adding works"""
+        """Make sure the callback adding works."""
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
         for test_method, expected_key in (
             (self.connection.add_on_open_callback,
@@ -339,14 +335,14 @@ class ConnectionTests(unittest.TestCase):
                 0, expected_key, dummy_callback, False)
 
     def test_add_on_close_callback(self):
-        """make sure the add on close callback is added"""
+        """Make sure the add on close callback is added."""
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
         self.connection.add_on_open_callback(dummy_callback)
         self.connection.callbacks.add.assert_called_once_with(
             0, self.connection.ON_CONNECTION_OPEN_OK, dummy_callback, False)
 
     def test_add_on_open_error_callback(self):
-        """make sure the add on open error callback is added"""
+        """Make sure the add on open error callback is added."""
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
         # Test with remove default first (also checks default is True)
         self.connection.add_on_open_error_callback(dummy_callback)
@@ -357,7 +353,7 @@ class ConnectionTests(unittest.TestCase):
             0, self.connection.ON_CONNECTION_ERROR, dummy_callback, False)
 
     def test_channel(self):
-        """test the channel method"""
+        """Test the channel method."""
         self.connection._next_channel_number = mock.Mock(return_value=42)
         test_channel = mock.Mock(spec=channel.Channel)
         self.connection._create_channel = mock.Mock(return_value=test_channel)
@@ -401,7 +397,9 @@ class ConnectionTests(unittest.TestCase):
 
     def test_connect_no_adapter_connect_from_constructor_with_external_workflow(
             self):
-        """check that adapter connection is not happening in constructor with external connection workflow."""
+        """Check that adapter connection is not happening in constructor with external connection
+        workflow.
+        """
         with mock.patch.object(
                 ConstructibleConnection,
                 '_adapter_connect_stream') as adapter_connect_stack_mock:
@@ -412,7 +410,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(conn.connection_state, conn.CONNECTION_INIT)
 
     def test_client_properties(self):
-        """make sure client properties has some important keys"""
+        """Make sure client properties has some important keys."""
         client_props = self.connection._client_properties
         self.assertTrue(isinstance(client_props, dict))
         for required_key in ('product', 'platform', 'capabilities',
@@ -465,7 +463,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertDictEqual(conn._client_properties, expectation)
 
     def test_close_channels(self):
-        """test closing all channels"""
+        """Test closing all channels."""
         self.connection.connection_state = self.connection.CONNECTION_OPEN
         self.connection.callbacks = mock.Mock(spec=self.connection.callbacks)
 
@@ -503,7 +501,7 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.frame.ProtocolHeader')
     def test_on_stream_connected(self, frame_protocol_header):
-        """make sure the _on_stream_connected() sets the state and sends a frame"""
+        """Make sure the _on_stream_connected() sets the state and sends a frame."""
         self.connection.connection_state = self.connection.CONNECTION_INIT
         self.connection._adapter_connect = mock.Mock(return_value=None)
         self.connection._send_frame = mock.Mock()
@@ -515,7 +513,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection._send_frame.assert_called_once_with('frame object')
 
     def test_on_connection_start(self):
-        """make sure starting a connection sets the correct class vars"""
+        """Make sure starting a connection sets the correct class vars."""
         method_frame = mock.Mock()
         method_frame.method = mock.Mock()
         method_frame.method.mechanisms = str(credentials.PlainCredentials.TYPE)
@@ -546,7 +544,7 @@ class ConnectionTests(unittest.TestCase):
                        spec_set=connection.Connection._adapter_emit_data)
     def test_on_connection_tune(self, _adapter_emit_data, method,
                                 heartbeat_checker):
-        """make sure _on_connection_tune tunes the connection params"""
+        """Make sure _on_connection_tune tunes the connection params."""
         heartbeat_checker.return_value = 'hearbeat obj'
         self.connection._flush_outbound = mock.Mock()
         marshal = mock.Mock(return_value='ab')
@@ -645,7 +643,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(60, self.connection.params.heartbeat)
 
     def test_on_connection_close_from_broker_passes_correct_exception(self):
-        """make sure connection close from broker passes correct exception"""
+        """Make sure connection close from broker passes correct exception."""
         method_frame = mock.Mock()
         method_frame.method = mock.Mock(spec=spec.Connection.Close)
         method_frame.method.reply_code = 1
@@ -663,7 +661,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(exc.reply_text, 'hello')
 
     def test_on_connection_close_ok(self):
-        """make sure _on_connection_close_ok terminates connection"""
+        """Make sure _on_connection_close_ok terminates connection."""
         method_frame = mock.Mock()
         method_frame.method = mock.Mock(spec=spec.Connection.CloseOk)
         self.connection._terminate_stream = mock.Mock()
@@ -675,7 +673,7 @@ class ConnectionTests(unittest.TestCase):
 
     @mock.patch('pika.frame.decode_frame')
     def test_on_data_available(self, decode_frame):
-        """test on data available and process frame"""
+        """Test on data available and process frame."""
         data_in = ['data']
         self.connection._frame_buffer = ['old_data']
         for frame_type in (frame.Method, spec.Basic.Deliver, frame.Heartbeat):

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.channel.ContentFrameAssembler
+"""Tests for pika.channel.ContentFrameAssembler."""
 
-"""
 import marshal
 import unittest
 

--- a/tests/unit/credentials_tests.py
+++ b/tests/unit/credentials_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.credentials
+"""Tests for pika.credentials."""
 
-"""
 import unittest
 from unittest import mock
 

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -1,7 +1,5 @@
-"""
-pika.data tests
+"""pika.data tests."""
 
-"""
 import datetime
 import decimal
 import struct
@@ -92,10 +90,11 @@ class DataTests(unittest.TestCase):
         self.assertEqual(byte_count, 233)
 
     def test_decode_signed_long_negative(self):
-        """Verify that type tag 'l' decodes as signed 64-bit (fixes #1531).
+        """
+        Verify that type tag 'l' decodes as signed 64-bit (fixes #1531).
 
-        RabbitMQ encodes negative longs (e.g. x-delay after delivery)
-        with type tag 'l' and signed 64-bit representation.
+        RabbitMQ encodes negative longs (e.g. x-delay after delivery) with type tag 'l' and signed
+        64-bit representation.
         """
         # Table with x-delay = -30000 encoded as signed 64-bit 'l'
         input = (b'\x00\x00\x00\x10'

--- a/tests/unit/delivery_mode_test.py
+++ b/tests/unit/delivery_mode_test.py
@@ -1,6 +1,5 @@
-"""
-Tests for pika.delivery_mode
-"""
+"""Tests for pika.delivery_mode."""
+
 import struct
 import unittest
 
@@ -17,12 +16,12 @@ class DeliveryModeTests(unittest.TestCase):
         self.assertEqual(DeliveryMode.Persistent.value, 2)
 
     def test_delivery_mode_is_int(self):
-        """DeliveryMode members must be usable as integers.
+        """
+        DeliveryMode members must be usable as integers.
 
-        Required for compatibility with the wire encoder, which calls
-        ``struct.pack('B', delivery_mode)``.  ``struct.pack`` requires
-        ``__index__()`` on its argument; a plain ``Enum`` does not satisfy
-        this and a publish would raise ``struct.error: required argument
+        Required for compatibility with the wire encoder, which calls ``struct.pack('B',
+        delivery_mode)``.  ``struct.pack`` requires ``__index__()`` on its argument; a plain
+        ``Enum`` does not satisfy this and a publish would raise ``struct.error: required argument
         is not an integer``.
         """
         self.assertEqual(int(DeliveryMode.Transient), 1)
@@ -43,9 +42,11 @@ class DeliveryModeTests(unittest.TestCase):
         self.assertEqual(struct.pack('B', DeliveryMode.Persistent), b'\x02')
 
     def test_basic_properties_encode_with_enum(self):
-        """A ``BasicProperties`` constructed with a ``DeliveryMode`` enum
-        member must encode without error.  This exercises the real
-        publish path that broke when ``DeliveryMode`` was a plain enum.
+        """
+        A ``BasicProperties`` constructed with a ``DeliveryMode`` enum member must encode without
+        error.
+
+        This exercises the real publish path that broke when ``DeliveryMode`` was a plain enum.
         """
         props = BasicProperties(delivery_mode=DeliveryMode.Persistent)
         encoded = b''.join(props.encode())
@@ -63,8 +64,8 @@ class DeliveryModeTests(unittest.TestCase):
         self.assertGreater(len(encoded), 0)
 
     def test_basic_properties_round_trip_with_enum(self):
-        """Encoding a ``BasicProperties`` with a ``DeliveryMode`` enum
-        member and decoding it must recover the integer value.
+        """Encoding a ``BasicProperties`` with a ``DeliveryMode`` enum member and decoding it must
+        recover the integer value.
         """
         original = BasicProperties(delivery_mode=DeliveryMode.Persistent)
         encoded = b''.join(original.encode())
@@ -76,9 +77,7 @@ class DeliveryModeTests(unittest.TestCase):
         self.assertEqual(decoded.delivery_mode, DeliveryMode.Persistent)
 
     def test_basic_properties_round_trip_with_integer(self):
-        """Encoding with an integer literal and decoding must recover the
-        same integer.
-        """
+        """Encoding with an integer literal and decoding must recover the same integer."""
         original = BasicProperties(delivery_mode=1)
         encoded = b''.join(original.encode())
         decoded = BasicProperties()
@@ -86,9 +85,8 @@ class DeliveryModeTests(unittest.TestCase):
         self.assertEqual(decoded.delivery_mode, 1)
 
     def test_basic_properties_encode_rejects_non_integer(self):
-        """A ``BasicProperties`` constructed with a non-integer
-        delivery_mode (e.g. a string) must raise at encode time so callers
-        passing the wrong type get a useful diagnostic.
+        """A ``BasicProperties`` constructed with a non-integer delivery_mode (e.g. a string) must
+        raise at encode time so callers passing the wrong type get a useful diagnostic.
         """
         props = BasicProperties(delivery_mode='persistent')  # type: ignore
         with self.assertRaises((struct.error, TypeError)):

--- a/tests/unit/deprecation_tests.py
+++ b/tests/unit/deprecation_tests.py
@@ -1,8 +1,9 @@
 """
-Tests that adapters slated for removal in Pika 2.0 emit a DeprecationWarning
-on instantiation. See https://github.com/pika/pika/issues/1608.
+Tests that adapters slated for removal in Pika 2.0 emit a DeprecationWarning on instantiation.
 
+See https://github.com/pika/pika/issues/1608.
 """
+
 import sys
 import unittest
 import warnings
@@ -30,8 +31,8 @@ except ImportError:
 
 
 class DeprecationTestCase(unittest.TestCase):
-    """Base class with a helper to instantiate an adapter and assert that it
-    emits a single, well-formed DeprecationWarning.
+    """Base class with a helper to instantiate an adapter and assert that it emits a single, well-
+    formed DeprecationWarning.
     """
 
     def assert_deprecated(self, adapter_name, factory):

--- a/tests/unit/diagnostic_utils_test.py
+++ b/tests/unit/diagnostic_utils_test.py
@@ -1,6 +1,4 @@
-"""
-Test of `pika.diagnostic_utils`
-"""
+"""Test of `pika.diagnostic_utils`"""
 
 import logging
 import unittest

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.exceptions
+"""Tests for pika.exceptions."""
 
-"""
 import unittest
 from unittest.mock import MagicMock
 

--- a/tests/unit/exchange_type_test.py
+++ b/tests/unit/exchange_type_test.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.exchange_type
+"""Tests for pika.exchange_type."""
 
-"""
 import unittest
 
 from pika.exchange_type import ExchangeType

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.frame
+"""Tests for pika.frame."""
 
-"""
 import unittest
 
 from pika import DeliveryMode, exceptions, frame, spec

--- a/tests/unit/heartbeat_tests.py
+++ b/tests/unit/heartbeat_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.heartbeat
+"""Tests for pika.heartbeat."""
 
-"""
 import unittest
 from unittest import mock
 
@@ -10,9 +8,8 @@ from pika import connection, frame, heartbeat
 
 
 class ConstructableConnection(connection.Connection):
-    """Adds dummy overrides for `Connection`'s abstract methods so
-    that we can instantiate and test it.
-
+    """Adds dummy overrides for `Connection`'s abstract methods so that we can instantiate and test
+    it.
     """
 
     def _adapter_connect_stream(self):

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -1,6 +1,5 @@
-"""
-Test for io_services_test_stubs.py
-"""
+"""Test for io_services_test_stubs.py."""
+
 from __future__ import annotations
 
 import pika._utils

--- a/tests/unit/select_connection_interrupt_tests.py
+++ b/tests/unit/select_connection_interrupt_tests.py
@@ -1,16 +1,14 @@
-"""Unit test for `_PollerBase._read_interrupt` non-blocking errno handling.
+"""
+Unit test for `_PollerBase._read_interrupt` non-blocking errno handling.
 
-Regression coverage for pika/pika#1314. On Windows, a non-blocking `recv`
-against an empty socket raises `BlockingIOError` with `errno.EWOULDBLOCK`
-(`WSAEWOULDBLOCK`, 10035) rather than `errno.EAGAIN` (11). The interrupt
-handler must swallow both; otherwise a spurious wake or a drained buffer
-kills the poller thread on Windows.
+Regression coverage for pika/pika#1314. On Windows, a non-blocking `recv` against an empty socket
+raises `BlockingIOError` with `errno.EWOULDBLOCK` (`WSAEWOULDBLOCK`, 10035) rather than
+`errno.EAGAIN` (11). The interrupt handler must swallow both; otherwise a spurious wake or a drained
+buffer kills the poller thread on Windows.
 
-This test uses a real `SelectPoller` and a real non-blocking socket pair,
-so it exercises whatever errno the OS actually raises. On Linux both
-symbols share a value and the test is a no-op guard; on Windows it fails
-against the pre-fix code and passes against the fix.
-
+This test uses a real `SelectPoller` and a real non-blocking socket pair, so it exercises whatever
+errno the OS actually raises. On Linux both symbols share a value and the test is a no-op guard; on
+Windows it fails against the pre-fix code and passes against the fix.
 """
 
 import unittest
@@ -19,12 +17,12 @@ from pika.adapters import select_connection
 
 
 class ReadInterruptHandlesEmptySocket(unittest.TestCase):
-    """`_read_interrupt` must return cleanly when the interrupt fd is empty.
+    """
+    `_read_interrupt` must return cleanly when the interrupt fd is empty.
 
-    The interrupt socket pair created by `_PollerBase.__init__` is
-    non-blocking, so calling `_read_interrupt` against an empty read side
-    triggers an OS-native "would block" error. The handler is expected to
-    recognize it and return without propagating.
+    The interrupt socket pair created by `_PollerBase.__init__` is non-blocking, so calling
+    `_read_interrupt` against an empty read side triggers an OS-native "would block" error. The
+    handler is expected to recognize it and return without propagating.
     """
 
     def setUp(self):

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -1,7 +1,4 @@
-"""
-Tests for SelectConnection IOLoops
-
-"""
+"""Tests for SelectConnection IOLoops."""
 
 import errno
 import functools
@@ -38,7 +35,7 @@ POLLPRI = getattr(select, 'POLLPRI', 0) or 2
 
 
 def _trace_stderr(fmt, *args):
-    """Format and output the text to stderr"""
+    """Format and output the text to stderr."""
     print((fmt % args) + "\n", end="", file=sys.stderr)
 
 
@@ -99,10 +96,7 @@ class IOLoopBaseTest(unittest.TestCase):
         return f'{method_desc} ({self.SELECT_POLLER})'
 
     def start(self):
-        """Setup timeout handler for detecting 'no-activity'
-        and start polling.
-
-        """
+        """Setup timeout handler for detecting 'no-activity' and start polling."""
         fail_timer = self.ioloop.call_later(self.TIMEOUT, self.on_timeout)
         self.addCleanup(self.ioloop.remove_timeout, fail_timer)
         self.ioloop.start()
@@ -111,13 +105,14 @@ class IOLoopBaseTest(unittest.TestCase):
         self.ioloop._poller.deactivate_poller.assert_called_once_with()
 
     def on_timeout(self):
-        """Called when stuck waiting for connection to close"""
+        """Called when stuck waiting for connection to close."""
         self.ioloop.stop()  # force the ioloop to stop
         self.fail('Test timed out')
 
 
 class IOLoopCloseClosesSubordinateObjectsTestSelect(IOLoopBaseTest):
-    """ Test ioloop being closed """
+    """Test ioloop being closed."""
+
     SELECT_POLLER = 'select'
 
     def test_start(self):
@@ -132,7 +127,8 @@ class IOLoopCloseClosesSubordinateObjectsTestSelect(IOLoopBaseTest):
 
 
 class IOLoopCloseAfterStartReturnsTest(IOLoopBaseTest):
-    """ Test IOLoop.close() after normal return from start(). """
+    """Test IOLoop.close() after normal return from start()."""
+
     SELECT_POLLER = 'select'
 
     def test_start(self):
@@ -143,7 +139,8 @@ class IOLoopCloseAfterStartReturnsTest(IOLoopBaseTest):
 
 
 class IOLoopStartReentrancyNotAllowedTestSelect(IOLoopBaseTest):
-    """ Test calling IOLoop.start() while arleady in start() raises exception. """
+    """Test calling IOLoop.start() while arleady in start() raises exception."""
+
     SELECT_POLLER = 'select'
 
     def test_start(self):
@@ -164,7 +161,8 @@ class IOLoopStartReentrancyNotAllowedTestSelect(IOLoopBaseTest):
 
 
 class IOLoopCloseBeforeStartReturnsTestSelect(IOLoopBaseTest):
-    """ Test calling IOLoop.close() before return from start() raises exception. """
+    """Test calling IOLoop.close() before return from start() raises exception."""
+
     SELECT_POLLER = 'select'
 
     def test_start(self):
@@ -185,11 +183,12 @@ class IOLoopCloseBeforeStartReturnsTestSelect(IOLoopBaseTest):
 
 
 class IOLoopThreadStopTestSelect(IOLoopBaseTest):
-    """ Test ioloop being stopped by another Thread. """
+    """Test ioloop being stopped by another Thread."""
+
     SELECT_POLLER = 'select'
 
     def test_start(self):
-        """Starts a thread that stops ioloop after a while and start polling"""
+        """Starts a thread that stops ioloop after a while and start polling."""
         timer = threading.Timer(
             0.1, lambda: self.ioloop.add_callback_threadsafe(self.ioloop.stop))
         self.addCleanup(timer.cancel)
@@ -200,23 +199,27 @@ class IOLoopThreadStopTestSelect(IOLoopBaseTest):
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class IOLoopThreadStopTestPoll(IOLoopThreadStopTestSelect):
     """Same as IOLoopThreadStopTestSelect but uses 'poll' syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class IOLoopThreadStopTestEPoll(IOLoopThreadStopTestSelect):
     """Same as IOLoopThreadStopTestSelect but uses 'epoll' syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class IOLoopThreadStopTestKqueue(IOLoopThreadStopTestSelect):
     """Same as IOLoopThreadStopTestSelect but uses 'kqueue' syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
 class IOLoopAddCallbackAfterCloseDoesNotRaiseTestSelect(IOLoopBaseTest):
-    """ Test ioloop add_callback_threadsafe() after ioloop close doesn't raise exception. """
+    """Test ioloop add_callback_threadsafe() after ioloop close doesn't raise exception."""
+
     SELECT_POLLER = 'select'
 
     def test_start(self):
@@ -233,19 +236,16 @@ class IOLoopAddCallbackAfterCloseDoesNotRaiseTestSelect(IOLoopBaseTest):
 @unittest.skipIf(platform.python_implementation() == 'PyPy',
                  'test is flaky on PyPy')
 class IOLoopTimerTestSelect(IOLoopBaseTest):
-    """Set a bunch of very short timers to fire in reverse order and check
-    that they fire in order of time, not
-
+    """Set a bunch of very short timers to fire in reverse order and check that they fire in order
+    of time, not.
     """
+
     NUM_TIMERS = 5
     TIMER_INTERVAL = 0.25
     SELECT_POLLER = 'select'
 
     def set_timers(self):
-        """Set timers that timers that fires in succession with the specified
-        interval.
-
-        """
+        """Set timers that timers that fires in succession with the specified interval."""
         self.timer_stack = []
         for i in range(self.NUM_TIMERS, 0, -1):
             deadline = i * self.TIMER_INTERVAL
@@ -259,10 +259,7 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.start()
 
     def on_timer(self, val):
-        """A timeout handler that verifies that the given parameter matches
-        what is expected.
-
-        """
+        """A timeout handler that verifies that the given parameter matches what is expected."""
         self.assertEqual(val, self.timer_stack.pop())
         if not self.timer_stack:
             self.ioloop.stop()
@@ -272,9 +269,8 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.start_test()
 
     def test_timer_for_deleting_itself(self):
-        """Verifies that an attempt to delete a timeout within the
-        corresponding handler generates no exceptions.
-
+        """Verifies that an attempt to delete a timeout within the corresponding handler generates
+        no exceptions.
         """
         self.timer_stack = []
         handle_holder = []
@@ -295,10 +291,11 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.ioloop.stop()
 
     def test_timer_delete_another(self):
-        """Verifies that an attempt by a timeout handler to delete another,
-        that  is ready to run, cancels the execution of the latter without
-        generating an exception. This should pose no issues.
+        """
+        Verifies that an attempt by a timeout handler to delete another, that  is ready to run,
+        cancels the execution of the latter without generating an exception.
 
+        This should pose no issues.
         """
         holder_for_target_timer = []
         self.ioloop.call_later(
@@ -313,18 +310,18 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
         self.assertTrue(self.concluded)
 
     def _on_timer_delete_another(self, holder):
-        """A timeout handler that tries to remove another timeout handler
-        that is ready to run. This should pose no issues.
+        """
+        A timeout handler that tries to remove another timeout handler that is ready to run.
 
+        This should pose no issues.
         """
         target_timer = holder[0]
         self.ioloop.remove_timeout(target_timer)
         self.deleted_another_timer = True
 
         def _on_timer_conclude():
-            """A timeout handler that is called to verify outcome of calling
-            or not calling of previously set handlers.
-
+            """A timeout handler that is called to verify outcome of calling or not calling of
+            previously set handlers.
             """
             self.concluded = True
             self.assertTrue(self.deleted_another_timer)
@@ -340,28 +337,30 @@ class IOLoopTimerTestSelect(IOLoopBaseTest):
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class IOLoopTimerTestPoll(IOLoopTimerTestSelect):
-    """Same as IOLoopTimerTestSelect but uses 'poll' syscall"""
+    """Same as IOLoopTimerTestSelect but uses 'poll' syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class IOLoopTimerTestEPoll(IOLoopTimerTestSelect):
-    """Same as IOLoopTimerTestSelect but uses 'epoll' syscall"""
+    """Same as IOLoopTimerTestSelect but uses 'epoll' syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class IOLoopTimerTestKqueue(IOLoopTimerTestSelect):
-    """Same as IOLoopTimerTestSelect but uses 'kqueue' syscall"""
+    """Same as IOLoopTimerTestSelect but uses 'kqueue' syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
 class IOLoopSleepTimerTestSelect(IOLoopTimerTestSelect):
-    """Sleep until all the timers should have passed and check they still
-        fire in deadline order"""
+    """Sleep until all the timers should have passed and check they still fire in deadline order."""
 
     def start_test(self):
-        """ Setup timers, sleep and start polling """
+        """Setup timers, sleep and start polling."""
         self.set_timers()
         time.sleep(self.NUM_TIMERS * self.TIMER_INTERVAL)
         self.start()
@@ -369,24 +368,28 @@ class IOLoopSleepTimerTestSelect(IOLoopTimerTestSelect):
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class IOLoopSleepTimerTestPoll(IOLoopSleepTimerTestSelect):
-    """Same as IOLoopSleepTimerTestSelect but uses 'poll' syscall"""
+    """Same as IOLoopSleepTimerTestSelect but uses 'poll' syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class IOLoopSleepTimerTestEPoll(IOLoopSleepTimerTestSelect):
-    """Same as IOLoopSleepTimerTestSelect but uses 'epoll' syscall"""
+    """Same as IOLoopSleepTimerTestSelect but uses 'epoll' syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class IOLoopSleepTimerTestKqueue(IOLoopSleepTimerTestSelect):
-    """Same as IOLoopSleepTimerTestSelect but uses 'kqueue' syscall"""
+    """Same as IOLoopSleepTimerTestSelect but uses 'kqueue' syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
 class IOLoopSocketBaseSelect(IOLoopBaseTest):
     """A base class for setting up a communicating pair of sockets."""
+
     SELECT_POLLER = 'select'
     READ_SIZE = 1024
 
@@ -408,7 +411,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         super().tearDown()
 
     def create_accept_socket(self):
-        """Create a socket and setup 'accept' handler"""
+        """Create a socket and setup 'accept' handler."""
         listen_sock = socket.socket()
         listen_sock.setblocking(0)
         listen_sock.bind(('localhost', 0))
@@ -418,7 +421,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         self.ioloop.add_handler(fd_, self.do_accept, self.ioloop.READ)
 
     def create_write_socket(self, on_connected):
-        """ Create a pair of socket and setup 'connected' handler """
+        """Create a pair of socket and setup 'connected' handler."""
         write_sock = socket.socket()
         write_sock.setblocking(0)
         err = write_sock.connect_ex(self.listen_addr)
@@ -429,7 +432,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         return write_sock
 
     def do_accept(self, fd_, events):
-        """ Create socket from the given fd_ and setup 'read' handler """
+        """Create socket from the given fd_ and setup 'read' handler."""
         self.assertEqual(events, self.ioloop.READ)
         listen_sock = self.sock_map[fd_]
         read_sock, _ = listen_sock.accept()
@@ -437,23 +440,29 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         self.ioloop.add_handler(fd_, self.do_read, self.ioloop.READ)
 
     def connected(self, _fd, _events):
-        """ Create socket from given _fd and respond to 'connected'.
-            Implemenation is subclass's responsibility. """
+        """
+        Create socket from given _fd and respond to 'connected'.
+
+        Implemenation is subclass's responsibility.
+        """
         self.fail("IOLoopSocketBase.connected not extended")
 
     def do_read(self, fd_, events):
-        """ read from fd and check the received content """
+        """Read from fd and check the received content."""
         self.assertEqual(events, self.ioloop.READ)
         # NOTE Use socket.recv instead of os.read for Windows compatibility
         self.verify_message(self.sock_map[fd_].recv(self.READ_SIZE))
 
     def verify_message(self, _msg):
-        """ See if 'msg' matches what is expected. This is a stub.
-            Real implementation is subclass's responsibility """
+        """
+        See if 'msg' matches what is expected.
+
+        This is a stub. Real implementation is subclass's responsibility
+        """
         self.fail("IOLoopSocketBase.verify_message not extended")
 
     def on_timeout(self):
-        """called when stuck waiting for connection to close"""
+        """Called when stuck waiting for connection to close."""
         # force the ioloop to stop
         self.ioloop.stop()
         self.fail('Test timed out')
@@ -461,30 +470,32 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class IOLoopSocketBasePoll(IOLoopSocketBaseSelect):
-    """Same as IOLoopSocketBaseSelect but uses 'poll' syscall"""
+    """Same as IOLoopSocketBaseSelect but uses 'poll' syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class IOLoopSocketBaseEPoll(IOLoopSocketBaseSelect):
-    """Same as IOLoopSocketBaseSelect but uses 'epoll' syscall"""
+    """Same as IOLoopSocketBaseSelect but uses 'epoll' syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class IOLoopSocketBaseKqueue(IOLoopSocketBaseSelect):
-    """ Same as IOLoopSocketBaseSelect but uses 'kqueue' syscall """
+    """Same as IOLoopSocketBaseSelect but uses 'kqueue' syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
 class IOLoopSimpleMessageTestCaseSelect(IOLoopSocketBaseSelect):
-    """Test read/write by creating a pair of sockets, writing to one
-    end and reading from the other
-
+    """Test read/write by creating a pair of sockets, writing to one end and reading from the
+    other.
     """
 
     def start(self):
-        """Create a pair of sockets and poll"""
+        """Create a pair of sockets and poll."""
         self.create_write_socket(self.connected)
         super().start()
 
@@ -496,42 +507,45 @@ class IOLoopSimpleMessageTestCaseSelect(IOLoopSocketBaseSelect):
         self.ioloop.update_handler(fd, 0)
 
     def verify_message(self, msg):
-        """Make sure we get what is expected and stop polling """
+        """Make sure we get what is expected and stop polling."""
         self.assertEqual(msg, b'X')
         self.ioloop.stop()
 
     def test_start(self):
-        """Simple message Test"""
+        """Simple message Test."""
         self.start()
 
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class IOLoopSimpleMessageTestCasetPoll(IOLoopSimpleMessageTestCaseSelect):
-    """Same as IOLoopSimpleMessageTestCaseSelect but uses 'poll' syscall"""
+    """Same as IOLoopSimpleMessageTestCaseSelect but uses 'poll' syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class IOLoopSimpleMessageTestCasetEPoll(IOLoopSimpleMessageTestCaseSelect):
-    """Same as IOLoopSimpleMessageTestCaseSelect but uses 'epoll' syscall"""
+    """Same as IOLoopSimpleMessageTestCaseSelect but uses 'epoll' syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class IOLoopSimpleMessageTestCasetKqueue(IOLoopSimpleMessageTestCaseSelect):
-    """Same as IOLoopSimpleMessageTestCaseSelect but uses 'kqueue' syscall"""
+    """Same as IOLoopSimpleMessageTestCaseSelect but uses 'kqueue' syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
 class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
-    """ Tests if EINTR is properly caught and polling gets resumed. """
+    """Tests if EINTR is properly caught and polling gets resumed."""
+
     SELECT_POLLER = 'select'
     MSG_CONTENT = b'hello'
 
     @staticmethod
     def signal_handler(signum, interrupted_stack):
-        """A signal handler that gets called in response to
-           os.kill(signal.SIGUSR1)."""
+        """A signal handler that gets called in response to os.kill(signal.SIGUSR1)."""
 
     def _eintr_read_handler(self, fileno, events):
         """Read from within poll loop that gets receives eintr error."""
@@ -546,8 +560,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         self._eintr_read_handler_is_called = True
 
     def _eintr_test_fail(self):
-        """This function gets called when eintr-test failed to get
-           _eintr_read_handler called."""
+        """This function gets called when eintr-test failed to get _eintr_read_handler called."""
         self.poller.stop()
         self.fail('Eintr-test timed out')
 
@@ -558,9 +571,12 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
             self,
             is_resumable_mock,
             is_resumable_raw=pika.adapters.select_connection._is_resumable):
-        """Test that poll() is properly restarted after receiving EINTR error.
-           Class of an exception raised to signal the error differs in one
-           implementation of polling mechanism and another."""
+        """
+        Test that poll() is properly restarted after receiving EINTR error.
+
+        Class of an exception raised to signal the error differs in one implementation of polling
+        mechanism and another.
+        """
         if threading.current_thread() is not threading.main_thread():
             self.skipTest("signal.signal() requires the main thread")
 
@@ -581,8 +597,8 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
 
         self.ioloop.call_later(self.TIMEOUT, self._eintr_test_fail)
 
-        original_signal_handler = \
-            signal.signal(signal.SIGUSR1, self.signal_handler)
+        original_signal_handler = signal.signal(signal.SIGUSR1,
+                                                self.signal_handler)
         self.addCleanup(signal.signal, signal.SIGUSR1, original_signal_handler)
 
         tmr_k = threading.Timer(0.1,
@@ -599,19 +615,22 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class IOLoopEintrTestCasePoll(IOLoopEintrTestCaseSelect):
-    """Same as IOLoopEintrTestCaseSelect but uses poll syscall"""
+    """Same as IOLoopEintrTestCaseSelect but uses poll syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class IOLoopEintrTestCaseEPoll(IOLoopEintrTestCaseSelect):
-    """Same as IOLoopEINTRrTestCaseSelect but uses epoll syscall"""
+    """Same as IOLoopEINTRrTestCaseSelect but uses epoll syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class IOLoopEintrTestCaseKqueue(IOLoopEintrTestCaseSelect):
-    """Same as IOLoopEINTRTestCaseSelect but uses kqueue syscall"""
+    """Same as IOLoopEINTRTestCaseSelect but uses kqueue syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
@@ -672,26 +691,28 @@ class PollerTestCaseSelect(unittest.TestCase):
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 class PollerTestCasePoll(PollerTestCaseSelect):
-    """Same as PollerTestCaseSelect but uses poll syscall"""
+    """Same as PollerTestCaseSelect but uses poll syscall."""
+
     SELECT_POLLER = 'poll'
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 class PollerTestCaseEPoll(PollerTestCaseSelect):
-    """Same as PollerTestCaseSelect but uses epoll syscall"""
+    """Same as PollerTestCaseSelect but uses epoll syscall."""
+
     SELECT_POLLER = 'epoll'
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 class PollerTestCaseKqueue(PollerTestCaseSelect):
-    """Same as PollerTestCaseSelect but uses kqueue syscall"""
+    """Same as PollerTestCaseSelect but uses kqueue syscall."""
+
     SELECT_POLLER = 'kqueue'
 
 
 class DefaultPollerSocketEventsTestCase(unittest.TestCase):
-    """This test suite outputs diagnostic information usful for debugging the
-    IOLoop poller's fd watcher
-
+    """This test suite outputs diagnostic information usful for debugging the IOLoop poller's fd
+    watcher.
     """
 
     DEFAULT_TEST_TIMEOUT = 15
@@ -703,14 +724,12 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
     ERROR = IOLOOP_CLS.ERROR
 
     def create_ioloop_with_timeout(self):
-        """Create IOLoop with test timeout and schedule cleanup to close it
-
-        """
+        """Create IOLoop with test timeout and schedule cleanup to close it."""
         ioloop = select_connection.IOLoop()
         self.addCleanup(ioloop.close)
 
         def _on_test_timeout():
-            """Called when test times out"""
+            """Called when test times out."""
             LOGGER.info('%s TIMED OUT (%s)', datetime.now(timezone.utc), self)
             self.fail('Test timed out')
 
@@ -719,20 +738,17 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         return ioloop
 
     def create_nonblocking_tcp_socket(self):
-        """Create a TCP stream socket and schedule cleanup to close it
-
-        """
+        """Create a TCP stream socket and schedule cleanup to close it."""
         sock = socket.socket()
         sock.setblocking(False)
         self.addCleanup(sock.close)
         return sock
 
     def create_nonblocking_socketpair(self):
-        """Creates a non-blocking socket pair and schedules cleanup to close
-        them
+        """
+        Creates a non-blocking socket pair and schedules cleanup to close them.
 
         :returns: two-tuple of connected non-blocking sockets
-
         """
         pair = pika._utils.nonblocking_socketpair()
         self.addCleanup(pair[0].close)
@@ -740,11 +756,10 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
         return pair
 
     def create_blocking_socketpair(self):
-        """Creates a blocking socket pair and schedules cleanup to close
-        them
+        """
+        Creates a blocking socket pair and schedules cleanup to close them.
 
         :returns: two-tuple of connected non-blocking sockets
-
         """
         pair = self.create_nonblocking_socketpair()
         pair[0].setblocking(True)
@@ -753,9 +768,8 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
     @staticmethod
     def safe_connect_nonblocking_socket(sock, addr_pair):
-        """Initiate socket connection, suppressing EINPROGRESS/EWOULDBLOCK
-        :param socket.socket sock
-        :param addr_pair: two tuple of address string and port integer
+        """Initiate socket connection, suppressing EINPROGRESS/EWOULDBLOCK :param socket.socket sock
+        :param addr_pair: two tuple of address string and port integer.
         """
         try:
             sock.connect(addr_pair)
@@ -781,8 +795,10 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
     def which_events_are_set_with_varying_eventmasks(self, sock,
                                                      requested_eventmasks,
                                                      msg_prefix):
-        """Common logic for which_events_are_set_* tests. Runs the event loop
-        while varying eventmasks at each socket event callback
+        """
+        Common logic for which_events_are_set_* tests.
+
+        Runs the event loop while varying eventmasks at each socket event callback
 
         :param sock: socket to watch for events
         :param requested_eventmasks: a mutable list of eventmasks to apply after
@@ -1031,24 +1047,22 @@ class DefaultPollerSocketEventsTestCase(unittest.TestCase):
 
 @mock.patch.multiple(select_connection, SELECT_TYPE='select')
 class SelectPollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
-    """Runs `DefaultPollerSocketEventsTestCase` tests with forced use of
-    SelectPoller
-    """
+    """Runs `DefaultPollerSocketEventsTestCase` tests with forced use of SelectPoller."""
 
 
 @unittest.skipIf(not POLL_SUPPORTED, 'poll not supported')
 @mock.patch.multiple(select_connection, SELECT_TYPE='poll')
 class PollPollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
-    """Same as DefaultPollerSocketEventsTestCase but uses poll syscall"""
+    """Same as DefaultPollerSocketEventsTestCase but uses poll syscall."""
 
 
 @unittest.skipIf(not EPOLL_SUPPORTED, 'epoll not supported')
 @mock.patch.multiple(select_connection, SELECT_TYPE='epoll')
 class EpollPollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
-    """Same as DefaultPollerSocketEventsTestCase but uses epoll syscall"""
+    """Same as DefaultPollerSocketEventsTestCase but uses epoll syscall."""
 
 
 @unittest.skipIf(not KQUEUE_SUPPORTED, 'kqueue not supported')
 @mock.patch.multiple(select_connection, SELECT_TYPE='kqueue')
 class KqueuePollerSocketEventsTestCase(DefaultPollerSocketEventsTestCase):
-    """Same as DefaultPollerSocketEventsTestCase but uses kqueue syscall"""
+    """Same as DefaultPollerSocketEventsTestCase but uses kqueue syscall."""

--- a/tests/unit/select_connection_timer_tests.py
+++ b/tests/unit/select_connection_timer_tests.py
@@ -1,7 +1,4 @@
-"""
-Tests for SelectConnection _Timer and _Timeout classes
-
-"""
+"""Tests for SelectConnection _Timer and _Timeout classes."""
 
 import math
 import unittest
@@ -34,7 +31,7 @@ class ChildTimeout(select_connection._Timeout):
 
 
 class TimeoutClassTests(unittest.TestCase):
-    """Test select_connection._Timeout class"""
+    """Test select_connection._Timeout class."""
 
     def test_properties(self):
         now = _now()
@@ -224,7 +221,7 @@ class TimeoutClassTests(unittest.TestCase):
 
 
 class TimerClassTests(unittest.TestCase):
-    """Test select_connection._Timer class"""
+    """Test select_connection._Timer class."""
 
     def test_close_empty(self):
         timer = select_connection._Timer()

--- a/tests/unit/spec_tests.py
+++ b/tests/unit/spec_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.spec
+"""Tests for pika.spec."""
 
-"""
 import unittest
 
 from pika import spec

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1567,8 +1567,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
 
         def execute_scheduled(cb):
             mock_raw_ch = MagicMock()
-            mock_conn.channel.side_effect = lambda on_open_callback: \
-                on_open_callback(mock_raw_ch)
+            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(mock_raw_ch)
             cb()
 
         mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled
@@ -1584,8 +1583,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
 
         def execute_scheduled(cb):
             mock_raw_ch = MagicMock()
-            mock_conn.channel.side_effect = lambda on_open_callback: \
-                on_open_callback(mock_raw_ch)
+            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(mock_raw_ch)
             cb()
 
         mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -439,7 +439,8 @@ class ThreadSafeChannelTests(unittest.TestCase):
         def execute_and_fire(cb):
             close_callbacks = []
             raw_ch.add_on_close_callback.side_effect = close_callbacks.append
-            raw_ch.close.side_effect = lambda reply_code, reply_text: close_callbacks[0](raw_ch, ChannelClosedByClient(reply_code, reply_text))
+            raw_ch.close.side_effect = lambda reply_code, reply_text: close_callbacks[
+                0](raw_ch, ChannelClosedByClient(reply_code, reply_text))
             cb()
 
         wrapper.add_callback_threadsafe.side_effect = execute_and_fire
@@ -671,7 +672,8 @@ class ConsumerWorkPoolTests(unittest.TestCase):
                 # Second call: channel close
                 close_callbacks = []
                 raw_ch.add_on_close_callback.side_effect = close_callbacks.append
-                raw_ch.close.side_effect = lambda reply_code, reply_text: close_callbacks[-1](raw_ch, ChannelClosedByClient(reply_code, reply_text))
+                raw_ch.close.side_effect = lambda reply_code, reply_text: close_callbacks[
+                    -1](raw_ch, ChannelClosedByClient(reply_code, reply_text))
                 cb()
 
         wrapper.add_callback_threadsafe.side_effect = execute_and_fire

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1567,7 +1567,8 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
 
         def execute_scheduled(cb):
             mock_raw_ch = MagicMock()
-            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(mock_raw_ch)
+            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(
+                mock_raw_ch)
             cb()
 
         mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled
@@ -1583,7 +1584,8 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
 
         def execute_scheduled(cb):
             mock_raw_ch = MagicMock()
-            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(mock_raw_ch)
+            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(
+                mock_raw_ch)
             cb()
 
         mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -439,8 +439,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         def execute_and_fire(cb):
             close_callbacks = []
             raw_ch.add_on_close_callback.side_effect = close_callbacks.append
-            raw_ch.close.side_effect = lambda reply_code, reply_text: \
-                close_callbacks[0](raw_ch, ChannelClosedByClient(reply_code, reply_text))
+            raw_ch.close.side_effect = lambda reply_code, reply_text: close_callbacks[0](raw_ch, ChannelClosedByClient(reply_code, reply_text))
             cb()
 
         wrapper.add_callback_threadsafe.side_effect = execute_and_fire
@@ -672,8 +671,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
                 # Second call: channel close
                 close_callbacks = []
                 raw_ch.add_on_close_callback.side_effect = close_callbacks.append
-                raw_ch.close.side_effect = lambda reply_code, reply_text: \
-                    close_callbacks[-1](raw_ch, ChannelClosedByClient(reply_code, reply_text))
+                raw_ch.close.side_effect = lambda reply_code, reply_text: close_callbacks[-1](raw_ch, ChannelClosedByClient(reply_code, reply_text))
                 cb()
 
         wrapper.add_callback_threadsafe.side_effect = execute_and_fire

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1,4 +1,5 @@
-"""Tests for pika.adapters.thread_safe_connection"""
+"""Tests for pika.adapters.thread_safe_connection."""
+
 import threading
 import unittest
 from unittest.mock import MagicMock, patch
@@ -50,8 +51,9 @@ class ThreadSafeChannelTests(unittest.TestCase):
         )
 
     def test_basic_publish_callback_swallows_channel_wrong_state_error(self):
-        """ChannelWrongStateError inside the scheduled callback must not
-        propagate to the IOLoop — that would crash the IOLoop thread."""
+        """ChannelWrongStateError inside the scheduled callback must not propagate to the IOLoop —
+        that would crash the IOLoop thread.
+        """
         from pika.exceptions import ChannelWrongStateError
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.basic_publish.side_effect = ChannelWrongStateError(
@@ -62,8 +64,9 @@ class ThreadSafeChannelTests(unittest.TestCase):
         raw_ch.basic_publish.assert_called_once()
 
     def test_on_publish_not_called_when_confirms_not_enabled(self):
-        """on_publish callback is ignored when confirm_delivery has not been
-        called (_next_publish_seq_no is None)."""
+        """on_publish callback is ignored when confirm_delivery has not been called
+        (_next_publish_seq_no is None).
+        """
         ch, raw_ch, wrapper = self._make_channel()
         on_publish = MagicMock()
         ch.basic_publish(exchange='ex',
@@ -76,8 +79,9 @@ class ThreadSafeChannelTests(unittest.TestCase):
         on_publish.assert_not_called()
 
     def test_on_publish_called_with_delivery_tag_when_confirms_enabled(self):
-        """After confirms are armed, on_publish receives monotonically
-        increasing delivery tags starting at 1."""
+        """After confirms are armed, on_publish receives monotonically increasing delivery tags
+        starting at 1.
+        """
         ch, _raw_ch, wrapper = self._make_channel()
         ch._next_publish_seq_no = 0  # simulate confirm_delivery success
         tags = []
@@ -99,8 +103,9 @@ class ThreadSafeChannelTests(unittest.TestCase):
         self.assertEqual(tags, [1, 2, 3])
 
     def test_on_publish_not_called_when_publish_raises(self):
-        """If the raw basic_publish raises, the tag is not consumed and
-        on_publish is not invoked."""
+        """If the raw basic_publish raises, the tag is not consumed and on_publish is not
+        invoked.
+        """
         from pika.exceptions import ChannelWrongStateError
         ch, raw_ch, wrapper = self._make_channel()
         ch._next_publish_seq_no = 0
@@ -116,9 +121,12 @@ class ThreadSafeChannelTests(unittest.TestCase):
         self.assertEqual(ch._next_publish_seq_no, 0)
 
     def test_seq_no_increments_without_on_publish_when_confirms_enabled(self):
-        """The delivery tag counter advances on every successful publish
-        when confirms are armed, regardless of whether on_publish is
-        provided.  This matches the RabbitMQ Java and .NET client behavior."""
+        """
+        The delivery tag counter advances on every successful publish when confirms are armed,
+        regardless of whether on_publish is provided.
+
+        This matches the RabbitMQ Java and .NET client behavior.
+        """
         ch, _raw_ch, wrapper = self._make_channel()
         ch._next_publish_seq_no = 0
         ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
@@ -540,8 +548,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_callback_runs_on_worker_thread_not_ioloop(self):
-        """on_message_callback must execute on the pool thread, not the
-        thread that invoked the wrapped callback (which is the IOLoop thread)."""
+        """on_message_callback must execute on the pool thread, not the thread that invoked the
+        wrapped callback (which is the IOLoop thread).
+        """
         ch, raw_ch, wrapper = self._make_channel()
         mock_frame = MagicMock()
         mock_frame.method.consumer_tag = 'ctag1'
@@ -598,8 +607,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         self.assertEqual(order, list(range(10)))
 
     def test_callback_exception_does_not_kill_pool(self):
-        """An exception in a delivery callback must not prevent subsequent
-        deliveries from being processed."""
+        """An exception in a delivery callback must not prevent subsequent deliveries from being
+        processed.
+        """
         ch, raw_ch, wrapper = self._make_channel()
         mock_frame = MagicMock()
         mock_frame.method.consumer_tag = 'ctag1'
@@ -629,7 +639,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         self.assertEqual(delivered, ['explode', 'after'])
 
     def test_channel_close_waits_for_pending_callbacks(self):
-        """close() must wait for in-flight callbacks to complete before returning."""
+        """Close() must wait for in-flight callbacks to complete before returning."""
         import time
 
         from pika.exceptions import ChannelClosedByClient
@@ -881,8 +891,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         wrapper.add_callback_threadsafe.assert_not_called()
 
     def test_return_listener_exception_is_logged_not_lost(self):
-        """An exception raised inside a return listener must be logged
-        (not silently dropped on an unobserved Future)."""
+        """An exception raised inside a return listener must be logged (not silently dropped on an
+        unobserved Future).
+        """
         ch, raw_ch, wrapper = self._make_channel()
 
         def boom(channel, method, properties, body):
@@ -955,8 +966,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             f'Expected "publisher confirm callback" in logs, got: {cm.output}')
 
     def test_confirm_delivery_arms_publish_seq_no_counter(self):
-        """After confirm_delivery succeeds, _next_publish_seq_no is 0
-        (armed) so subsequent publishes will track tags."""
+        """After confirm_delivery succeeds, _next_publish_seq_no is 0 (armed) so subsequent
+        publishes will track tags.
+        """
         ch, raw_ch, wrapper = self._make_channel()
         self.assertIsNone(ch._next_publish_seq_no)
         ok_frame = MagicMock()
@@ -974,8 +986,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         self.assertEqual(ch._next_publish_seq_no, 0)
 
     def test_confirm_delivery_is_idempotent(self):
-        """Calling confirm_delivery a second time returns the cached
-        Confirm.SelectOk without sending a frame or resetting the counter."""
+        """Calling confirm_delivery a second time returns the cached Confirm.SelectOk without
+        sending a frame or resetting the counter.
+        """
         ch, raw_ch, wrapper = self._make_channel()
         ok_frame = MagicMock()
 
@@ -1099,7 +1112,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
         self.assertIn('basic_cancel', str(ctx.exception))
 
     def test_channel_close_does_not_raise_on_timeout(self):
-        """close() should log and continue, not raise TimeoutError."""
+        """Close() should log and continue, not raise TimeoutError."""
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.is_closed = False
         raw_ch.is_closing = False
@@ -1166,7 +1179,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
         self.assertEqual(wrapper._blocking_waiters, [])
 
     def test_close_timeout_unregisters_waiter(self):
-        """close() timeout must not leak a waiter."""
+        """Close() timeout must not leak a waiter."""
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.is_closed = False
         raw_ch.is_closing = False
@@ -1183,11 +1196,11 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
 
 
 class BlockingRPCPassthroughTests(unittest.TestCase):
-    """Cover the eight thin RPC method wrappers that delegate to _blocking_rpc.
+    """
+    Cover the eight thin RPC method wrappers that delegate to _blocking_rpc.
 
-    Each method's only logic is to forward arguments to the raw channel via
-    self._blocking_rpc and return its result.  These tests verify the success
-    path of each wrapper end-to-end.
+    Each method's only logic is to forward arguments to the raw channel via self._blocking_rpc and
+    return its result.  These tests verify the success path of each wrapper end-to-end.
     """
 
     def _make_channel(self):
@@ -1278,7 +1291,8 @@ class BlockingRPCPassthroughTests(unittest.TestCase):
 
 
 class BlockingRPCErrorPathTests(unittest.TestCase):
-    """Cover the two error paths inside ThreadSafeChannel._blocking_rpc:
+    """
+    Cover the two error paths inside ThreadSafeChannel._blocking_rpc:
 
     * channel_method itself raises during _invoke (connection already
       torn down on the IOLoop thread).
@@ -1308,8 +1322,9 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
         self.assertIs(ctx.exception, boom)
 
     def test_channel_close_during_rpc_propagates_reason(self):
-        """Channel-close callback firing before _on_ok must surface the close
-        reason to the blocked caller."""
+        """Channel-close callback firing before _on_ok must surface the close reason to the blocked
+        caller.
+        """
         ch, raw_ch, wrapper = self._make_channel()
         reason = Exception('channel closed by broker')
         captured_close_cb = {}
@@ -1333,8 +1348,7 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
 
 
 class BasicGetTests(unittest.TestCase):
-    """Cover ThreadSafeChannel.basic_get success, empty, error and
-    channel-close paths."""
+    """Cover ThreadSafeChannel.basic_get success, empty, error and channel-close paths."""
 
     def _make_channel(self):
         raw_ch = MagicMock()
@@ -1459,8 +1473,7 @@ class ChannelCloseErrorPathTests(unittest.TestCase):
 
 
 class CallbackRegistrationFailureTests(unittest.TestCase):
-    """Cover the LOGGER.warning branches when raw-channel registration
-    methods raise."""
+    """Cover the LOGGER.warning branches when raw-channel registration methods raise."""
 
     def _make_channel(self):
         raw_ch = MagicMock()
@@ -1496,8 +1509,9 @@ class CallbackRegistrationFailureTests(unittest.TestCase):
                       mock_logger.warning.call_args[0][0])
 
     def test_publisher_confirm_drops_when_pool_shut_down(self):
-        """The wrapped ack/nack callback logs and drops if the consumer pool
-        has been shut down by the time the broker delivers the confirm."""
+        """The wrapped ack/nack callback logs and drops if the consumer pool has been shut down by
+        the time the broker delivers the confirm.
+        """
         ch, _raw_ch, _wrapper = self._make_channel()
         # Capture the wrapped callback by short-circuiting _blocking_rpc.
         captured = {}
@@ -1563,8 +1577,9 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         self.assertIn(ch, conn._channels)
 
     def test_connection_close_shuts_down_channel_pools(self):
-        """Pool shutdown happens after ioloop.start() returns, not inside
-        _on_connection_closed (which runs on the IOLoop thread)."""
+        """Pool shutdown happens after ioloop.start() returns, not inside _on_connection_closed
+        (which runs on the IOLoop thread).
+        """
         conn, mock_conn, mock_ioloop = self._make_connection()
 
         def execute_scheduled(cb):
@@ -1640,8 +1655,9 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         self.assertTrue(ch._pool_shutdown)
 
     def test_init_raises_timeout_error(self):
-        """Constructor must raise TimeoutError if connection is not established
-        within the specified timeout."""
+        """Constructor must raise TimeoutError if connection is not established within the specified
+        timeout.
+        """
         with patch('pika.adapters.thread_safe_connection.SelectConnection'
                   ) as MockSelectConn:
             mock_conn = MagicMock()
@@ -1664,8 +1680,10 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             mock_ioloop.add_callback_threadsafe.assert_called()
 
     def test_init_failure_shuts_down_connection_pool(self):
-        """If SelectConnection construction raises, the connection-event
-        pool must be shut down before __init__ propagates the exception.
+        """
+        If SelectConnection construction raises, the connection-event pool must be shut down before
+        __init__ propagates the exception.
+
         Otherwise its worker thread leaks for the lifetime of the process.
         """
         boom = RuntimeError('boom')
@@ -1700,8 +1718,9 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
                 captured[0].submit(lambda: None)
 
     def test_init_timeout_joins_ioloop_thread(self):
-        """When __init__ raises TimeoutError it must wait for the IOLoop
-        thread to exit so consumer/connection pools are shut down."""
+        """When __init__ raises TimeoutError it must wait for the IOLoop thread to exit so
+        consumer/connection pools are shut down.
+        """
         with patch('pika.adapters.thread_safe_connection.SelectConnection'
                   ) as MockSelectConn:
             mock_conn = MagicMock()
@@ -1748,7 +1767,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
                 self.fail('Expected TimeoutError')
 
     def test_channel_raises_timeout_error(self):
-        """channel() must raise TimeoutError if Channel.OpenOk never arrives."""
+        """Channel() must raise TimeoutError if Channel.OpenOk never arrives."""
         conn, mock_conn, mock_ioloop = self._make_connection()
 
         def never_respond(cb):
@@ -1764,7 +1783,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         self.assertIn('channel open', str(ctx.exception))
 
     def test_channel_timeout_unregisters_waiter(self):
-        """channel() timeout must not leak a waiter."""
+        """Channel() timeout must not leak a waiter."""
         conn, mock_conn, mock_ioloop = self._make_connection()
 
         def never_respond(cb):
@@ -1779,12 +1798,12 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         self.assertEqual(conn._blocking_waiters, [])
 
     def test_channel_raises_if_connection_closes_during_open(self):
-        """channel() must raise (not return a leaked channel) if the
-        connection closes between Channel.OpenOk and the caller waking.
+        """
+        Channel() must raise (not return a leaked channel) if the connection closes between
+        Channel.OpenOk and the caller waking.
 
-        Without the race guard, a ThreadSafeChannel would be appended to
-        _channels after _shutdown_all_consumer_pools() had already run,
-        leaking the per-channel consumer pool.
+        Without the race guard, a ThreadSafeChannel would be appended to _channels after
+        _shutdown_all_consumer_pools() had already run, leaking the per-channel consumer pool.
         """
         conn, mock_conn, mock_ioloop = self._make_connection()
         mock_raw_ch = MagicMock()
@@ -2071,8 +2090,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         self.assertEqual(conn._blocking_waiters, [])
 
     def test_close_safe_close_suppresses_connection_wrong_state_error(self):
-        """_safe_close must swallow ConnectionWrongStateError so it does not
-        propagate through the IOLoop and crash the IOLoop thread."""
+        """_safe_close must swallow ConnectionWrongStateError so it does not propagate through the
+        IOLoop and crash the IOLoop thread.
+        """
         from pika.exceptions import ConnectionWrongStateError
         conn, mock_conn, _ = self._make_connection()
         conn._ioloop_thread = MagicMock()
@@ -2238,8 +2258,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         conn._shutdown_connection_pool()  # second call must be a no-op
 
     def test_close_force_stop_shuts_down_connection_pool(self):
-        """When close() force-stops the IOLoop, the connection pool must be
-        shut down so no callback worker thread is left dangling."""
+        """When close() force-stops the IOLoop, the connection pool must be shut down so no callback
+        worker thread is left dangling.
+        """
         conn, _mock_conn, _ = self._make_connection()
         conn._ioloop_thread = MagicMock()
         # First join() returns with thread still alive, second returns dead
@@ -2248,8 +2269,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         self.assertTrue(conn._connection_pool_shutdown)
 
     def test_connection_event_listener_exception_is_logged_not_lost(self):
-        """A blocked-listener exception must be logged, not silently lost
-        on an unobserved Future."""
+        """A blocked-listener exception must be logged, not silently lost on an unobserved
+        Future.
+        """
         import concurrent.futures
         conn, mock_conn, mock_ioloop = self._make_connection()
         conn._connection_work_pool = concurrent.futures.ThreadPoolExecutor(
@@ -2292,8 +2314,9 @@ class ConnectionInitErrorPathTests(unittest.TestCase):
     """Cover the IOLoop-thread error paths in ThreadSafeConnection.__init__."""
 
     def test_ioloop_crash_before_open_propagates_to_init(self):
-        """If ioloop.start() raises before on_open_callback fires, __init__
-        must surface the exception (it cannot silently hang forever)."""
+        """If ioloop.start() raises before on_open_callback fires, __init__ must surface the
+        exception (it cannot silently hang forever).
+        """
         crash = RuntimeError('IOLoop crashed before open')
         with patch('pika.adapters.thread_safe_connection.SelectConnection'
                   ) as MockSelectConn:
@@ -2309,8 +2332,9 @@ class ConnectionInitErrorPathTests(unittest.TestCase):
         self.assertIs(ctx.exception, crash)
 
     def test_on_connection_open_error_invokes_user_callback(self):
-        """When the broker rejects the open, the user-supplied
-        on_open_error_callback must be called with the error."""
+        """When the broker rejects the open, the user-supplied on_open_error_callback must be called
+        with the error.
+        """
         error = Exception('refused')
         captured = {}
         user_cb = MagicMock()
@@ -2342,8 +2366,7 @@ class ConnectionInitErrorPathTests(unittest.TestCase):
 
 
 class ConnectionCloseFromIOLoopTests(unittest.TestCase):
-    """Cover the close-from-IOLoop-thread path in
-    ThreadSafeConnection.close()."""
+    """Cover the close-from-IOLoop-thread path in ThreadSafeConnection.close()."""
 
     def _make_connection(self):
         with patch('pika.adapters.thread_safe_connection.SelectConnection'
@@ -2368,9 +2391,9 @@ class ConnectionCloseFromIOLoopTests(unittest.TestCase):
         return conn, mock_conn, mock_ioloop
 
     def test_close_from_ioloop_thread_suppresses_connection_close_error(self):
-        """When close() runs on the IOLoop thread and connection.close()
-        raises (e.g. already closing), the exception must be swallowed and
-        logged, not propagated."""
+        """When close() runs on the IOLoop thread and connection.close() raises (e.g. already
+        closing), the exception must be swallowed and logged, not propagated.
+        """
         conn, mock_conn, _ = self._make_connection()
         # Make `current_thread() is self._ioloop_thread` true.
         conn._ioloop_thread = threading.current_thread()
@@ -2382,8 +2405,9 @@ class ConnectionCloseFromIOLoopTests(unittest.TestCase):
 
 
 class ConnectionEventRegistrationFailureTests(unittest.TestCase):
-    """Cover the LOGGER.warning branch when the raw connection's
-    blocked/unblocked registration method raises."""
+    """Cover the LOGGER.warning branch when the raw connection's blocked/unblocked registration
+    method raises.
+    """
 
     def _make_connection(self):
         with patch('pika.adapters.thread_safe_connection.SelectConnection'
@@ -2422,8 +2446,9 @@ class ConnectionEventRegistrationFailureTests(unittest.TestCase):
 
 
 class ChannelOpenExceptionPathTests(unittest.TestCase):
-    """Cover the exception path inside ThreadSafeConnection.channel() when
-    the inner connection.channel() call itself raises."""
+    """Cover the exception path inside ThreadSafeConnection.channel() when the inner
+    connection.channel() call itself raises.
+    """
 
     def _make_connection(self):
         with patch('pika.adapters.thread_safe_connection.SelectConnection'

--- a/tests/unit/threaded_test_wrapper_test.py
+++ b/tests/unit/threaded_test_wrapper_test.py
@@ -1,7 +1,4 @@
-"""
-Tests for threaded_test_wrapper.py
-
-"""
+"""Tests for threaded_test_wrapper.py."""
 
 import sys
 import threading
@@ -15,15 +12,10 @@ from tests.wrappers.threaded_test_wrapper import _ThreadedTestWrapper, run_in_th
 
 
 class ThreadedTestWrapperSelfChecks(unittest.TestCase):
-    """Tests for threaded_test_wrapper.py.
-
-    """
+    """Tests for threaded_test_wrapper.py."""
 
     def start(self):
-        """Each of the tests in this test case patches this method to run its
-        own test
-
-        """
+        """Each of the tests in this test case patches this method to run its own test."""
         raise NotImplementedError
 
     def test_propagation_of_failure_from_test_execution_thread(self):

--- a/tests/unit/tornado_tests.py
+++ b/tests/unit/tornado_tests.py
@@ -1,7 +1,5 @@
-"""
-Tests for pika.adapters.tornado_connection
+"""Tests for pika.adapters.tornado_connection."""
 
-"""
 import unittest
 from unittest import mock
 

--- a/tests/wrappers/threaded_test_wrapper.py
+++ b/tests/wrappers/threaded_test_wrapper.py
@@ -1,8 +1,4 @@
-"""
-Implements run_in_thread_with_timeout decorator for running tests that might
-deadlock.
-
-"""
+"""Implements run_in_thread_with_timeout decorator for running tests that might deadlock."""
 
 import functools
 import os
@@ -63,11 +59,13 @@ run_in_thread_with_timeout = create_run_in_thread_decorator()
 
 
 class _ThreadedTestWrapper:
-    """Runs user's function in a thread. Then wait on the
-    thread to terminate up to the given `test_timeout` seconds, raising
-    `AssertionError` if user's function exits with exception or times out.
-
     """
+    Runs user's function in a thread.
+
+    Then wait on the thread to terminate up to the given `test_timeout` seconds, raising
+    `AssertionError` if user's function exits with exception or times out.
+    """
+
     # We use the saved member when printing to facilitate patching by our
     # self-tests
     _stderr = sys.stderr
@@ -97,14 +95,15 @@ class _ThreadedTestWrapper:
         self._exc_info = None
 
     def kick_off(self):
-        """Run user's function in a thread. Then wait on the
-        thread to terminate up to self._test_timeout seconds, raising
+        """
+        Run user's function in a thread.
+
+        Then wait on the thread to terminate up to self._test_timeout seconds, raising
         `AssertionError` if user's function exits with exception or times out.
 
-        :return: the value returned by function if function exited without
-            exception and didn't time out
-        :raises AssertionError: if user's function timed out or exited with
-            exception.
+        :return: the value returned by function if function exited without exception and didn't time
+            out
+        :raises AssertionError: if user's function timed out or exited with exception.
         """
         try:
             runner = threading.Thread(target=self._thread_entry)
@@ -131,11 +130,11 @@ class _ThreadedTestWrapper:
             self._fun = None
 
     def _thread_entry(self):
-        """Our test-execution thread entry point that calls the test's `start()`
-        method.
+        """
+        Our test-execution thread entry point that calls the test's `start()` method.
 
-        Here, we catch all exceptions from `start()`, save the `exc_info` for
-        processing by `_kick_off()`, and print the stack trace to `sys.stderr`.
+        Here, we catch all exceptions from `start()`, save the `exc_info` for processing by
+        `_kick_off()`, and print the stack trace to `sys.stderr`.
         """
         try:
             self._fun_result = self._fun()

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -1,11 +1,10 @@
 """
-codegen.py generates pika/spec.py
+codegen.py generates pika/spec.py.
 
-The required spec json file can be found at
-https://github.com/rabbitmq/rabbitmq-server
-.
+The required spec json file can be found at https://github.com/rabbitmq/rabbitmq-server .
 
-After cloning it run the following to generate a spec.py file:
+After cloning it run the following to generate a spec.py
+file:
 python ./utils/codegen.py ../rabbitmq-server
 """
 
@@ -284,12 +283,14 @@ def generate(specPath):
 
     def fieldInitList(prefix, fields):
         if fields:
-            return ''.join([f"{prefix}self.{pyize(f.name)} = {pyize(f.name)}\n" \
-                            for f in fields])
+            return ''.join([
+                f"{prefix}self.{pyize(f.name)} = {pyize(f.name)}\n"
+                for f in fields
+            ])
         else:
             return f'{prefix}pass\n'
-
-    print("""\"\"\"
+    print(\
+          """\"\"\"
 AMQP Specification
 ==================
 This module implements the constants and classes that comprise AMQP protocol
@@ -306,7 +307,8 @@ import struct
 from pika import amqp_object
 from pika import data
 
-""")
+"""
+    )
 
     print("PROTOCOL_VERSION = (%d, %d, %d)" %
           (spec.major, spec.minor, spec.revision))


### PR DESCRIPTION
## Proposed Changes

Add [`docformatter`](https://github.com/PyCQA/docformatter) to the project's toolchain to automatically enforce [PEP 257](https://peps.python.org/pep-0257/) docstring style. The codebase has been receiving significant docstring changes (#1621) and without an automated formatter, consistency will erode as contributors write docstrings in varying styles.

This PR implements the changes proposed in #1623.

## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1623

## Further Comments

**What was added:**
- `docformatter` dev dependency + `[tool.docformatter]` config in `pyproject.toml` (wrap at 100 chars to match existing `ruff` line length, `pre-summary-newline`, `close-quotes-on-newline`)
- `docfmt` and `docfmt-check` hatch scripts
- `docformatter` job in `.github/workflows/lint.yaml` gating PRs on `hatch run docfmt-check`
- Initial formatting pass across all of `pika/`, `tests/`, `examples/`, `utils/` (excluding the generated `pika/spec.py`)

**Non-obvious changes:**
- Six backslash line continuations (`\` at end of line) were converted to parenthesised form across `pika/credentials.py`, `pika/adapters/base_connection.py`, `pika/adapters/utils/connection_workflow.py`, `pika/adapters/blocking_connection.py`, `tests/`, and `utils/codegen.py`. These triggered a `docformatter` 1.7.8 + Python 3.14 tokeniser bug; the conversion is valid style regardless.
- Two spots required surgical fixes to prevent a blank-line ping-pong between `yapf` and `docformatter`:
  - `pika/connection.py` — `class _DEFAULT` gained `...  # noqa: PIE790` so `yapf` preserves the post-docstring blank line that `docformatter` requires.
  - `pika/adapters/select_connection.py` — the `# It's a no op in SelectPoller` comment in `_unregister_fd` was folded into the docstring, making the function body docstring-only and eliminating the conflicting blank-line insertion.

**_Not related at all but surfaced during this PR:_**
`NEW in v1.0.0` in docstrings can probably be removed