### PR TITLE
Chore: remove redundant `rtype`

### DIFF
--- a/examples/asynchronous_consumer_example.py
+++ b/examples/asynchronous_consumer_example.py
@@ -48,12 +48,10 @@ class ExampleConsumer:
         # for higher consumer throughput
         self._prefetch_count = 1
 
-    def connect(self):
+    def connect(self) -> pika.SelectConnection:
         """This method connects to RabbitMQ, returning the connection handle.
         When the connection is established, the on_connection_open method
         will be invoked by pika.
-
-        :rtype: pika.SelectConnection
 
         """
         LOGGER.info('Connecting to %s', self._url)

--- a/examples/asynchronous_publisher_example.py
+++ b/examples/asynchronous_publisher_example.py
@@ -47,12 +47,10 @@ class ExamplePublisher:
         self._stopping = False
         self._url = amqp_url
 
-    def connect(self):
+    def connect(self) -> pika.SelectConnection:
         """This method connects to RabbitMQ, returning the connection handle.
         When the connection is established, the on_connection_open method
         will be invoked by pika.
-
-        :rtype: pika.SelectConnection
 
         """
         LOGGER.info('Connecting to %s', self._url)

--- a/examples/asyncio_consumer_example.py
+++ b/examples/asyncio_consumer_example.py
@@ -49,12 +49,10 @@ class ExampleConsumer:
         # for higher consumer throughput
         self._prefetch_count = 1
 
-    def connect(self):
+    def connect(self) -> AsyncioConnection:
         """This method connects to RabbitMQ, returning the connection handle.
         When the connection is established, the on_connection_open method
         will be invoked by pika.
-
-        :rtype: pika.adapters.asyncio_connection.AsyncioConnection
 
         """
         LOGGER.info('Connecting to %s', self._url)

--- a/examples/tornado_consumer.py
+++ b/examples/tornado_consumer.py
@@ -40,12 +40,10 @@ class ExampleConsumer:
         self._consumer_tag = None
         self._url = amqp_url
 
-    def connect(self):
+    def connect(self) -> TornadoConnection:
         """This method connects to RabbitMQ, returning the connection handle.
         When the connection is established, the on_connection_open method
         will be invoked by pika.
-
-        :rtype: pika.SelectConnection
 
         """
         LOGGER.info('Connecting to %s', self._url)

--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -33,7 +33,6 @@ _LOCALHOST_V6 = '::1'
 def time_now() -> float:
     """Returns monotonic time.
 
-    :rtype: float
     """
     return time.monotonic()
 
@@ -42,7 +41,6 @@ def as_bytes(value: str | bytes) -> bytes:
     """Returns value as bytes.
 
     :param value: value to convert
-    :rtype: bytes
     """
     if not isinstance(value, bytes):
         return value.encode('UTF-8')
@@ -53,7 +51,6 @@ def to_digit(value: str) -> int:
     """Returns value as an integer.
 
     :param value: string containing digits
-    :rtype: int
     """
     if value.isdigit():
         return int(value)
@@ -65,7 +62,6 @@ def get_linux_version(release_str: str) -> tuple[int, ...]:
     """Gets linux version.
 
     :param release_str: kernel release string
-    :rtype: tuple[int, ...]
     """
     ver_str = release_str.split('-', 1)[0]
     return tuple(map(to_digit, ver_str.split('.', 3)[:3]))
@@ -90,7 +86,6 @@ def nonblocking_socketpair(
     :param socket_type: socket type (default SOCK_STREAM)
     :param proto: socket protocol (default 0)
     :returns: a pair of connected non-blocking sockets
-    :rtype: tuple[socket.socket, socket.socket]
     """
     if family == socket.AF_INET:
         host = _LOCALHOST

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -263,8 +263,6 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
         :param on_done: User callback that takes the completion result
             or exception as its only arg. It will not be called if the operation
             was cancelled.
-        :rtype: _AsyncioIOReference which is derived from
-            nbio_interface.AbstractIOReference
 
         """
         if not callable(on_done):
@@ -290,7 +288,6 @@ class _TimerHandle(nbio_interface.AbstractTimerReference):
     def cancel(self) -> None:
         """Cancel the timer handle.
 
-        :rtype: None
         """
         if self._handle is not None:
             self._handle.cancel()
@@ -336,7 +333,6 @@ class _AsyncioIOReference(nbio_interface.AbstractIOReference):
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
 
         """
         return self._future.cancel()

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -147,7 +147,6 @@ class BaseConnection(connection.Connection):
             `connection_workflow.AbstractAMQPConnectionWorkflow | None`.
         :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
-        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
 
         """
         raise NotImplementedError
@@ -181,7 +180,6 @@ class BaseConnection(connection.Connection):
             :py:meth:`connection_workflow.AbstractAMQPConnectionWorkflow.start()`.
         :returns: Connection workflow instance in use. The user should limit
             their interaction with this object only to it's `abort()` method.
-        :rtype: connection_workflow.AbstractAMQPConnectionWorkflow
 
         """
         if workflow is None:
@@ -214,7 +212,6 @@ class BaseConnection(connection.Connection):
             by user or the default selected by the specialized connection
             adapter (e.g., Twisted reactor, `asyncio.SelectorEventLoop`,
             `select_connection.IOLoop`, etc.)
-        :rtype: object
         """
         return self._nbio.get_native_ioloop()
 
@@ -225,7 +222,6 @@ class BaseConnection(connection.Connection):
         :param delay: Delay in seconds.
         :param callback: Callback to call.
         :returns: Timeout handle that can be used to cancel.
-        :rtype: object
         """
         return self._nbio.call_later(delay, callback)
 
@@ -233,7 +229,6 @@ class BaseConnection(connection.Connection):
         """Remove a scheduled timeout.
 
         :param timeout_id: Timeout handle to cancel.
-        :rtype: None
         """
         cast(nbio_interface.AbstractTimerReference, timeout_id).cancel()
 
@@ -242,7 +237,6 @@ class BaseConnection(connection.Connection):
         """Add a callback to be called from the I/O loop thread.
 
         :param callback: Callback to call.
-        :rtype: None
         """
         if not callable(callback):
             raise TypeError(
@@ -478,7 +472,6 @@ class BaseConnection(connection.Connection):
             close itself, resulting in an eventual `connection_lost()` call
             from the transport. If a truthy value is returned, it will be the
             protocol's responsibility to close/abort the transport.
-        :rtype: falsy|truthy
         :raises Exception: Exception-based exception on error
 
         """

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -104,7 +104,6 @@ class _CallbackResult:
     def is_ready(self) -> bool:
         """
         :returns: True if the object is in a signaled state
-        :rtype: bool
         """
         return self._ready
 
@@ -164,7 +163,6 @@ class _CallbackResult:
     def value(self) -> Any:
         """
         :returns: a reference to the value that was set via `set_value_once`
-        :rtype: object
         :raises AssertionError: if result was not set or value is incompatible
                                 with `set_value_once`
         """
@@ -180,7 +178,6 @@ class _CallbackResult:
         """
         :returns: a reference to the list containing one or more elements that
             were added via `append_element`
-        :rtype: list
         :raises AssertionError: if result was not set or value is incompatible
                                 with `append_element`
         """
@@ -224,7 +221,6 @@ class _IoloopTimerContext:
     def is_ready(self) -> bool:
         """
         :returns: True if timer has fired, False otherwise
-        :rtype: bool
         """
         return self._callback_result.is_ready()
 
@@ -456,7 +452,6 @@ class BlockingConnection:
             Type: `None | pika.connection.Parameters | sequence`.
         :param impl_class: for tests/debugging only; implementation class.
 
-        :rtype: impl_class
 
         :raises Exception: on failure
         """
@@ -515,7 +510,6 @@ class BlockingConnection:
             completion callback.
 
         :returns: Exception value from the last connection attempt
-        :rtype: Exception
         """
         if isinstance(error, connection_workflow.AMQPConnectionWorkflowFailed):
             # Extract exception value from the last connection attempt
@@ -764,7 +758,6 @@ class BlockingConnection:
         :param callback: The callback method with the signature
             callback()
         :returns: Opaque timer id
-        :rtype: int
 
         """
         validators.require_callback(callback)
@@ -959,7 +952,6 @@ class BlockingConnection:
         numbers.
 
         :param channel_number: optional channel number to use
-        :rtype: pika.adapters.blocking_connection.BlockingChannel
         """
         with _CallbackResult(self._OnChannelOpenedArgs) as opened_args:
             impl_channel = self._impl.channel(
@@ -1003,7 +995,6 @@ class BlockingConnection:
     def basic_nack_supported(self) -> bool:
         """Specifies if the server supports basic.nack on the active connection.
 
-        :rtype: bool
 
         """
         return self._impl.basic_nack
@@ -1013,7 +1004,6 @@ class BlockingConnection:
         """Specifies if the server supports consumer cancel notification on the
         active connection.
 
-        :rtype: bool
 
         """
         return self._impl.consumer_cancel_notify
@@ -1023,7 +1013,6 @@ class BlockingConnection:
         """Specifies if the active connection supports exchange to exchange
         bindings.
 
-        :rtype: bool
 
         """
         return self._impl.exchange_exchange_bindings
@@ -1032,7 +1021,6 @@ class BlockingConnection:
     def publisher_confirms_supported(self) -> bool:
         """Specifies if the active connection can use publisher confirmations.
 
-        :rtype: bool
 
         """
         return self._impl.publisher_confirms
@@ -1359,7 +1347,6 @@ class BlockingChannel:
         NOTE: inherited from legacy BlockingConnection; might be error-prone;
         use `channel_number` property instead.
 
-        :rtype: int
 
         """
         return self.channel_number
@@ -1397,7 +1384,6 @@ class BlockingChannel:
     def is_closed(self) -> bool:
         """Returns True if the channel is closed.
 
-        :rtype: bool
 
         """
         return self._impl.is_closed
@@ -1406,7 +1392,6 @@ class BlockingChannel:
     def is_open(self) -> bool:
         """Returns True if the channel is open.
 
-        :rtype: bool
 
         """
         return self._impl.is_open
@@ -1416,7 +1401,6 @@ class BlockingChannel:
         """Property method that returns a list of consumer tags for active
         consumers
 
-        :rtype: list
 
         """
         return list(self._consumer_infos.keys())
@@ -1659,7 +1643,6 @@ class BlockingChannel:
 
         :param active: Turn flow on (True) or off (False)
         :returns: True if broker will start or continue sending; False if not
-        :rtype: bool
 
         """
         with _CallbackResult(self._FlowOkCallbackResultArgs) as flow_ok_result:
@@ -1748,7 +1731,6 @@ class BlockingChannel:
           empty, a consumer tag will be generated automatically
         :param arguments: Custom key/value pair arguments for the consumer
         :returns: consumer tag
-        :rtype: str
         :raises pika.exceptions.DuplicateConsumerTag: if consumer with given
             consumer_tag is already present.
 
@@ -1879,7 +1861,6 @@ class BlockingChannel:
             - method: spec.Basic.Deliver
             - properties: spec.BasicProperties
             - body: bytes
-        :rtype: list
         """
         try:
             consumer_info = self._consumer_infos[consumer_tag]
@@ -1959,7 +1940,6 @@ class BlockingChannel:
 
         :returns: a (possibly empty) sequence of _ConsumerDeliveryEvt destined
             for the given consumer tag
-        :rtype: list
         """
         remaining_events: deque[Any] = deque()
         unprocessed_messages: list[Any] = []
@@ -2185,7 +2165,6 @@ class BlockingChannel:
         NEW in pika 0.10.0
 
         :returns: The number of waiting messages
-        :rtype: int
         """
         if self._queue_consumer_generator is not None:
             pending_events = self._queue_consumer_generator.pending_events
@@ -2207,7 +2186,6 @@ class BlockingChannel:
 
         :returns: The number of messages requeued by Basic.Nack.
             NEW in 0.10.0: returns 0
-        :rtype: int
 
         """
         if self._queue_consumer_generator is None:
@@ -2300,7 +2278,6 @@ class BlockingChannel:
         :param auto_ack: Tell the broker to not expect a reply
         :returns: a three-tuple; (None, None, None) if the queue was empty;
             otherwise (method, properties, body); NOTE: body may be None
-        :rtype: (spec.Basic.GetOk|None, spec.BasicProperties|None, bytes|None)
         """
         assert not self._basic_getempty_result
 
@@ -2524,8 +2501,6 @@ class BlockingChannel:
         :param internal: Can only be published to by other exchanges
         :param arguments: Custom key/value pair arguments for the exchange
         :returns: Method frame from the Exchange.Declare-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Exchange.DeclareOk`
 
         """
         validators.require_string(exchange, 'exchange')
@@ -2553,8 +2528,6 @@ class BlockingChannel:
         :param exchange: The exchange name
         :param if_unused: only delete if the exchange is unused
         :returns: Method frame from the Exchange.Delete-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Exchange.DeleteOk`
 
         """
         with _CallbackResult(
@@ -2580,8 +2553,6 @@ class BlockingChannel:
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Method frame from the Exchange.Bind-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-          `spec.Exchange.BindOk`
 
         """
         validators.require_string(destination, 'destination')
@@ -2611,8 +2582,6 @@ class BlockingChannel:
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Method frame from the Exchange.Unbind-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Exchange.UnbindOk`
 
         """
         with _CallbackResult(
@@ -2653,8 +2622,6 @@ class BlockingChannel:
         :param auto_delete: Delete after consumer cancels or disconnects
         :param arguments: Custom key/value arguments for the queue
         :returns: Method frame from the Queue.Declare-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Queue.DeclareOk`
 
         """
         validators.require_string(queue, 'queue')
@@ -2682,8 +2649,6 @@ class BlockingChannel:
         :param if_unused: only delete if it's unused
         :param if_empty: only delete if the queue is empty
         :returns: Method frame from the Queue.Delete-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Queue.DeleteOk`
 
         """
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
@@ -2702,8 +2667,6 @@ class BlockingChannel:
 
         :param queue: The queue to purge
         :returns: Method frame from the Queue.Purge-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Queue.PurgeOk`
 
         """
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
@@ -2728,8 +2691,6 @@ class BlockingChannel:
         :param arguments: Custom key/value pair arguments for the binding
 
         :returns: Method frame from the Queue.Bind-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Queue.BindOk`
 
         """
         validators.require_string(queue, 'queue')
@@ -2759,8 +2720,6 @@ class BlockingChannel:
         :param arguments: Custom key/value pair arguments for the binding
 
         :returns: Method frame from the Queue.Unbind-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Queue.UnbindOk`
 
         """
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
@@ -2779,8 +2738,6 @@ class BlockingChannel:
         a channel before using the Commit or Rollback methods.
 
         :returns: Method frame from the Tx.Select-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Tx.SelectOk`
 
         """
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
@@ -2794,8 +2751,6 @@ class BlockingChannel:
         """Commit a transaction.
 
         :returns: Method frame from the Tx.Commit-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Tx.CommitOk`
 
         """
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \
@@ -2809,8 +2764,6 @@ class BlockingChannel:
         """Rollback a transaction.
 
         :returns: Method frame from the Tx.Rollback-ok response
-        :rtype: `pika.frame.Method` having `method` attribute of type
-            `spec.Tx.RollbackOk`
 
         """
         with _CallbackResult(self._MethodFrameCallbackResultArgs) as \

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -153,7 +153,6 @@ class _TSafeCallbackQueue:
     def __init__(self) -> None:
         """Initialize the callback queue.
 
-        :rtype: None
         """
         # Thread-safe, blocking queue.
         self._queue: queue.Queue[Callable[[], None]] = queue.Queue()
@@ -173,7 +172,6 @@ class _TSafeCallbackQueue:
         will be invoked with the callback in the main thread.
 
         :param callback: Callback to add to the queue.
-        :rtype: None
         """
         self._queue.put(callback)
         with self._write_lock:
@@ -295,7 +293,6 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         :param callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
-        :rtype: object
         """
         timer = self._hub.loop.timer(
             delay)  # pyright: ignore[reportOptionalMemberAccess]
@@ -396,7 +393,6 @@ class _GeventIOLoopIOHandle(AbstractIOReference):
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
         """
         return self._cancel()
 
@@ -461,7 +457,6 @@ class _GeventAddressResolver:
     def cancel(self) -> bool:
         """Cancel the pending resolver.
 
-        :rtype: bool
         """
         changed = False
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -178,7 +178,6 @@ class SelectConnection(BaseConnection):
     def _get_write_buffer_size(self) -> int:
         """
         :returns: Current size of output data buffered by the transport
-        :rtype: int
         """
         assert self._transport is not None
         return self._transport.get_write_buffer_size()
@@ -284,7 +283,6 @@ class _Timer:
         :param callback: The callback method, having the signature
             `callback()`
 
-        :rtype: _Timeout
         :raises ValueError, TypeError
 
         """
@@ -333,7 +331,6 @@ class _Timer:
 
         :returns: non-negative number of seconds until next timer expiration;
                   None if there are no timers
-        :rtype: float
 
         """
         if self._timeout_heap:
@@ -445,7 +442,6 @@ class IOLoop(AbstractSelectorIOLoop):
                                  poller
 
         :returns: The instantiated poller instance supporting `_PollerBase` API
-        :rtype: object
         """
 
         poller = None
@@ -487,7 +483,6 @@ class IOLoop(AbstractSelectorIOLoop):
         :param callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
-        :rtype: object
 
         """
         return self._timer.call_later(delay, callback)
@@ -549,7 +544,6 @@ class IOLoop(AbstractSelectorIOLoop):
 
         :returns: non-negative number of seconds until next callback or timer
                   expiration; None if there are no callbacks and timers
-        :rtype: float
 
         """
         if self._callbacks:
@@ -733,7 +727,6 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :returns: maximum number of self.POLL_TIMEOUT_MULT-scaled time units
                   to wait for IO events
-        :rtype: float
 
         """
         delay = self._get_wait_seconds()
@@ -805,7 +798,6 @@ class _PollerBase(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         :param events: The event mask (READ, WRITE, ERROR)
 
         :returns: a 2-tuple (events_cleared, events_set)
-        :rtype: tuple
         """
         assert self._fd_events is not None
 
@@ -1102,7 +1094,6 @@ class KQueuePoller(_PollerBase):
         """return the event type associated with a kevent object
 
         :param kevent: a kevent object as returned by kqueue.control()
-        :rtype: int
 
         """
         mask = 0
@@ -1257,7 +1248,6 @@ class PollPoller(_PollerBase):
     @staticmethod
     def _create_poller() -> Any:
         """
-        :rtype: `select.poll`
         """
         return getattr(select, 'poll')()
 
@@ -1351,6 +1341,5 @@ class EPollPoller(PollPoller):
     @staticmethod
     def _create_poller() -> Any:
         """
-        :rtype: `select.poll`
         """
         return getattr(select, 'epoll')()

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -514,7 +514,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Confirm.SelectOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -571,7 +570,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The consumer tag assigned by the broker.
-        :rtype: str
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -325,7 +325,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Basic.QosOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -355,7 +354,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: ``(method, properties, body)`` or ``(None, None, None)``.
-        :rtype: tuple
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -612,7 +610,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Basic.CancelOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -645,7 +642,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Queue.DeclareOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -685,7 +681,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Exchange.DeclareOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -721,7 +716,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Queue.BindOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -754,7 +748,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Queue.UnbindOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -784,7 +777,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Queue.DeleteOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -807,7 +799,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Queue.PurgeOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -836,7 +827,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Exchange.BindOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -868,7 +858,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Exchange.UnbindOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -896,7 +885,6 @@ class ThreadSafeChannel:
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
         :returns: The Exchange.DeleteOk method frame.
-        :rtype: pika.frame.Method
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
@@ -1216,7 +1204,6 @@ class ThreadSafeConnection:
         :param timeout: Seconds to wait for Channel.OpenOk.
             Defaults to :data:`DEFAULT_RPC_TIMEOUT` (10 s).
             Pass ``None`` to wait indefinitely.
-        :rtype: ThreadSafeChannel
         :raises Exception: if the connection is closed before the channel opens.
         :raises TimeoutError: if *timeout* expires before the channel opens.
         """

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -75,7 +75,6 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         The Deferred will errback if the queue is closed.
 
         :returns: Deferred that fires with the next item.
-        :rtype: Deferred
 
         """
         if self.closed:
@@ -278,7 +277,6 @@ class TwistedChannel:
     def is_closed(self) -> bool:
         """Returns True if the channel is closed.
 
-        :rtype: bool
 
         """
         return self._channel.is_closed
@@ -288,7 +286,6 @@ class TwistedChannel:
         """Returns True if client-initiated closing of the channel is in
         progress.
 
-        :rtype: bool
 
         """
         return self._channel.is_closing
@@ -297,7 +294,6 @@ class TwistedChannel:
     def is_open(self) -> bool:
         """Returns True if the channel is open.
 
-        :rtype: bool
 
         """
         return self._channel.is_open
@@ -390,7 +386,6 @@ class TwistedChannel:
 
         :param consumer_tag: Identifier for the consumer
         :returns: Deferred that fires on the Basic.CancelOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -438,7 +433,6 @@ class TwistedChannel:
             - method: pika.spec.Basic.Deliver
             - properties: pika.spec.BasicProperties
             - body: bytes
-        :rtype: Deferred
 
         """
         if self._closed:
@@ -511,7 +505,6 @@ class TwistedChannel:
              - properties: pika.spec.BasicProperties
              - body: bytes
             If the queue is empty, None will be returned.
-        :rtype: Deferred
         :raises pika.exceptions.DuplicateGetOkCallback:
 
         """
@@ -591,7 +584,6 @@ class TwistedChannel:
         :param mandatory: The mandatory flag
         :returns: A Deferred that fires with the result of the channel's
             basic_publish.
-        :rtype: Deferred
         :raises UnroutableError: raised when a message published in
             publisher-acknowledgments mode (see
             `BlockingChannel.confirm_delivery`) is returned via `Basic.Return`
@@ -649,7 +641,6 @@ class TwistedChannel:
         :param global_qos:    Should the QoS apply to all channels on the
                                    connection.
         :returns: Deferred that fires on the Basic.QosOk response
-        :rtype: Deferred
 
         """
         return self._wrap_channel_method("basic_qos")(
@@ -684,7 +675,6 @@ class TwistedChannel:
                              attempt to requeue the message, potentially then
                              delivering it to an alternative subscriber.
         :returns: Deferred that fires on the Basic.RecoverOk response
-        :rtype: Deferred
 
         """
         return self._wrap_channel_method("basic_recover")(requeue=requeue)
@@ -714,7 +704,6 @@ class TwistedChannel:
             https://www.rabbitmq.com/confirms.html#publisher-confirms
 
         :returns: Deferred that fires on the Confirm.SelectOk response
-        :rtype: Deferred
 
         """
         if self._delivery_confirmation:
@@ -833,7 +822,6 @@ class TwistedChannel:
         :param arguments: Custom key/value pair arguments for the binding
         :raises ValueError:
         :returns: Deferred that fires on the Exchange.BindOk response
-        :rtype: Deferred
 
         """
         return self._wrap_channel_method("exchange_bind")(
@@ -872,7 +860,6 @@ class TwistedChannel:
         :param internal: Can only be published to by other exchanges
         :param arguments: Custom key/value pair arguments for the exchange
         :returns: Deferred that fires on the Exchange.DeclareOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -894,7 +881,6 @@ class TwistedChannel:
         :param exchange: The exchange name
         :param if_unused: only delete if the exchange is unused
         :returns: Deferred that fires on the Exchange.DeleteOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -916,7 +902,6 @@ class TwistedChannel:
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Exchange.UnbindOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -937,7 +922,6 @@ class TwistedChannel:
 
         :param active: Turn flow on or off
         :returns: Deferred that fires with the channel flow state
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -960,7 +944,6 @@ class TwistedChannel:
         :param routing_key: The routing key to bind on
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Queue.BindOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -995,7 +978,6 @@ class TwistedChannel:
         :param auto_delete: Delete after consumer cancels or disconnects
         :param arguments: Custom key/value arguments for the queue
         :returns: Deferred that fires on the Queue.DeclareOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1023,7 +1005,6 @@ class TwistedChannel:
         :param if_unused: only delete if it's unused
         :param if_empty: only delete if the queue is empty
         :returns: Deferred that fires on the Queue.DeleteOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1048,7 +1029,6 @@ class TwistedChannel:
 
         :param queue: The queue to purge
         :returns: Deferred that fires on the Queue.PurgeOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1067,7 +1047,6 @@ class TwistedChannel:
         :param routing_key: The routing key to unbind
         :param arguments: Custom key/value pair arguments for the binding
         :returns: Deferred that fires on the Queue.UnbindOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1082,7 +1061,6 @@ class TwistedChannel:
         """Commit a transaction.
 
         :returns: Deferred that fires on the Tx.CommitOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1092,7 +1070,6 @@ class TwistedChannel:
         """Rollback a transaction.
 
         :returns: Deferred that fires on the Tx.RollbackOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1104,7 +1081,6 @@ class TwistedChannel:
         a channel before using the Commit or Rollback methods.
 
         :returns: Deferred that fires on the Tx.SelectOk response
-        :rtype: Deferred
         :raises ValueError:
 
         """
@@ -1295,7 +1271,6 @@ class TwistedProtocolConnection(protocol.Protocol):
                                    next available.
         :returns: a Deferred that fires with an instance of a wrapper around
             the Pika Channel class.
-        :rtype: Deferred
 
         """
         d: defer.Deferred[Any] = defer.Deferred()

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -51,7 +51,6 @@ def check_callback_arg(callback: Any, name: str) -> None:
     :param callback: callback to check
     :param name: Name to include in exception text
     :raises TypeError:
-    :rtype: None
 
     """
     if not callable(callback):
@@ -63,7 +62,6 @@ def check_fd_arg(fd: int) -> None:
 
     :param fd: file descriptor
     :raises TypeError:
-    :rtype: None
 
     """
     if not isinstance(fd, numbers.Integral):
@@ -108,7 +106,6 @@ class SocketConnectionMixin:
         :param sock: non-blocking socket to connect
         :param resolved_addr: resolved destination address/port two-tuple
         :param on_done: user callback called upon completion
-        :rtype: _AsyncServiceAsyncHandle
 
         """
         return _AsyncSocketConnector(nbio=cast(
@@ -144,7 +141,6 @@ class StreamingConnectionMixin:
         :param on_done: completion callback
         :param ssl_context: SSL context (optional)
         :param server_hostname: server hostname for SSL (optional)
-        :rtype: AbstractIOReference
 
         """
         try:
@@ -186,7 +182,6 @@ class _AsyncServiceAsyncHandle(AbstractIOReference):
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
 
         """
         return self._cancel()
@@ -254,7 +249,6 @@ class _AsyncSocketConnector:
     def start(self) -> AbstractIOReference:
         """Start asynchronous connection establishment.
 
-        :rtype: AbstractIOReference
         """
         assert self._state == self._STATE_NOT_STARTED, (
             '_AsyncSocketConnector.start(): expected _STATE_NOT_STARTED',
@@ -273,7 +267,6 @@ class _AsyncSocketConnector:
         callback.
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
 
         """
         if self._state == self._STATE_ACTIVE:
@@ -495,7 +488,6 @@ class _AsyncStreamConnector:
     def start(self) -> AbstractIOReference:
         """Kick off the workflow
 
-        :rtype: AbstractIOReference
         """
         _LOGGER.debug('_AsyncStreamConnector.start(); %s', self._sock)
 
@@ -517,7 +509,6 @@ class _AsyncStreamConnector:
         callback.
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
 
         """
         if self._state == self._STATE_ACTIVE:
@@ -802,7 +793,6 @@ class _AsyncTransportBase(AbstractStreamTransport):
     def get_protocol(self) -> nbio_interface.AbstractStreamProtocol:
         """Return the protocol linked to this transport.
 
-        :rtype: pika.adapters.utils.nbio_interface.AbstractStreamProtocol
         """
         assert self._protocol is not None
         return self._protocol
@@ -810,7 +800,6 @@ class _AsyncTransportBase(AbstractStreamTransport):
     def get_write_buffer_size(self) -> int:
         """
         :returns: Current size of output data buffered by the transport
-        :rtype: int
         """
         return self._tx_buffered_byte_count
 
@@ -909,7 +898,6 @@ class _AsyncTransportBase(AbstractStreamTransport):
         :param sock: stream or SSL socket
         :param max_bytes: maximum number of bytes to receive
         :returns: received data or empty bytes uppon end of file
-        :rtype: bytes
         :raises: whatever the corresponding `sock.recv()` raises except socket
                  error with errno.EINTR
 
@@ -925,7 +913,6 @@ class _AsyncTransportBase(AbstractStreamTransport):
         :param sock: stream or SSL socket
         :param data: data bytes to send
         :returns: number of bytes actually sent
-        :rtype: int
         :raises: whatever the corresponding `sock.send()` raises except socket
                  error with errno.EINTR
 

--- a/pika/adapters/utils/nbio_interface.py
+++ b/pika/adapters/utils/nbio_interface.py
@@ -125,7 +125,6 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         :param delay: The number of seconds to wait to call callback
         :param callback: The callback method
         :returns: A handle that can be used to cancel the request.
-        :rtype: AbstractTimerReference
 
         """
         raise NotImplementedError
@@ -153,7 +152,6 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         :param socktype: Socket type (e.g. ``socket.SOCK_STREAM``)
         :param proto: Protocol number (0 for default)
         :param flags: :func:`socket.getaddrinfo` flags
-        :rtype: AbstractIOReference
         """
         raise NotImplementedError
 
@@ -181,7 +179,6 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
             completion or exception (check for `BaseException`) upon error as
             its only arg. It will not be called if the operation was cancelled.
 
-        :rtype: AbstractIOReference
         :raises ValueError: if host portion of `resolved_addr` is not an IP
             address or is inconsistent with the socket's address family as
             validated via `socket.inet_pton()`
@@ -225,7 +222,6 @@ class AbstractIOServices(pika._utils.AbstractBase):  # type: ignore[valid-type, 
         :param server_hostname: For use during SSL session
             establishment to match against the target server's certificate. The
             value `None` disables this check (which is a huge security risk)
-        :rtype: AbstractIOReference
         """
         raise NotImplementedError
 
@@ -260,7 +256,6 @@ class AbstractFileDescriptorServices(
 
         :param fd: file descriptor
         :returns: True if reader was removed; False if none was registered.
-        :rtype: bool
 
         """
         raise NotImplementedError
@@ -292,7 +287,6 @@ class AbstractFileDescriptorServices(
 
         :param fd: file descriptor
         :returns: True if reader was removed; False if none was registered.
-        :rtype: bool
 
         """
         raise NotImplementedError
@@ -318,7 +312,6 @@ class AbstractIOReference(pika._utils.AbstractBase):  # type: ignore[valid-type,
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
         """
         raise NotImplementedError
 
@@ -365,7 +358,6 @@ class AbstractStreamProtocol(
             close itself, resulting in an eventual `connection_lost()` call
             from the transport. If a truthy value is returned, it will be the
             protocol's responsibility to close/abort the transport.
-        :rtype: falsy|truthy
         :raises Exception: Exception-based exception on error
         """
         raise NotImplementedError
@@ -421,7 +413,6 @@ class AbstractStreamTransport(
     def get_protocol(self) -> AbstractStreamProtocol:
         """Return the protocol linked to this transport.
 
-        :rtype: AbstractStreamProtocol
         :raises Exception: Exception-based exception on error
         """
         raise NotImplementedError
@@ -440,7 +431,6 @@ class AbstractStreamTransport(
     def get_write_buffer_size(self) -> int:
         """
         :returns: Current size of output data buffered by the transport
-        :rtype: int
         """
         raise NotImplementedError
 

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -92,7 +92,6 @@ class AbstractSelectorIOLoop:
         :param callback: The callback method
         :returns: handle to the created timeout that may be passed to
             `remove_timeout()`
-        :rtype: object
 
         """
 
@@ -435,7 +434,6 @@ class _FileDescriptorCallbacks:
 
         :param reader: Read callback.
         :param writer: Write callback.
-        :rtype: None
         """
         self.reader = reader
         self.writer = writer
@@ -480,7 +478,6 @@ class _SelectorIOLoopIOHandle(nbio_interface.AbstractIOReference):
         """Cancel pending operation
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
 
         """
         return self._cancel()
@@ -543,7 +540,6 @@ class _AddressResolver:
     def start(self) -> _SelectorIOLoopIOHandle:
         """Start asynchronous DNS lookup.
 
-        :rtype: nbio_interface.AbstractIOReference
 
         """
         assert self._state == self.NOT_STARTED, self._state
@@ -558,7 +554,6 @@ class _AddressResolver:
         """Cancel the pending resolver
 
         :returns: False if was already done or cancelled; True otherwise
-        :rtype: bool
 
         """
         # Try to cancel, but no guarantees

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -53,7 +53,6 @@ class Method(AMQPObject):
     def get_properties(self) -> Properties:
         """Return the properties if they are set.
 
-        :rtype: pika.frame.Properties
 
         """
         return self._properties
@@ -61,7 +60,6 @@ class Method(AMQPObject):
     def get_body(self) -> bytes:
         """Return the message body if it is set.
 
-        :rtype: bytes
 
         """
         return self._body
@@ -69,7 +67,6 @@ class Method(AMQPObject):
     def encode(self) -> list[bytes]:
         """Encode the method into a binary format.
 
-        :rtype: list[bytes]
 
         """
         raise NotImplementedError("Subclasses must implement this method")
@@ -80,7 +77,6 @@ class Method(AMQPObject):
         :param encoded: The encoded method data
         :param offset: The offset to start decoding from
 
-        :rtype: Method
         """
         raise NotImplementedError("Subclasses must implement this method")
 

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -25,7 +25,6 @@ def name_or_value(value: AMQPValue) -> str:
     string identifier for them.
 
     :param value: The value to sanitize
-    :rtype: str
 
     """
     # Is it subclass of AMQPObject
@@ -48,7 +47,6 @@ def sanitize_prefix(function: _Callback) -> _Callback:
     """Automatically call name_or_value on the prefix passed in.
 
     :param function: The function to wrap
-    :rtype: _Callback
     """
 
     @functools.wraps(function)
@@ -75,7 +73,6 @@ def check_for_prefix_and_key(function: _Callback) -> _Callback:
     for the instance.
 
     :param function: Callback to validate
-    :rtype: _Callback
 
     """
 
@@ -146,7 +143,6 @@ class CallbackManager:
         :param only_caller: Only allow one_caller value to call the
                                    event that fires the callback.
         :param arguments: Arguments to validate when processing
-        :rtype: tuple(prefix, key)
 
         """
         # Prep the stack
@@ -187,7 +183,6 @@ class CallbackManager:
         if keys were there to be removed
 
         :param prefix: The prefix for keeping track of callbacks with
-        :rtype: bool
 
         """
         LOGGER.debug('Clearing out %r from the stack', prefix)
@@ -222,7 +217,6 @@ class CallbackManager:
         :param caller: Who is firing the event
         :param args: Any optional arguments
         :param keywords: Optional keyword arguments
-        :rtype: bool
 
         """
         LOGGER.debug('Processing %s:%s', prefix, key)
@@ -263,7 +257,6 @@ class CallbackManager:
         :param key: The callback key
         :param callback_value: The method defined to call on callback
         :param arguments: Optional arguments to check
-        :rtype: bool
 
         """
         if callback_value:
@@ -329,7 +322,6 @@ class CallbackManager:
         :param only_caller: Only allow one_caller value to call the
                                    event that fires the callback.
         :param arguments: arguments to attach to the callback dict
-        :rtype: dict
 
         """
         value = {
@@ -363,7 +355,6 @@ class CallbackManager:
 
         :param value: The dict to evaluate
         :param expectation: The values to check against
-        :rtype: bool
 
         """
         LOGGER.debug('Comparing %r to %r', value, expectation)
@@ -381,7 +372,6 @@ class CallbackManager:
 
         :param value: The object to evaluate
         :param expectation: The values to check against
-        :rtype: bool
 
         """
         for key, expected in expectation.items():
@@ -402,7 +392,6 @@ class CallbackManager:
         :param callback_dict: The callback configuration
         :param caller: Who is firing the event
         :param args: Any optional arguments
-        :rtype: bool
 
         """
         if not self._arguments_match(callback_dict, args):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -134,7 +134,6 @@ class Channel:
     def __int__(self) -> int:
         """Return the channel object as its channel number
 
-        :rtype: int
 
         """
         return self.channel_number
@@ -339,7 +338,6 @@ class Channel:
         :param callback: callback(pika.frame.Method) for method
           Basic.ConsumeOk.
         :returns: Consumer tag which may be used to cancel the consumer.
-        :rtype: str
         :raises ValueError:
 
         """
@@ -382,7 +380,6 @@ class Channel:
         NOTE: this protected method may be called by derived classes
 
         :returns: consumer tag
-        :rtype: str
 
         """
         return f'ctag{self.channel_number}.{uuid.uuid4().hex}'
@@ -652,7 +649,6 @@ class Channel:
     def consumer_tags(self) -> list[str]:
         """Property method that returns a list of currently active consumers
 
-        :rtype: list[str]
 
         """
         return list(self._consumers.keys())
@@ -813,7 +809,6 @@ class Channel:
     def is_closed(self) -> bool:
         """Returns True if the channel is closed.
 
-        :rtype: bool
 
         """
         return self._state == self.CLOSED
@@ -823,7 +818,6 @@ class Channel:
         """Returns True if client-initiated closing of the channel is in
         progress.
 
-        :rtype: bool
 
         """
         return self._state == self.CLOSING
@@ -832,7 +826,6 @@ class Channel:
     def is_open(self) -> bool:
         """Returns True if the channel is open.
 
-        :rtype: bool
 
         """
         return self._state == self.OPEN
@@ -841,7 +834,6 @@ class Channel:
     def is_opening(self) -> bool:
         """Returns True if the channel is opening.
 
-        :rtype: bool
 
         """
         return self._state == self.OPENING
@@ -1103,7 +1095,6 @@ class Channel:
         retrieve the cookie that it set via `_set_cookie`
 
         :returns: opaque cookie value that was set via `_set_cookie`
-        :rtype: object
 
         """
         return self._cookie
@@ -1604,7 +1595,6 @@ class ContentFrameAssembler:
     def _finish(self) -> tuple[frame.Method, frame.Header, bytes]:
         """Invoked when all of the message has been received
 
-        :rtype: tuple(pika.frame.Method, pika.frame.Header, bytes)
 
         """
         assert self._method_frame is not None
@@ -1622,7 +1612,6 @@ class ContentFrameAssembler:
 
         :param body_frame: The body frame
         :raises: pika.exceptions.BodyTooLongError
-        :rtype: tuple(pika.frame.Method, pika.frame.Header, bytes)|None
 
         """
         self._seen_so_far += len(body_frame.fragment)

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -142,7 +142,6 @@ class Parameters:
     def __repr__(self) -> str:
         """Represent the info about the instance.
 
-        :rtype: str
 
         """
         return (
@@ -165,7 +164,6 @@ class Parameters:
         """
         :returns: blocked connection timeout. Defaults to
             `DEFAULT_BLOCKED_CONNECTION_TIMEOUT`.
-        :rtype: float|None
 
         """
         return self._blocked_connection_timeout
@@ -193,7 +191,6 @@ class Parameters:
         """
         :returns: max preferred number of channels. Defaults to
             `DEFAULT_CHANNEL_MAX`.
-        :rtype: int
 
         """
         return self._channel_max
@@ -219,7 +216,6 @@ class Parameters:
         :returns: client properties used to override the fields in the default
             client properties reported  to RabbitMQ via `Connection.StartOk`
             method. Defaults to `DEFAULT_CLIENT_PROPERTIES`.
-        :rtype: dict|None
 
         """
         return self._client_properties
@@ -245,7 +241,6 @@ class Parameters:
         """
         :returns: number of socket connection attempts. Defaults to
             `DEFAULT_CONNECTION_ATTEMPTS`. See also `retry_delay`.
-        :rtype: int
 
         """
         return self._connection_attempts
@@ -270,7 +265,6 @@ class Parameters:
     ) -> (pika.credentials.PlainCredentials |
           pika.credentials.ExternalCredentials):
         """
-        :rtype: one of the classes from `pika.credentials.VALID_TYPES`. Defaults
             to `DEFAULT_CREDENTIALS`.
 
         """
@@ -298,7 +292,6 @@ class Parameters:
         """
         :returns: desired maximum AMQP frame size to use. Defaults to
             `DEFAULT_FRAME_MAX`.
-        :rtype: int
 
         """
         return self._frame_max
@@ -329,7 +322,6 @@ class Parameters:
             connection tuning or callable which is invoked during connection tuning.
             None to accept broker's value. 0 turns heartbeat off. Defaults to
             `DEFAULT_HEARTBEAT_TIMEOUT`.
-        :rtype: int|callable|None
 
         """
         return self._heartbeat
@@ -359,7 +351,6 @@ class Parameters:
     def host(self) -> str:
         """
         :returns: hostname or ip address of broker. Defaults to `DEFAULT_HOST`.
-        :rtype: str
 
         """
         return self._host
@@ -378,7 +369,6 @@ class Parameters:
         """
         :returns: locale value to pass to broker; e.g., 'en_US'. Defaults to
             `DEFAULT_LOCALE`.
-        :rtype: str
 
         """
         return self._locale
@@ -397,7 +387,6 @@ class Parameters:
         """
         :returns: port number of broker's listening socket. Defaults to
             `DEFAULT_PORT`.
-        :rtype: int
 
         """
         return self._port
@@ -418,7 +407,6 @@ class Parameters:
         """
         :returns: interval between socket connection attempts; see also
             `connection_attempts`. Defaults to `DEFAULT_RETRY_DELAY`.
-        :rtype: float
 
         """
         return self._retry_delay
@@ -440,7 +428,6 @@ class Parameters:
         """
         :returns: socket connect timeout in seconds. Defaults to
             `DEFAULT_SOCKET_TIMEOUT`. The value None disables this timeout.
-        :rtype: float|None
 
         """
         return self._socket_timeout
@@ -469,7 +456,6 @@ class Parameters:
         :returns: full protocol stack TCP/[SSL]/AMQP bring-up timeout in
             seconds. Defaults to `DEFAULT_STACK_TIMEOUT`. The value None
             disables this timeout.
-        :rtype: float
 
         """
         return self._stack_timeout
@@ -498,7 +484,6 @@ class Parameters:
     def ssl_options(self) -> SSLOptions | None:
         """
         :returns: None for plaintext or `pika.SSLOptions` instance for SSL/TLS.
-        :rtype: `pika.SSLOptions`|None
         """
         return self._ssl_options
 
@@ -519,7 +504,6 @@ class Parameters:
         """
         :returns: rabbitmq virtual host name. Defaults to
             `DEFAULT_VIRTUAL_HOST`.
-        :rtype: str
 
         """
         return self._virtual_host
@@ -537,7 +521,6 @@ class Parameters:
     def tcp_options(self) -> dict[str, int] | None:
         """
         :returns: None or a dict of options to pass to the underlying socket
-        :rtype: dict|None
         """
         return self._tcp_options
 
@@ -1290,7 +1273,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         :param on_open_callback: The callback when the channel is
             opened.  The callback will be invoked with the `Channel` instance
             as its only argument.
-        :rtype: pika.channel.Channel
 
         """
         if not self.is_open:
@@ -1434,7 +1416,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def basic_nack(self) -> bool:
         """Specifies if the server supports basic.nack on the active connection.
 
-        :rtype: bool
 
         """
         if self.server_capabilities is None:
@@ -1446,7 +1427,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Specifies if the server supports consumer cancel notification on the
         active connection.
 
-        :rtype: bool
 
         """
         if self.server_capabilities is None:
@@ -1458,7 +1438,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Specifies if the active connection supports exchange to exchange
         bindings.
 
-        :rtype: bool
 
         """
         if self.server_capabilities is None:
@@ -1469,7 +1448,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def publisher_confirms(self) -> bool:
         """Specifies if the active connection can use publisher confirmations.
 
-        :rtype: bool
 
         """
         if self.server_capabilities is None:
@@ -1487,7 +1465,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         :param callback: The callback will be called without args.
         :returns: Handle that can be passed to `_adapter_remove_timeout()` to
             cancel the callback.
-        :rtype: object
 
         """
         raise NotImplementedError
@@ -1595,7 +1572,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _client_properties(self) -> dict[str, Any]:
         """Return the client properties dictionary.
 
-        :rtype: dict
 
         """
         properties = {
@@ -1653,7 +1629,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Create a heartbeat checker instance if there is a heartbeat interval
         set.
 
-        :rtype: pika.heartbeat.Heartbeat|None
 
         """
         if isinstance(self.params.heartbeat, int) and self.params.heartbeat > 0:
@@ -1695,7 +1670,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
     def _get_body_frame_max_length(self) -> int:
         """Calculate the maximum amount of bytes that can be in a body frame.
 
-        :rtype: int
 
         """
         return (self.params.frame_max - spec.FRAME_HEADER_SIZE -
@@ -1707,7 +1681,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Get credentials for authentication.
 
         :param method_frame: The Connection.Start frame
-        :rtype: tuple(str, bytes|None)
 
         """
         (auth_type,
@@ -1723,7 +1696,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         frame.
 
         :param value: The frame to check
-        :rtype: int|None
 
         """
         return self.callbacks.pending(value.channel_number, value.method)
@@ -1732,7 +1704,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Returns true if the frame is a method frame.
 
         :param value: The frame to evaluate
-        :rtype: bool
 
         """
         return isinstance(value, frame.Method)
@@ -1741,14 +1712,12 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         """Returns True if it's a protocol header frame.
 
         :param value: Frame to inspect
-        :rtype: bool
         """
         return isinstance(value, frame.ProtocolHeader)
 
     def _next_channel_number(self) -> int:
         """Return the next available channel number or raise an exception.
 
-        :rtype: int
 
         """
         limit = self.params.channel_max or pika.channel.MAX_CHANNELS
@@ -1955,7 +1924,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
 
         :param client_value: The client value
         :param server_value: The server value
-        :rtype: int
 
         """
         if client_value is None:
@@ -1992,7 +1960,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             broker; 0 (zero) to disable heartbeat.
 
         :returns: the value of the heartbeat timeout to use and return to broker
-        :rtype: int
         """
         if client_value is None:
             # Accept server's limit
@@ -2187,7 +2154,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
         and if it has any callbacks pending.
 
         :param frame_value: The frame to process
-        :rtype: bool
 
         """
         if (self._is_method_frame(frame_value) and

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2204,8 +2204,6 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
             self) -> tuple[int, frame.Frame | frame.ProtocolHeader | None]:
         """Try and read from the frame buffer and decode a frame.
 
-        :rtype tuple: (int, pika.frame.Frame)
-
         """
         return frame.decode_frame(self._frame_buffer)
 

--- a/pika/credentials.py
+++ b/pika/credentials.py
@@ -79,7 +79,6 @@ class PlainCredentials:
         """Validate that this type of authentication is supported
 
         :param start: Connection.Start method
-        :rtype: tuple(str|None, bytes|None)
 
         """
         if as_bytes(PlainCredentials.TYPE) not in\
@@ -123,7 +122,6 @@ class ExternalCredentials:
         """Validate that this type of authentication is supported
 
         :param start: Connection.Start method
-        :rtype: tuple(str|None, bytes|None)
 
         """
         if as_bytes(ExternalCredentials.TYPE) not in\

--- a/pika/data.py
+++ b/pika/data.py
@@ -17,7 +17,6 @@ def encode_short_string(pieces: list[bytes], value: str) -> int:
 
     :param pieces: Already encoded values
     :param value: String value to encode
-    :rtype: int
 
     """
     encoded_value = as_bytes(value)
@@ -48,7 +47,6 @@ def decode_short_string(encoded: bytes, offset: int) -> tuple[str | bytes, int]:
     :param encoded: encoded data
     :param offset: starting offset in the encoded data
     :returns: tuple of (decoded value, new offset)
-    :rtype: tuple[Union[str, bytes], int]
     """
     length = struct.unpack_from('B', encoded, offset)[0]
     offset += 1
@@ -67,7 +65,6 @@ def encode_table(pieces: list[bytes], table: dict[str, Any] | None) -> int:
 
     :param pieces: Already encoded frame pieces
     :param table: The dict to encode
-    :rtype: int
 
     """
     table = table or {}
@@ -89,7 +86,6 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
 
     :param pieces: Already encoded values
     :param value: The value to encode
-    :rtype: int
 
     """
 
@@ -152,7 +148,6 @@ def decode_table(encoded: bytes,
 
     :param encoded: The binary encoded data to decode
     :param offset: The starting byte offset
-    :rtype: tuple
 
     """
     result = {}
@@ -172,7 +167,6 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     :param encoded: The binary encoded data to decode
     :param offset: The starting byte offset
-    :rtype: tuple
     :raises: pika.exceptions.InvalidFieldTypeException
 
     """

--- a/pika/diagnostic_utils.py
+++ b/pika/diagnostic_utils.py
@@ -22,7 +22,6 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
 
     :param logger:
     :returns: the decorator
-    :rtype: callable
 
     Usage example
 
@@ -43,7 +42,6 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
 
         :param func: function to be wrapped
         :returns: the function wrapper
-        :rtype: callable
         """
 
         @functools.wraps(func)
@@ -56,7 +54,6 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
             :param args: positional args passed to wrapped function
             :param kwargs: keyword args passed to wrapped function
             :returns: whatever the wrapped function returns
-            :rtype: object
             """
             try:
                 return func(*args, **kwargs)

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -99,7 +99,6 @@ class ConnectionClosed(AMQPConnectionError):
     @property
     def reply_code(self) -> int:
         """ NEW in v1.0.0
-        :rtype: int
 
         """
         return self.args[0]
@@ -107,7 +106,6 @@ class ConnectionClosed(AMQPConnectionError):
     @property
     def reply_text(self) -> str:
         """ NEW in v1.0.0
-        :rtype: str
 
         """
         return self.args[1]
@@ -164,7 +162,6 @@ class ChannelClosed(AMQPChannelError):
     @property
     def reply_code(self) -> int:
         """ NEW in v1.0.0
-        :rtype: int
 
         """
         return self.args[0]
@@ -172,7 +169,6 @@ class ChannelClosed(AMQPChannelError):
     @property
     def reply_text(self) -> str:
         """ NEW in v1.0.0
-        :rtype: str
 
         """
         return self.args[1]

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -34,7 +34,6 @@ class Frame(amqp_object.AMQPObject):
         """Create the full AMQP wire protocol frame data representation
 
         :param pieces: Encoded AMQP frame fragments to assemble
-        :rtype: bytes
 
         """
         payload = b''.join(pieces)
@@ -45,7 +44,6 @@ class Frame(amqp_object.AMQPObject):
         """To be ended by child classes
 
         :raises NotImplementedError
-        :rtype: bytes
 
         """
         raise NotImplementedError
@@ -71,7 +69,6 @@ class Method(Frame, Generic[_MethodT]):
     def marshal(self) -> bytes:
         """Return the AMQP binary encoded value of the frame
 
-        :rtype: bytes
 
         """
         pieces = self.method.encode()
@@ -102,7 +99,6 @@ class Header(Frame):
     def marshal(self) -> bytes:
         """Return the AMQP binary encoded value of the frame
 
-        :rtype: bytes
 
         """
         pieces = self.properties.encode()
@@ -129,7 +125,6 @@ class Body(Frame):
     def marshal(self) -> bytes:
         """Return the AMQP binary encoded value of the frame
 
-        :rtype: bytes
 
         """
         return self._marshal([self.fragment])
@@ -150,7 +145,6 @@ class Heartbeat(Frame):
     def marshal(self) -> bytes:
         """Return the AMQP binary encoded value of the frame
 
-        :rtype: bytes
 
         """
         return self._marshal([])
@@ -184,7 +178,6 @@ class ProtocolHeader(amqp_object.AMQPObject):
         """Return the full AMQP wire protocol frame data representation of the
         ProtocolHeader frame
 
-        :rtype: bytes
 
         """
         return b'AMQP' + struct.pack('BBBB', 0, self.major, self.minor,
@@ -196,7 +189,6 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
     Returns the number of bytes consumed from the stream and the frame.
 
     :param data_in: The raw data stream
-    :rtype: tuple(int, Frame|ProtocolHeader)
     :raises: pika.exceptions.InvalidFrameError
 
     """

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -32,7 +32,6 @@ class HeartbeatChecker:
                             timeout window the connection will be closed. The
                             interval used to send heartbeats is calculated from
                             this value by dividing it by two.
-        :rtype: None
 
         """
         if timeout < 1:
@@ -85,7 +84,6 @@ class HeartbeatChecker:
     def bytes_received_on_connection(self) -> int:
         """Return the number of bytes received by the connection bytes object.
 
-        :rtype: int
 
         """
         return self._connection.bytes_received
@@ -95,7 +93,6 @@ class HeartbeatChecker:
         """Returns true if the byte count hasn't changed in enough intervals
         to trip the max idle threshold.
 
-        :rtype: bool
 
         """
         return self._idle_byte_intervals > 0
@@ -163,7 +160,6 @@ class HeartbeatChecker:
     def _has_received_data(self) -> bool:
         """Returns True if the connection has received data.
 
-        :rtype: bool
 
         """
         return self._bytes_received != self.bytes_received_on_connection
@@ -172,7 +168,6 @@ class HeartbeatChecker:
     def _new_heartbeat_frame() -> frame.Heartbeat:
         """Return a new heartbeat frame.
 
-        :rtype: pika.frame.Heartbeat
 
         """
         return frame.Heartbeat()

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -35,7 +35,6 @@ def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
 
     :param callback: RPC completion callback, or None if no callback is expected (i.e. nowait=True)
     :returns: boolean indicating nowait
-    :rtype: bool
     :raises: TypeError
 
     """

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -1032,14 +1032,15 @@ class TestStreamConnectorEOFReceived(StreamingTestBase, IOServicesTestStubs):
 class TestStreamConnectorProtocolInterfaceFailsBase(StreamingTestBase):
     """Base test class for streaming protocol method fails"""
 
-    def linkup_streaming_connection(self,
-                                    nbio,
-                                    sock,
-                                    on_create_done,
-                                    proto_constructor_exc=None,
-                                    proto_connection_made_exc=None,
-                                    proto_eof_received_exc=None,
-                                    proto_data_received_exc=None):
+    def linkup_streaming_connection(
+            self,
+            nbio,
+            sock,
+            on_create_done,
+            proto_constructor_exc=None,
+            proto_connection_made_exc=None,
+            proto_eof_received_exc=None,
+            proto_data_received_exc=None) -> nbio_interface.AbstractIOReference:
         """Links up transport and protocol. On protocol.connection_lost(),
         requests stop of ioloop.
 
@@ -1055,7 +1056,6 @@ class TestStreamConnectorProtocolInterfaceFailsBase(StreamingTestBase):
         :param proto_data_received_exc:  None or exception to raise in
             `data_received()`
         :return: return value of `create_streaming_connection()`
-        :rtype: nbio_interface.AbstractIOReference
 
         """
         logger = self.logger

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -87,30 +87,19 @@ class AsyncTestCase(unittest.TestCase):
         self._public_stop_error_in = None  # exception passed to our stop()
         super().setUp()
 
-    def new_connection_params(self):
-        """
-        :rtype: pika.ConnectionParameters
-
-        """
+    def new_connection_params(
+            self) -> pika.ConnectionParameters | pika.URLParameters:
         if enable_tls():
             return self._new_tls_connection_params()
         return self._new_plaintext_connection_params()
 
-    def _new_tls_connection_params(self):
-        """
-        :rtype: pika.ConnectionParameters
-
-        """
+    def _new_tls_connection_params(self) -> pika.URLParameters:
         self.logger.info('testing using TLS/SSL connection to port 5671')
         url = 'amqps://localhost:5671/%2F?ssl_options=%7B%27ca_certs%27%3A%27tests%2Fcerts%2Fca_certificate.pem%27%2C%27keyfile%27%3A%27tests%2Fcerts%2Fclient_key.pem%27%2C%27certfile%27%3A%27tests%2Fcerts%2Fclient_certificate.pem%27%7D'
         return pika.URLParameters(url)
 
     @staticmethod
-    def _new_plaintext_connection_params():
-        """
-        :rtype: pika.ConnectionParameters
-
-        """
+    def _new_plaintext_connection_params() -> pika.ConnectionParameters:
         return pika.ConnectionParameters(host='127.0.0.1', port=5672)
 
     def tearDown(self):

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -1,6 +1,8 @@
 """Base test classes for async_adapter_tests.py
 
 """
+from __future__ import annotations
+
 import functools
 import logging
 import select

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -22,6 +22,7 @@ class TestGetNativeIOLoop(unittest.TestCase,
 
 """
 
+from pika.adapters.utils import nbio_interface
 from tests.wrappers.threaded_test_wrapper import run_in_thread_with_timeout
 
 
@@ -43,12 +44,11 @@ class IOServicesTestStubs:
         """
         raise NotImplementedError
 
-    def create_nbio(self):
+    def create_nbio(self) -> nbio_interface.AbstractIOServices:
         """Create the configured AbstractIOServices adaptation and schedule
         it to be closed automatically when the test terminates.
 
         :param unittest.TestCase self:
-        :rtype: pika.adapters.utils.nbio_interface.AbstractIOServices
 
         """
         nbio = self._nbio_factory()

--- a/tests/wrappers/threaded_test_wrapper.py
+++ b/tests/wrappers/threaded_test_wrapper.py
@@ -149,12 +149,11 @@ class _ThreadedTestWrapper:
                     file=self._stderr)
 
     @staticmethod
-    def _exc_info_to_str(exc_info):
+    def _exc_info_to_str(exc_info) -> str:
         """Convenience method for converting the value returned by
         `sys.exc_info()` to a string.
 
         :param tuple exc_info: Value returned by `sys.exc_info()`.
         :return: A string representation of the given `exc_info`.
-        :rtype: str
         """
         return ''.join(traceback.format_exception(*exc_info))


### PR DESCRIPTION
## Proposed Changes

- Remove redundant `:rtype:` lines from docstrings where the function already declares a return type via `->` annotation. 
- Add return type where functions mentioned in `rtype` and remove their `rtype` to be consisted across the codebase

No logic changes.

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [x] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

<!-- Link related issues using GitHub keywords:
- Fixes #123
- Closes #456
- Resolves owner/repo#789
-->

- Fixes #

