### PR TITLE
feat: Callback removal API

### DIFF
--- a/pika/callback.py
+++ b/pika/callback.py
@@ -208,6 +208,15 @@ class CallbackManager:
         return len(self._stack[prefix][key])
 
     @sanitize_prefix
+    def keys(self, prefix: _Prefix) -> list[AMQPValue]:
+        """
+        Return a snapshot list of the keys registered under a prefix.
+
+        :param prefix: Categorize the callback
+        """
+        return list(self._stack.get(prefix, {}).keys())
+
+    @sanitize_prefix
     @check_for_prefix_and_key
     def process(self, prefix: _Prefix, key: AMQPValue, caller: _Caller, *args:
                 Any, **keywords: Any) -> bool:
@@ -284,6 +293,38 @@ class CallbackManager:
 
         self._cleanup_callback_dict(prefix, key)
         return True
+
+    @sanitize_prefix
+    @check_for_prefix_and_key
+    def remove_matching(
+            self, prefix: _Prefix, key: AMQPValue,
+            predicate: Callable[[Callable[..., Any]], bool]) -> bool:
+        """
+        Remove callbacks under prefix/key whose stored callable satisfies predicate.
+
+        Unlike :meth:`remove`, which matches by equality and reports success whenever the prefix/key
+        exist, this returns True only if at least one callback was actually removed. That makes it
+        suitable for backing public ``remove_on_*_callback`` APIs that report whether removal
+        occurred, and for matching callbacks that were wrapped (e.g. in ``functools.partial``) at
+        registration time, where equality matching against the original callable would fail.
+
+        :param prefix: The prefix for keeping track of callbacks with
+        :param key: The callback key
+        :param predicate: Called with each stored callable; truthy means remove
+        """
+        remaining = []
+        removed = []
+        for callback_dict in self._stack[prefix][key]:
+            if predicate(callback_dict[self.CALLBACK]):
+                removed.append(callback_dict)
+            else:
+                remaining.append(callback_dict)
+        if removed:
+            self._stack[prefix][key] = remaining
+            for callback_dict in removed:
+                LOGGER.debug('Removed: %r', callback_dict)
+            self._cleanup_callback_dict(prefix, key)
+        return bool(removed)
 
     @sanitize_prefix
     @check_for_prefix_and_key

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -216,6 +216,74 @@ class Channel:
         """
         self.callbacks.add(self.channel_number, '_on_return', callback, False)
 
+    def remove_callback(
+            self,
+            callback: Callable[..., Any],
+            replies: Sequence[type[amqp_object.Method]] | None = None) -> bool:
+        """
+        Remove a callback previously registered via :meth:`add_callback`.
+
+        Mirrors :meth:`add_callback`: the callback is matched by identity and removed
+        from each reply key it is registered under. If ``replies`` is ``None``, the
+        callback is removed from every reply key it is currently registered under.
+
+        :param callback: The callback to remove
+        :param replies: The replies to remove the callback from, or ``None`` to
+            remove it from every reply key it is registered under
+        :returns: ``True`` if at least one matching callback was removed
+        """
+        reply_keys = (self.callbacks.keys(self.channel_number)
+                      if replies is None else replies)
+        removed = False
+        for reply in reply_keys:
+            if self.callbacks.remove_matching(self.channel_number, reply,
+                                              lambda cb: cb == callback):
+                removed = True
+        return removed
+
+    def remove_on_cancel_callback(self, callback: _OnCancelCallback) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_cancel_callback`.
+
+        :param callback: The callback to remove
+        :returns:``True`` if the callback was removed, ``False`` if it was absent
+        """
+        return self.callbacks.remove_matching(self.channel_number,
+                                              spec.Basic.Cancel,
+                                              lambda cb: cb == callback)
+
+    def remove_on_close_callback(self, callback: _OnCloseCallback) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_close_callback`.
+
+        :param callback: The callback to remove
+        :returns:``True`` if the callback was removed, ``False`` if it was absent
+        """
+        return self.callbacks.remove_matching(self.channel_number,
+                                              '_on_channel_close',
+                                              lambda cb: cb == callback)
+
+    def remove_on_flow_callback(self, callback: _OnFlowCallback) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_flow_callback`.
+
+        :param callback: The callback to remove
+        :returns:``True`` if the callback was removed, ``False`` if it was absent
+        """
+        return self.callbacks.remove_matching(self.channel_number,
+                                              spec.Channel.Flow,
+                                              lambda cb: cb == callback)
+
+    def remove_on_return_callback(self, callback: _OnReturnCallback) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_return_callback`.
+
+        :param callback: The callback to remove
+        :returns:``True`` if the callback was removed, ``False`` if it was absent
+        """
+        return self.callbacks.remove_matching(self.channel_number, '_on_return',
+                                              lambda cb: cb == callback)
+
     def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
         """
         Acknowledge one or more messages.

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1276,6 +1276,83 @@ class Connection(pika._utils.AbstractBase):  # type: ignore[valid-type, misc]
                                   self._default_on_connection_error)
         self.callbacks.add(0, self.ON_CONNECTION_ERROR, callback, False)
 
+    def remove_on_close_callback(
+            self, callback: Callable[[Connection, Exception], Any]) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_close_callback`.
+
+        :param callback: The callback to remove
+        :returns: True if a callback was removed, otherwise False
+        """
+        return self.callbacks.remove_matching(0, self.ON_CONNECTION_CLOSED,
+                                              lambda cb: cb == callback)
+
+    def remove_on_connection_blocked_callback(
+        self,
+        callback: Callable[[Connection, frame.Method[spec.Connection.Blocked]],
+                           Any]
+    ) -> bool:
+        """Remove a callback registered via
+        :meth:`add_on_connection_blocked_callback`.
+
+        The callback was wrapped in a ``functools.partial`` at registration time,
+        so it is matched here by the original callable rather than by equality.
+
+        :param callback: The callback to remove
+        :returns: True if a callback was removed, otherwise False
+        """
+
+        def matches(stored: Callable[..., Any]) -> bool:
+            return (isinstance(stored, functools.partial) and
+                    stored.func == callback and stored.args == (self,))
+
+        return self.callbacks.remove_matching(0, spec.Connection.Blocked,
+                                              matches)
+
+    def remove_on_connection_unblocked_callback(
+        self, callback: Callable[
+            [Connection, frame.Method[spec.Connection.Unblocked]], Any]
+    ) -> bool:
+        """Remove a callback registered via
+        :meth:`add_on_connection_unblocked_callback`.
+
+        The callback was wrapped in a ``functools.partial`` at registration time,
+        so it is matched here by the original callable rather than by equality.
+
+        :param callback: The callback to remove
+        :returns: True if a callback was removed, otherwise False
+        """
+
+        def matches(stored: Callable[..., Any]) -> bool:
+            return (isinstance(stored, functools.partial) and
+                    stored.func == callback and stored.args == (self,))
+
+        return self.callbacks.remove_matching(0, spec.Connection.Unblocked,
+                                              matches)
+
+    def remove_on_open_callback(self, callback: Callable[[Connection],
+                                                         Any]) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_open_callback`.
+
+        :param callback: The callback to remove
+        :returns: True if a callback was removed, otherwise False
+        """
+        return self.callbacks.remove_matching(0, self.ON_CONNECTION_OPEN_OK,
+                                              lambda cb: cb == callback)
+
+    def remove_on_open_error_callback(
+            self, callback: Callable[[Connection, BaseException | None],
+                                     Any]) -> bool:
+        """
+        Remove a callback registered via :meth:`add_on_open_error_callback`.
+
+        :param callback: The callback to remove
+        :returns: True if a callback was removed, otherwise False
+        """
+        return self.callbacks.remove_matching(0, self.ON_CONNECTION_ERROR,
+                                              lambda cb: cb == callback)
+
     def channel(
             self,
             channel_number: int | None = None,

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -304,6 +304,67 @@ class CallbackTests(unittest.TestCase):
         self.obj.remove_all(self.PREFIX, self.KEY)
         self.assertNotIn(self.PREFIX, self.obj._stack)
 
+    def test_keys_empty(self):
+        self.assertEqual(self.obj.keys(self.PREFIX), [])
+
+    def test_keys_returns_registered_keys(self):
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
+        self.obj.add(self.PREFIX_CLASS, 'Other Key', self.mock_caller)
+        self.assertEqual(sorted(self.obj.keys(self.PREFIX)),
+                         sorted([self.KEY, 'Other Key']))
+
+    def test_keys_returns_snapshot(self):
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
+        keys = self.obj.keys(self.PREFIX)
+        self.obj.remove(self.PREFIX, self.KEY, self.callback_mock)
+        # Mutating the stack does not affect the previously returned snapshot
+        self.assertEqual(keys, [self.KEY])
+
+    def test_remove_matching_absent_returns_false(self):
+        self.assertFalse(
+            self.obj.remove_matching(self.PREFIX, self.KEY, lambda cb: True))
+
+    def test_remove_matching_no_match_returns_false(self):
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock, False)
+        self.assertFalse(
+            self.obj.remove_matching(self.PREFIX, self.KEY, lambda cb: False))
+        self.assertEqual(self.obj.pending(self.PREFIX, self.KEY), 1)
+
+    def test_remove_matching_match_returns_true(self):
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock, False)
+        self.assertTrue(
+            self.obj.remove_matching(self.PREFIX, self.KEY,
+                                     lambda cb: cb == self.callback_mock))
+        self.assertNotIn(self.PREFIX, self.obj._stack)
+
+    def test_remove_matching_idempotent(self):
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock, False)
+
+        def predicate(cb):
+            return cb == self.callback_mock
+
+        self.assertTrue(
+            self.obj.remove_matching(self.PREFIX, self.KEY, predicate))
+        self.assertFalse(
+            self.obj.remove_matching(self.PREFIX, self.KEY, predicate))
+
+    def test_remove_matching_only_removes_matching(self):
+        other = mock.Mock()
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock, False)
+        self.obj.add(self.PREFIX_CLASS, self.KEY, other, False)
+        self.assertTrue(
+            self.obj.remove_matching(self.PREFIX, self.KEY,
+                                     lambda cb: cb == self.callback_mock))
+        self.assertEqual(
+            other, self.obj._stack[self.PREFIX][self.KEY][0][self.CALLBACK])
+
+    def test_remove_matching_prevents_processing(self):
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock, False)
+        self.obj.remove_matching(self.PREFIX, self.KEY,
+                                 lambda cb: cb == self.callback_mock)
+        self.assertFalse(self.obj.process(self.PREFIX_CLASS, self.KEY, self))
+        self.assertFalse(self.callback_mock.called)
+
     def test_should_process_callback_true(self):
         self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
         value = self.obj._callback_dict(self.callback_mock, False, None, None)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -137,6 +137,64 @@ class ChannelTests(unittest.TestCase):
         self.connection.callbacks.add.assert_called_once_with(
             self.obj.channel_number, '_on_return', mock_callback, False)
 
+    def _assert_remove_matching(self, expected_key, callback):
+        """Assert the last remove_matching call targeted expected_key with a predicate that selects
+        callback and rejects others.
+        """
+        prefix, key, predicate = (
+            self.connection.callbacks.remove_matching.call_args[0])
+        self.assertEqual(prefix, self.obj.channel_number)
+        self.assertEqual(key, expected_key)
+        self.assertTrue(predicate(callback))
+        self.assertFalse(predicate(mock.Mock()))
+
+    def test_remove_on_cancel_callback(self):
+        mock_callback = mock.Mock()
+        self.obj.remove_on_cancel_callback(mock_callback)
+        self._assert_remove_matching(spec.Basic.Cancel, mock_callback)
+
+    def test_remove_on_close_callback(self):
+        mock_callback = mock.Mock()
+        self.obj.remove_on_close_callback(mock_callback)
+        self._assert_remove_matching('_on_channel_close', mock_callback)
+
+    def test_remove_on_flow_callback(self):
+        mock_callback = mock.Mock()
+        self.obj.remove_on_flow_callback(mock_callback)
+        self._assert_remove_matching(spec.Channel.Flow, mock_callback)
+
+    def test_remove_on_return_callback(self):
+        mock_callback = mock.Mock()
+        self.obj.remove_on_return_callback(mock_callback)
+        self._assert_remove_matching('_on_return', mock_callback)
+
+    def test_remove_callback_with_replies(self):
+        mock_callback = mock.Mock()
+        self.connection.callbacks.remove_matching.return_value = True
+        self.assertTrue(
+            self.obj.remove_callback(mock_callback,
+                                     [spec.Basic.Qos, spec.Basic.QosOk]))
+        calls = [
+            mock.call(self.obj.channel_number, spec.Basic.Qos, mock.ANY),
+            mock.call(self.obj.channel_number, spec.Basic.QosOk, mock.ANY)
+        ]
+        self.connection.callbacks.remove_matching.assert_has_calls(calls)
+
+    def test_remove_callback_all_replies(self):
+        mock_callback = mock.Mock()
+        self.connection.callbacks.keys.return_value = [spec.Basic.Qos]
+        self.connection.callbacks.remove_matching.return_value = True
+        self.assertTrue(self.obj.remove_callback(mock_callback))
+        self.connection.callbacks.keys.assert_called_once_with(
+            self.obj.channel_number)
+        self.connection.callbacks.remove_matching.assert_called_once_with(
+            self.obj.channel_number, spec.Basic.Qos, mock.ANY)
+
+    def test_remove_callback_returns_false_when_absent(self):
+        self.connection.callbacks.keys.return_value = [spec.Basic.Qos]
+        self.connection.callbacks.remove_matching.return_value = False
+        self.assertFalse(self.obj.remove_callback(mock.Mock()))
+
     def test_basic_ack_channel_closed(self):
         self.assertRaises(exceptions.ChannelWrongStateError, self.obj.basic_ack)
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -723,6 +723,89 @@ class ConnectionTests(unittest.TestCase):
         self.assertIs(conn, self.connection)
         self.assertIs(frame, unblocked_frame)
 
+    def test_remove_on_close_callback(self):
+        cb = mock.Mock()
+        self.connection.add_on_close_callback(cb)
+        self.assertTrue(self.connection.remove_on_close_callback(cb))
+        self.assertFalse(self.connection.remove_on_close_callback(cb))
+        self.connection.callbacks.process(0,
+                                          self.connection.ON_CONNECTION_CLOSED,
+                                          self.connection, self.connection,
+                                          None)
+        self.assertFalse(cb.called)
+
+    def test_remove_on_close_callback_isolation(self):
+        keep, remove = mock.Mock(), mock.Mock()
+        self.connection.add_on_close_callback(keep)
+        self.connection.add_on_close_callback(remove)
+        self.assertTrue(self.connection.remove_on_close_callback(remove))
+        self.connection.callbacks.process(0,
+                                          self.connection.ON_CONNECTION_CLOSED,
+                                          self.connection, self.connection,
+                                          None)
+        self.assertTrue(keep.called)
+        self.assertFalse(remove.called)
+
+    def test_remove_on_open_callback(self):
+        cb = mock.Mock()
+        self.connection.add_on_open_callback(cb)
+        self.assertTrue(self.connection.remove_on_open_callback(cb))
+        self.assertFalse(self.connection.remove_on_open_callback(cb))
+
+    def test_remove_on_open_error_callback(self):
+        cb = mock.Mock()
+        self.connection.add_on_open_error_callback(cb)
+        self.assertTrue(self.connection.remove_on_open_error_callback(cb))
+        self.assertFalse(self.connection.remove_on_open_error_callback(cb))
+
+    def test_remove_on_connection_blocked_callback(self):
+        buffer = []
+
+        def cb(conn, frame):
+            buffer.append(frame)
+
+        self.connection.add_on_connection_blocked_callback(cb)
+        self.assertTrue(
+            self.connection.remove_on_connection_blocked_callback(cb))
+        self.assertFalse(
+            self.connection.remove_on_connection_blocked_callback(cb))
+        self.connection._process_frame(
+            pika.frame.Method(0, pika.spec.Connection.Blocked('reason')))
+        self.assertEqual(buffer, [])
+
+    def test_remove_on_connection_blocked_callback_isolation(self):
+        kept, removed = [], []
+
+        def cb_keep(conn, frame):
+            kept.append(frame)
+
+        def cb_remove(conn, frame):
+            removed.append(frame)
+
+        self.connection.add_on_connection_blocked_callback(cb_keep)
+        self.connection.add_on_connection_blocked_callback(cb_remove)
+        self.assertTrue(
+            self.connection.remove_on_connection_blocked_callback(cb_remove))
+        self.connection._process_frame(
+            pika.frame.Method(0, pika.spec.Connection.Blocked('reason')))
+        self.assertEqual(len(kept), 1)
+        self.assertEqual(removed, [])
+
+    def test_remove_on_connection_unblocked_callback(self):
+        buffer = []
+
+        def cb(conn, frame):
+            buffer.append(frame)
+
+        self.connection.add_on_connection_unblocked_callback(cb)
+        self.assertTrue(
+            self.connection.remove_on_connection_unblocked_callback(cb))
+        self.assertFalse(
+            self.connection.remove_on_connection_unblocked_callback(cb))
+        self.connection._process_frame(
+            pika.frame.Method(0, pika.spec.Connection.Unblocked()))
+        self.assertEqual(buffer, [])
+
     @mock.patch.object(connection.Connection,
                        '_adapter_connect_stream',
                        spec_set=connection.Connection._adapter_connect_stream)


### PR DESCRIPTION
## Proposed Changes

Adds a public callback **removal** API mirroring the existing `add_on_X_callback` methods.
Implemented based #1601.

**Tests added** (`tests/unit/`):
- `callback_tests.py` - `keys` (empty/registered/snapshot) and `remove_matching` (absent→`False`, no-match→`False`, match→`True`, idempotent, only-removes-matching, prevents-processing).
- `channel_tests.py` - each `remove_on_*` targets the correct prefix/key with a predicate that selects the callback and rejects others; `remove_callback` with explicit `replies`, with `replies=None` (walks `keys`), and the absent→`False` case.
- `connection_tests.py` - behavioral: `remove_on_close`/`open`/`open_error` return `True` then `False` and stop firing; isolation (removing one leaves others); blocked/unblocked removal matches the original callable through its stored `functools.partial`, including the isolation case.

Covers the four cases the issue lists: removal prevents firing, `True`/`False` on present/absent, idempotent repeat removal, and no effect on other registrations under the same key.

**Code changes:**

`pika/callback.py` - two new `CallbackManager` helpers:
- `remove_matching(prefix, key, predicate) -> bool` - removes callbacks whose stored callable satisfies `predicate`, returning whether any were removed.
- `keys(prefix) -> list` - read-only snapshot of registered keys.

These are needed because the existing `remove` returns `True` whenever the prefix/key merely exist (so it can't report a real match for the required bool), and because the connection blocked/unblocked callbacks are stored wrapped in `functools.partial`, which equality-matching against the original callable can't find.

`pika/channel.py`:
- `remove_callback(callback, replies=None)`
- `remove_on_cancel_callback`
- `remove_on_close_callback`
- `remove_on_flow_callback`
- `remove_on_return_callback`

`pika/connection.py`:

- `remove_on_close_callback`
- `remove_on_connection_blocked_callback`
- `remove_on_connection_unblocked_callback`
- `remove_on_open_callback`
- `remove_on_open_error_callback`

All return `bool` (`True` iff something was removed), match by equality, are idempotent (absent→`False`, no exception), and reuse the exact prefix/key of their paired `add_on_*`. `remove_callback(replies=None)` removes from every reply key the callback is registered under; a `replies` subset narrows it. `cleanup(prefix)` and `one_shot` behavior are unchanged - a `one_shot` callback can still be removed before it fires.

## Types of Changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Closes #1601

## Further Comments
