### PR TITLE
`Channel.confirm_delivery`: append ack/nack callback instead replace

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -116,6 +116,7 @@ class Channel:
         self._consumers_with_noack: set = set()
         self._on_flowok_callback: Callable[..., Any] | None = None
         self._on_getok_callback: Callable[..., Any] | None = None
+        self._on_ack_nack_callback: _OnAckNackCallback | None = None
         self._on_openok_callback: None | (Callable[..., Any]) = on_open_callback
         self._state: int = self.CLOSED
 
@@ -662,6 +663,12 @@ class Channel:
         :param callback: callback(pika.frame.Method) for method
             Confirm.SelectOk
         :raises ValueError:
+
+        .. note::
+            Calling this method more than once on the same channel replaces
+            the previously registered ``ack_nack_callback`` rather than adding
+            an additional one. Only the most recently registered callback
+            receives ``Basic.Ack``/``Basic.Nack`` notifications.
         """
         if not callable(ack_nack_callback):
             # confirm_deliver requires a callback; it's meaningless
@@ -677,11 +684,20 @@ class Channel:
             raise exceptions.MethodNotImplemented(
                 'Confirm.Select not Supported by Server')
 
+        # Replace any previously registered ack/nack callback so repeated
+        # calls don't stack listeners and fire stale callbacks (see #1602).
+        if self._on_ack_nack_callback is not None:
+            self.callbacks.remove(self.channel_number, spec.Basic.Ack,
+                                  self._on_ack_nack_callback)
+            self.callbacks.remove(self.channel_number, spec.Basic.Nack,
+                                  self._on_ack_nack_callback)
+
         # Add the ack and nack callback
         self.callbacks.add(self.channel_number, spec.Basic.Ack,
                            ack_nack_callback, False)
         self.callbacks.add(self.channel_number, spec.Basic.Nack,
                            ack_nack_callback, False)
+        self._on_ack_nack_callback = ack_nack_callback
 
         self._rpc(spec.Confirm.Select(nowait), callback,
                   [spec.Confirm.SelectOk] if not nowait else [])

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -847,6 +847,29 @@ class ChannelTests(unittest.TestCase):
         self.obj.confirm_delivery(ack_nack_callback=user_callback)
         self.assertIn(expectation_item, self.obj.callbacks.add.call_args_list)
 
+    def test_confirm_delivery_first_call_does_not_remove_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        self.obj.confirm_delivery(ack_nack_callback=mock.Mock())
+        self.obj.callbacks.remove.assert_not_called()
+
+    def test_confirm_delivery_replaces_previous_callback(self):
+        self.obj._set_state(self.obj.OPEN)
+        first_callback = mock.Mock()
+        second_callback = mock.Mock()
+
+        self.obj.confirm_delivery(ack_nack_callback=first_callback)
+        self.obj.confirm_delivery(ack_nack_callback=second_callback)
+
+        # The previously registered callback is removed for both Ack and Nack
+        self.obj.callbacks.remove.assert_any_call(self.obj.channel_number,
+                                                  spec.Basic.Ack,
+                                                  first_callback)
+        self.obj.callbacks.remove.assert_any_call(self.obj.channel_number,
+                                                  spec.Basic.Nack,
+                                                  first_callback)
+        # The most recent callback is the one tracked for future replacement
+        self.assertIs(self.obj._on_ack_nack_callback, second_callback)
+
     def test_consumer_tags(self):
         self.assertListEqual(self.obj.consumer_tags,
                              list(self.obj._consumers.keys()))


### PR DESCRIPTION
## Proposed Changes

`Channel.confirm_delivery` registered its ack/nack callback with `callbacks.add`, which appends.
Calling the method more than once on the same channel left every previously registered callback active, so each `Basic.Ack`/`Basic.Nack` from the broker fired all of them

Implements Option A (replace semantics) from issue #1602.
## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change <!-- only for code that relied on the previously undocumented append behavior -->
- [ ] Documentation <!-- docstring note describing the replace behavior -->
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1602

## Further Comments