### PR TITLE
Chore: expand ruff rules

### DIFF
--- a/examples/async_as_callback.py
+++ b/examples/async_as_callback.py
@@ -101,7 +101,7 @@ class BasicPikaClient:
                       exclusive: bool = False,
                       max_priority: int = 10):
         self.check_connection()
-        logger.debug(f"Trying to declare queue({queue_name})...")
+        logger.debug("Trying to declare queue(%s)...", queue_name)
         self.channel.queue_declare(
             queue=queue_name,
             exclusive=exclusive,
@@ -155,7 +155,10 @@ class BasicMessageSender(BasicPikaClient):
             ),
         )
         logger.debug(
-            f"Sent message. Exchange: {exchange_name}, Routing Key: {routing_key}, Body: {body[:128]}"
+            "Sent message. Exchange: %s, Routing Key: %s, Body: %s",
+            exchange_name,
+            routing_key,
+            body[:128],
         )
 
 
@@ -174,7 +177,7 @@ class BasicMessageReceiver(BasicPikaClient):
         method_frame, header_frame, body = self.channel.basic_get(
             queue=queue_name, auto_ack=auto_ack)
         if method_frame:
-            logger.debug(f"{method_frame}, {header_frame}, {body}")
+            logger.debug("%s, %s, %s", method_frame, header_frame, body)
             return method_frame, header_frame, body
         logger.debug("No message returned")
         return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,9 @@ select = [
     "PLC",  # Pylint convention rules
     "RUF",  # Ruff-specific rules
     "FURB", # refurbishing and modernizing codebase
+    "G",    # flake8-logging-format: lazy %-formatting in log calls
+    "ISC",  # implicit string concatenation
+    "PGH",  # pygrep-hooks: blanket type-ignore / eval
 ]
 
 ignore = [

--- a/tests/unit/delivery_mode_test.py
+++ b/tests/unit/delivery_mode_test.py
@@ -88,6 +88,6 @@ class DeliveryModeTests(unittest.TestCase):
         """A ``BasicProperties`` constructed with a non-integer delivery_mode (e.g. a string) must
         raise at encode time so callers passing the wrong type get a useful diagnostic.
         """
-        props = BasicProperties(delivery_mode='persistent')  # type: ignore
+        props = BasicProperties(delivery_mode='persistent')
         with self.assertRaises((struct.error, TypeError)):
             b''.join(props.encode())


### PR DESCRIPTION
## Proposed Changes

Enable three additional Ruff lint rule families to guard against common issues going forward:

- `G` (flake8-logging-format) - enforces lazy `%`-style args in log calls
- `ISC` (implicit-string-concatenation) - catches accidental string concatenation from missing commas
- `PGH` (pygrep-hooks) - flags blanket `# type: ignore` comments

The codebase is already (almost) clean against all three, so this adds no churn - it simply locks in good practices for future contributions.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [x] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- N/A, lint config -->
- [ ] I have added necessary documentation (if appropriate) <!-- N/A -->

## Fixes

<!-- none -->

## Further Comments