### PR TITLE
Include hostname and port in connection error reporting

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -372,7 +372,9 @@ class BaseConnection(connection.Connection):
                             conn_or_exc.exceptions[-1],
                             connection_workflow.AMQPConnectorSocketConnectError)
                    ):
-                    error = pika.exceptions.AMQPConnectionError(conn_or_exc)
+                    last_exc = conn_or_exc.exceptions[-1]
+                    error = pika.exceptions.AMQPConnectionError(
+                        conn_or_exc, host=last_exc.host, port=last_exc.port)
                 else:
                     error = conn_or_exc
 
@@ -468,10 +470,14 @@ class BaseConnection(connection.Connection):
             # Either result of `eof_received()` or abort
             if self._got_eof:
                 error = pika.exceptions.StreamLostError(
-                    'Transport indicated EOF')
+                    'Transport indicated EOF',
+                    host=self.params.host,
+                    port=self.params.port)
         else:
             error = pika.exceptions.StreamLostError(
-                f'Stream connection lost: {error!r}')
+                f'Stream connection lost: {error!r}',
+                host=self.params.host,
+                port=self.params.port)
 
         LOGGER.log(logging.DEBUG if error is None else logging.ERROR,
                    'connection_lost: %r', error)

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -516,13 +516,17 @@ class BlockingConnection:
         """
         if isinstance(error, connection_workflow.AMQPConnectionWorkflowFailed):
             # Extract exception value from the last connection attempt
-            error = error.exceptions[-1]
-            if isinstance(error,
+            last = error.exceptions[-1]
+            if isinstance(last,
                           connection_workflow.AMQPConnectorSocketConnectError):
-                error = exceptions.AMQPConnectionError(error)
-            elif isinstance(error,
+                error = exceptions.AMQPConnectionError(last,
+                                                       host=last.host,
+                                                       port=last.port)
+            elif isinstance(last,
                             connection_workflow.AMQPConnectorPhaseErrorBase):
-                error = error.exception
+                error = last.exception
+            else:
+                error = last
 
         return error
 

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1293,7 +1293,9 @@ class TwistedProtocolConnection(protocol.Protocol):
         d, self.ready = self.ready, None
         if d:
             attempts = self._impl.params.connection_attempts
-            exc = exceptions.AMQPConnectionError(attempts)
+            exc = exceptions.AMQPConnectionError(attempts,
+                                                 host=self._impl.params.host,
+                                                 port=self._impl.params.port)
             d.errback(exc)
 
     def _on_connection_closed(self, _connection: pika.connection.Connection,

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -53,18 +53,29 @@ class AMQPConnectorWrongState(AMQPConnectorException):
 class AMQPConnectorPhaseErrorBase(AMQPConnectorException):
     """Wrapper for exception that occurred during a particular bring-up phase."""
 
-    def __init__(self, exception: BaseException, *args: Any) -> None:
+    def __init__(self,
+                 exception: BaseException,
+                 *args: Any,
+                 host: str | None = None,
+                 port: int | None = None) -> None:
         """
 
         :param exception: error that occurred while waiting for a
             subclass-specific protocol bring-up phase to complete.
         :param args: args for parent class
+        :param host: hostname or IP of the broker that failed
+        :param port: port of the broker that failed
         """
         super().__init__(*args)
         self.exception = exception
+        self.host = host
+        self.port = port
 
     @override
     def __repr__(self) -> str:
+        if self.host is not None:
+            return (f'{self.__class__.__name__}: {self.exception!r}'
+                    f' (host={self.host!r}, port={self.port})')
         return f'{self.__class__.__name__}: {self.exception!r}'
 
 
@@ -330,10 +341,11 @@ class AMQPConnector:
         assert self._conn_params is not None
         self._tcp_timeout_ref = None
 
-        error = AMQPConnectorSocketConnectError(
-            socket.timeout(
-                f'TCP connection attempt timed out: {self._conn_params.host!r}/{self._addr_record}'
-            ))
+        error = AMQPConnectorSocketConnectError(socket.timeout(
+            f'TCP connection attempt timed out: {self._conn_params.host!r}/{self._addr_record}'
+        ),
+                                                host=self._conn_params.host,
+                                                port=self._conn_params.port)
         self._report_completion_and_cleanup(error)
 
     def _on_overall_timeout(self) -> None:
@@ -370,13 +382,18 @@ class AMQPConnector:
             error: Exception = AMQPConnectorSocketConnectError(
                 AMQPConnectorStackTimeout(
                     f'Timeout while connecting socket to {self._conn_params.host!r}/{self._addr_record}'
-                ))
+                ),
+                host=self._conn_params.host,
+                port=self._conn_params.port)
         else:
             assert prev_state == self._STATE_TRANSPORT
-            error = AMQPConnectorTransportSetupError(
-                AMQPConnectorStackTimeout(
-                    f'Timeout while setting up transport to {self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
-                ))
+            error = AMQPConnectorTransportSetupError(AMQPConnectorStackTimeout(
+                f'Timeout while setting up transport to {self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
+            ),
+                                                     host=self._conn_params.
+                                                     host,
+                                                     port=self._conn_params.port
+                                                    )
 
         self._report_completion_and_cleanup(error)
 
@@ -402,7 +419,9 @@ class AMQPConnector:
             _LOG.error('TCP Connection attempt failed: %r; dest=%r', exc,
                        self._addr_record)
             self._report_completion_and_cleanup(
-                AMQPConnectorSocketConnectError(exc))
+                AMQPConnectorSocketConnectError(exc,
+                                                host=self._conn_params.host,
+                                                port=self._conn_params.port))
             return
 
         # We succeeded in making a TCP/IP connection to the server
@@ -453,7 +472,9 @@ class AMQPConnector:
                 '%r/%s; ssl=%s', result, self._conn_params.host,
                 self._addr_record, bool(self._conn_params.ssl_options))
             self._report_completion_and_cleanup(
-                AMQPConnectorTransportSetupError(result))
+                AMQPConnectorTransportSetupError(result,
+                                                 host=self._conn_params.host,
+                                                 port=self._conn_params.port))
             return
 
         # We succeeded in setting up the streaming transport!
@@ -502,10 +523,13 @@ class AMQPConnector:
             result: (BaseException |
                      pika.connection.Connection) = AMQPConnectorAborted()
         elif self._state == self._STATE_TIMEOUT:
-            result = AMQPConnectorAMQPHandshakeError(
-                AMQPConnectorStackTimeout(
-                    f'Timeout during AMQP handshake{self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
-                ))
+            result = AMQPConnectorAMQPHandshakeError(AMQPConnectorStackTimeout(
+                f'Timeout during AMQP handshake{self._conn_params.host!r}/{self._addr_record}; ssl={bool(self._conn_params.ssl_options)}'
+            ),
+                                                     host=self._conn_params.
+                                                     host,
+                                                     port=self._conn_params.port
+                                                    )
         elif self._state == self._STATE_AMQP:
             if error is None:
                 _LOG.debug(
@@ -517,7 +541,10 @@ class AMQPConnector:
                     'AMQPConnector: AMQP connection handshake failed for '
                     '%r/%s: %r', self._conn_params.host, self._addr_record,
                     error)
-                result = AMQPConnectorAMQPHandshakeError(error)
+                result = AMQPConnectorAMQPHandshakeError(
+                    error,
+                    host=self._conn_params.host,
+                    port=self._conn_params.port)
         else:
             # We timed out or aborted and initiated closing of the connection,
             # but this callback snuck in

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1438,13 +1438,17 @@ class Connection(abc.ABC):
 
             error = exceptions.ConnectionOpenAborted(
                 'Connection.close() called before connection '
-                f'finished opening: prev_state={self._STATE_NAMES[prev_state]} ({reply_code}): {reply_text!r}'
-            )
+                f'finished opening: prev_state={self._STATE_NAMES[prev_state]} ({reply_code}): {reply_text!r}',
+                host=self.params.host,
+                port=self.params.port)
             self._terminate_stream(error)
 
         else:
             self._error = exceptions.ConnectionClosedByClient(
-                reply_code, reply_text)
+                reply_code,
+                reply_text,
+                host=self.params.host,
+                port=self.params.port)
 
             # If there are channels that haven't finished closing yet, then
             # _on_close_ready will finally be called from _on_channel_cleanup once
@@ -1715,7 +1719,9 @@ class Connection(abc.ABC):
         (auth_type,
          response) = self.params.credentials.response_for(method_frame.method)
         if not auth_type:
-            raise exceptions.AuthenticationError(self.params.credentials.TYPE)
+            raise exceptions.AuthenticationError(self.params.credentials.TYPE,
+                                                 host=self.params.host,
+                                                 port=self.params.port)
         self.params.credentials.erase_credentials()
         return auth_type, response
 
@@ -1748,7 +1754,8 @@ class Connection(abc.ABC):
         """Return the next available channel number or raise an exception."""
         limit = self.params.channel_max or pika.channel.MAX_CHANNELS
         if len(self._channels) >= limit:
-            raise exceptions.NoFreeChannels()
+            raise exceptions.NoFreeChannels(host=self.params.host,
+                                            port=self.params.port)
 
         for num in range(1, len(self._channels) + 1):
             if num not in self._channels:
@@ -1819,7 +1826,9 @@ class Connection(abc.ABC):
         self._blocked_conn_timer = None
         self._terminate_stream(
             exceptions.ConnectionBlockedTimeout(
-                'Blocked connection timeout expired.'))
+                'Blocked connection timeout expired.',
+                host=self.params.host,
+                port=self.params.port))
 
     def _on_connection_blocked(
             self, _connection: Connection,
@@ -1879,8 +1888,9 @@ class Connection(abc.ABC):
             exceptions.ConnectionClosedByBroker(
                 method_frame.method.
                 reply_code,  # pyright: ignore[reportArgumentType]
-                method_frame.method.reply_text)
-        )  # pyright: ignore[reportArgumentType]
+                method_frame.method.reply_text,
+                host=self.params.host,
+                port=self.params.port))  # pyright: ignore[reportArgumentType]
 
     def _on_connection_close_ok(
             self, method_frame: frame.Method[spec.Connection.CloseOk]) -> None:
@@ -2136,19 +2146,25 @@ class Connection(abc.ABC):
             if self.connection_state == self.CONNECTION_PROTOCOL:
                 LOGGER.error('Probably incompatible Protocol Versions')
                 self._error = exceptions.IncompatibleProtocolError(
-                    repr(self._error))
+                    repr(self._error),
+                    host=self.params.host,
+                    port=self.params.port)
             elif self.connection_state == self.CONNECTION_START:
                 LOGGER.error(
                     'Connection closed while authenticating indicating a '
                     'probable authentication error')
                 self._error = exceptions.ProbableAuthenticationError(
-                    repr(self._error))
+                    repr(self._error),
+                    host=self.params.host,
+                    port=self.params.port)
             elif self.connection_state == self.CONNECTION_TUNE:
                 LOGGER.error('Connection closed while tuning the connection '
                              'indicating a probable permission error when '
                              'accessing a virtual host')
                 self._error = exceptions.ProbableAccessDeniedError(
-                    repr(self._error))
+                    repr(self._error),
+                    host=self.params.host,
+                    port=self.params.port)
             elif self.connection_state not in [
                     self.CONNECTION_OPEN, self.CONNECTION_CLOSED,
                     self.CONNECTION_CLOSING

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -28,14 +28,19 @@ class AMQPConnectionError(AMQPError):
         self.host = host
         self.port = port
 
+    def _host_port_suffix(self) -> str:
+        """Return a ` (host=..., port=...)` repr suffix, or '' when unset."""
+        if self.host is not None:
+            return f' (host={self.host!r}, port={self.port})'
+        return ''
+
+    @override
     def __repr__(self) -> str:
         if len(self.args) == 2:
             base = f'{self.__class__.__name__}: ({self.args[0]}) {self.args[1]}'
         else:
             base = f'{self.__class__.__name__}: {self.args}'
-        if self.host is not None:
-            return f'{base} (host={self.host!r}, port={self.port})'
-        return base
+        return f'{base}{self._host_port_suffix()}'
 
 
 class ConnectionOpenAborted(AMQPConnectionError):
@@ -52,7 +57,7 @@ class IncompatibleProtocolError(AMQPConnectionError):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}: The protocol returned by the server is not supported: {self.args}'
-        )
+            f'{self._host_port_suffix()}')
 
 
 class AuthenticationError(AMQPConnectionError):
@@ -61,7 +66,7 @@ class AuthenticationError(AMQPConnectionError):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}: Server and client could not negotiate use of the {self.args[0]} '
-            'authentication mechanism')
+            f'authentication mechanism{self._host_port_suffix()}')
 
 
 class ProbableAuthenticationError(AMQPConnectionError):
@@ -70,7 +75,8 @@ class ProbableAuthenticationError(AMQPConnectionError):
     def __repr__(self) -> str:
         return (
             f'{self.__class__.__name__}: Client was disconnected at a connection stage indicating a '
-            f'probable authentication error: {self.args}')
+            f'probable authentication error: {self.args}{self._host_port_suffix()}'
+        )
 
 
 class ProbableAccessDeniedError(AMQPConnectionError):
@@ -80,14 +86,16 @@ class ProbableAccessDeniedError(AMQPConnectionError):
         return (
             f'{self.__class__.__name__}: Client was disconnected at a connection stage indicating a '
             f'probable denial of access to the specified virtual host: {self.args}'
-        )
+            f'{self._host_port_suffix()}')
 
 
 class NoFreeChannels(AMQPConnectionError):
 
     @override
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}: The connection has run out of free channels'
+        return (
+            f'{self.__class__.__name__}: The connection has run out of free channels'
+            f'{self._host_port_suffix()}')
 
 
 class ConnectionWrongStateError(AMQPConnectionError):
@@ -99,7 +107,7 @@ class ConnectionWrongStateError(AMQPConnectionError):
             return super().__repr__()
         return (
             f'{self.__class__.__name__}: The connection is in wrong state for the requested '
-            'operation.')
+            f'operation.{self._host_port_suffix()}')
 
 
 class ConnectionClosed(AMQPConnectionError):
@@ -123,7 +131,9 @@ class ConnectionClosed(AMQPConnectionError):
 
     @override
     def __repr__(self) -> str:
-        return f'{self.__class__.__name__}: ({self.reply_code}) {self.reply_text!r}'
+        return (
+            f'{self.__class__.__name__}: ({self.reply_code}) {self.reply_text!r}'
+            f'{self._host_port_suffix()}')
 
     @property
     def reply_code(self) -> int:

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -20,10 +20,22 @@ class AMQPError(Exception):
 class AMQPConnectionError(AMQPError):
 
     @override
+    def __init__(self,
+                 *args,
+                 host: str | None = None,
+                 port: int | None = None) -> None:
+        super().__init__(*args)
+        self.host = host
+        self.port = port
+
     def __repr__(self) -> str:
         if len(self.args) == 2:
-            return f'{self.__class__.__name__}: ({self.args[0]}) {self.args[1]}'
-        return f'{self.__class__.__name__}: {self.args}'
+            base = f'{self.__class__.__name__}: ({self.args[0]}) {self.args[1]}'
+        else:
+            base = f'{self.__class__.__name__}: {self.args}'
+        if self.host is not None:
+            return f'{base} (host={self.host!r}, port={self.port})'
+        return base
 
 
 class ConnectionOpenAborted(AMQPConnectionError):
@@ -92,7 +104,11 @@ class ConnectionWrongStateError(AMQPConnectionError):
 
 class ConnectionClosed(AMQPConnectionError):
 
-    def __init__(self, reply_code: int, reply_text: str) -> None:
+    def __init__(self,
+                 reply_code: int,
+                 reply_text: str,
+                 host: str | None = None,
+                 port: int | None = None) -> None:
         """
 
         :param reply_code: reply-code that was used in user's or broker's
@@ -100,8 +116,10 @@ class ConnectionClosed(AMQPConnectionError):
         :param reply_text: reply-text that was used in user's or broker's
             `Connection.Close` method. Human-readable string corresponding to
             `reply_code`. NEW in v1.0.0
+        :param host: hostname or IP of the broker
+        :param port: port of the broker
         """
-        super().__init__(int(reply_code), str(reply_text))
+        super().__init__(int(reply_code), str(reply_text), host=host, port=port)
 
     @override
     def __repr__(self) -> str:

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -148,7 +148,10 @@ class HeartbeatChecker:
         # close the AMQP connection since lack of heartbeat suggests that the
         # stream is dead.
         self._connection._terminate_stream(
-            pika.exceptions.AMQPHeartbeatTimeout(text))
+            pika.exceptions.AMQPHeartbeatTimeout(
+                text,
+                host=self._connection.params.host,
+                port=self._connection.params.port))
 
     @property
     def _has_received_data(self) -> bool:

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -43,6 +43,17 @@ class ExceptionTests(unittest.TestCase):
         exc = exceptions.StreamLostError('eof', host='10.0.0.1', port=5672)
         self.assertEqual(exc.host, '10.0.0.1')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='10.0.0.1', port=5672)", repr(exc))
+
+    def test_custom_repr_subclass_omits_host_port_when_unset(self):
+        # Subclasses that override __repr__ must not emit a host/port suffix
+        # when neither is set.
+        for exc in (exceptions.NoFreeChannels(),
+                    exceptions.AuthenticationError('PLAIN'),
+                    exceptions.IncompatibleProtocolError('bad'),
+                    exceptions.ConnectionClosedByBroker(320, 'forced')):
+            self.assertNotIn('host=', repr(exc))
+            self.assertNotIn('port=', repr(exc))
 
     def test_incompatible_protocol_error_host_port(self):
         exc = exceptions.IncompatibleProtocolError('bad',
@@ -50,16 +61,19 @@ class ExceptionTests(unittest.TestCase):
                                                    port=5672)
         self.assertEqual(exc.host, 'host1')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='host1', port=5672)", repr(exc))
 
     def test_probable_authentication_error_host_port(self):
         exc = exceptions.ProbableAuthenticationError('x', host='h', port=5672)
         self.assertEqual(exc.host, 'h')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='h', port=5672)", repr(exc))
 
     def test_probable_access_denied_error_host_port(self):
         exc = exceptions.ProbableAccessDeniedError('x', host='h', port=5672)
         self.assertEqual(exc.host, 'h')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='h', port=5672)", repr(exc))
 
     def test_connection_blocked_timeout_host_port(self):
         exc = exceptions.ConnectionBlockedTimeout('timeout',
@@ -90,6 +104,7 @@ class ExceptionTests(unittest.TestCase):
                                                   port=5672)
         self.assertEqual(exc.host, 'r')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='r', port=5672)", repr(exc))
 
     def test_connection_closed_no_host_port_by_default(self):
         exc = exceptions.ConnectionClosed(200, 'OK')
@@ -100,11 +115,13 @@ class ExceptionTests(unittest.TestCase):
         exc = exceptions.AuthenticationError('PLAIN', host='broker', port=5672)
         self.assertEqual(exc.host, 'broker')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='broker', port=5672)", repr(exc))
 
     def test_no_free_channels_host_port(self):
         exc = exceptions.NoFreeChannels(host='broker', port=5672)
         self.assertEqual(exc.host, 'broker')
         self.assertEqual(exc.port, 5672)
+        self.assertIn("(host='broker', port=5672)", repr(exc))
 
     def test_authentication_error_repr(self):
         self.assertEqual(

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from pika import exceptions
+from pika.adapters.utils import connection_workflow
 
 
 class ExceptionTests(unittest.TestCase):
@@ -15,6 +16,95 @@ class ExceptionTests(unittest.TestCase):
     def test_amqp_connection_error_two_params_repr(self):
         self.assertEqual(repr(exceptions.AMQPConnectionError(1, 'Test')),
                          'AMQPConnectionError: (1) Test')
+
+    def test_amqp_connection_error_host_port(self):
+        exc = exceptions.AMQPConnectionError('fail',
+                                             host='rabbit.local',
+                                             port=5672)
+        self.assertEqual(exc.host, 'rabbit.local')
+        self.assertEqual(exc.port, 5672)
+        self.assertIn("host='rabbit.local'", repr(exc))
+        self.assertIn('port=5672', repr(exc))
+
+    def test_amqp_connection_error_no_host_port_by_default(self):
+        exc = exceptions.AMQPConnectionError('fail')
+        self.assertIsNone(exc.host)
+        self.assertIsNone(exc.port)
+        self.assertNotIn('host=', repr(exc))
+
+    def test_connection_open_aborted_host_port(self):
+        exc = exceptions.ConnectionOpenAborted('aborted',
+                                               host='broker1',
+                                               port=5671)
+        self.assertEqual(exc.host, 'broker1')
+        self.assertEqual(exc.port, 5671)
+
+    def test_stream_lost_error_host_port(self):
+        exc = exceptions.StreamLostError('eof', host='10.0.0.1', port=5672)
+        self.assertEqual(exc.host, '10.0.0.1')
+        self.assertEqual(exc.port, 5672)
+
+    def test_incompatible_protocol_error_host_port(self):
+        exc = exceptions.IncompatibleProtocolError('bad',
+                                                   host='host1',
+                                                   port=5672)
+        self.assertEqual(exc.host, 'host1')
+        self.assertEqual(exc.port, 5672)
+
+    def test_probable_authentication_error_host_port(self):
+        exc = exceptions.ProbableAuthenticationError('x', host='h', port=5672)
+        self.assertEqual(exc.host, 'h')
+        self.assertEqual(exc.port, 5672)
+
+    def test_probable_access_denied_error_host_port(self):
+        exc = exceptions.ProbableAccessDeniedError('x', host='h', port=5672)
+        self.assertEqual(exc.host, 'h')
+        self.assertEqual(exc.port, 5672)
+
+    def test_connection_blocked_timeout_host_port(self):
+        exc = exceptions.ConnectionBlockedTimeout('timeout',
+                                                  host='h',
+                                                  port=5672)
+        self.assertEqual(exc.host, 'h')
+        self.assertEqual(exc.port, 5672)
+
+    def test_amqp_heartbeat_timeout_host_port(self):
+        exc = exceptions.AMQPHeartbeatTimeout('timeout', host='h', port=5672)
+        self.assertEqual(exc.host, 'h')
+        self.assertEqual(exc.port, 5672)
+
+    def test_connection_closed_host_port(self):
+        exc = exceptions.ConnectionClosed(200,
+                                          'Normal shutdown',
+                                          host='rabbit',
+                                          port=5672)
+        self.assertEqual(exc.host, 'rabbit')
+        self.assertEqual(exc.port, 5672)
+        self.assertEqual(exc.reply_code, 200)
+        self.assertEqual(exc.reply_text, 'Normal shutdown')
+
+    def test_connection_closed_by_broker_host_port(self):
+        exc = exceptions.ConnectionClosedByBroker(320,
+                                                  'forced',
+                                                  host='r',
+                                                  port=5672)
+        self.assertEqual(exc.host, 'r')
+        self.assertEqual(exc.port, 5672)
+
+    def test_connection_closed_no_host_port_by_default(self):
+        exc = exceptions.ConnectionClosed(200, 'OK')
+        self.assertIsNone(exc.host)
+        self.assertIsNone(exc.port)
+
+    def test_authentication_error_host_port(self):
+        exc = exceptions.AuthenticationError('PLAIN', host='broker', port=5672)
+        self.assertEqual(exc.host, 'broker')
+        self.assertEqual(exc.port, 5672)
+
+    def test_no_free_channels_host_port(self):
+        exc = exceptions.NoFreeChannels(host='broker', port=5672)
+        self.assertEqual(exc.host, 'broker')
+        self.assertEqual(exc.port, 5672)
 
     def test_authentication_error_repr(self):
         self.assertEqual(
@@ -173,3 +263,38 @@ class ExceptionTests(unittest.TestCase):
             repr(exceptions.DuplicateGetOkCallback()),
             'DuplicateGetOkCallback: basic_get can only be called again after the callback for '
             'the previous basic_get is executed')
+
+
+class ConnectorPhaseErrorTests(unittest.TestCase):
+
+    def test_socket_connect_error_host_port(self):
+        inner = OSError('Connection refused')
+        exc = connection_workflow.AMQPConnectorSocketConnectError(
+            inner, host='rabbit.local', port=5672)
+        self.assertEqual(exc.host, 'rabbit.local')
+        self.assertEqual(exc.port, 5672)
+        self.assertEqual(exc.exception, inner)
+        self.assertIn("host='rabbit.local'", repr(exc))
+        self.assertIn('port=5672', repr(exc))
+
+    def test_socket_connect_error_no_host_port(self):
+        inner = OSError('Connection refused')
+        exc = connection_workflow.AMQPConnectorSocketConnectError(inner)
+        self.assertIsNone(exc.host)
+        self.assertIsNone(exc.port)
+        self.assertNotIn('host=', repr(exc))
+
+    def test_transport_setup_error_host_port(self):
+        inner = Exception('SSL failed')
+        exc = connection_workflow.AMQPConnectorTransportSetupError(
+            inner, host='10.0.0.1', port=5671)
+        self.assertEqual(exc.host, '10.0.0.1')
+        self.assertEqual(exc.port, 5671)
+
+    def test_amqp_handshake_error_host_port(self):
+        inner = Exception('auth failed')
+        exc = connection_workflow.AMQPConnectorAMQPHandshakeError(inner,
+                                                                  host='broker',
+                                                                  port=5672)
+        self.assertEqual(exc.host, 'broker')
+        self.assertEqual(exc.port, 5672)


### PR DESCRIPTION
## Summary

- Add `host` and `port` attributes to all connection-related exceptions so users can programmatically identify which broker failed
- `AMQPConnectorPhaseErrorBase` (and subclasses `AMQPConnectorSocketConnectError`, `AMQPConnectorTransportSetupError`, `AMQPConnectorAMQPHandshakeError`) now carry `host`/`port` from the connection parameters at the point of failure
- `AMQPConnectionError` gains optional `host`/`port` keyword args, propagated through to `__repr__`
- `ConnectionClosed` (and `ConnectionClosedByBroker`, `ConnectionClosedByClient`) accepts optional `host`/`port` kwargs
- All instantiation sites within `Connection` and `BaseConnection` pass `self.params.host`/`self.params.port`: `StreamLostError`, `ConnectionOpenAborted`, `IncompatibleProtocolError`, `ProbableAuthenticationError`, `ProbableAccessDeniedError`, `ConnectionBlockedTimeout`, `AMQPHeartbeatTimeout`, `ConnectionClosedByBroker`, `ConnectionClosedByClient`
- All adapter paths (asyncio, select, gevent, tornado, twisted, blocking, thread-safe) get structured host/port in errors
- Backward compatible: new parameters are keyword-only with `None` defaults
- Builds on the idea from #1634; supersedes it

## Test plan

- [x] Unit tests verify `host`/`port` attributes and repr output for every `AMQPConnectionError` subclass
- [x] Unit tests verify `host`/`port` on all `AMQPConnectorPhaseErrorBase` subclasses
- [x] Unit tests verify `None` defaults when host/port not passed
- [x] All existing tests pass (862 passed)
- [ ] Integration test: connect to unreachable host, verify exception carries host/port
