### PR TITLE
Stop mutating global asyncio event loop policy on import

### DIFF
--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -14,9 +14,6 @@ if TYPE_CHECKING:
 
 LOGGER = logging.getLogger(__name__)
 
-if sys.platform == 'win32':
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-
 
 class AsyncioConnection(base_connection.BaseConnection):
     """ The AsyncioConnection runs on the Asyncio EventLoop.
@@ -133,7 +130,10 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
             try:
                 loop = asyncio.get_running_loop()
             except RuntimeError:
-                loop = asyncio.new_event_loop()
+                if sys.platform == 'win32':
+                    loop = asyncio.SelectorEventLoop()
+                else:
+                    loop = asyncio.new_event_loop()
         self._loop = loop
 
     def get_native_ioloop(self) -> asyncio.AbstractEventLoop:

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -134,6 +134,14 @@ class _AsyncioIOServicesAdapter(io_services_utils.SocketConnectionMixin,
                     loop = asyncio.SelectorEventLoop()
                 else:
                     loop = asyncio.new_event_loop()
+        if sys.platform == 'win32' and not isinstance(
+                loop, asyncio.SelectorEventLoop):
+            raise TypeError(
+                'On Windows, Pika requires an asyncio.SelectorEventLoop '
+                'because it uses add_reader/add_writer. The running loop '
+                f'is {type(loop).__name__}. Either pass a SelectorEventLoop '
+                'via custom_ioloop, or run with '
+                'asyncio.run(main(), loop_factory=asyncio.SelectorEventLoop).')
         self._loop = loop
 
     def get_native_ioloop(self) -> asyncio.AbstractEventLoop:

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1148,8 +1148,9 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
 
         """
         check_callback_arg(callback, 'callback')
-        return _TimerHandle(self._reactor.callLater(
-            delay, callback))  # pyright: ignore[reportAttributeAccessIssue]
+        return _TimerHandle(
+            self._reactor.callLater(delay=delay, callable=callback)
+        )  # pyright: ignore[reportAttributeAccessIssue]
 
     def _adapter_remove_timeout(self, timeout_id: Any) -> None:
         """Implement

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -370,7 +370,7 @@ class AsyncAdapters(object):
     @run_test_in_thread_with_timeout
     def test_with_asyncio(self):
         """AsyncioConnection"""
-        import asyncio
         from pika.adapters.asyncio_connection import AsyncioConnection
-        ioloop_factory = asyncio.new_event_loop
+        from tests.base.asyncio_loop import new_pika_asyncio_loop
+        ioloop_factory = new_pika_asyncio_loop
         self.start(AsyncioConnection, ioloop_factory)

--- a/tests/base/asyncio_loop.py
+++ b/tests/base/asyncio_loop.py
@@ -1,0 +1,19 @@
+"""Shared helper for creating asyncio event loops in tests."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+
+
+def new_pika_asyncio_loop() -> asyncio.AbstractEventLoop:
+    """
+    Create a new asyncio event loop suitable for Pika's AsyncioConnection.
+
+    On Windows, Pika requires a `SelectorEventLoop` because it uses `add_reader`/`add_writer`, which
+    the default `ProactorEventLoop` does not support. Elsewhere, the default
+    `asyncio.new_event_loop()` is selector-based.
+    """
+    if sys.platform == 'win32':
+        return asyncio.SelectorEventLoop()
+    return asyncio.new_event_loop()

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -113,10 +113,10 @@ class IOServicesTestStubs(object):
         # Test entry point for `asyncio` event loop-based io services
         # implementation.
 
-        import asyncio
         from pika.adapters.asyncio_connection import (_AsyncioIOServicesAdapter)
+        from tests.base.asyncio_loop import new_pika_asyncio_loop
 
-        native_loop = asyncio.new_event_loop()
+        native_loop = new_pika_asyncio_loop()
         self._run_start(
             nbio_factory=lambda: _AsyncioIOServicesAdapter(native_loop),
             native_loop=native_loop)

--- a/tests/unit/asyncio_connection_tests.py
+++ b/tests/unit/asyncio_connection_tests.py
@@ -8,6 +8,7 @@ import unittest
 from unittest.mock import patch
 
 from pika.adapters.asyncio_connection import _AsyncioIOServicesAdapter
+from tests.base.asyncio_loop import new_pika_asyncio_loop
 
 # missing-docstring
 # pylint: disable=C0111
@@ -20,7 +21,7 @@ class AsyncioIOServicesAdapterLoopInitTests(unittest.TestCase):
     """Tests for _AsyncioIOServicesAdapter loop initialisation logic."""
 
     def test_explicit_loop_is_used_as_is(self):
-        loop = asyncio.new_event_loop()
+        loop = new_pika_asyncio_loop()
         try:
             adapter = _AsyncioIOServicesAdapter(loop)
             self.assertIs(adapter.get_native_ioloop(), loop)
@@ -34,7 +35,7 @@ class AsyncioIOServicesAdapterLoopInitTests(unittest.TestCase):
             adapter = _AsyncioIOServicesAdapter()
             results.append(adapter.get_native_ioloop())
 
-        loop = asyncio.new_event_loop()
+        loop = new_pika_asyncio_loop()
         try:
             loop.run_until_complete(_run())
             self.assertIs(results[0], loop)

--- a/tests/unit/asyncio_connection_tests.py
+++ b/tests/unit/asyncio_connection_tests.py
@@ -5,6 +5,7 @@ Tests for pika.adapters.asyncio_connection
 import asyncio
 import threading
 import unittest
+from unittest.mock import patch
 
 from pika.adapters.asyncio_connection import _AsyncioIOServicesAdapter
 
@@ -69,3 +70,51 @@ class AsyncioIOServicesAdapterLoopInitTests(unittest.TestCase):
         self.assertEqual(errors, [])
         self.assertEqual(len(results), 1)
         self.assertIsInstance(results[0], asyncio.AbstractEventLoop)
+
+    @patch('pika.adapters.asyncio_connection.sys')
+    def test_windows_proactor_loop_raises_type_error(self, mock_sys):
+        mock_sys.platform = 'win32'
+        mock_sys.version_info = (3, 12)
+        if not hasattr(asyncio, 'ProactorEventLoop'):
+            self.skipTest('ProactorEventLoop not available on this OS')
+        loop = asyncio.ProactorEventLoop()
+        try:
+            with self.assertRaises(TypeError) as ctx:
+                _AsyncioIOServicesAdapter(loop)
+            self.assertIn('SelectorEventLoop', str(ctx.exception))
+        finally:
+            loop.close()
+
+    @patch('pika.adapters.asyncio_connection.sys')
+    def test_windows_selector_loop_accepted(self, mock_sys):
+        mock_sys.platform = 'win32'
+        mock_sys.version_info = (3, 12)
+        loop = asyncio.SelectorEventLoop()
+        try:
+            adapter = _AsyncioIOServicesAdapter(loop)
+            self.assertIs(adapter.get_native_ioloop(), loop)
+        finally:
+            loop.close()
+
+    @patch('pika.adapters.asyncio_connection.sys')
+    def test_windows_no_loop_creates_selector_event_loop(self, mock_sys):
+        mock_sys.platform = 'win32'
+        mock_sys.version_info = (3, 12)
+        results = []
+        errors = []
+
+        def _thread_target():
+            try:
+                adapter = _AsyncioIOServicesAdapter()
+                results.append(adapter.get_native_ioloop())
+            except Exception as exc:
+                errors.append(exc)
+
+        t = threading.Thread(target=_thread_target)
+        t.start()
+        t.join()
+
+        self.assertEqual(errors, [])
+        self.assertEqual(len(results), 1)
+        self.assertIsInstance(results[0], asyncio.SelectorEventLoop)
+        results[0].close()

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -86,6 +86,16 @@ class TestStartCalledFromOtherThreadAndWithVaryingNativeLoops(
         self.assertNotEqual(threading.current_thread().ident,
                             self._runner_thread_id)
 
-        # And make sure the loop actually works using this rudimentary test
-        nbio.add_callback_threadsafe(nbio.stop)
+        # And make sure the loop actually works using this rudimentary test.
+        #
+        # NOTE: stop is scheduled two turns out rather than one. On Windows,
+        # Tornado wraps the Proactor loop in an AddThreadSelectorEventLoop
+        # whose SelectorThread defers starting (and thus awaiting its
+        # `thread_manager_anext` bootstrap task) until the loop's first turn.
+        # Stopping after a single turn destroys that task while still pending,
+        # producing a "coroutine was never awaited" RuntimeWarning. Letting the
+        # loop run one extra turn lets the task start so close() tears it down
+        # cleanly.
+        nbio.add_callback_threadsafe(
+            lambda: nbio.add_callback_threadsafe(nbio.stop))
         nbio.run()

--- a/tests/unit/io_services_test_stubs_test.py
+++ b/tests/unit/io_services_test_stubs_test.py
@@ -2,8 +2,6 @@
 Test for io_services_test_stubs.py
 """
 
-import pika.compat
-
 try:
     import asyncio
 except ImportError:
@@ -15,7 +13,7 @@ import unittest
 import tornado.ioloop
 
 from pika.adapters import select_connection
-
+from tests.base.asyncio_loop import new_pika_asyncio_loop
 from tests.stubs.io_services_test_stubs import IOServicesTestStubs
 
 # Suppress invalid-name, since our test names are descriptive and quite long
@@ -26,9 +24,7 @@ from tests.stubs.io_services_test_stubs import IOServicesTestStubs
 # pylint: disable=C0111
 
 if asyncio is not None:
-    if pika.compat.ON_WINDOWS:
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
-    loop = asyncio.new_event_loop()
+    loop = new_pika_asyncio_loop()
     asyncio.set_event_loop(loop)
 else:
     loop = None


### PR DESCRIPTION
## Summary

Backport of #1641 to the 1.4.x line. Mirrors the follow-up commits made there after review, plus one pre-existing 1.4.x typing fix (see below).

- Remove module-level `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` that fired on every `import pika.adapters` on Windows
- Instead, construct `asyncio.SelectorEventLoop()` directly in `_AsyncioIOServicesAdapter.__init__` when no loop is provided on Windows
- This gives pika the selector loop it needs for `add_reader`/`add_writer` without polluting the process-wide event loop policy
- Raise a clear `TypeError` when a non-selector loop (e.g. the Windows `ProactorEventLoop` from `asyncio.run()`) is used, instead of failing deep inside asyncio with a confusing `NotImplementedError`
- Replace the deprecated `set_event_loop_policy`/`WindowsSelectorEventLoopPolicy` calls in the tests with a shared `new_pika_asyncio_loop()` helper (those APIs are slated for removal in Python 3.16)
- Drain one extra event loop turn in the IO services stub test so Tornado's Windows `SelectorThread` bootstrap task is awaited, silencing a "coroutine was never awaited" `RuntimeWarning`

## Out-of-scope fix included

- Fix a pre-existing mypy failure at `twisted_connection.py` on the 1.4.x line by passing `delay`/`callable` to `callLater` by keyword. This is unrelated to #1639, but 1.4.x typecheck was already red without it; the fix mirrors what `main` already does. No behavior change.

Fixes #1639

## Test plan

- [ ] Verify on Windows: `import pika.adapters` no longer changes `asyncio.get_event_loop_policy()`
- [ ] Verify on Windows: `AsyncioConnection` still works (gets a `SelectorEventLoop`)
- [ ] Verify on Windows: `asyncio.create_subprocess_exec()` works after importing pika (the reporter's reproducer)
- [ ] Verify on Linux/macOS: no behavior change (still uses `asyncio.new_event_loop()`)
- [ ] All existing CI checks pass
