### PR TITLE
Add `FA` ruff rule and apply fixes

### DIFF
--- a/examples/async_as_callback.py
+++ b/examples/async_as_callback.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import asyncio
 import functools
 import logging
 import ssl
 import time
 from enum import Enum
-from typing import Dict, Optional
 
 import msgpack
 from pydantic import BaseModel, validator
@@ -33,7 +34,7 @@ class Priority(Enum):
 class Headers(BaseModel):
     job_id: str
     priority: Priority
-    task_type: Optional[str] = None
+    task_type: str | None = None
 
     @validator("priority", pre=True)
     def _convert_priority(self, value):
@@ -131,7 +132,7 @@ class BasicPikaClient:
 
 class BasicMessageSender(BasicPikaClient):
 
-    def encode_message(self, body: Dict, encoding_type: str = "bytes"):
+    def encode_message(self, body: dict, encoding_type: str = "bytes"):
         if encoding_type == "bytes":
             return msgpack.packb(body)
         raise NotImplementedError
@@ -140,8 +141,8 @@ class BasicMessageSender(BasicPikaClient):
         self,
         exchange_name: str,
         routing_key: str,
-        body: Dict,
-        headers: Optional[Headers],
+        body: dict,
+        headers: Headers | None,
     ):
         body = self.encode_message(body=body)
         self.channel.basic_publish(

--- a/pika/tcp_socket_opts.py
+++ b/pika/tcp_socket_opts.py
@@ -1,12 +1,13 @@
+from __future__ import annotations
+
 import logging
 import socket
-from typing import Dict, Optional
 
 import pika._utils
 
 LOGGER = logging.getLogger(__name__)
 
-_SUPPORTED_TCP_OPTIONS: Dict[str, int] = {}
+_SUPPORTED_TCP_OPTIONS: dict[str, int] = {}
 
 if hasattr(socket, 'TCP_USER_TIMEOUT'):
     try:
@@ -33,12 +34,12 @@ else:
     _SUPPORTED_TCP_OPTIONS['TCP_KEEPINTVL'] = tcp_keepintvl
 
 
-def socket_requires_keepalive(tcp_options: Dict[str, int]) -> bool:
+def socket_requires_keepalive(tcp_options: dict[str, int]) -> bool:
     return ('TCP_KEEPIDLE' in tcp_options or 'TCP_KEEPCNT' in tcp_options or
             'TCP_KEEPINTVL' in tcp_options)
 
 
-def set_sock_opts(tcp_options: Optional[Dict[str, int]],
+def set_sock_opts(tcp_options: dict[str, int] | None,
                   sock: socket.socket) -> None:
     if not tcp_options:
         return

--- a/pika/validators.py
+++ b/pika/validators.py
@@ -1,6 +1,8 @@
 """Common validation functions."""
 
-from typing import Any, Callable, Optional
+from __future__ import annotations
+
+from typing import Any, Callable
 
 
 def require_string(value: Any, value_name: str) -> None:
@@ -29,7 +31,7 @@ def require_callback(callback: Callable[..., Any],
             f'callback {callback_name} must be callable, but got {callback!r}')
 
 
-def rpc_completion_callback(callback: Optional[Callable[..., Any]]) -> bool:
+def rpc_completion_callback(callback: Callable[..., Any] | None) -> bool:
     """
     Verify callback is callable if not None.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ select = [
     "G",    # flake8-logging-format: lazy %-formatting in log calls
     "ISC",  # implicit string concatenation
     "PGH",  # pygrep-hooks: blanket type-ignore / eval
+    "FA",   # flake8-future-annotations: use `from __future__ import annotations`
 ]
 
 ignore = [


### PR DESCRIPTION
## Proposed Changes

Enables the `FA` (flake8-future-annotations) rule in Ruff and fixes the resulting FA100 findings across the codebase. 
Each affected module now imports `from __future__ import annotations`, which lets us drop the
`typing` shims (`Dict`, `Optional`) in favor of the modern built-in and PEP 604 syntax (`dict`, `X | None`).

This keeps annotations consistent with the style already used elsewhere in the project, reduces `typing` imports, and prevents the same lint findings from sneaking back in. 
A description comment for the `FA` rule was also added to `pyproject.toml` to match the documentation style of the other selected rules.

Files touched:

- `examples/async_as_callback.py` — modernize `Dict`/`Optional` annotations
- `pika/tcp_socket_opts.py` — modernize `Dict`/`Optional` annotations
- `pika/validators.py` — modernize `Optional` annotation
- `pyproject.toml` — enable and document the `FA` rule

## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [x] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #