### PR TITLE
Chore: guard type-only imports and tighten mypy

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -7,6 +7,9 @@ check_untyped_defs = True
 no_implicit_optional = True
 show_error_codes = True
 warn_unused_ignores = True
+warn_redundant_casts = True
+strict_equality = True
+extra_checks = True
 enable_error_code = explicit-override
 
 [mypy-pika.spec]

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -44,7 +44,7 @@ import pika.spec
 import pika.validators as validators
 from pika._utils import override
 
-# NOTE: import SelectConnection after others to avoid circular depenency
+# NOTE: import SelectConnection after others to avoid circular dependency
 from pika.adapters import select_connection
 from pika.adapters.utils import connection_workflow
 from pika.exchange_type import ExchangeType
@@ -723,7 +723,7 @@ class BlockingConnection:
             functools.partial(
                 self._on_connection_blocked,
                 functools.partial(callback,
-                                  cast(pika.connection.Connection, self))))
+                                  cast('pika.connection.Connection', self))))
 
     def add_on_connection_unblocked_callback(
         self, callback: Callable[[
@@ -745,7 +745,7 @@ class BlockingConnection:
             functools.partial(
                 self._on_connection_unblocked,
                 functools.partial(callback,
-                                  cast(pika.connection.Connection, self))))
+                                  cast('pika.connection.Connection', self))))
 
     def call_later(self, delay: float, callback: Callable[[], None]) -> int:
         """
@@ -769,7 +769,7 @@ class BlockingConnection:
 
         evt = _TimerEvt(callback=callback)
         timer_id = cast(
-            int,
+            'int',
             self._impl._adapter_call_later(
                 delay, functools.partial(self._on_timer_ready, evt)))
         evt.timer_id = timer_id

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -39,6 +39,7 @@ import pika._utils
 import pika.channel
 import pika.connection
 import pika.exceptions as exceptions
+import pika.frame
 import pika.spec
 import pika.validators as validators
 from pika._utils import override
@@ -47,13 +48,12 @@ from pika._utils import override
 from pika.adapters import select_connection
 from pika.adapters.utils import connection_workflow
 from pika.exchange_type import ExchangeType
-from pika.spec import Basic
 
 if TYPE_CHECKING:
     from traceback import TracebackException
     from types import TracebackType
 
-    import pika.frame
+    from pika.spec import Basic
 
 T = TypeVar(
     'T', bound='pika.spec.Connection.Blocked | pika.spec.Connection.Unblocked')

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -723,7 +723,7 @@ class BlockingConnection:
             functools.partial(
                 self._on_connection_blocked,
                 functools.partial(callback,
-                                  cast('pika.connection.Connection', self))))
+                                  cast(pika.connection.Connection, self))))
 
     def add_on_connection_unblocked_callback(
         self, callback: Callable[[
@@ -745,7 +745,7 @@ class BlockingConnection:
             functools.partial(
                 self._on_connection_unblocked,
                 functools.partial(callback,
-                                  cast('pika.connection.Connection', self))))
+                                  cast(pika.connection.Connection, self))))
 
     def call_later(self, delay: float, callback: Callable[[], None]) -> int:
         """
@@ -769,7 +769,7 @@ class BlockingConnection:
 
         evt = _TimerEvt(callback=callback)
         timer_id = cast(
-            'int',
+            int,
             self._impl._adapter_call_later(
                 delay, functools.partial(self._on_timer_ready, evt)))
         evt.timer_id = timer_id

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -20,7 +20,6 @@ import twisted.internet.base
 import twisted.python.failure
 from twisted.internet import defer, protocol, reactor
 from twisted.internet import error as twisted_error
-from twisted.internet.defer import Deferred
 from twisted.python.failure import Failure
 
 import pika.connection
@@ -34,6 +33,7 @@ from pika.exchange_type import ExchangeType
 
 if TYPE_CHECKING:
     import twisted.internet.interfaces
+    from twisted.internet.defer import Deferred
 
     from pika import amqp_object, channel
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -674,9 +674,9 @@ class Channel:
         """
         if not callable(ack_nack_callback):
             # confirm_deliver requires a callback; it's meaningless
-            # without a user callback to receieve Basic.Ack/Basic.Nack notifications
+            # without a user callback to receive Basic.Ack/Basic.Nack notifications
             raise ValueError('confirm_delivery requires a callback '
-                             'to receieve Basic.Ack/Basic.Nack notifications')
+                             'to receive Basic.Ack/Basic.Nack notifications')
 
         self._raise_if_not_open()
         nowait = validators.rpc_completion_callback(callback)
@@ -1587,7 +1587,7 @@ class ContentFrameAssembler:
     """
 
     def __init__(self) -> None:
-        """Create a new instance of the conent frame assembler."""
+        """Create a new instance of the content frame assembler."""
         self._method_frame: frame.Method | None = None
         self._header_frame: frame.Header | None = None
         self._seen_so_far = 0

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 import logging
 import uuid
 from collections import deque
-from collections.abc import Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, Union
 
@@ -19,6 +18,8 @@ from pika._utils import as_bytes, override
 from pika.exchange_type import ExchangeType
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pika import amqp_object
     from pika.connection import Connection
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2035,10 +2035,10 @@ class Connection(abc.ABC):
                 raise TypeError('heartbeat callback must not return None '
                                 f'or callable, but got {ret_heartbeat!r}')
 
-            # Leave it to hearbeat setter deal with the rest of the validation
+            # Leave it to heartbeat setter deal with the rest of the validation
             self.params.heartbeat = ret_heartbeat
 
-        # Negotiate heatbeat timeout
+        # Negotiate heartbeat timeout
         self.params.heartbeat = self._tune_heartbeat_timeout(
             client_value=self.params.heartbeat,
             server_value=method_frame.method.heartbeat)

--- a/pika/data.py
+++ b/pika/data.py
@@ -63,7 +63,7 @@ def decode_short_string(encoded: bytes, offset: int) -> tuple[str | bytes, int]:
 
 def encode_table(pieces: list[bytes], table: dict[str, Any] | None) -> int:
     """
-    Encode a dict as an AMQP table appending the encded table to the pieces list passed in.
+    Encode a dict as an AMQP table appending the encoded table to the pieces list passed in.
 
     :param pieces: Already encoded frame pieces
     :param table: The dict to encode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ select = [
     "ISC",  # implicit string concatenation
     "PGH",  # pygrep-hooks: blanket type-ignore / eval
     "FA",   # flake8-future-annotations: use `from __future__ import annotations`
+    "TC",   # flake8-type-checking: guard type-only imports behind TYPE_CHECKING
 ]
 
 ignore = [
@@ -93,6 +94,7 @@ ignore = [
     "C901",    # function is too complex
     "PLC0415", # import should be at the top level of a file
     "PERF203", # `try`-`except` within a loop incurs performance overhead
+    "TC006",   # add quotes to `cast()` type expr: churny and hurts editor "go to definition"
 ]
 
 [tool.yapf]


### PR DESCRIPTION
## Proposed Changes

This PR continues the ongoing lint/type-checking hardening effort (following #1633, #1638, #1643) with two focused, low-risk improvements plus some incidental typo fixes.

**1. Enable the `TC` (flake8-type-checking) Ruff rule.** This is the natural sequel to the `from __future__ import annotations` work in #1643: it moves imports used *only* in type annotations behind `if TYPE_CHECKING:`, trimming runtime import cost and making the runtime-vs-typing intent of each import explicit. The fixes applied:

- `pika/channel.py` — `collections.abc.Sequence` (annotation-only) → `TYPE_CHECKING`
- `pika/adapters/twisted_connection.py` — `Deferred` (annotation-only) → `TYPE_CHECKING`
- `pika/adapters/blocking_connection.py` — `spec.Basic` → `TYPE_CHECKING`; and `import pika.frame` moved *out* to the runtime imports (TC004: the import also binds the `pika` root name, which is used at runtime)

`TC006` (which quotes the type expression in `cast()` calls) is added to the `ignore` list. Applying it turned cast types into forward-reference strings that then triggered a `UP007`/`UP045` PEP-604 rewrite cascade — a lot of churn for a micro-optimization, and quoted casts break editor "go to definition". The valuable part of the family (guarding imports) is kept; the one debatable rule is disabled with a comment explaining why.

**2. Enable zero-churn strict mypy flags.** After the recent typing pushes (#1638, #1619) the codebase already satisfies several stricter mypy checks, so this locks them in to prevent regressions — no code changes required:

- `warn_redundant_casts` — flags unnecessary `cast()` calls
- `strict_equality` — flags non-overlapping `==`/`!=` comparisons (a real bug class)
- `extra_checks` — additional type-consistency checks

Higher-churn flags (`disallow_incomplete_defs`, `warn_return_any`, etc.) each carry 40–70 existing errors and are intentionally left for a dedicated typing pass.

**3. Minor typo fixes** in comments and docstrings (`dependency`, `receive`, `content`, `heartbeat`, `encoded`).

## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- N/A: lint/type-config and no-op typing changes; verified via ruff, mypy, and the existing suite (867 passed, 21 skipped) -->
- [ ] I have added necessary documentation (if appropriate) <!-- N/A -->

## Fixes

<!-- none -->

## Further Comments
