### PR TITLE
Remove dead capabilities-stripping code from Connection._set_server_information

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -93,28 +93,6 @@ class BaseConnection(connection.Connection):
 
     @override
     def __repr__(self) -> str:
-
-        # def get_socket_repr(sock):
-        #     """Return socket info suitable for use in repr"""
-        #     if sock is None:
-        #         return None
-        #
-        #     sockname = None
-        #     peername = None
-        #     try:
-        #         sockname = sock.getsockname()
-        #     except pika._utils.SOCKET_ERROR:
-        #         # closed?
-        #         pass
-        #     else:
-        #         try:
-        #             peername = sock.getpeername()
-        #         except pika._utils.SOCKET_ERROR:
-        #             # not connected?
-        #             pass
-        #
-        #     return '%s->%s' % (sockname, peername)
-        # TODO need helpful __repr__ in transports
         return (
             f'<{self.__class__.__name__} {self._STATE_NAMES[self.connection_state]} transport={self._transport} params={self.params}>'
         )

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2421,11 +2421,8 @@ class Connection(abc.ABC):
         :param method_frame: The Connection.Start frame
         """
         self.server_properties = method_frame.method.server_properties  # pyright: ignore[reportAttributeAccessIssue]
-        self.server_capabilities = self.server_properties.get(  # pyright: ignore[reportOptionalMemberAccess]
-            'capabilities', {})
-        if hasattr(self.server_properties, 'capabilities'):
-            del self.server_properties[
-                'capabilities']  # pyright: ignore[reportOptionalSubscript]
+        assert self.server_properties is not None
+        self.server_capabilities = self.server_properties.pop('capabilities', {})
 
     def _trim_frame_buffer(self, byte_count: int) -> None:
         """

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2422,7 +2422,11 @@ class Connection(abc.ABC):
         """
         self.server_properties = method_frame.method.server_properties  # pyright: ignore[reportAttributeAccessIssue]
         assert self.server_properties is not None
-        self.server_capabilities = self.server_properties.pop(
+        # Note: 'capabilities' is deliberately kept in server_properties.
+        # Code that removed it never worked (it used hasattr on a dict, dead
+        # since 2011), so callers have always seen the key there; removing it
+        # now would break them.
+        self.server_capabilities = self.server_properties.get(
             'capabilities', {})
 
     def _trim_frame_buffer(self, byte_count: int) -> None:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2422,7 +2422,8 @@ class Connection(abc.ABC):
         """
         self.server_properties = method_frame.method.server_properties  # pyright: ignore[reportAttributeAccessIssue]
         assert self.server_properties is not None
-        self.server_capabilities = self.server_properties.pop('capabilities', {})
+        self.server_capabilities = self.server_properties.pop(
+            'capabilities', {})
 
     def _trim_frame_buffer(self, byte_count: int) -> None:
         """

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -526,8 +526,6 @@ class ConnectionTests(unittest.TestCase):
         method_frame.method.mechanisms = str(credentials.PlainCredentials.TYPE)
         method_frame.method.version_major = 0
         method_frame.method.version_minor = 9
-        # This may be incorrectly mocked, or the code is wrong
-        # TODO: Code does hasattr check, should this be a has_key/in check?
         method_frame.method.server_properties = {
             'capabilities': {
                 'basic.nack': True,
@@ -535,7 +533,7 @@ class ConnectionTests(unittest.TestCase):
                 'exchange_exchange_bindings': False
             }
         }
-        # This will be called, but should not be implmented here, just mock it
+        # This will be called, but should not be implemented here, just mock it
         self.connection._flush_outbound = mock.Mock()
         self.connection._adapter_emit_data = mock.Mock()
         self.connection._on_connection_start(method_frame)
@@ -543,6 +541,8 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(False, self.connection.consumer_cancel_notify)
         self.assertEqual(False, self.connection.exchange_exchange_bindings)
         self.assertEqual(False, self.connection.publisher_confirms)
+        # 'capabilities' is moved into server_capabilities, not left behind
+        self.assertNotIn('capabilities', self.connection.server_properties)
 
     @mock.patch('pika.heartbeat.HeartbeatChecker')
     @mock.patch('pika.frame.Method')

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -541,8 +541,11 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(False, self.connection.consumer_cancel_notify)
         self.assertEqual(False, self.connection.exchange_exchange_bindings)
         self.assertEqual(False, self.connection.publisher_confirms)
-        # 'capabilities' is moved into server_capabilities, not left behind
-        self.assertNotIn('capabilities', self.connection.server_properties)
+        # 'capabilities' stays in server_properties as sent by the broker;
+        # server_capabilities is a convenience view of the same dict.
+        self.assertIn('capabilities', self.connection.server_properties)
+        self.assertIs(self.connection.server_capabilities,
+                      self.connection.server_properties['capabilities'])
 
     @mock.patch('pika.heartbeat.HeartbeatChecker')
     @mock.patch('pika.frame.Method')


### PR DESCRIPTION
## Proposed Changes

`Connection._set_server_information` contained dead code intended to remove the `capabilities` entry from `server_properties` after copying it into `server_capabilities`:

```python
if hasattr(self.server_properties, 'capabilities'):
    del self.server_properties['capabilities']
```

`server_properties` is a `dict`, so `hasattr(some_dict, 'capabilities')` checks for an *attribute* named `capabilities`, not a *key* - which is always `False`. The `del` therefore never ran, and since 7cd60baef213f9b11fcd0e2f3c85cb773378f049 (2011) the public `server_properties` attribute has always retained the `capabilities` key.

Because removing the key never actually worked, stripping it now would silently change 15-year-old observable behavior for any user code reading `connection.server_properties['capabilities']`. So this PR resolves the inconsistency by declaring the de facto behavior intentional (see [this review comment](https://github.com/pika/pika/pull/1647#pullrequestreview-4680406909)):

- `server_properties` is left exactly as the broker sent it, `capabilities` included.
- `server_capabilities` is populated with `.get('capabilities', {})` as a convenience view of the same dict.
- The dead `hasattr`/`del` code is removed, and a comment documents why the key deliberately stays.
- The regression test pins the kept-key behavior and asserts `server_capabilities` is the same object as `server_properties['capabilities']`.

Also included: removal of a stale commented-out `get_socket_repr` block and its dangling `# TODO` in `BaseConnection.__repr__`, plus comment/typo cleanups in the affected test.

## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Cosmetics <!-- dead-code removal, no behavior change -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate) <!-- N/A, behavior documented in code comment -->

## Fixes

<!-- none -->

## Further Comments

There are 5 more `# TODO` comments in the code base which are not handled in this PR.
