### PR TITLE
Clarify connection_is_idle single-interval threshold is by design

### DIFF
--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -87,8 +87,15 @@ class HeartbeatChecker:
 
     @property
     def connection_is_idle(self) -> bool:
-        """Returns true if the byte count hasn't changed in enough intervals to trip the max idle
-        threshold.
+        """
+        Returns true if no bytes were received during the last check interval.
+
+        A single idle check interval is the threshold by design, not an off-by-one: the check
+        interval is ``timeout + 5`` seconds while the broker sends a heartbeat every ``timeout / 2``
+        seconds, so one check interval with zero bytes received already spans at least two missed
+        broker heartbeats as required by the AMQP spec. See the ``_check_interval`` comment in
+        ``__init__`` and
+        https://github.com/pika/pika/pull/1072.
         """
         return self._idle_byte_intervals > 0
 


### PR DESCRIPTION
## Summary

Clarifies the `HeartbeatChecker.connection_is_idle` docstring. The old wording, "hasn't changed in enough intervals to trip the max idle threshold", reads as if a multi-interval count were intended, which invites misreading the `> 0` threshold as an off-by-one. PR #1645 was based on exactly that misreading.

The new docstring explains that a single check interval is the threshold by design: the check interval is `timeout + 5` seconds while the broker sends a heartbeat every `timeout / 2` seconds, so one check interval with zero bytes received already spans at least two missed broker heartbeats, satisfying the AMQP spec's two-missed-heartbeats timeout. It points to the `_check_interval` comment in `__init__` and #1072 for the design rationale.

Documentation only, no behavior change.

## Testing

`hatch run fmt-check`, `hatch run docfmt-check`, `hatch run lint`, `hatch run typecheck`, and `hatch run unit` (867 passed, 21 skipped) all pass locally.

See #1645.
