### PR TITLE
Fix: address pyright issues

### DIFF
--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -7,7 +7,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 # ruff: noqa: E402
 
-from pika import adapters
+from pika import adapters, frame, spec
 from pika.adapters import BaseConnection, BlockingConnection, SelectConnection, ThreadSafeConnection
 from pika.adapters.utils.connection_workflow import AMQPConnectionWorkflow
 from pika.connection import ConnectionParameters, SSLOptions, URLParameters
@@ -28,4 +28,6 @@ __all__ = [
     'ThreadSafeConnection',
     'URLParameters',
     'adapters',
+    'frame',
+    'spec',
 ]

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -145,7 +145,8 @@ class ThreadSafeChannel:
             except ValueError:
                 pass
 
-    def _blocking_rpc(self, method_name: str, channel_method, timeout: int,
+    def _blocking_rpc(self, method_name: str, channel_method,
+                      timeout: float | None,
                       *args, **kwargs) -> Any:
         """
         Execute a channel RPC and block until the broker responds.
@@ -326,7 +327,7 @@ class ThreadSafeChannel:
                   prefetch_size: int = 0,
                   prefetch_count: int = 0,
                   global_qos: bool = False,
-                  timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                  timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """Set channel QoS and block until Basic.QosOk arrives.
 
         Safe to call from any thread.
@@ -353,7 +354,7 @@ class ThreadSafeChannel:
     def basic_get(self,
                   queue,
                   auto_ack: bool = False,
-                  timeout: int = DEFAULT_RPC_TIMEOUT) -> tuple[None, ...]:
+                  timeout: float | None = DEFAULT_RPC_TIMEOUT) -> tuple[None, ...]:
         """
         Get a single message from the broker and block until it arrives.
 
@@ -497,7 +498,7 @@ class ThreadSafeChannel:
 
     def confirm_delivery(self,
                          ack_nack_callback,
-                         timeout: int = DEFAULT_RPC_TIMEOUT):
+                         timeout: float | None = DEFAULT_RPC_TIMEOUT):
         """
         Enable publisher confirms and block until Confirm.SelectOk arrives.
 
@@ -552,7 +553,7 @@ class ThreadSafeChannel:
                       exclusive: bool = False,
                       consumer_tag=None,
                       arguments=None,
-                      timeout: int = DEFAULT_RPC_TIMEOUT):
+                      timeout: float | None = DEFAULT_RPC_TIMEOUT):
         """
         Register a consumer and block until Basic.ConsumeOk arrives.
 
@@ -602,7 +603,7 @@ class ThreadSafeChannel:
 
     def basic_cancel(self,
                      consumer_tag,
-                     timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                     timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Cancel a consumer and block until Basic.CancelOk arrives.
 
@@ -629,7 +630,7 @@ class ThreadSafeChannel:
                       exclusive: bool = False,
                       auto_delete: bool = False,
                       arguments=None,
-                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                      timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Declare a queue and block the calling thread until Queue.DeclareOk arrives.
 
@@ -667,7 +668,7 @@ class ThreadSafeChannel:
                          auto_delete: bool = False,
                          internal: bool = False,
                          arguments=None,
-                         timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                         timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Declare an exchange and block until Exchange.DeclareOk arrives.
 
@@ -704,7 +705,7 @@ class ThreadSafeChannel:
                    exchange,
                    routing_key=None,
                    arguments=None,
-                   timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                   timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Bind a queue to an exchange and block until Queue.BindOk arrives.
 
@@ -735,7 +736,7 @@ class ThreadSafeChannel:
                      exchange=None,
                      routing_key=None,
                      arguments=None,
-                     timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                     timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Unbind a queue from an exchange and block until Queue.UnbindOk arrives.
 
@@ -765,7 +766,7 @@ class ThreadSafeChannel:
                      queue,
                      if_unused: bool = False,
                      if_empty: bool = False,
-                     timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                     timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Delete a queue and block until Queue.DeleteOk arrives.
 
@@ -789,7 +790,7 @@ class ThreadSafeChannel:
             if_empty=if_empty,
         )
 
-    def queue_purge(self, queue, timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+    def queue_purge(self, queue, timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Purge all messages from a queue and block until Queue.PurgeOk arrives.
 
@@ -814,7 +815,7 @@ class ThreadSafeChannel:
                       source,
                       routing_key: str = '',
                       arguments=None,
-                      timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                      timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Bind an exchange to another exchange and block until Exchange.BindOk.
 
@@ -845,7 +846,7 @@ class ThreadSafeChannel:
                         source,
                         routing_key: str = '',
                         arguments=None,
-                        timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                        timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Unbind an exchange from another exchange and block until Exchange.UnbindOk.
 
@@ -874,7 +875,7 @@ class ThreadSafeChannel:
     def exchange_delete(self,
                         exchange=None,
                         if_unused: bool = False,
-                        timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                        timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Delete an exchange and block until Exchange.DeleteOk arrives.
 
@@ -899,7 +900,7 @@ class ThreadSafeChannel:
     def close(self,
               reply_code: int = 0,
               reply_text: str = 'Normal shutdown',
-              timeout: int = 10) -> None:
+              timeout: float | None = 10) -> None:
         """
         Close the channel and block until the Channel.CloseOk arrives.
 
@@ -953,7 +954,7 @@ class ThreadSafeChannel:
     def abort(self,
               reply_code: int = 0,
               reply_text: str = 'Normal shutdown',
-              timeout: int = 10) -> None:
+              timeout: float | None = 10) -> None:
         """
         Close the channel, swallowing any errors.
 
@@ -1059,7 +1060,7 @@ class ThreadSafeConnection:
                  parameters,
                  on_open_error_callback=None,
                  on_close_callback=None,
-                 timeout: int = DEFAULT_RPC_TIMEOUT) -> None:
+                 timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         self._user_on_open_error_callback = on_open_error_callback
         self._user_on_close_callback = on_close_callback
 
@@ -1193,7 +1194,7 @@ class ThreadSafeConnection:
     # Public API
     # ------------------------------------------------------------------
 
-    def channel(self, timeout: int = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
+    def channel(self, timeout: float | None = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
         """
         Open a new channel and return a :class:`ThreadSafeChannel`.
 
@@ -1253,7 +1254,7 @@ class ThreadSafeConnection:
             self._channels.append(ch)
         return ch
 
-    def close(self, timeout: int = 10) -> None:
+    def close(self, timeout: float | None = 10) -> None:
         """
         Close the connection and block until the IOLoop thread exits.
 
@@ -1314,7 +1315,7 @@ class ThreadSafeConnection:
             self._shutdown_all_consumer_pools()
             self._shutdown_connection_pool()
 
-    def abort(self, timeout: int = 10) -> None:
+    def abort(self, timeout: float | None = 10) -> None:
         """
         Close the connection, swallowing any errors.
 

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -146,8 +146,7 @@ class ThreadSafeChannel:
                 pass
 
     def _blocking_rpc(self, method_name: str, channel_method,
-                      timeout: float | None,
-                      *args, **kwargs) -> Any:
+                      timeout: float | None, *args, **kwargs) -> Any:
         """
         Execute a channel RPC and block until the broker responds.
 
@@ -351,10 +350,11 @@ class ThreadSafeChannel:
             global_qos=global_qos,
         )
 
-    def basic_get(self,
-                  queue,
-                  auto_ack: bool = False,
-                  timeout: float | None = DEFAULT_RPC_TIMEOUT) -> tuple[None, ...]:
+    def basic_get(
+            self,
+            queue,
+            auto_ack: bool = False,
+            timeout: float | None = DEFAULT_RPC_TIMEOUT) -> tuple[None, ...]:
         """
         Get a single message from the broker and block until it arrives.
 
@@ -790,7 +790,9 @@ class ThreadSafeChannel:
             if_empty=if_empty,
         )
 
-    def queue_purge(self, queue, timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
+    def queue_purge(self,
+                    queue,
+                    timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
         """
         Purge all messages from a queue and block until Queue.PurgeOk arrives.
 
@@ -1194,7 +1196,9 @@ class ThreadSafeConnection:
     # Public API
     # ------------------------------------------------------------------
 
-    def channel(self, timeout: float | None = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
+    def channel(
+            self,
+            timeout: float | None = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
         """
         Open a new channel and return a :class:`ThreadSafeChannel`.
 

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -781,7 +781,7 @@ class Channel:
                 exchange,
                 exchange_type,
                 passive,
-                durable,  # pyright: ignore[reportArgumentType]
+                durable,
                 auto_delete,
                 internal,
                 nowait,

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -776,17 +776,9 @@ class Channel:
         if isinstance(exchange_type, Enum):
             exchange_type = exchange_type.value
         return self._rpc(
-            spec.Exchange.Declare(
-                0,
-                exchange,
-                exchange_type,
-                passive,
-                durable,
-                auto_delete,
-                internal,
-                nowait,
-                arguments or {}),
-            callback,
+            spec.Exchange.Declare(0, exchange, exchange_type, passive, durable,
+                                  auto_delete, internal, nowait, arguments or
+                                  {}), callback,
             [spec.Exchange.DeclareOk] if not nowait else [])
 
     def exchange_delete(

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1890,7 +1890,7 @@ class Connection(abc.ABC):
                 reply_code,  # pyright: ignore[reportArgumentType]
                 method_frame.method.reply_text,
                 host=self.params.host,
-                port=self.params.port))  # pyright: ignore[reportArgumentType]
+                port=self.params.port))
 
     def _on_connection_close_ok(
             self, method_frame: frame.Method[spec.Connection.CloseOk]) -> None:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1804,7 +1804,7 @@ class Connection(abc.ABC):
             LOGGER.warning('_on_close_ready invoked when already closed')
             return
 
-        assert isinstance(self._error, pika.exceptions.ConnectionClosed)
+        assert isinstance(self._error, exceptions.ConnectionClosed)
         self._send_connection_close(self._error.reply_code,
                                     self._error.reply_text)
 

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -824,7 +824,8 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn.closed = "TESTING"
         value = self.conn.close()
         self.assertEqual(value, "TESTING")
-        self.conn_impl_mock.close.assert_called_once_with(200, "Normal shutdown")
+        self.conn_impl_mock.close.assert_called_once_with(
+            200, "Normal shutdown")
 
     def test_close_twice(self):
         # Verify that the close method is only transmitted when open.

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -149,10 +149,11 @@ class TwistedChannelTestCase(TestCase):
         self.pika_channel.add_on_close_callback.assert_called_with(
             self.channel._on_channel_closed)
         calls = self.channel._calls = [defer.Deferred()]
-        consumers = self.channel._consumers = {"test-delivery-tag": mock.Mock()}
+        consumer_mock = mock.Mock()
+        self.channel._consumers = {"test-delivery-tag": consumer_mock}
         error = RuntimeError("testing")
         self.channel._on_channel_closed(None, error)
-        consumers["test-delivery-tag"].close.assert_called_once_with(error)
+        consumer_mock.close.assert_called_once_with(error)
         self.assertEqual(len(self.channel._calls), 0)
         self.assertEqual(len(self.channel._consumers), 0)
         self.assertFailure(calls[0], RuntimeError)
@@ -655,7 +656,10 @@ class TwistedProtocolConnectionTestCase(TestCase):
 
     def setUp(self):
         self.conn = TwistedProtocolConnection()
-        self.conn._impl = mock.Mock()
+        # Assert/set on self.conn_impl_mock (a Mock) rather than through
+        # self.conn._impl, whose static type is the real connection.
+        self.conn_impl_mock = mock.Mock()
+        self.conn._impl = self.conn_impl_mock
 
     @pytest.mark.timeout(5)
     def test_connection(self):
@@ -663,7 +667,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         transport = mock.Mock()
         self.conn.connectionMade = mock.Mock()
         self.conn.makeConnection(transport)
-        self.conn._impl.connection_made.assert_called_once_with(transport)
+        self.conn_impl_mock.connection_made.assert_called_once_with(transport)
         self.conn.connectionMade.assert_called_once()
         d = self.conn.ready
         self.conn._on_connection_ready(None)
@@ -673,9 +677,9 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_channel(self):
         # Verify that the request for a channel works properly.
         channel = mock.Mock()
-        self.conn._impl.channel.side_effect = lambda n, cb: cb(channel)
+        self.conn_impl_mock.channel.side_effect = lambda n, cb: cb(channel)
         d = self.conn.channel()
-        self.conn._impl.channel.assert_called_once()
+        self.conn_impl_mock.channel.assert_called_once()
 
         def check(result):
             self.assertTrue(isinstance(result, TwistedChannel))
@@ -700,7 +704,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_dataReceived(self):
         # Verify that the data is transmitted to the callback method.
         self.conn.dataReceived("testdata")
-        self.conn._impl.data_received.assert_called_once_with("testdata")
+        self.conn_impl_mock.data_received.assert_called_once_with("testdata")
 
     @pytest.mark.timeout(5)
     def test_connectionLost(self):
@@ -709,7 +713,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         ready_d = self.conn.ready
         error = RuntimeError("testreason")
         self.conn.connectionLost(error)
-        self.conn._impl.connection_lost.assert_called_with(error)
+        self.conn_impl_mock.connection_lost.assert_called_with(error)
         self.assertIsNone(self.conn.ready)
         self.assertFailure(ready_d, RuntimeError)
         assert ready_d.called
@@ -816,17 +820,17 @@ class TwistedProtocolConnectionTestCase(TestCase):
 
     def test_close(self):
         # Verify that the close method is properly wrapped.
-        self.conn._impl.is_closed = False
+        self.conn_impl_mock.is_closed = False
         self.conn.closed = "TESTING"
         value = self.conn.close()
         self.assertEqual(value, "TESTING")
-        self.conn._impl.close.assert_called_once_with(200, "Normal shutdown")
+        self.conn_impl_mock.close.assert_called_once_with(200, "Normal shutdown")
 
     def test_close_twice(self):
         # Verify that the close method is only transmitted when open.
-        self.conn._impl.is_closed = True
+        self.conn_impl_mock.is_closed = True
         self.conn.close()
-        self.conn._impl.close.assert_not_called()
+        self.conn_impl_mock.close.assert_not_called()
 
 
 class TwistedConnectionAdapterTestCase(TestCase):

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -110,7 +110,7 @@ class AsyncTestCase(unittest.TestCase):
             return f"{self.DESCRIPTION} ({method_desc})"
         return method_desc
 
-    def begin(self, channel):
+    def begin(self, channel) -> None:
         """Extend to start the actual tests on the channel."""
         self.fail("AsyncTestCase.begin_test not extended")
 

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -55,7 +55,7 @@ class IOServicesTestStubs:
 
     def _run_start(self, nbio_factory, native_loop, use_ssl=False):
         """
-        Called by framework-specific test stubs to initialize test paramters and execute the
+        Called by framework-specific test stubs to initialize test parameters and execute the
         `self.start()` method.
 
         :param nbio_interface.AbstractIOServices _() nbio_factory: function to call to create an

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -28,7 +28,7 @@ class BlockingChannelTests(unittest.TestCase):
                                            is_closed=False,
                                            is_open=True)
         self.obj = blocking_connection.BlockingChannel(self.channel_impl_mock,
-                                                        self.connection)
+                                                       self.connection)
 
     def tearDown(self):
         del self.connection

--- a/tests/unit/blocking_channel_tests.py
+++ b/tests/unit/blocking_channel_tests.py
@@ -23,12 +23,12 @@ class BlockingChannelTests(unittest.TestCase):
 
     def setUp(self):
         self.connection = self._create_connection()
-        channel_impl_mock = mock.Mock(spec=ChannelTemplate,
-                                      is_closing=False,
-                                      is_closed=False,
-                                      is_open=True)
-        self.obj = blocking_connection.BlockingChannel(channel_impl_mock,
-                                                       self.connection)
+        self.channel_impl_mock = mock.Mock(spec=ChannelTemplate,
+                                           is_closing=False,
+                                           is_closed=False,
+                                           is_open=True)
+        self.obj = blocking_connection.BlockingChannel(self.channel_impl_mock,
+                                                        self.connection)
 
     def tearDown(self):
         del self.connection
@@ -75,8 +75,8 @@ class BlockingChannelTests(unittest.TestCase):
 
     def test_basic_consume(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
-            self.obj._impl._generate_consumer_tag.return_value = 'ctag0'
-            self.obj._impl.basic_consume.return_value = 'ctag0'
+            self.channel_impl_mock._generate_consumer_tag.return_value = 'ctag0'
+            self.channel_impl_mock.basic_consume.return_value = 'ctag0'
 
             self.obj.basic_consume('queue', mock.Mock())
 
@@ -84,10 +84,10 @@ class BlockingChannelTests(unittest.TestCase):
                              blocking_connection._ConsumerInfo.ACTIVE)
 
     def test_context_manager(self):
-        with self.obj as chan:
-            self.assertFalse(chan._impl.close.called)
-        chan._impl.close.assert_called_once_with(reply_code=0,
-                                                 reply_text='Normal shutdown')
+        with self.obj:
+            self.assertFalse(self.channel_impl_mock.close.called)
+        self.channel_impl_mock.close.assert_called_once_with(
+            reply_code=0, reply_text='Normal shutdown')
 
     def test_context_manager_does_not_suppress_exception(self):
 
@@ -95,24 +95,24 @@ class BlockingChannelTests(unittest.TestCase):
             pass
 
         with self.assertRaises(TestException):
-            with self.obj as chan:
-                self.assertFalse(chan._impl.close.called)
+            with self.obj:
+                self.assertFalse(self.channel_impl_mock.close.called)
                 raise TestException()
-        chan._impl.close.assert_called_once_with(reply_code=0,
-                                                 reply_text='Normal shutdown')
+        self.channel_impl_mock.close.assert_called_once_with(
+            reply_code=0, reply_text='Normal shutdown')
 
     def test_context_manager_exit_with_closed_channel(self):
         with self.obj as chan:
-            self.assertFalse(chan._impl.close.called)
+            self.assertFalse(self.channel_impl_mock.close.called)
             chan.close()
-        chan._impl.close.assert_called_with(reply_code=0,
-                                            reply_text='Normal shutdown')
+        self.channel_impl_mock.close.assert_called_with(
+            reply_code=0, reply_text='Normal shutdown')
 
     def test_consumer_tags_property(self):
         with mock.patch.object(self.obj._impl, '_generate_consumer_tag'):
             self.assertEqual(0, len(self.obj.consumer_tags))
-            self.obj._impl._generate_consumer_tag.return_value = 'ctag0'
-            self.obj._impl.basic_consume.return_value = 'ctag0'
+            self.channel_impl_mock._generate_consumer_tag.return_value = 'ctag0'
+            self.channel_impl_mock.basic_consume.return_value = 'ctag0'
             self.obj.basic_consume('queue', mock.Mock())
             self.assertEqual(1, len(self.obj.consumer_tags))
             self.assertIn('ctag0', self.obj.consumer_tags)

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -27,7 +27,7 @@ class SelectConnectionTemplate(
 
 
 class BlockingConnectionTests(unittest.TestCase):
-    """TODO: test properties."""
+    """Tests for BlockingConnection."""
 
     @patch.object(blocking_connection.select_connection,
                   'SelectConnection',
@@ -404,3 +404,79 @@ class BlockingConnectionTests(unittest.TestCase):
 
             self.assertEqual(cm.exception.reply_code, 406)
             self.assertEqual(cm.exception.reply_text, "consumer_timeout")
+
+    @staticmethod
+    def _make_open_connection(select_connection_class_mock):
+        """Create a BlockingConnection and return it with its impl mock.
+
+        Set attributes on the returned mock (not connection._impl) so pyright
+        sees a MagicMock rather than the real SelectConnection properties.
+        """
+        impl_mock = select_connection_class_mock.return_value
+        impl_mock.is_closed = False
+        with mock.patch.object(blocking_connection.BlockingConnection,
+                               '_create_connection',
+                               return_value=impl_mock):
+            return blocking_connection.BlockingConnection('params'), impl_mock
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_is_closed_delegates_to_impl(self, select_connection_class_mock):
+        connection, impl_mock = self._make_open_connection(
+            select_connection_class_mock)
+        impl_mock.is_closed = True
+        self.assertIs(connection.is_closed, True)
+        impl_mock.is_closed = False
+        self.assertIs(connection.is_closed, False)
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_is_open_delegates_to_impl(self, select_connection_class_mock):
+        connection, impl_mock = self._make_open_connection(
+            select_connection_class_mock)
+        impl_mock.is_open = True
+        self.assertIs(connection.is_open, True)
+        impl_mock.is_open = False
+        self.assertIs(connection.is_open, False)
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_basic_nack_supported_delegates_to_impl(
+            self, select_connection_class_mock):
+        connection, impl_mock = self._make_open_connection(
+            select_connection_class_mock)
+        impl_mock.basic_nack = True
+        self.assertIs(connection.basic_nack_supported, True)
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_consumer_cancel_notify_supported_delegates_to_impl(
+            self, select_connection_class_mock):
+        connection, impl_mock = self._make_open_connection(
+            select_connection_class_mock)
+        impl_mock.consumer_cancel_notify = True
+        self.assertIs(connection.consumer_cancel_notify_supported, True)
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_exchange_exchange_bindings_supported_delegates_to_impl(
+            self, select_connection_class_mock):
+        connection, impl_mock = self._make_open_connection(
+            select_connection_class_mock)
+        impl_mock.exchange_exchange_bindings = True
+        self.assertIs(connection.exchange_exchange_bindings_supported, True)
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
+    def test_publisher_confirms_supported_delegates_to_impl(
+            self, select_connection_class_mock):
+        connection, impl_mock = self._make_open_connection(
+            select_connection_class_mock)
+        impl_mock.publisher_confirms = True
+        self.assertIs(connection.publisher_confirms_supported, True)

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -22,7 +22,7 @@ class SelectConnectionTemplate(
     # _get_write_buffer_size (method) are inherited and already part of the
     # mock spec. Only the instance attributes below need declaring at class
     # level so spec_set exposes them.
-    _channels = {}  # noqa: RUF012 -- throwaway mock-spec template, not real state
+    _channels = {}  # noqa: RUF012
     _transport = None
 
 
@@ -407,10 +407,11 @@ class BlockingConnectionTests(unittest.TestCase):
 
     @staticmethod
     def _make_open_connection(select_connection_class_mock):
-        """Create a BlockingConnection and return it with its impl mock.
+        """
+        Create a BlockingConnection and return it with its impl mock.
 
-        Set attributes on the returned mock (not connection._impl) so pyright
-        sees a MagicMock rather than the real SelectConnection properties.
+        Set attributes on the returned mock (not connection._impl) so pyright sees a MagicMock
+        rather than the real SelectConnection properties.
         """
         impl_mock = select_connection_class_mock.return_value
         impl_mock.is_closed = False

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -18,13 +18,12 @@ class BlockingConnectionMockTemplate(blocking_connection.BlockingConnection):
 
 class SelectConnectionTemplate(
         blocking_connection.select_connection.SelectConnection):
-    is_closed = None
-    is_closing = None
-    is_open = None
-    _channels = None
-    ioloop = None
+    # is_closed/is_closing/is_open/ioloop (properties) and
+    # _get_write_buffer_size (method) are inherited and already part of the
+    # mock spec. Only the instance attributes below need declaring at class
+    # level so spec_set exposes them.
+    _channels = {}  # noqa: RUF012 -- throwaway mock-spec template, not real state
     _transport = None
-    _get_write_buffer_size = None
 
 
 class BlockingConnectionTests(unittest.TestCase):

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -40,7 +40,8 @@ class BlockingConnectionTests(unittest.TestCase):
 
         _create_connection_mock.assert_called_once_with('params', None)
 
-        connection._impl.add_on_close_callback.assert_called_once_with(
+        impl_mock = _create_connection_mock.return_value
+        impl_mock.add_on_close_callback.assert_called_once_with(
             connection._closed_result.set_value_once)
 
     @patch.object(blocking_connection.select_connection,

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -5,6 +5,7 @@ import logging
 import sys
 import unittest
 import warnings
+from typing import cast
 from unittest import mock
 
 from pika import channel, connection, exceptions, frame, spec
@@ -40,6 +41,9 @@ class ChannelTests(unittest.TestCase):
         self.connection = self._create_connection()
         self._on_openok_callback = mock.Mock()
         self.obj = channel.Channel(self.connection, 1, self._on_openok_callback)
+        # self.obj.callbacks is the autospec'd connection mock at runtime; expose it as a
+        # Mock-typed handle so assertions on .add/.process/.remove/.cleanup type-check.
+        self.callbacks = cast(mock.Mock, self.obj.callbacks)
         warnings.resetwarnings()
 
     def tearDown(self):
@@ -212,7 +216,7 @@ class ChannelTests(unittest.TestCase):
         self.obj.basic_cancel(consumer_tag='ctag0')
 
         self.assertTrue(self.obj._rpc.called)
-        self.assertFalse(self.obj.callbacks.add.called)
+        self.assertFalse(self.callbacks.add.called)
 
     def test_basic_cancel_asynch_with_user_callback_raises_value_error(self):
         self.obj._set_state(self.obj.OPEN)
@@ -246,17 +250,17 @@ class ChannelTests(unittest.TestCase):
         # Verify consumer tag added to the cancelled list
         self.assertListEqual(list(self.obj._cancelled), [consumer_tag])
         # Verify user completion callback registered
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Basic.CancelOk,
                                                callback_mock)
         # Verify Channel._on_cancelok callback registered
-        self.obj.callbacks.add.assert_any_call(
+        self.callbacks.add.assert_any_call(
             self.obj.channel_number,
             spec.Basic.CancelOk,
             self.obj._on_cancelok,
             arguments={'consumer_tag': 'ctag0'})
         # Verify Channel._on_synchronous_complete callback registered
-        self.obj.callbacks.add.assert_any_call(
+        self.callbacks.add.assert_any_call(
             self.obj.channel_number,
             spec.Basic.CancelOk,
             self.obj._on_synchronous_complete,
@@ -703,14 +707,14 @@ class ChannelTests(unittest.TestCase):
             frame.Method(self.obj.channel_number,
                          spec.Channel.OpenOk(self.obj.channel_number)))
         self.assertEqual(self.obj._state, self.obj.CLOSING)
-        self.assertEqual(self.obj.callbacks.process.call_count, 0)
+        self.assertEqual(self.callbacks.process.call_count, 0)
 
         # CloseOk method from broker
         self.obj._on_closeok(
             frame.Method(self.obj.channel_number, spec.Channel.CloseOk()))
         self.assertEqual(self.obj._state, self.obj.CLOSED)
 
-        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+        self.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
                                                    self.obj, self.obj, mock.ANY)
 
@@ -767,11 +771,11 @@ class ChannelTests(unittest.TestCase):
         user_ack_nack_callback = mock.Mock()
         self.obj.confirm_delivery(ack_nack_callback=user_ack_nack_callback)
 
-        self.assertEqual(self.obj.callbacks.add.call_count, 2)
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.assertEqual(self.callbacks.add.call_count, 2)
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Basic.Ack,
                                                user_ack_nack_callback, False)
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Basic.Nack,
                                                user_ack_nack_callback, False)
 
@@ -783,21 +787,21 @@ class ChannelTests(unittest.TestCase):
         ]
         self.obj.confirm_delivery(ack_nack_callback=logging.debug,
                                   callback=self.obj._on_selectok)
-        self.obj.callbacks.add.assert_called_with(*expectation, arguments=None)
+        self.callbacks.add.assert_called_with(*expectation, arguments=None)
 
     def test_confirm_delivery_callback_basic_ack(self):
         self.obj._set_state(self.obj.OPEN)
         expectation = (self.obj.channel_number, spec.Basic.Ack, logging.debug,
                        False)
         self.obj.confirm_delivery(ack_nack_callback=logging.debug)
-        self.obj.callbacks.add.assert_any_call(*expectation)
+        self.callbacks.add.assert_any_call(*expectation)
 
     def test_confirm_delivery_callback_basic_nack(self):
         self.obj._set_state(self.obj.OPEN)
         expectation = (self.obj.channel_number, spec.Basic.Nack, logging.debug,
                        False)
         self.obj.confirm_delivery(ack_nack_callback=logging.debug)
-        self.obj.callbacks.add.assert_any_call(*expectation)
+        self.callbacks.add.assert_any_call(*expectation)
 
     def test_confirm_delivery_no_callback_callback_call_count(self):
         self.obj._set_state(self.obj.OPEN)
@@ -825,7 +829,7 @@ class ChannelTests(unittest.TestCase):
             ],
                       arguments=None)
         ]
-        self.assertEqual(self.obj.callbacks.add.call_args_list, expectation)
+        self.assertEqual(self.callbacks.add.call_args_list, expectation)
 
     def test_confirm_delivery_callback_yes_basic_ack_callback(self):
         self.obj._set_state(self.obj.OPEN)
@@ -835,7 +839,7 @@ class ChannelTests(unittest.TestCase):
         ]
         expectation_item = mock.call(*expectation)
         self.obj.confirm_delivery(ack_nack_callback=user_callback)
-        self.assertIn(expectation_item, self.obj.callbacks.add.call_args_list)
+        self.assertIn(expectation_item, self.callbacks.add.call_args_list)
 
     def test_confirm_delivery_callback_yes_basic_nack_callback(self):
         self.obj._set_state(self.obj.OPEN)
@@ -845,12 +849,12 @@ class ChannelTests(unittest.TestCase):
         ]
         expectation_item = mock.call(*expectation)
         self.obj.confirm_delivery(ack_nack_callback=user_callback)
-        self.assertIn(expectation_item, self.obj.callbacks.add.call_args_list)
+        self.assertIn(expectation_item, self.callbacks.add.call_args_list)
 
     def test_confirm_delivery_first_call_does_not_remove_callback(self):
         self.obj._set_state(self.obj.OPEN)
         self.obj.confirm_delivery(ack_nack_callback=mock.Mock())
-        self.obj.callbacks.remove.assert_not_called()
+        self.callbacks.remove.assert_not_called()
 
     def test_confirm_delivery_replaces_previous_callback(self):
         self.obj._set_state(self.obj.OPEN)
@@ -861,10 +865,10 @@ class ChannelTests(unittest.TestCase):
         self.obj.confirm_delivery(ack_nack_callback=second_callback)
 
         # The previously registered callback is removed for both Ack and Nack
-        self.obj.callbacks.remove.assert_any_call(self.obj.channel_number,
+        self.callbacks.remove.assert_any_call(self.obj.channel_number,
                                                   spec.Basic.Ack,
                                                   first_callback)
-        self.obj.callbacks.remove.assert_any_call(self.obj.channel_number,
+        self.callbacks.remove.assert_any_call(self.obj.channel_number,
                                                   spec.Basic.Nack,
                                                   first_callback)
         # The most recent callback is the one tracked for future replacement
@@ -1226,32 +1230,32 @@ class ChannelTests(unittest.TestCase):
 
     def test_add_callbacks_basic_cancel_empty_added(self):
         self.obj._add_callbacks()
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Basic.Cancel,
                                                self.obj._on_cancel, False)
 
     def test_add_callbacks_basic_get_empty_added(self):
         self.obj._add_callbacks()
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Basic.GetEmpty,
                                                self.obj._on_getempty, False)
 
     def test_add_callbacks_channel_close_added(self):
         self.obj._add_callbacks()
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Channel.Close,
                                                self.obj._on_close_from_broker,
                                                True)
 
     def test_add_callbacks_channel_flow_added(self):
         self.obj._add_callbacks()
-        self.obj.callbacks.add.assert_any_call(self.obj.channel_number,
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
                                                spec.Channel.Flow,
                                                self.obj._on_flow, False)
 
     def test_cleanup(self):
         self.obj._cleanup()
-        self.obj.callbacks.cleanup.assert_called_once_with(
+        self.callbacks.cleanup.assert_called_once_with(
             str(self.obj.channel_number))
 
     def test_handle_content_frame_method_returns_none(self):
@@ -1345,11 +1349,11 @@ class ChannelTests(unittest.TestCase):
 
         self.obj._send_method.assert_called_once_with(spec.Channel.CloseOk())
 
-        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+        self.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
                                                    self.obj, self.obj, mock.ANY)
 
-        reason = self.obj.callbacks.process.call_args_list[0][0][4]
+        reason = self.callbacks.process.call_args_list[0][0][4]
         self.assertIsInstance(reason, exceptions.ChannelClosedByBroker)
         self.assertEqual((reason.reply_code, reason.reply_text), (400, 'error'))
 
@@ -1372,8 +1376,8 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(self.obj._closing_reason.reply_code, 400)
         self.assertEqual(self.obj._closing_reason.reply_text, 'error')
 
-        self.assertFalse(self.obj.callbacks.process.called,
-                         self.obj.callbacks.process.call_args_list)
+        self.assertFalse(self.callbacks.process.called,
+                         self.callbacks.process.call_args_list)
 
         self.assertFalse(self.obj._cleanup.called)
 
@@ -1402,13 +1406,13 @@ class ChannelTests(unittest.TestCase):
 
         self.assertEqual(self.obj._cleanup.call_count, 1)
 
-        self.assertEqual(self.obj.callbacks.process.call_count, 2)
+        self.assertEqual(self.callbacks.process.call_count, 2)
 
-        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+        self.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
                                                    self.obj, self.obj, reason)
 
-        self.obj.callbacks.process.assert_any_call(
+        self.callbacks.process.assert_any_call(
             self.obj.channel_number, self.obj._ON_CHANNEL_CLEANUP_CB_KEY,
             self.obj, self.obj)
 
@@ -1428,7 +1432,7 @@ class ChannelTests(unittest.TestCase):
         self.obj._on_close_meta(Exception('Internal error'))
 
         self.assertTrue(self.obj.is_closed)
-        self.assertEqual(self.obj.callbacks.process.call_count, 0)
+        self.assertEqual(self.callbacks.process.call_count, 0)
         self.assertEqual(self.obj._cleanup.call_count, 0)
 
     def test_on_deliver_callback_called(self):
@@ -1459,10 +1463,10 @@ class ChannelTests(unittest.TestCase):
         self.assertTrue(self.obj.is_closed,
                         f'Channel was not closed; state={self.obj._state}')
 
-        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+        self.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
                                                    self.obj, self.obj, mock.ANY)
-        reason = self.obj.callbacks.process.call_args_list[0][0][4]
+        reason = self.callbacks.process.call_args_list[0][0][4]
         self.assertIsInstance(reason, exceptions.ChannelClosedByClient)
         self.assertEqual((reason.reply_code, reason.reply_text),
                          (200, 'All is well'))
@@ -1498,9 +1502,9 @@ class ChannelTests(unittest.TestCase):
         self.assertTrue(self.obj.is_closed,
                         f'Channel was not closed; state={self.obj._state}')
 
-        self.assertEqual(self.obj.callbacks.process.call_count, 2)
+        self.assertEqual(self.callbacks.process.call_count, 2)
 
-        self.obj.callbacks.process.assert_any_call(self.obj.channel_number,
+        self.callbacks.process.assert_any_call(self.obj.channel_number,
                                                    '_on_channel_close',
                                                    self.obj, self.obj, mock.ANY)
 
@@ -1616,7 +1620,7 @@ class ChannelTests(unittest.TestCase):
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = frame.Body(1, b'0123456789')
         self.obj._on_return(method_value, header_value, body_value)
-        self.obj.callbacks.process.assert_called_with(
+        self.callbacks.process.assert_called_with(
             self.obj.channel_number, '_on_return', self.obj, self.obj,
             method_value.method, header_value.properties, body_value)
 
@@ -1667,7 +1671,7 @@ class ChannelTests(unittest.TestCase):
         method_frame = spec.Channel.Open()
         self.obj._rpc(method_frame, None, [spec.Channel.OpenOk])
         self.assertEqual(self.obj._blocking, method_frame.NAME)
-        self.obj.callbacks.add.assert_called_with(
+        self.callbacks.add.assert_called_with(
             self.obj.channel_number,
             spec.Channel.OpenOk,
             self.obj._on_synchronous_complete,
@@ -1680,7 +1684,7 @@ class ChannelTests(unittest.TestCase):
         self.obj._rpc(method_frame, None, acceptable_replies=[])
         self.assertIsNone(self.obj._blocking)
         with self.assertRaises(AssertionError):
-            self.obj.callbacks.add.assert_called_with(
+            self.callbacks.add.assert_called_with(
                 mock.ANY,
                 mock.ANY,
                 self.obj._on_synchronous_complete,
@@ -1691,7 +1695,7 @@ class ChannelTests(unittest.TestCase):
         method_frame = spec.Channel.Open()
         mock_callback = mock.Mock()
         self.obj._rpc(method_frame, mock_callback, [spec.Channel.OpenOk])
-        self.obj.callbacks.add.assert_called_with(self.obj.channel_number,
+        self.callbacks.add.assert_called_with(self.obj.channel_number,
                                                   spec.Channel.OpenOk,
                                                   mock_callback,
                                                   arguments=None)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1703,7 +1703,7 @@ class ChannelTests(unittest.TestCase):
     def test_send_method(self):
         expectation = [2, 3]
         self.obj._send_method(*expectation)
-        self.obj.connection._send_method.assert_called_once_with(
+        cast(mock.Mock, self.obj.connection)._send_method.assert_called_once_with(
             self.obj.channel_number, *expectation)
 
     def test_set_state(self):

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -251,20 +251,17 @@ class ChannelTests(unittest.TestCase):
         self.assertListEqual(list(self.obj._cancelled), [consumer_tag])
         # Verify user completion callback registered
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Basic.CancelOk,
-                                               callback_mock)
+                                           spec.Basic.CancelOk, callback_mock)
         # Verify Channel._on_cancelok callback registered
-        self.callbacks.add.assert_any_call(
-            self.obj.channel_number,
-            spec.Basic.CancelOk,
-            self.obj._on_cancelok,
-            arguments={'consumer_tag': 'ctag0'})
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
+                                           spec.Basic.CancelOk,
+                                           self.obj._on_cancelok,
+                                           arguments={'consumer_tag': 'ctag0'})
         # Verify Channel._on_synchronous_complete callback registered
-        self.callbacks.add.assert_any_call(
-            self.obj.channel_number,
-            spec.Basic.CancelOk,
-            self.obj._on_synchronous_complete,
-            arguments={'consumer_tag': 'ctag0'})
+        self.callbacks.add.assert_any_call(self.obj.channel_number,
+                                           spec.Basic.CancelOk,
+                                           self.obj._on_synchronous_complete,
+                                           arguments={'consumer_tag': 'ctag0'})
 
     def test_basic_cancel_synch_no_user_callback_raises_value_error(self):
         self.obj._set_state(self.obj.OPEN)
@@ -715,8 +712,8 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(self.obj._state, self.obj.CLOSED)
 
         self.callbacks.process.assert_any_call(self.obj.channel_number,
-                                                   '_on_channel_close',
-                                                   self.obj, self.obj, mock.ANY)
+                                               '_on_channel_close', self.obj,
+                                               self.obj, mock.ANY)
 
         self.assertEqual(self.obj._cleanup.call_count, 1)
 
@@ -773,11 +770,11 @@ class ChannelTests(unittest.TestCase):
 
         self.assertEqual(self.callbacks.add.call_count, 2)
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Basic.Ack,
-                                               user_ack_nack_callback, False)
+                                           spec.Basic.Ack,
+                                           user_ack_nack_callback, False)
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Basic.Nack,
-                                               user_ack_nack_callback, False)
+                                           spec.Basic.Nack,
+                                           user_ack_nack_callback, False)
 
     def test_confirm_delivery_callback_without_nowait_selectok(self):
         self.obj._set_state(self.obj.OPEN)
@@ -866,11 +863,9 @@ class ChannelTests(unittest.TestCase):
 
         # The previously registered callback is removed for both Ack and Nack
         self.callbacks.remove.assert_any_call(self.obj.channel_number,
-                                                  spec.Basic.Ack,
-                                                  first_callback)
+                                              spec.Basic.Ack, first_callback)
         self.callbacks.remove.assert_any_call(self.obj.channel_number,
-                                                  spec.Basic.Nack,
-                                                  first_callback)
+                                              spec.Basic.Nack, first_callback)
         # The most recent callback is the one tracked for future replacement
         self.assertIs(self.obj._on_ack_nack_callback, second_callback)
 
@@ -1231,27 +1226,26 @@ class ChannelTests(unittest.TestCase):
     def test_add_callbacks_basic_cancel_empty_added(self):
         self.obj._add_callbacks()
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Basic.Cancel,
-                                               self.obj._on_cancel, False)
+                                           spec.Basic.Cancel,
+                                           self.obj._on_cancel, False)
 
     def test_add_callbacks_basic_get_empty_added(self):
         self.obj._add_callbacks()
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Basic.GetEmpty,
-                                               self.obj._on_getempty, False)
+                                           spec.Basic.GetEmpty,
+                                           self.obj._on_getempty, False)
 
     def test_add_callbacks_channel_close_added(self):
         self.obj._add_callbacks()
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Channel.Close,
-                                               self.obj._on_close_from_broker,
-                                               True)
+                                           spec.Channel.Close,
+                                           self.obj._on_close_from_broker, True)
 
     def test_add_callbacks_channel_flow_added(self):
         self.obj._add_callbacks()
         self.callbacks.add.assert_any_call(self.obj.channel_number,
-                                               spec.Channel.Flow,
-                                               self.obj._on_flow, False)
+                                           spec.Channel.Flow, self.obj._on_flow,
+                                           False)
 
     def test_cleanup(self):
         self.obj._cleanup()
@@ -1350,8 +1344,8 @@ class ChannelTests(unittest.TestCase):
         self.obj._send_method.assert_called_once_with(spec.Channel.CloseOk())
 
         self.callbacks.process.assert_any_call(self.obj.channel_number,
-                                                   '_on_channel_close',
-                                                   self.obj, self.obj, mock.ANY)
+                                               '_on_channel_close', self.obj,
+                                               self.obj, mock.ANY)
 
         reason = self.callbacks.process.call_args_list[0][0][4]
         self.assertIsInstance(reason, exceptions.ChannelClosedByBroker)
@@ -1409,8 +1403,8 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(self.callbacks.process.call_count, 2)
 
         self.callbacks.process.assert_any_call(self.obj.channel_number,
-                                                   '_on_channel_close',
-                                                   self.obj, self.obj, reason)
+                                               '_on_channel_close', self.obj,
+                                               self.obj, reason)
 
         self.callbacks.process.assert_any_call(
             self.obj.channel_number, self.obj._ON_CHANNEL_CLEANUP_CB_KEY,
@@ -1464,8 +1458,8 @@ class ChannelTests(unittest.TestCase):
                         f'Channel was not closed; state={self.obj._state}')
 
         self.callbacks.process.assert_any_call(self.obj.channel_number,
-                                                   '_on_channel_close',
-                                                   self.obj, self.obj, mock.ANY)
+                                               '_on_channel_close', self.obj,
+                                               self.obj, mock.ANY)
         reason = self.callbacks.process.call_args_list[0][0][4]
         self.assertIsInstance(reason, exceptions.ChannelClosedByClient)
         self.assertEqual((reason.reply_code, reason.reply_text),
@@ -1505,8 +1499,8 @@ class ChannelTests(unittest.TestCase):
         self.assertEqual(self.callbacks.process.call_count, 2)
 
         self.callbacks.process.assert_any_call(self.obj.channel_number,
-                                                   '_on_channel_close',
-                                                   self.obj, self.obj, mock.ANY)
+                                               '_on_channel_close', self.obj,
+                                               self.obj, mock.ANY)
 
         self.assertEqual(self.obj._cleanup.call_count, 1)
 
@@ -1620,9 +1614,11 @@ class ChannelTests(unittest.TestCase):
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = frame.Body(1, b'0123456789')
         self.obj._on_return(method_value, header_value, body_value)
-        self.callbacks.process.assert_called_with(
-            self.obj.channel_number, '_on_return', self.obj, self.obj,
-            method_value.method, header_value.properties, body_value)
+        self.callbacks.process.assert_called_with(self.obj.channel_number,
+                                                  '_on_return', self.obj,
+                                                  self.obj, method_value.method,
+                                                  header_value.properties,
+                                                  body_value)
 
     @mock.patch('pika.channel.Channel._rpc')
     def test_on_synchronous_complete(self, rpc):
@@ -1671,11 +1667,10 @@ class ChannelTests(unittest.TestCase):
         method_frame = spec.Channel.Open()
         self.obj._rpc(method_frame, None, [spec.Channel.OpenOk])
         self.assertEqual(self.obj._blocking, method_frame.NAME)
-        self.callbacks.add.assert_called_with(
-            self.obj.channel_number,
-            spec.Channel.OpenOk,
-            self.obj._on_synchronous_complete,
-            arguments=None)
+        self.callbacks.add.assert_called_with(self.obj.channel_number,
+                                              spec.Channel.OpenOk,
+                                              self.obj._on_synchronous_complete,
+                                              arguments=None)
 
     def test_rpc_not_blocking_and_no_on_synchronous_complete_when_no_replies(
             self):
@@ -1696,15 +1691,16 @@ class ChannelTests(unittest.TestCase):
         mock_callback = mock.Mock()
         self.obj._rpc(method_frame, mock_callback, [spec.Channel.OpenOk])
         self.callbacks.add.assert_called_with(self.obj.channel_number,
-                                                  spec.Channel.OpenOk,
-                                                  mock_callback,
-                                                  arguments=None)
+                                              spec.Channel.OpenOk,
+                                              mock_callback,
+                                              arguments=None)
 
     def test_send_method(self):
         expectation = [2, 3]
         self.obj._send_method(*expectation)
-        cast(mock.Mock, self.obj.connection)._send_method.assert_called_once_with(
-            self.obj.channel_number, *expectation)
+        cast(mock.Mock,
+             self.obj.connection)._send_method.assert_called_once_with(
+                 self.obj.channel_number, *expectation)
 
     def test_set_state(self):
         self.obj._state = channel.Channel.CLOSED

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -837,10 +837,10 @@ class ConnectionTests(unittest.TestCase):
                     blocked_connection_timeout=60))
 
         # Check
-        conn.add_on_connection_blocked_callback.assert_called_once_with(
+        add_on_blocked_callback_mock.assert_called_once_with(
             conn._on_connection_blocked)
 
-        conn.add_on_connection_unblocked_callback.assert_called_once_with(
+        add_on_unblocked_callback_mock.assert_called_once_with(
             conn._on_connection_unblocked)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_call_later')
@@ -858,7 +858,7 @@ class ConnectionTests(unittest.TestCase):
             conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         # Check
-        conn._adapter_call_later.assert_called_once_with(
+        call_later_mock.assert_called_once_with(
             60, conn._on_blocked_connection_timeout)
 
         self.assertIsNotNone(conn._blocked_conn_timer)
@@ -881,7 +881,7 @@ class ConnectionTests(unittest.TestCase):
             conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
         # Check
-        conn._adapter_call_later.assert_called_once_with(
+        call_later_mock.assert_called_once_with(
             60, conn._on_blocked_connection_timeout)
 
         self.assertIsNotNone(conn._blocked_conn_timer)
@@ -892,7 +892,7 @@ class ConnectionTests(unittest.TestCase):
         conn._on_connection_blocked(
             conn, mock.Mock(name='frame.Method(Connection.Blocked)'))
 
-        self.assertEqual(conn._adapter_call_later.call_count, 1)
+        self.assertEqual(call_later_mock.call_count, 1)
         self.assertIs(conn._blocked_conn_timer, timer)
 
     @mock.patch.object(connection.Connection, '_on_stream_terminated')
@@ -905,9 +905,10 @@ class ConnectionTests(unittest.TestCase):
     def test_blocked_connection_timeout_terminates_connection(
             self, connect_mock, call_later_mock, on_terminate_mock):
 
+        terminate_stream_mock = mock.Mock()
         with mock.patch.multiple(ConstructibleConnection,
                                  _adapter_connect_stream=mock.Mock(),
-                                 _terminate_stream=mock.Mock()):
+                                 _terminate_stream=terminate_stream_mock):
             conn = ConstructibleConnection(
                 parameters=connection.ConnectionParameters(
                     blocked_connection_timeout=60))
@@ -918,9 +919,9 @@ class ConnectionTests(unittest.TestCase):
             conn._on_blocked_connection_timeout()
 
             # Check
-            conn._terminate_stream.assert_called_once_with(mock.ANY)
+            terminate_stream_mock.assert_called_once_with(mock.ANY)
 
-            exc = conn._terminate_stream.call_args[0][0]
+            exc = terminate_stream_mock.call_args[0][0]
             self.assertIsInstance(exc, exceptions.ConnectionBlockedTimeout)
             self.assertSequenceEqual(exc.args,
                                      ['Blocked connection timeout expired.'])
@@ -955,7 +956,7 @@ class ConnectionTests(unittest.TestCase):
             conn, mock.Mock(name='frame.Method(Connection.Unblocked)'))
 
         # Check
-        conn._adapter_remove_timeout.assert_called_once_with(timer)
+        remove_timeout_mock.assert_called_once_with(timer)
         self.assertIsNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_remove_timeout')
@@ -987,14 +988,14 @@ class ConnectionTests(unittest.TestCase):
             conn, mock.Mock(name='frame.Method(Connection.Unblocked)'))
 
         # Check
-        conn._adapter_remove_timeout.assert_called_once_with(timer)
+        remove_timeout_mock.assert_called_once_with(timer)
         self.assertIsNone(conn._blocked_conn_timer)
 
         # Simulate Connection.Unblocked again
         conn._on_connection_unblocked(
             conn, mock.Mock(name='frame.Method(Connection.Unblocked)'))
 
-        self.assertEqual(conn._adapter_remove_timeout.call_count, 1)
+        self.assertEqual(remove_timeout_mock.call_count, 1)
         self.assertIsNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection, '_adapter_remove_timeout')
@@ -1029,7 +1030,7 @@ class ConnectionTests(unittest.TestCase):
         conn._on_stream_terminated(exceptions.StreamLostError())
 
         # Check
-        conn._adapter_remove_timeout.assert_called_once_with(timer)
+        remove_timeout_mock.assert_called_once_with(timer)
         self.assertIsNone(conn._blocked_conn_timer)
 
     @mock.patch.object(ConstructibleConnection,

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -216,19 +216,19 @@ class ConnectionTests(unittest.TestCase):
 
     def test_on_stream_terminated_invokes_connection_closed_callback(self):
         """_on_stream_terminated invokes `Connection.ON_CONNECTION_CLOSED` callbacks."""
-        self.connection.callbacks.process = mock.Mock(
-            wraps=self.connection.callbacks.process)
+        process_mock = mock.Mock(wraps=self.connection.callbacks.process)
+        self.connection.callbacks.process = process_mock
 
         self.connection._adapter_disconnect_stream = mock.Mock()
 
         self.connection._on_stream_terminated(Exception(1, 'error text'))
 
-        self.connection.callbacks.process.assert_called_once_with(
+        process_mock.assert_called_once_with(
             0, self.connection.ON_CONNECTION_CLOSED, self.connection,
             self.connection, mock.ANY)
 
         with self.assertRaises(AssertionError):
-            self.connection.callbacks.process.assert_any_call(
+            process_mock.assert_any_call(
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
@@ -237,7 +237,8 @@ class ConnectionTests(unittest.TestCase):
         r"""_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \ `IncompatibleProtocolError`
         and `ON_CONNECTION_CLOSED` callbacks.
         """
-        with mock.patch.object(self.connection.callbacks, 'process'):
+        with mock.patch.object(self.connection.callbacks,
+                               'process') as process_mock:
 
             self.connection._adapter_disconnect_stream = mock.Mock()
 
@@ -248,13 +249,13 @@ class ConnectionTests(unittest.TestCase):
             original_exc = exceptions.StreamLostError(1, 'error text')
             self.connection._on_stream_terminated(original_exc)
 
-            self.assertEqual(self.connection.callbacks.process.call_count, 1)
+            self.assertEqual(process_mock.call_count, 1)
 
-            self.connection.callbacks.process.assert_any_call(
+            process_mock.assert_any_call(
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
-            conn_exc = self.connection.callbacks.process.call_args_list[0][0][4]
+            conn_exc = process_mock.call_args_list[0][0][4]
             self.assertIs(type(conn_exc), exceptions.IncompatibleProtocolError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
 
@@ -263,7 +264,8 @@ class ConnectionTests(unittest.TestCase):
         r"""_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \ `ProbableAuthenticationError`
         and `ON_CONNECTION_CLOSED` callbacks.
         """
-        with mock.patch.object(self.connection.callbacks, 'process'):
+        with mock.patch.object(self.connection.callbacks,
+                               'process') as process_mock:
 
             self.connection._adapter_disconnect_stream = mock.Mock()
 
@@ -274,13 +276,13 @@ class ConnectionTests(unittest.TestCase):
             original_exc = exceptions.StreamLostError(1, 'error text')
             self.connection._on_stream_terminated(original_exc)
 
-            self.assertEqual(self.connection.callbacks.process.call_count, 1)
+            self.assertEqual(process_mock.call_count, 1)
 
-            self.connection.callbacks.process.assert_any_call(
+            process_mock.assert_any_call(
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
-            conn_exc = self.connection.callbacks.process.call_args_list[0][0][4]
+            conn_exc = process_mock.call_args_list[0][0][4]
             self.assertIs(type(conn_exc),
                           exceptions.ProbableAuthenticationError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
@@ -290,7 +292,8 @@ class ConnectionTests(unittest.TestCase):
         r"""_on_stream_terminated invokes `ON_CONNECTION_ERROR` with \ `ProbableAccessDeniedError`
         and `ON_CONNECTION_CLOSED` callbacks.
         """
-        with mock.patch.object(self.connection.callbacks, 'process'):
+        with mock.patch.object(self.connection.callbacks,
+                               'process') as process_mock:
 
             self.connection._adapter_disconnect_stream = mock.Mock()
 
@@ -301,13 +304,13 @@ class ConnectionTests(unittest.TestCase):
             original_exc = exceptions.StreamLostError(1, 'error text')
             self.connection._on_stream_terminated(original_exc)
 
-            self.assertEqual(self.connection.callbacks.process.call_count, 1)
+            self.assertEqual(process_mock.call_count, 1)
 
-            self.connection.callbacks.process.assert_any_call(
+            process_mock.assert_any_call(
                 0, self.connection.ON_CONNECTION_ERROR, self.connection,
                 self.connection, mock.ANY)
 
-            conn_exc = self.connection.callbacks.process.call_args_list[0][0][4]
+            conn_exc = process_mock.call_args_list[0][0][4]
             self.assertIs(type(conn_exc), exceptions.ProbableAccessDeniedError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
 

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -513,7 +513,6 @@ class ConnectionTests(unittest.TestCase):
     def test_on_stream_connected(self, frame_protocol_header):
         """Make sure the _on_stream_connected() sets the state and sends a frame."""
         self.connection.connection_state = self.connection.CONNECTION_INIT
-        self.connection._adapter_connect = mock.Mock(return_value=None)
         self.connection._send_frame = mock.Mock()
         frame_protocol_header.spec = frame.ProtocolHeader
         frame_protocol_header.return_value = 'frame object'
@@ -536,8 +535,6 @@ class ConnectionTests(unittest.TestCase):
                 'exchange_exchange_bindings': False
             }
         }
-        # This will be called, but should not be implemented here, just mock it
-        self.connection._flush_outbound = mock.Mock()
         self.connection._adapter_emit_data = mock.Mock()
         self.connection._on_connection_start(method_frame)
         self.assertEqual(True, self.connection.basic_nack)
@@ -559,7 +556,6 @@ class ConnectionTests(unittest.TestCase):
                                 heartbeat_checker):
         """Make sure _on_connection_tune tunes the connection params."""
         heartbeat_checker.return_value = 'hearbeat obj'
-        self.connection._flush_outbound = mock.Mock()
         marshal = mock.Mock(return_value='ab')
         method.return_value = mock.Mock(marshal=marshal)
         # may be good to test this here, but i don't want to test too much
@@ -1038,7 +1034,6 @@ class ConnectionTests(unittest.TestCase):
                        spec_set=connection.Connection._adapter_emit_data)
     def test_send_message_updates_frames_sent_and_bytes_sent(
             self, _adapter_emit_data):
-        self.connection._flush_outbound = mock.Mock()
         self.connection._body_max_length = 10000
         method = spec.Basic.Publish(exchange='my-exchange',
                                     routing_key='my-route')

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -228,9 +228,9 @@ class ConnectionTests(unittest.TestCase):
             self.connection, mock.ANY)
 
         with self.assertRaises(AssertionError):
-            process_mock.assert_any_call(
-                0, self.connection.ON_CONNECTION_ERROR, self.connection,
-                self.connection, mock.ANY)
+            process_mock.assert_any_call(0, self.connection.ON_CONNECTION_ERROR,
+                                         self.connection, self.connection,
+                                         mock.ANY)
 
     def test_on_stream_terminated_invokes_protocol_on_connection_error_and_closed(
             self):
@@ -251,9 +251,9 @@ class ConnectionTests(unittest.TestCase):
 
             self.assertEqual(process_mock.call_count, 1)
 
-            process_mock.assert_any_call(
-                0, self.connection.ON_CONNECTION_ERROR, self.connection,
-                self.connection, mock.ANY)
+            process_mock.assert_any_call(0, self.connection.ON_CONNECTION_ERROR,
+                                         self.connection, self.connection,
+                                         mock.ANY)
 
             conn_exc = process_mock.call_args_list[0][0][4]
             self.assertIs(type(conn_exc), exceptions.IncompatibleProtocolError)
@@ -278,9 +278,9 @@ class ConnectionTests(unittest.TestCase):
 
             self.assertEqual(process_mock.call_count, 1)
 
-            process_mock.assert_any_call(
-                0, self.connection.ON_CONNECTION_ERROR, self.connection,
-                self.connection, mock.ANY)
+            process_mock.assert_any_call(0, self.connection.ON_CONNECTION_ERROR,
+                                         self.connection, self.connection,
+                                         mock.ANY)
 
             conn_exc = process_mock.call_args_list[0][0][4]
             self.assertIs(type(conn_exc),
@@ -306,9 +306,9 @@ class ConnectionTests(unittest.TestCase):
 
             self.assertEqual(process_mock.call_count, 1)
 
-            process_mock.assert_any_call(
-                0, self.connection.ON_CONNECTION_ERROR, self.connection,
-                self.connection, mock.ANY)
+            process_mock.assert_any_call(0, self.connection.ON_CONNECTION_ERROR,
+                                         self.connection, self.connection,
+                                         mock.ANY)
 
             conn_exc = process_mock.call_args_list[0][0][4]
             self.assertIs(type(conn_exc), exceptions.ProbableAccessDeniedError)

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -29,12 +29,12 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         self.assertEqual(self.obj._method_frame, value)
 
     def test_process_with_content_header(self):
-        value = frame.Header(1, 100, spec.BasicProperties)
+        value = frame.Header(1, 100, spec.BasicProperties())
         self.obj.process(value)
         self.assertEqual(self.obj._header_frame, value)
 
     def test_process_with_body_frame_partial(self):
-        value = frame.Header(1, 100, spec.BasicProperties)
+        value = frame.Header(1, 100, spec.BasicProperties())
         self.obj.process(value)
         value = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(value)
@@ -45,7 +45,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_process_with_full_message(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 6, spec.BasicProperties)
+        header_frame = frame.Header(1, 6, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abc123')
         response = self.obj.process(body_frame)
@@ -54,7 +54,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_process_with_body_frame_six_bytes(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 10, spec.BasicProperties)
+        header_frame = frame.Header(1, 10, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abc123')
         self.obj.process(body_frame)
@@ -63,7 +63,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_process_with_body_frame_too_big(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 6, spec.BasicProperties)
+        header_frame = frame.Header(1, 6, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abcd1234')
         self.assertRaises(exceptions.BodyTooLongError, self.obj.process,
@@ -77,7 +77,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_reset_method_frame(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 10, spec.BasicProperties)
+        header_frame = frame.Header(1, 10, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abc123')
         self.obj.process(body_frame)
@@ -87,7 +87,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_reset_header_frame(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 10, spec.BasicProperties)
+        header_frame = frame.Header(1, 10, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abc123')
         self.obj.process(body_frame)
@@ -97,7 +97,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_reset_seen_so_far(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 10, spec.BasicProperties)
+        header_frame = frame.Header(1, 10, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abc123')
         self.obj.process(body_frame)
@@ -107,7 +107,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_reset_body_fragments(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 10, spec.BasicProperties)
+        header_frame = frame.Header(1, 10, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'abc123')
         self.obj.process(body_frame)
@@ -117,7 +117,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
     def test_ascii_bytes_body_instance(self):
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 11, spec.BasicProperties)
+        header_frame = frame.Header(1, 11, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'foo-bar-baz')
         method_frame, header_frame, body_value = self.obj.process(body_frame)
@@ -128,7 +128,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         self.obj = channel.ContentFrameAssembler()
         method_frame = frame.Method(1, spec.Basic.Deliver())
         self.obj.process(method_frame)
-        header_frame = frame.Header(1, 11, spec.BasicProperties)
+        header_frame = frame.Header(1, 11, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'foo-bar-baz')
         method_frame, header_frame, body_value = self.obj.process(body_frame)
@@ -142,7 +142,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         self.obj.process(method_frame)
         marshalled_body = marshal.dumps(expectation)
         header_frame = frame.Header(1, len(marshalled_body),
-                                    spec.BasicProperties)
+                                    spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, marshalled_body)
         method_frame, header_frame, body_value = self.obj.process(body_frame)

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -60,8 +60,9 @@ class FrameTests(unittest.TestCase):
         self.assertEqual(frame.decode_frame(self.BASIC_ACK)[0], 21)
 
     def test_decode_method_frame_method(self):
-        self.assertIsInstance(
-            frame.decode_frame(self.BASIC_ACK)[1].method, spec.Basic.Ack)
+        decoded = frame.decode_frame(self.BASIC_ACK)[1]
+        assert isinstance(decoded, frame.Method)
+        self.assertIsInstance(decoded.method, spec.Basic.Ack)
 
     def test_decode_header_frame_instance(self):
         self.assertIsInstance(
@@ -72,6 +73,7 @@ class FrameTests(unittest.TestCase):
 
     def test_decode_header_frame_properties(self):
         frame_value = frame.decode_frame(self.CONTENT_HEADER)[1]
+        assert isinstance(frame_value, frame.Header)
         self.assertIsInstance(frame_value.properties, spec.BasicProperties)
 
     def test_decode_frame_decoding_failure(self):
@@ -90,9 +92,9 @@ class FrameTests(unittest.TestCase):
             frame.decode_frame(self.BODY_FRAME)[1], frame.Body)
 
     def test_decode_body_frame_fragment(self):
-        self.assertEqual(
-            frame.decode_frame(self.BODY_FRAME)[1].fragment,
-            self.BODY_FRAME_VALUE)
+        decoded = frame.decode_frame(self.BODY_FRAME)[1]
+        assert isinstance(decoded, frame.Body)
+        self.assertEqual(decoded.fragment, self.BODY_FRAME_VALUE)
 
     def test_decode_body_frame_fragment_consumed_bytes(self):
         self.assertEqual(frame.decode_frame(self.BODY_FRAME)[0], 28)

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -570,7 +570,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
     def test_eintr(
             self,
             is_resumable_mock,
-            is_resumable_raw=pika.adapters.select_connection._is_resumable):
+            is_resumable_raw=select_connection._is_resumable):
         """
         Test that poll() is properly restarted after receiving EINTR error.
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -439,7 +439,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         fd_ = self.save_sock(read_sock)
         self.ioloop.add_handler(fd_, self.do_read, self.ioloop.READ)
 
-    def connected(self, _fd, _events):
+    def connected(self, _fd, _events) -> None:
         """
         Create socket from given _fd and respond to 'connected'.
 
@@ -453,7 +453,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         # NOTE Use socket.recv instead of os.read for Windows compatibility
         self.verify_message(self.sock_map[fd_].recv(self.READ_SIZE))
 
-    def verify_message(self, _msg):
+    def verify_message(self, _msg) -> None:
         """
         See if 'msg' matches what is expected.
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -567,10 +567,9 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
     @unittest.skipUnless(pika._utils.HAVE_SIGNAL,
                          "This platform doesn't support posix signals")
     @mock.patch('pika.adapters.select_connection._is_resumable')
-    def test_eintr(
-            self,
-            is_resumable_mock,
-            is_resumable_raw=select_connection._is_resumable):
+    def test_eintr(self,
+                   is_resumable_mock,
+                   is_resumable_raw=select_connection._is_resumable):
         """
         Test that poll() is properly restarted after receiving EINTR error.
 

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -81,14 +81,14 @@ class IOLoopBaseTest(unittest.TestCase):
             self.ioloop._poller,
             'activate_poller',
             wraps=self.ioloop._poller.activate_poller)
-        activate_poller_patch.start()
+        self._activate_poller_mock = activate_poller_patch.start()
         self.addCleanup(activate_poller_patch.stop)
 
         deactivate_poller_patch = mock.patch.object(
             self.ioloop._poller,
             'deactivate_poller',
             wraps=self.ioloop._poller.deactivate_poller)
-        deactivate_poller_patch.start()
+        self._deactivate_poller_mock = deactivate_poller_patch.start()
         self.addCleanup(deactivate_poller_patch.stop)
 
     def shortDescription(self):
@@ -101,8 +101,8 @@ class IOLoopBaseTest(unittest.TestCase):
         self.addCleanup(self.ioloop.remove_timeout, fail_timer)
         self.ioloop.start()
 
-        self.ioloop._poller.activate_poller.assert_called_once_with()
-        self.ioloop._poller.deactivate_poller.assert_called_once_with()
+        self._activate_poller_mock.assert_called_once_with()
+        self._deactivate_poller_mock.assert_called_once_with()
 
     def on_timeout(self):
         """Called when stuck waiting for connection to close."""

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -443,7 +443,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
         """
         Create socket from given _fd and respond to 'connected'.
 
-        Implemenation is subclass's responsibility.
+        Implementation is subclass's responsibility.
         """
         self.fail("IOLoopSocketBase.connected not extended")
 

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -6,8 +6,6 @@ from unittest.mock import ANY, MagicMock, patch
 
 from pika.adapters.thread_safe_connection import ThreadSafeChannel, ThreadSafeConnection
 
-# pylint: disable=W0212,C0111,C0103
-
 
 class ThreadSafeChannelTests(unittest.TestCase):
 

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2,7 +2,7 @@
 
 import threading
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import ANY, MagicMock, patch
 
 from pika.adapters.thread_safe_connection import ThreadSafeChannel, ThreadSafeConnection
 
@@ -269,7 +269,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             exclusive=False,
             auto_delete=False,
             arguments=None,
-            callback=unittest.mock.ANY,
+            callback=ANY,
         )
 
     def test_queue_declare_raises_when_connection_already_closed(self):
@@ -324,7 +324,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             prefetch_size=0,
             prefetch_count=10,
             global_qos=False,
-            callback=unittest.mock.ANY,
+            callback=ANY,
         )
 
     def test_basic_qos_raises_when_connection_already_closed(self):
@@ -417,7 +417,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         self.assertIs(result, mock_frame)
         raw_ch.basic_cancel.assert_called_once_with(
             consumer_tag='ctag1',
-            callback=unittest.mock.ANY,
+            callback=ANY,
         )
 
     def test_basic_cancel_raises_when_connection_already_closed(self):


### PR DESCRIPTION
## Proposed Changes

This PR addresses pyright type-checker errors across the `pika` package and test suite. The goal was to make the codebase type-check cleanly without changing runtime behavior — most fixes are annotations, import hygiene, and tightening test mocks so the checker can see them correctly. Where pyright surfaced genuinely dead or incorrect test code, that code was removed or corrected rather than silenced.

**Error count (excluding the auto-generated `pika/spec.py`, which is unchanged at 133 errors):**

|                     | Errors  |
| ------------------- | ------- |
| Before (`main`)     | **878** |
| After (this branch) | **635** |
| **Resolved**        | **243** |

Changes are grouped by the class of error they resolve:

**1. Module / submodule attribute access (`reportAttributeAccessIssue`)**
- Re-export `frame` and `spec` submodules from the `pika` package so `pika.frame` / `pika.spec` resolve statically (they previously worked only via transitive import).
- Reference submodules through their imported names instead of package paths: `unittest.mock.ANY` → imported `ANY`; `pika.exceptions` / `pika.adapters.select_connection` → the bound local names.

**2. `timeout` parameter types**
- Widen `timeout: int` → `timeout: float | None` in `thread_safe_connection`. The value flows to `Thread.join()` / `Event.wait()`, which accept fractional seconds and `None`; several docstrings already documented passing `None`.

**3. Mock false positives (`reportFunctionMemberAccess` / `reportAttributeAccessIssue` on `MethodType`/`FunctionType`)**
- Assert on the actual mock handle rather than through a statically real-typed attribute — via `with ... as m`, decorator-injected mock params, a `setUp` handle (e.g. `self.callbacks`, `self.channel_impl_mock`, `self.conn_impl_mock`), or a local `cast`. Covers `connection_tests`, `channel_tests`, `blocking_channel_tests`, `blocking_connection_tests`, `select_connection_ioloop_tests`, and `twisted_adapter_tests`.

**4. Type narrowing / incorrect test values**
- Narrow `decode_frame(...)` results with `assert isinstance(...)` before accessing subclass-only attributes (`method`/`properties`/`fragment`).
- Instantiate `spec.BasicProperties()` where an instance (not the class) is required by `frame.Header`.

**5. Incompatible overrides (`reportIncompatibleMethodOverride`)**
- Annotate must-override test stubs (`begin`, `connected`, `verify_message`) as `-> None`. Their `self.fail(...)` bodies made pyright infer `NoReturn`, flagging every subclass override — one base annotation cleared 39 errors.
- Trim `SelectConnectionTemplate` so it no longer redeclares inherited properties (`is_closed`/`is_open`/`ioloop`/…) as `None`.

**6. Dead / no-op code removal**
- Remove a dead `# pylint: disable=...` comment (project uses ruff), two `# pyright: ignore` comments that suppressed nothing, and dead mock assignments to nonexistent `Connection` attributes (`_adapter_connect`, `_flush_outbound`).

**7. Test coverage**
- Add property-delegation tests for `BlockingConnection` (filled a `TODO: test properties`).

## Types of Changes

- [x] Bugfix <!-- type-checker correctness; no runtime behavior change -->
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Cosmetics <!-- annotations, import hygiene, dead-code removal -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works <!-- BlockingConnection property tests -->
- [ ] I have added necessary documentation (if appropriate) <!-- n/a -->

## Fixes

- Fixes #

## Further Comments

- `pika/spec.py` is intentionally untouched (auto-generated by `utils/codegen.py`); its 133 errors are excluded from the counts above.
