### PR TITLE
Bound work queues in `ThreadSafe*` adapters.

### DIFF
--- a/docs/modules/adapters/thread_safe.md
+++ b/docs/modules/adapters/thread_safe.md
@@ -55,11 +55,11 @@ Both knobs are constructor parameters on `ThreadSafeConnection`:
 conn = ThreadSafeConnection(
     pika.ConnectionParameters('localhost'),
     work_queue_maxsize=1000,     # 0 means unbounded
-    work_queue_put_timeout=None, # seconds; None blocks until space is available
+    work_queue_put_timeout=30.0, # seconds; must be positive, default 30 s
 )
 ```
 
-If `work_queue_put_timeout` is set and the queue stays full for that long, `pika.exceptions.WorkQueueFullError` is raised on the IOLoop thread, tearing the connection down rather than silently dropping the event.
+`work_queue_put_timeout` defaults to 30 seconds and must be a positive number; `None` (infinite) is rejected with `ValueError` because it lets a full queue stall or deadlock the IOLoop thread. Set an override comfortably below the negotiated heartbeat-death window (twice the heartbeat interval) so a stall surfaces as `WorkQueueFullError` rather than an opaque broker-side close. When the queue stays full for that long, `pika.exceptions.WorkQueueFullError` is raised on the IOLoop thread, tearing the connection down rather than silently dropping the event (which would lose an auto-acked delivery or force redelivery of a manually-acked one).
 
 ## Comparison with other adapters
 

--- a/docs/modules/adapters/thread_safe.md
+++ b/docs/modules/adapters/thread_safe.md
@@ -43,6 +43,24 @@ The `on_message_callback` registered with `basic_consume` is dispatched on a per
 - Messages are delivered to the callback in order (single worker thread per channel)
 - All `ThreadSafeChannel` methods (`basic_ack`, `basic_nack`, `basic_reject`, `basic_publish`) are safe to call from within the callback
 
+## Work queue bounds and back-pressure
+
+Each worker thread consumes from a bounded queue holding at most `work_queue_maxsize` pending dispatches (default 1000, matching the RabbitMQ Java client). When a slow callback lets the queue fill up, further enqueues block the IOLoop thread, which stops reading from the socket and applies back-pressure to the broker through TCP flow control instead of buffering events in memory without limit.
+
+Heartbeats are not sent while the IOLoop is blocked, so the broker's heartbeat timeout bounds how long a wedged consumer can stall the connection before the broker closes it.
+
+Both knobs are constructor parameters on `ThreadSafeConnection`:
+
+```python
+conn = ThreadSafeConnection(
+    pika.ConnectionParameters('localhost'),
+    work_queue_maxsize=1000,     # 0 means unbounded
+    work_queue_put_timeout=None, # seconds; None blocks until space is available
+)
+```
+
+If `work_queue_put_timeout` is set and the queue stays full for that long, `pika.exceptions.WorkQueueFullError` is raised on the IOLoop thread, tearing the connection down rather than silently dropping the event.
+
 ## Comparison with other adapters
 
 | | BlockingConnection | SelectConnection + add_callback_threadsafe | ThreadSafeConnection |

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -14,7 +14,6 @@ multiple threads call basic_publish() on a shared connection directly
 
 from __future__ import annotations
 
-import concurrent.futures
 import itertools
 import logging
 import queue
@@ -160,12 +159,17 @@ class ThreadSafeChannel:
     blocking channel methods (which would deadlock).
     """
 
-    def __init__(self, channel, wrapper) -> None:
+    def __init__(self,
+                 channel,
+                 wrapper,
+                 work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
+                 work_queue_put_timeout: float | None = None) -> None:
         self._channel = channel
         self._wrapper = wrapper
-        self._consumer_work_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix='pika-consumer',
+        self._consumer_work_pool = _BoundedWorkPool(
+            maxsize=work_queue_maxsize,
+            put_timeout=work_queue_put_timeout,
+            thread_name='pika-consumer',
         )
         self._pool_shutdown = False
         self._next_publish_seq_no: int | None = None
@@ -188,10 +192,9 @@ class ThreadSafeChannel:
         Execute *callback* on the pool worker, logging any exception.
 
         Used to wrap user callbacks before submitting them to a
-        :class:`concurrent.futures.ThreadPoolExecutor` so that exceptions
-        are not silently lost in the unobserved ``Future`` and so that one
-        failing dispatch does not prevent subsequent dispatches from being
-        processed.
+        :class:`_BoundedWorkPool` so that exceptions are not silently lost
+        and so that one failing dispatch does not prevent subsequent
+        dispatches from being processed.
 
         :param label: Human-readable name of the callback for log lines.
         :param callback: The user callback.
@@ -1146,6 +1149,20 @@ class ThreadSafeConnection:
         Pass ``None`` to wait indefinitely (relying on the socket timeout
         in *parameters*).  On timeout the IOLoop is stopped and
         :class:`TimeoutError` is raised.
+    :param work_queue_maxsize: Maximum number of user-callback dispatches
+        (deliveries, publisher confirms, returned messages, cancel and
+        blocked/unblocked notifications) that may be pending on each
+        worker's queue.  Defaults to :data:`DEFAULT_WORK_QUEUE_MAXSIZE`
+        (1000, matching the RabbitMQ Java client).  While a queue is full
+        the IOLoop blocks, applying back-pressure to the broker via TCP.
+        Heartbeats are not sent while the IOLoop is blocked, so the
+        broker's heartbeat timeout bounds how long a wedged consumer can
+        stall the connection.  Pass ``0`` for an unbounded queue.
+    :param work_queue_put_timeout: Seconds to wait for space on a full
+        work queue.  Defaults to ``None`` (wait indefinitely).  On timeout
+        :class:`pika.exceptions.WorkQueueFullError` is raised on the
+        IOLoop thread, closing the connection rather than silently
+        dropping the event.
     :raises Exception: if the connection cannot be established.
     :raises TimeoutError: if *timeout* expires before the connection opens.
     """
@@ -1156,9 +1173,13 @@ class ThreadSafeConnection:
                  parameters,
                  on_open_error_callback=None,
                  on_close_callback=None,
-                 timeout: float | None = DEFAULT_RPC_TIMEOUT) -> None:
+                 timeout: float | None = DEFAULT_RPC_TIMEOUT,
+                 work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
+                 work_queue_put_timeout: float | None = None) -> None:
         self._user_on_open_error_callback = on_open_error_callback
         self._user_on_close_callback = on_close_callback
+        self._work_queue_maxsize = work_queue_maxsize
+        self._work_queue_put_timeout = work_queue_put_timeout
 
         self._connect_error = None
         self._connected_event = threading.Event()
@@ -1174,9 +1195,10 @@ class ThreadSafeConnection:
         # Single-worker pool for connection-level event callbacks
         # (Connection.Blocked / Unblocked).  Keeps user code off the
         # IOLoop thread so a slow listener cannot stall heartbeats.
-        self._connection_work_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1,
-            thread_name_prefix=f'pika-conn-{self._instance_id}',
+        self._connection_work_pool = _BoundedWorkPool(
+            maxsize=work_queue_maxsize,
+            put_timeout=work_queue_put_timeout,
+            thread_name=f'pika-conn-{self._instance_id}',
         )
         self._connection_pool_shutdown = False
 
@@ -1348,7 +1370,11 @@ class ThreadSafeConnection:
         with self._channel_waiters_lock:
             if self._closed_reason is not None:
                 raise self._closed_reason
-            ch = ThreadSafeChannel(result[0], self)
+            ch = ThreadSafeChannel(
+                result[0],
+                self,
+                work_queue_maxsize=self._work_queue_maxsize,
+                work_queue_put_timeout=self._work_queue_put_timeout)
             self._channels.append(ch)
         return ch
 

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -35,6 +35,43 @@ DEFAULT_RPC_TIMEOUT = 10
 # Matches MAX_QUEUE_LENGTH in the RabbitMQ Java client's WorkPool.
 DEFAULT_WORK_QUEUE_MAXSIZE = 1000
 
+# Default seconds the IOLoop thread waits for space on a full work queue
+# before raising WorkQueueFullError and tearing down the connection.
+# While the queue is full the IOLoop blocks - it sends no heartbeats and
+# reads no frames - so a wedged consumer stalls the connection for up to
+# this long.  Keep an override comfortably under the negotiated
+# heartbeat-death window (twice the heartbeat interval) so the stall
+# surfaces as a clean WorkQueueFullError before the broker drops the link
+# with an opaque StreamLostError.
+DEFAULT_WORK_QUEUE_PUT_TIMEOUT = 30.0
+
+
+def _validate_put_timeout(put_timeout: float) -> float:
+    """
+    Validate a public work-queue put timeout.
+
+    A ``None`` (infinite) timeout is rejected because it lets a full work queue block the IOLoop
+    thread forever.  A non-positive timeout - including ``0`` and ``float('nan')`` - is rejected
+    because it cannot bound the stall.
+
+    :param put_timeout: Seconds the IOLoop thread waits for queue space before raising
+        :class:`pika.exceptions.WorkQueueFullError`.
+    :returns: *put_timeout* unchanged.
+    :raises ValueError: if *put_timeout* is ``None`` or is not a positive number.
+    """
+    if put_timeout is None:
+        raise ValueError(
+            'work_queue_put_timeout must be a number of seconds, not None; '
+            'an infinite timeout lets a full work queue block the IOLoop '
+            'thread forever')
+    # ``not put_timeout > 0`` (rather than ``put_timeout <= 0``) also
+    # rejects float('nan'), for which every comparison is False.
+    if not put_timeout > 0:
+        raise ValueError(
+            f'work_queue_put_timeout must be a positive number of seconds, '
+            f'got {put_timeout!r}')
+    return put_timeout
+
 
 class _BoundedWorkPool:
     """
@@ -55,14 +92,15 @@ class _BoundedWorkPool:
     :param maxsize: Maximum number of pending work items.  Pass ``0`` for
         an unbounded queue.
     :param put_timeout: Seconds :meth:`submit` waits for queue space before
-        raising :class:`pika.exceptions.WorkQueueFullError`.  Pass ``None``
-        to wait indefinitely.
+        raising :class:`pika.exceptions.WorkQueueFullError`.  Must be
+        finite; an infinite (``None``) timeout would let a full queue block
+        the IOLoop thread forever.
     :param thread_name: Name of the worker thread.
     """
 
     _SHUTDOWN = object()
 
-    def __init__(self, maxsize: int, put_timeout: float | None,
+    def __init__(self, maxsize: int, put_timeout: float,
                  thread_name: str) -> None:
         self._queue: queue.Queue[Any] = queue.Queue(maxsize=maxsize)
         self._put_timeout = put_timeout
@@ -159,11 +197,14 @@ class ThreadSafeChannel:
     blocking channel methods (which would deadlock).
     """
 
-    def __init__(self,
-                 channel,
-                 wrapper,
-                 work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
-                 work_queue_put_timeout: float | None = None) -> None:
+    def __init__(
+            self,
+            channel,
+            wrapper,
+            work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
+            work_queue_put_timeout: float = DEFAULT_WORK_QUEUE_PUT_TIMEOUT
+    ) -> None:
+        _validate_put_timeout(work_queue_put_timeout)
         self._channel = channel
         self._wrapper = wrapper
         self._consumer_work_pool = _BoundedWorkPool(
@@ -1159,23 +1200,34 @@ class ThreadSafeConnection:
         broker's heartbeat timeout bounds how long a wedged consumer can
         stall the connection.  Pass ``0`` for an unbounded queue.
     :param work_queue_put_timeout: Seconds to wait for space on a full
-        work queue.  Defaults to ``None`` (wait indefinitely).  On timeout
-        :class:`pika.exceptions.WorkQueueFullError` is raised on the
-        IOLoop thread, closing the connection rather than silently
-        dropping the event.
+        work queue.  Defaults to :data:`DEFAULT_WORK_QUEUE_PUT_TIMEOUT`
+        (30 s); must be a positive number, and ``None`` (infinite) is
+        rejected because it lets a full queue stall or deadlock the IOLoop
+        thread.  Set an override comfortably below the negotiated
+        heartbeat-death window (twice the heartbeat interval) so a stall
+        surfaces here rather than as an opaque broker-side close.  On
+        timeout :class:`pika.exceptions.WorkQueueFullError` is raised on
+        the IOLoop thread, closing the connection rather than silently
+        dropping the event (which would lose an auto-acked delivery or
+        force redelivery of a manually-acked one).
+    :raises ValueError: if *work_queue_put_timeout* is ``None`` or is not a
+        positive number.
     :raises Exception: if the connection cannot be established.
     :raises TimeoutError: if *timeout* expires before the connection opens.
     """
 
     _instance_counter = itertools.count(1)
 
-    def __init__(self,
-                 parameters,
-                 on_open_error_callback=None,
-                 on_close_callback=None,
-                 timeout: float | None = DEFAULT_RPC_TIMEOUT,
-                 work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
-                 work_queue_put_timeout: float | None = None) -> None:
+    def __init__(
+            self,
+            parameters,
+            on_open_error_callback=None,
+            on_close_callback=None,
+            timeout: float | None = DEFAULT_RPC_TIMEOUT,
+            work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
+            work_queue_put_timeout: float = DEFAULT_WORK_QUEUE_PUT_TIMEOUT
+    ) -> None:
+        _validate_put_timeout(work_queue_put_timeout)
         self._user_on_open_error_callback = on_open_error_callback
         self._user_on_close_callback = on_close_callback
         self._work_queue_maxsize = work_queue_maxsize

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -98,7 +98,11 @@ class _BoundedWorkPool:
     :param thread_name: Name of the worker thread.
     """
 
-    _SHUTDOWN = object()
+    # Seconds the idle worker waits on an empty queue before re-checking the
+    # shutdown flag.  Bounds how long shutdown(wait=True) lingers after the
+    # queue drains; small enough to feel instant, large enough that an idle
+    # pool wakes only a few times a second.
+    _SHUTDOWN_POLL_INTERVAL = 0.1
 
     def __init__(self, maxsize: int, put_timeout: float,
                  thread_name: str) -> None:
@@ -135,9 +139,14 @@ class _BoundedWorkPool:
 
     def _run_worker(self) -> None:
         while True:
-            item = self._queue.get()
-            if item is self._SHUTDOWN:
-                return
+            try:
+                item = self._queue.get(timeout=self._SHUTDOWN_POLL_INTERVAL)
+            except queue.Empty:
+                # No work pending; exit only once shutdown has been requested,
+                # otherwise keep waiting for the next item.
+                if self._shutdown:
+                    return
+                continue
             fn, args = item
             fn(*args)
 
@@ -146,6 +155,12 @@ class _BoundedWorkPool:
         Shut down the pool, allowing in-flight work to finish.
 
         Idempotent. Subsequent :meth:`submit` calls raise :class:`RuntimeError`.
+
+        Setting the shutdown flag (rather than enqueuing an in-band sentinel)
+        keeps this non-blocking even when the queue is full: a wedged worker
+        that has not freed a slot can never stall the caller here.  The worker
+        drains all pending work, then exits the next time it finds the queue
+        empty with the flag set.
 
         :param wait: Block until the worker thread has drained the queue and exited.
         """
@@ -156,9 +171,6 @@ class _BoundedWorkPool:
             thread = self._thread
         if thread is None:
             return
-        # The sentinel lands behind all pending work, so the worker drains
-        # the queue before exiting.
-        self._queue.put(self._SHUTDOWN)
         if wait:
             thread.join()
 

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -90,12 +90,27 @@ def _submit_or_terminate(pool: _BoundedWorkPool, connection: SelectConnection,
     :class:`~pika.exceptions.StreamLostError`.  A ``RuntimeError`` means the pool
     is already shut down, so the callback is dropped.
 
+    Once teardown has begun, ``connection._error`` is set synchronously (by the
+    first :meth:`~pika.connection.Connection._terminate_stream` call) while the
+    transport abort completes asynchronously on the IOLoop.  A broker that has
+    buffered a burst of deliveries would otherwise keep dispatching them on this
+    same thread before the abort runs, and each one would block for the full
+    ``work_queue_put_timeout`` and re-trigger teardown - so a backlog of ``N``
+    deliveries would take ``N * work_queue_put_timeout`` to close.  Short-circuit
+    once ``_error`` is set so the connection tears down within one put timeout;
+    the skipped deliveries were already lost to the overflow.
+
     :param pool: The work pool to submit to.
     :param connection: The underlying connection, torn down on overflow.
     :param drop_msg: Debug message logged when the pool is already shut down.
     :param fn: The callback to run on the pool worker.
     :param args: Positional arguments forwarded to *fn*.
     """
+    if connection._error is not None:
+        # Teardown already underway; do not block on a full queue or re-trigger
+        # it.  The delivery is dropped along with the rest of the overflow.
+        LOGGER.debug(drop_msg)
+        return
     try:
         pool.submit(fn, *args)
     except WorkQueueFullError as exc:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -17,19 +17,113 @@ from __future__ import annotations
 import concurrent.futures
 import itertools
 import logging
+import queue
 import threading
 from threading import Event
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from typing_extensions import Literal, Self
 
 from pika import spec
 from pika.adapters.select_connection import SelectConnection
+from pika.exceptions import WorkQueueFullError
 
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_RPC_TIMEOUT = 10
+
+# Matches MAX_QUEUE_LENGTH in the RabbitMQ Java client's WorkPool.
+DEFAULT_WORK_QUEUE_MAXSIZE = 1000
+
+
+class _BoundedWorkPool:
+    """
+    Single worker thread consuming from a bounded work queue.
+
+    Replaces :class:`concurrent.futures.ThreadPoolExecutor`, whose internal
+    queue is unbounded and grows without limit when user callbacks cannot
+    keep up with incoming events (issue #1600).
+
+    ``submit`` runs on the IOLoop thread.  While the queue is full it
+    blocks, which stops frame reads from the socket and applies
+    back-pressure to the broker via TCP flow control - the same strategy
+    as the RabbitMQ Java client's ``WorkPool``.
+
+    The worker thread starts lazily on first submit so that channels which
+    never dispatch callbacks (e.g. publish-only channels) do not start one.
+
+    :param maxsize: Maximum number of pending work items.  Pass ``0`` for
+        an unbounded queue.
+    :param put_timeout: Seconds :meth:`submit` waits for queue space before
+        raising :class:`pika.exceptions.WorkQueueFullError`.  Pass ``None``
+        to wait indefinitely.
+    :param thread_name: Name of the worker thread.
+    """
+
+    _SHUTDOWN = object()
+
+    def __init__(self, maxsize: int, put_timeout: float | None,
+                 thread_name: str) -> None:
+        self._queue: queue.Queue[Any] = queue.Queue(maxsize=maxsize)
+        self._put_timeout = put_timeout
+        self._thread_name = thread_name
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+        self._shutdown = False
+
+    def submit(self, fn: Callable[..., None], *args: Any) -> None:
+        """
+        Enqueue ``fn(*args)`` for execution on the worker thread.
+
+        :raises RuntimeError: if the pool has been shut down.
+        :raises WorkQueueFullError: if the queue stays full for *put_timeout* seconds.
+        """
+        with self._lock:
+            if self._shutdown:
+                raise RuntimeError('cannot submit work after pool shutdown')
+            if self._thread is None:
+                self._thread = threading.Thread(
+                    target=self._run_worker,
+                    name=self._thread_name,
+                    daemon=True,
+                )
+                self._thread.start()
+        try:
+            self._queue.put((fn, args), timeout=self._put_timeout)
+        except queue.Full:
+            raise WorkQueueFullError(
+                f'work queue full for {self._put_timeout} seconds '
+                f'(maxsize={self._queue.maxsize})') from None
+
+    def _run_worker(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is self._SHUTDOWN:
+                return
+            fn, args = item
+            fn(*args)
+
+    def shutdown(self, wait: bool = True) -> None:
+        """
+        Shut down the pool, allowing in-flight work to finish.
+
+        Idempotent. Subsequent :meth:`submit` calls raise :class:`RuntimeError`.
+
+        :param wait: Block until the worker thread has drained the queue and exited.
+        """
+        with self._lock:
+            if self._shutdown:
+                return
+            self._shutdown = True
+            thread = self._thread
+        if thread is None:
+            return
+        # The sentinel lands behind all pending work, so the worker drains
+        # the queue before exiting.
+        self._queue.put(self._SHUTDOWN)
+        if wait:
+            thread.join()
 
 
 class ThreadSafeChannel:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -18,6 +18,7 @@ import itertools
 import logging
 import queue
 import threading
+import time
 from threading import Event
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -150,11 +151,15 @@ class _BoundedWorkPool:
             fn, args = item
             fn(*args)
 
-    def shutdown(self, wait: bool = True) -> None:
+    def shutdown(self, wait: bool = True, timeout: float | None = None) -> bool:
         """
         Shut down the pool, allowing in-flight work to finish.
 
-        Idempotent. Subsequent :meth:`submit` calls raise :class:`RuntimeError`.
+        Idempotent: repeated calls are safe and subsequent :meth:`submit`
+        calls raise :class:`RuntimeError`.  A repeat call still joins (so a
+        caller whose first bounded call timed out can wait again for the
+        worker), which is why the flag is set unconditionally rather than
+        short-circuiting.
 
         Setting the shutdown flag (rather than enqueuing an in-band sentinel)
         keeps this non-blocking even when the queue is full: a wedged worker
@@ -162,17 +167,28 @@ class _BoundedWorkPool:
         drains all pending work, then exits the next time it finds the queue
         empty with the flag set.
 
-        :param wait: Block until the worker thread has drained the queue and exited.
+        When *wait* is true this joins the worker thread.  A finite *timeout*
+        bounds that join: if the worker is still running callbacks when the
+        timeout expires, the join returns anyway and the (daemon) worker is
+        left to finish and exit on its own.  A wedged worker therefore cannot
+        stall the caller past *timeout*, at the cost of possibly not draining
+        queued work before this returns.
+
+        :param wait: Block until the worker thread exits (subject to *timeout*).
+        :param timeout: Seconds to wait for the worker to exit.  ``None`` waits
+            indefinitely.  Ignored when *wait* is false.
+        :returns: ``True`` if the worker has exited (or never started),
+            ``False`` if *timeout* expired with the worker still alive.
         """
         with self._lock:
-            if self._shutdown:
-                return
             self._shutdown = True
             thread = self._thread
         if thread is None:
-            return
-        if wait:
-            thread.join()
+            return True
+        if not wait:
+            return not thread.is_alive()
+        thread.join(timeout=timeout)
+        return not thread.is_alive()
 
 
 class ThreadSafeChannel:
@@ -258,11 +274,22 @@ class ThreadSafeChannel:
         except Exception:
             LOGGER.exception('Unhandled exception in %s', label)
 
-    def _shutdown_pool(self) -> None:
-        """Shut down the consumer work pool, allowing in-flight work to finish."""
+    def _shutdown_pool(self, timeout: float | None = None) -> None:
+        """
+        Shut down the consumer work pool, allowing in-flight work to finish.
+
+        :param timeout: Seconds to wait for the worker to drain and exit. ``None`` waits
+            indefinitely. A wedged worker that outlives a finite *timeout* is left running (it is a
+            daemon thread) rather than stalling the caller; a warning is logged.
+        """
         if not self._pool_shutdown:
             self._pool_shutdown = True
-            self._consumer_work_pool.shutdown(wait=True)
+            if not self._consumer_work_pool.shutdown(wait=True,
+                                                     timeout=timeout):
+                LOGGER.warning(
+                    'Channel %s consumer work pool did not drain within '
+                    '%s seconds; abandoning its worker thread',
+                    self._channel.channel_number, timeout)
 
     def _register_waiter(self) -> tuple[Event, list[BaseException | None]]:
         """
@@ -1062,6 +1089,11 @@ class ThreadSafeChannel:
         If the channel is already closed or closing, returns immediately. Safe to call from any
         thread.
 
+        *timeout* bounds the whole call: it caps the wait for Channel.CloseOk and then the leftover
+        budget caps the consumer-pool drain, so a slow or wedged delivery callback cannot stall
+        ``close`` past *timeout*.  A worker still running when the budget is exhausted is left to
+        finish on its own (it is a daemon thread).
+
         :param reply_code: Close reason code to send to the broker.
         :param reply_text: Close reason text to send to the broker.
         :param timeout: Seconds to wait for Channel.CloseOk before treating the channel as closed
@@ -1070,6 +1102,7 @@ class ThreadSafeChannel:
             than by this client.
         """
         ready, error = self._register_waiter()
+        deadline = None if timeout is None else time.monotonic() + timeout
 
         def _close() -> None:
             if self._channel.is_closed or self._channel.is_closing:
@@ -1096,7 +1129,13 @@ class ThreadSafeChannel:
             if not ready.wait(timeout=timeout):
                 LOGGER.warning('Channel %s close timed out after %s seconds',
                                self._channel.channel_number, timeout)
-            self._shutdown_pool()
+            # Drain the pool within whatever remains of the caller's budget so
+            # the whole close honors *timeout* rather than up to twice it.
+            if deadline is None:
+                pool_timeout: float | None = None
+            else:
+                pool_timeout = max(0.0, deadline - time.monotonic())
+            self._shutdown_pool(timeout=pool_timeout)
         finally:
             self._unregister_waiter(ready, error)
 
@@ -1359,18 +1398,46 @@ class ThreadSafeConnection:
         if self._user_on_close_callback:
             self._user_on_close_callback(_connection, reason)
 
-    def _shutdown_all_consumer_pools(self) -> None:
-        """Shut down all tracked channel consumer pools."""
+    def _shutdown_all_consumer_pools(self,
+                                     timeout: float | None = None) -> None:
+        """
+        Shut down all tracked channel consumer pools.
+
+        :param timeout: Total seconds to wait across all channel pools. ``None`` waits indefinitely
+            (the clean-shutdown default). A finite budget is split across channels so the whole
+            sweep stays bounded.
+        """
         with self._channel_waiters_lock:
             channels = list(self._channels)
+        if not channels:
+            return
+        if timeout is None:
+            for ch in channels:
+                ch._shutdown_pool()
+            return
+        # Share the budget across channels using a common deadline so a slow
+        # early channel cannot consume the entire allowance and starve later
+        # ones of their chance to drain.
+        deadline = time.monotonic() + timeout
         for ch in channels:
-            ch._shutdown_pool()
+            ch._shutdown_pool(timeout=max(0.0, deadline - time.monotonic()))
 
-    def _shutdown_connection_pool(self) -> None:
-        """Shut down the connection-level event-callback pool."""
+    def _shutdown_connection_pool(self, timeout: float | None = None) -> None:
+        """
+        Shut down the connection-level event-callback pool.
+
+        :param timeout: Seconds to wait for the worker to drain and exit. ``None`` waits
+            indefinitely (the clean-shutdown default). A wedged worker outliving a finite *timeout*
+            is left running (daemon thread) rather than stalling the caller; a warning is logged.
+        """
         if not self._connection_pool_shutdown:
             self._connection_pool_shutdown = True
-            self._connection_work_pool.shutdown(wait=True)
+            if not self._connection_work_pool.shutdown(wait=True,
+                                                       timeout=timeout):
+                LOGGER.warning(
+                    'Connection %s event work pool did not drain within '
+                    '%s seconds; abandoning its worker thread',
+                    self._instance_id, timeout)
 
     # ------------------------------------------------------------------
     # Public API
@@ -1449,7 +1516,9 @@ class ThreadSafeConnection:
         Schedules a clean Connection.Close handshake and waits up to *timeout* seconds for the
         IOLoop thread to finish.  If the thread is still alive after the timeout (e.g. the broker
         never sends Connection.CloseOk), the IOLoop is force-stopped via ``add_callback_threadsafe``
-        and joined once more.
+        and joined once more under a second *timeout* budget.  A worker still draining when that
+        budget expires is left to finish on its own (it is a daemon thread), so a wedged delivery
+        callback cannot hang ``close`` indefinitely.
 
         Safe to call from any thread including the IOLoop thread itself (e.g. from within a channel
         callback).  When called from the IOLoop thread the close is initiated synchronously and the
@@ -1458,8 +1527,9 @@ class ThreadSafeConnection:
         Calling ``close()`` on an already-closed connection is a no-op.
 
         :param timeout: Seconds to wait for a clean close before force-stopping the IOLoop. Defaults
-            to 10 seconds, which is sufficient for a healthy broker on any reasonable network. Pass
-            ``None`` to wait indefinitely.
+            to 10 seconds, which is sufficient for a healthy broker on any reasonable network. The
+            pathological force path may wait up to twice this (once for the clean join, once for the
+            forced join). Pass ``None`` to wait indefinitely.
         """
         if threading.current_thread() is self._ioloop_thread:
             try:
@@ -1486,7 +1556,24 @@ class ThreadSafeConnection:
         if self._ioloop_thread.is_alive():
             self._connection.ioloop.add_callback_threadsafe(
                 self._connection.ioloop.stop)
-            self._ioloop_thread.join()
+            # The IOLoop thread runs its own pool-drain tail after
+            # ioloop.start() returns; a wedged consumer callback can keep it
+            # from exiting.  Bound the join (and the pool shutdowns below) by a
+            # fresh budget so a stuck worker cannot hang close() forever - the
+            # worker is a daemon thread and is left to finish on its own.
+            force_deadline = (None if timeout is None else time.monotonic() +
+                              timeout)
+
+            def _remaining() -> float | None:
+                if force_deadline is None:
+                    return None
+                return max(0.0, force_deadline - time.monotonic())
+
+            self._ioloop_thread.join(timeout=_remaining())
+            if self._ioloop_thread.is_alive():
+                LOGGER.warning(
+                    'Connection %s IOLoop thread did not exit within the close '
+                    'timeout; abandoning it', self._instance_id)
             # _on_connection_closed may not have fired if the IOLoop was
             # force-stopped before the broker sent Connection.CloseOk.
             # Wake any threads still blocked so they do not hang forever.
@@ -1500,8 +1587,10 @@ class ThreadSafeConnection:
                             err[0] = self._closed_reason
                         evt.set()
                     self._blocking_waiters.clear()
-            self._shutdown_all_consumer_pools()
-            self._shutdown_connection_pool()
+            # Normally the IOLoop tail already claimed these pools, making the
+            # calls no-ops; bound them in case this thread reaches them first.
+            self._shutdown_all_consumer_pools(timeout=_remaining())
+            self._shutdown_connection_pool(timeout=_remaining())
 
     def abort(self, timeout: float | None = 10) -> None:
         """

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -74,6 +74,36 @@ def _validate_put_timeout(put_timeout: float) -> float:
     return put_timeout
 
 
+def _submit_or_terminate(pool: _BoundedWorkPool, connection: SelectConnection,
+                         drop_msg: str, fn: Callable[...,
+                                                     None], *args: Any) -> None:
+    """
+    Submit *fn* to *pool*, tearing the connection down on queue overflow.
+
+    Called on the IOLoop thread from the wrappers that hand user callbacks to a
+    :class:`_BoundedWorkPool`.  A :class:`~pika.exceptions.WorkQueueFullError`
+    means a slow callback let the queue stay full past ``work_queue_put_timeout``;
+    it is routed through :meth:`~pika.connection.Connection._terminate_stream` so
+    the connection closes with :class:`~pika.exceptions.WorkQueueFullError` as the
+    reason the application observes, rather than being caught by the transport's
+    generic read-error handler and relabeled as an opaque
+    :class:`~pika.exceptions.StreamLostError`.  A ``RuntimeError`` means the pool
+    is already shut down, so the callback is dropped.
+
+    :param pool: The work pool to submit to.
+    :param connection: The underlying connection, torn down on overflow.
+    :param drop_msg: Debug message logged when the pool is already shut down.
+    :param fn: The callback to run on the pool worker.
+    :param args: Positional arguments forwarded to *fn*.
+    """
+    try:
+        pool.submit(fn, *args)
+    except WorkQueueFullError as exc:
+        connection._terminate_stream(exc)
+    except RuntimeError:
+        LOGGER.debug(drop_msg)
+
+
 class _BoundedWorkPool:
     """
     Single worker thread consuming from a bounded work queue.
@@ -634,13 +664,10 @@ class ThreadSafeChannel:
         self._check_not_closed()
 
         def _wrapped(method_frame) -> None:
-            try:
-                self._consumer_work_pool.submit(self._safe_dispatch,
-                                                'cancel listener', callback,
-                                                method_frame)
-            except RuntimeError:
-                LOGGER.debug(
-                    'Server-initiated cancel dropped: work pool shut down')
+            _submit_or_terminate(
+                self._consumer_work_pool, self._wrapper._connection,
+                'Server-initiated cancel dropped: work pool shut down',
+                self._safe_dispatch, 'cancel listener', callback, method_frame)
 
         def _register() -> None:
             try:
@@ -673,12 +700,11 @@ class ThreadSafeChannel:
         self._check_not_closed()
 
         def _wrapped(_raw_ch, method, properties, body) -> None:
-            try:
-                self._consumer_work_pool.submit(self._safe_dispatch,
-                                                'return listener', callback,
-                                                self, method, properties, body)
-            except RuntimeError:
-                LOGGER.debug('Returned message dropped: work pool shut down')
+            _submit_or_terminate(
+                self._consumer_work_pool, self._wrapper._connection,
+                'Returned message dropped: work pool shut down',
+                self._safe_dispatch, 'return listener', callback, self, method,
+                properties, body)
 
         def _register() -> None:
             try:
@@ -721,12 +747,11 @@ class ThreadSafeChannel:
             return self._confirm_select_ok
 
         def _wrapped_ack_nack(method_frame) -> None:
-            try:
-                self._consumer_work_pool.submit(self._safe_dispatch,
-                                                'publisher confirm callback',
-                                                ack_nack_callback, method_frame)
-            except RuntimeError:
-                LOGGER.debug('Publisher confirm dropped: work pool shut down')
+            _submit_or_terminate(
+                self._consumer_work_pool, self._wrapper._connection,
+                'Publisher confirm dropped: work pool shut down',
+                self._safe_dispatch, 'publisher confirm callback',
+                ack_nack_callback, method_frame)
 
         result = self._blocking_rpc(
             'confirm_delivery',
@@ -772,13 +797,11 @@ class ThreadSafeChannel:
         """
 
         def _wrapped_callback(ch, method, properties, body) -> None:
-            try:
-                self._consumer_work_pool.submit(self._safe_dispatch,
-                                                'consumer callback',
-                                                on_message_callback, self,
-                                                method, properties, body)
-            except RuntimeError:
-                LOGGER.debug('Consumer delivery dropped: work pool shut down')
+            _submit_or_terminate(
+                self._consumer_work_pool, self._wrapper._connection,
+                'Consumer delivery dropped: work pool shut down',
+                self._safe_dispatch, 'consumer callback', on_message_callback,
+                self, method, properties, body)
 
         frame = self._blocking_rpc(
             'basic_consume',
@@ -1709,12 +1732,11 @@ class ThreadSafeConnection:
                 raise self._closed_reason
 
         def _wrapped(_raw_conn, method_frame) -> None:
-            try:
-                self._connection_work_pool.submit(
-                    ThreadSafeChannel._safe_dispatch, raw_method_name, callback,
-                    self, method_frame)
-            except RuntimeError:
-                LOGGER.debug('Connection event dropped: work pool shut down')
+            _submit_or_terminate(
+                self._connection_work_pool, self._connection,
+                'Connection event dropped: work pool shut down',
+                ThreadSafeChannel._safe_dispatch, raw_method_name, callback,
+                self, method_frame)
 
         def _register() -> None:
             try:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -208,14 +208,29 @@ class ThreadSafeChannel:
     - Blocking operations (database writes, HTTP calls, even
       :meth:`queue_declare` / :meth:`basic_qos` / :meth:`basic_cancel`)
       are safe inside delivery callbacks.
-    - The IOLoop thread is never starved by slow consumer processing,
-      so heartbeats are always sent on time.
+    - As long as the callback keeps up with deliveries, the IOLoop
+      thread is not starved by consumer processing, so heartbeats are
+      sent on time.
     - Messages are delivered to the callback **in order** (a single
       worker thread per channel).
     - All :class:`ThreadSafeChannel` methods (:meth:`basic_ack`,
       :meth:`basic_nack`, :meth:`basic_reject`, :meth:`basic_publish`,
       :meth:`queue_declare`, etc.) are safe to call from within the
       callback.
+
+    .. rubric:: Sustained-backlog caveat
+
+    "Safe" assumes the callback keeps pace with incoming deliveries.
+    The worker consumes from a bounded queue (see *work_queue_maxsize*).
+    If a slow callback lets that queue fill, the IOLoop thread blocks
+    while enqueuing the next delivery - sending no heartbeats during the
+    stall - and, if the queue stays full for *work_queue_put_timeout*
+    seconds, raises :class:`pika.exceptions.WorkQueueFullError`, which
+    tears the connection down rather than silently dropping the event.
+    A persistently slow consumer therefore does not stall heartbeats
+    forever; it fails fast with an explicit error.  Keep callbacks
+    faster than the sustained delivery rate, or raise *work_queue_maxsize*
+    to absorb bursts.
 
     .. rubric:: IOLoop-thread callbacks
 

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -204,7 +204,7 @@ class ThreadSafeChannel:
             work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
             work_queue_put_timeout: float = DEFAULT_WORK_QUEUE_PUT_TIMEOUT
     ) -> None:
-        _validate_put_timeout(work_queue_put_timeout)
+        work_queue_put_timeout = _validate_put_timeout(work_queue_put_timeout)
         self._channel = channel
         self._wrapper = wrapper
         self._consumer_work_pool = _BoundedWorkPool(
@@ -1227,11 +1227,11 @@ class ThreadSafeConnection:
             work_queue_maxsize: int = DEFAULT_WORK_QUEUE_MAXSIZE,
             work_queue_put_timeout: float = DEFAULT_WORK_QUEUE_PUT_TIMEOUT
     ) -> None:
-        _validate_put_timeout(work_queue_put_timeout)
         self._user_on_open_error_callback = on_open_error_callback
         self._user_on_close_callback = on_close_callback
         self._work_queue_maxsize = work_queue_maxsize
-        self._work_queue_put_timeout = work_queue_put_timeout
+        self._work_queue_put_timeout = _validate_put_timeout(
+            work_queue_put_timeout)
 
         self._connect_error = None
         self._connected_event = threading.Event()

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -144,11 +144,11 @@ class _BoundedWorkPool:
     :param thread_name: Name of the worker thread.
     """
 
-    # Seconds the idle worker waits on an empty queue before re-checking the
-    # shutdown flag.  Bounds how long shutdown(wait=True) lingers after the
-    # queue drains; small enough to feel instant, large enough that an idle
-    # pool wakes only a few times a second.
-    _SHUTDOWN_POLL_INTERVAL = 0.1
+    # Best-effort wakeup ping enqueued by shutdown() to rouse a worker idling
+    # in a blocking get().  The shutdown flag remains the source of truth; the
+    # sentinel only nudges the worker to re-check it, so a dropped ping (full
+    # queue) is harmless - a busy worker re-checks the flag between items.
+    _SENTINEL = object()
 
     def __init__(self, maxsize: int, put_timeout: float,
                  thread_name: str) -> None:
@@ -185,13 +185,15 @@ class _BoundedWorkPool:
 
     def _run_worker(self) -> None:
         while True:
-            try:
-                item = self._queue.get(timeout=self._SHUTDOWN_POLL_INTERVAL)
-            except queue.Empty:
-                # No work pending; exit only once shutdown has been requested,
-                # otherwise keep waiting for the next item.
-                if self._shutdown:
-                    return
+            # Exit only once shutdown has been requested and every queued item
+            # has drained.  Checking before the blocking get() means a worker
+            # that finishes the last real item after shutdown() ran sees the
+            # flag and the empty queue and exits without waiting for a ping.
+            if self._shutdown and self._queue.empty():
+                return
+            item = self._queue.get()
+            if item is self._SENTINEL:
+                # Wakeup ping from shutdown(); re-check the flag at the loop top.
                 continue
             fn, args = item
             fn(*args)
@@ -206,11 +208,13 @@ class _BoundedWorkPool:
         worker), which is why the flag is set unconditionally rather than
         short-circuiting.
 
-        Setting the shutdown flag (rather than enqueuing an in-band sentinel)
-        keeps this non-blocking even when the queue is full: a wedged worker
-        that has not freed a slot can never stall the caller here.  The worker
-        drains all pending work, then exits the next time it finds the queue
-        empty with the flag set.
+        The shutdown flag is the source of truth.  A best-effort
+        :data:`_SENTINEL` ping is then enqueued via ``put_nowait`` purely to
+        rouse a worker idling in a blocking ``get()``; if the queue is full the
+        ping is dropped, which is harmless because a busy worker re-checks the
+        flag between items.  Either way this call never blocks on a full queue,
+        and the worker drains all pending work before exiting the next time it
+        finds the queue empty with the flag set.
 
         When *wait* is true this joins the worker thread.  A finite *timeout*
         bounds that join: if the worker is still running callbacks when the
@@ -229,6 +233,17 @@ class _BoundedWorkPool:
             self._shutdown = True
             thread = self._thread
         if thread is None:
+            return True
+        # Wake a worker blocked in get(); dropped if the queue is full (a busy
+        # worker re-checks the flag between items, so no wakeup is needed).
+        try:
+            self._queue.put_nowait(self._SENTINEL)
+        except queue.Full:
+            pass
+        if thread is threading.current_thread():
+            # A delivery callback is shutting down its own pool (e.g. it called
+            # channel.close()).  The worker cannot join itself; the flag is
+            # already set, so it exits once this callback returns.
             return True
         if not wait:
             return not thread.is_alive()

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -228,6 +228,10 @@ class _BoundedWorkPool:
             indefinitely.  Ignored when *wait* is false.
         :returns: ``True`` if the worker has exited (or never started),
             ``False`` if *timeout* expired with the worker still alive.
+            When called from the worker thread itself (a callback shutting down
+            its own pool), returns ``True`` without joining even though the
+            worker has not exited yet; it exits once the calling callback
+            returns.
         """
         with self._lock:
             self._shutdown = True

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -182,6 +182,16 @@ class _BoundedWorkPool:
             raise WorkQueueFullError(
                 f'work queue full for {self._put_timeout} seconds '
                 f'(maxsize={self._queue.maxsize})') from None
+        # shutdown() may have run between the flag check above and this put:
+        # it sets the flag and the worker exits once it finds the queue empty,
+        # so an item enqueued in that window could be stranded in a queue no
+        # worker will ever service.  The flag is always set before the worker
+        # can exit, so re-reading it after the put (lock-free, like the worker)
+        # detects that case.  Report it as a rejected submit rather than
+        # silently losing the work; a caller whose item actually still runs
+        # only sees a spurious "dropped" debug log, never a lost delivery.
+        if self._shutdown:
+            raise RuntimeError('cannot submit work after pool shutdown')
 
     def _run_worker(self) -> None:
         while True:
@@ -353,6 +363,16 @@ class ThreadSafeChannel:
         except Exception:
             LOGGER.exception('Unhandled exception in %s', label)
 
+    def _signal_pool_shutdown(self) -> None:
+        """
+        Tell the consumer pool to begin draining without joining its worker.
+
+        Sets the pool's shutdown flag and wakes an idle worker, but returns immediately.  Used to
+        signal every channel's pool up front so their workers drain concurrently before
+        :meth:`_shutdown_pool` joins them one at a time under a shared budget.
+        """
+        self._consumer_work_pool.shutdown(wait=False)
+
     def _shutdown_pool(self, timeout: float | None = None) -> None:
         """
         Shut down the consumer work pool, allowing in-flight work to finish.
@@ -361,14 +381,19 @@ class ThreadSafeChannel:
             indefinitely. A wedged worker that outlives a finite *timeout* is left running (it is a
             daemon thread) rather than stalling the caller; a warning is logged.
         """
-        if not self._pool_shutdown:
+        # Atomically claim the shutdown so concurrent close() calls do not both
+        # run the join.  The join itself stays outside the lock: it can block
+        # for the whole timeout, and holding the connection-wide lock that long
+        # would stall every other channel operation.
+        with self._wrapper._channel_waiters_lock:
+            if self._pool_shutdown:
+                return
             self._pool_shutdown = True
-            if not self._consumer_work_pool.shutdown(wait=True,
-                                                     timeout=timeout):
-                LOGGER.warning(
-                    'Channel %s consumer work pool did not drain within '
-                    '%s seconds; abandoning its worker thread',
-                    self._channel.channel_number, timeout)
+        if not self._consumer_work_pool.shutdown(wait=True, timeout=timeout):
+            LOGGER.warning(
+                'Channel %s consumer work pool did not drain within '
+                '%s seconds; abandoning its worker thread',
+                self._channel.channel_number, timeout)
 
     def _register_waiter(self) -> tuple[Event, list[BaseException | None]]:
         """
@@ -1487,9 +1512,16 @@ class ThreadSafeConnection:
             for ch in channels:
                 ch._shutdown_pool()
             return
-        # Share the budget across channels using a common deadline so a slow
-        # early channel cannot consume the entire allowance and starve later
-        # ones of their chance to drain.
+        # Signal every pool to start draining before joining any of them, so
+        # all workers drain concurrently.  Joining one at a time without this
+        # would let an early wedged channel burn the whole budget while later
+        # channels' workers had not even been told to stop, so those healthy
+        # workers would be abandoned at timeout=0 with a spurious warning.
+        for ch in channels:
+            ch._signal_pool_shutdown()
+        # Share the remaining budget across channels using a common deadline so
+        # a slow early channel cannot consume the entire allowance and starve
+        # later ones of their chance to drain.
         deadline = time.monotonic() + timeout
         for ch in channels:
             ch._shutdown_pool(timeout=max(0.0, deadline - time.monotonic()))
@@ -1502,14 +1534,18 @@ class ThreadSafeConnection:
             indefinitely (the clean-shutdown default). A wedged worker outliving a finite *timeout*
             is left running (daemon thread) rather than stalling the caller; a warning is logged.
         """
-        if not self._connection_pool_shutdown:
+        # Atomically claim the shutdown so the IOLoop tail and a concurrent
+        # close() do not both run the join.  The join stays outside the lock so
+        # it cannot stall other channel operations for the whole timeout.
+        with self._channel_waiters_lock:
+            if self._connection_pool_shutdown:
+                return
             self._connection_pool_shutdown = True
-            if not self._connection_work_pool.shutdown(wait=True,
-                                                       timeout=timeout):
-                LOGGER.warning(
-                    'Connection %s event work pool did not drain within '
-                    '%s seconds; abandoning its worker thread',
-                    self._instance_id, timeout)
+        if not self._connection_work_pool.shutdown(wait=True, timeout=timeout):
+            LOGGER.warning(
+                'Connection %s event work pool did not drain within '
+                '%s seconds; abandoning its worker thread', self._instance_id,
+                timeout)
 
     # ------------------------------------------------------------------
     # Public API

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -364,7 +364,7 @@ class WorkQueueFullError(Exception):
     """
     The work queue stayed full for longer than the configured ``work_queue_put_timeout``.
 
-    Used by ThreadSafeConnection/ThreadSafeChannel
+    Used by ThreadSafeConnection/ThreadSafeChannel.
     """
 
 

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -360,6 +360,14 @@ class ReentrancyError(Exception):
     """
 
 
+class WorkQueueFullError(Exception):
+    """
+    The work queue stayed full for longer than the configured ``work_queue_put_timeout``.
+
+    Used by ThreadSafeConnection/ThreadSafeChannel
+    """
+
+
 class ShortStringTooLong(AMQPError):
 
     @override

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -360,11 +360,13 @@ class ReentrancyError(Exception):
     """
 
 
-class WorkQueueFullError(Exception):
+class WorkQueueFullError(AMQPConnectionError):
     """
     The work queue stayed full for longer than the configured ``work_queue_put_timeout``.
 
-    Used by ThreadSafeConnection/ThreadSafeChannel.
+    Used by ThreadSafeConnection/ThreadSafeChannel.  Subclasses :class:`AMQPConnectionError` because
+    an overflow tears the connection down, so applications catching connection loss by base class
+    see it too.
     """
 
 

--- a/tests/acceptance/thread_safe_bounded_queue_test.py
+++ b/tests/acceptance/thread_safe_bounded_queue_test.py
@@ -1,0 +1,216 @@
+"""
+Integration tests for the ThreadSafeConnection bounded work queue.
+
+These tests require a RabbitMQ broker listening on 127.0.0.1:5672 with the
+default guest/guest credentials.  They will fail, not skip, if the broker is
+unreachable - consistent with the rest of the acceptance suite.
+
+They exercise the bounded-queue paths added in #1651 against a real broker,
+which unit tests with mocks cannot: a slow consumer overflowing the queue tears
+the connection down with a WorkQueueFullError (Finding 1), close() honours its
+timeout even with a wedged consumer (Finding 2), and a merely-slow consumer that
+keeps pace does NOT trip overflow (the back-pressure negative control).
+"""
+
+import threading
+import time
+import unittest
+import uuid
+
+import pika
+from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.exceptions import WorkQueueFullError
+from tests.misc.test_utils import retry_assertion
+
+DEFAULT_PARAMS = pika.ConnectionParameters(
+    host='127.0.0.1',
+    port=5672,
+    credentials=pika.PlainCredentials('guest', 'guest'),
+)
+
+# Timeout used for join() calls that assert a thread does not hang.
+BLOCKING_CALL_TIMEOUT = 10
+
+
+class ThreadSafeBoundedQueueTestCaseBase(unittest.TestCase):
+
+    def _connect(self, **kwargs):
+        conn = ThreadSafeConnection(DEFAULT_PARAMS, **kwargs)
+        self.addCleanup(self._safe_close, conn)
+        return conn
+
+    @staticmethod
+    def _safe_close(conn):
+        try:
+            conn.close(timeout=BLOCKING_CALL_TIMEOUT)
+        except Exception:
+            pass
+
+    @staticmethod
+    def _unique_queue():
+        return f'tsbq-test-{uuid.uuid4().hex}'
+
+    def _declare_and_fill(self, ch, queue, count):
+        """Declare *queue* and publish *count* small messages into it."""
+        ch.queue_declare(queue=queue, durable=False, exclusive=True)
+        for i in range(count):
+            ch.basic_publish(exchange='',
+                             routing_key=queue,
+                             body=f'msg-{i}'.encode())
+
+
+class TestSlowConsumerOverflowClosesConnection(
+        ThreadSafeBoundedQueueTestCaseBase):
+    """
+    A consumer that wedges lets the bounded queue overflow and tear the connection down with a
+    WorkQueueFullError the application can catch by type.
+
+    This is the Finding 1 regression test: before the bounded queue the IOLoop
+    grew an unbounded backlog; before the exception-visibility fix (6a5f4a73) the
+    overflow surfaced as an opaque StreamLostError instead of WorkQueueFullError.
+    """
+
+    def test(self):
+        close_reason = []
+        closed = threading.Event()
+
+        def on_close(_conn, reason):
+            close_reason.append(reason)
+            closed.set()
+
+        # maxsize=2 with a 1 s put timeout so overflow surfaces quickly once the
+        # single worker wedges on its first delivery.
+        conn = self._connect(on_close_callback=on_close,
+                             work_queue_maxsize=2,
+                             work_queue_put_timeout=1.0)
+        ch = conn.channel()
+        queue = self._unique_queue()
+        self._declare_and_fill(ch, queue, count=50)
+
+        release = threading.Event()
+        self.addCleanup(release.set)
+
+        def wedged_consumer(channel, method, properties, body):
+            # Block the single worker so the queue backs up and overflows.
+            release.wait(BLOCKING_CALL_TIMEOUT * 3)
+
+        ch.basic_consume(queue=queue,
+                         on_message_callback=wedged_consumer,
+                         auto_ack=True)
+
+        self.assertTrue(closed.wait(BLOCKING_CALL_TIMEOUT),
+                        'connection did not close on queue overflow')
+        self.assertIsInstance(
+            close_reason[0], WorkQueueFullError,
+            f'expected WorkQueueFullError, got {close_reason[0]!r}')
+        self.assertTrue(conn.is_closed)
+
+
+class TestCloseHonorsTimeoutWithWedgedConsumer(
+        ThreadSafeBoundedQueueTestCaseBase):
+    """
+    Close() must return within its timeout even when a consumer callback is wedged, rather than
+    hanging on the stuck worker.
+
+    This is the Finding 2 regression test: before the bounded-join fix the IOLoop
+    thread's pool-drain tail waited out the wedged worker forever, so close()
+    never returned.
+    """
+
+    def test(self):
+        conn = self._connect(work_queue_maxsize=2, work_queue_put_timeout=1.0)
+        ch = conn.channel()
+        queue = self._unique_queue()
+        self._declare_and_fill(ch, queue, count=10)
+
+        release = threading.Event()
+        self.addCleanup(release.set)
+        wedged = threading.Event()
+
+        def wedged_consumer(channel, method, properties, body):
+            wedged.set()
+            release.wait(BLOCKING_CALL_TIMEOUT * 6)
+
+        ch.basic_consume(queue=queue,
+                         on_message_callback=wedged_consumer,
+                         auto_ack=True)
+
+        # Wait until the worker is actually wedged inside the callback.
+        self.assertTrue(wedged.wait(BLOCKING_CALL_TIMEOUT),
+                        'consumer never started')
+
+        # close() must return promptly despite the wedged worker.  Give it a
+        # short timeout and assert it returns within a generous multiple of that
+        # (the force path may wait up to ~2x timeout) - well under the 6x
+        # BLOCKING_CALL_TIMEOUT the callback would otherwise block for.
+        close_timeout = 1.0
+        done = threading.Event()
+
+        def do_close():
+            conn.close(timeout=close_timeout)
+            done.set()
+
+        closer = threading.Thread(target=do_close)
+        closer.start()
+        self.assertTrue(
+            done.wait(BLOCKING_CALL_TIMEOUT),
+            'close() did not honour its timeout with a wedged consumer')
+        closer.join(timeout=BLOCKING_CALL_TIMEOUT)
+        self.assertFalse(closer.is_alive())
+
+
+class TestSlowConsumerKeepingPaceDoesNotOverflow(
+        ThreadSafeBoundedQueueTestCaseBase):
+    """
+    A consumer that is slow but keeps pace must NOT trip overflow: the connection stays open and
+    every message is consumed.
+
+    This is the back-pressure negative control - it proves the bounded queue
+    applies back-pressure to merely-slow consumers rather than tearing the
+    connection down, so overflow is reserved for genuinely stuck callbacks.
+    """
+
+    def test(self):
+        n = 20
+        close_reason = []
+
+        def on_close(_conn, reason):
+            close_reason.append(reason)
+
+        # A small queue plus a per-message delay guarantees the queue is under
+        # sustained pressure, but each delay (0.05 s) stays well under the 5 s
+        # put timeout so no put ever times out.
+        conn = self._connect(on_close_callback=on_close,
+                             work_queue_maxsize=2,
+                             work_queue_put_timeout=5.0)
+        ch = conn.channel()
+        queue = self._unique_queue()
+        self._declare_and_fill(ch, queue, count=n)
+
+        received = []
+        lock = threading.Lock()
+
+        def slow_consumer(channel, method, properties, body):
+            time.sleep(0.05)
+            channel.basic_ack(delivery_tag=method.delivery_tag)
+            with lock:
+                received.append(body)
+
+        ch.basic_consume(queue=queue,
+                         on_message_callback=slow_consumer,
+                         auto_ack=False)
+
+        @retry_assertion(timeout_sec=BLOCKING_CALL_TIMEOUT * 2)
+        def assert_all_consumed():
+            with lock:
+                self.assertEqual(len(received), n)
+
+        assert_all_consumed()
+
+        self.assertEqual([], close_reason,
+                         f'connection closed unexpectedly: {close_reason}')
+        self.assertTrue(conn.is_open)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/acceptance/thread_safe_bounded_queue_test.py
+++ b/tests/acceptance/thread_safe_bounded_queue_test.py
@@ -78,11 +78,15 @@ class TestSlowConsumerOverflowClosesConnection(
             close_reason.append(reason)
             closed.set()
 
-        # maxsize=2 with a 1 s put timeout so overflow surfaces quickly once the
-        # single worker wedges on its first delivery.
+        # maxsize=1 with a short put timeout so overflow surfaces quickly once
+        # the single worker wedges on its first delivery.  Teardown is bounded
+        # by roughly one put timeout because _submit_or_terminate short-circuits
+        # once _error is set (rather than paying a put timeout per buffered
+        # delivery), but broker delivery scheduling and CI load still add
+        # variable slack, so the wait window is generous.
         conn = self._connect(on_close_callback=on_close,
-                             work_queue_maxsize=2,
-                             work_queue_put_timeout=1.0)
+                             work_queue_maxsize=1,
+                             work_queue_put_timeout=0.5)
         ch = conn.channel()
         queue = self._unique_queue()
         self._declare_and_fill(ch, queue, count=50)
@@ -98,7 +102,7 @@ class TestSlowConsumerOverflowClosesConnection(
                          on_message_callback=wedged_consumer,
                          auto_ack=True)
 
-        self.assertTrue(closed.wait(BLOCKING_CALL_TIMEOUT),
+        self.assertTrue(closed.wait(BLOCKING_CALL_TIMEOUT * 3),
                         'connection did not close on queue overflow')
         self.assertIsInstance(
             close_reason[0], WorkQueueFullError,

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -79,6 +79,33 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool.shutdown(wait=True)
         self.assertEqual(done, list(range(5)))
 
+    def test_shutdown_does_not_block_when_queue_full(self):
+        """
+        Shutdown() must not block when the queue is full and the worker is wedged.
+
+        The worker holds its first item while a second fills the single queue slot, so no slot is
+        free.  An in-band shutdown sentinel would block here; the flag-based shutdown must return
+        promptly.
+        """
+        pool, release = self._make_blocked_pool(maxsize=1)
+        pool.submit(lambda: None)  # fills the one queue slot
+
+        returned = threading.Event()
+
+        def do_shutdown():
+            pool.shutdown(wait=False)
+            returned.set()
+
+        shutter = threading.Thread(target=do_shutdown, daemon=True)
+        shutter.start()
+        self.assertTrue(returned.wait(timeout=5),
+                        'shutdown(wait=False) blocked on a full queue')
+        shutter.join(timeout=5)
+
+        # Releasing the worker lets it drain and exit cleanly.
+        release.set()
+        pool.shutdown(wait=True)
+
     def test_submit_after_shutdown_raises_runtime_error(self):
         """A submit() on a shut-down pool must raise RuntimeError."""
         pool = _BoundedWorkPool(maxsize=1,

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -146,6 +146,18 @@ class BoundedWorkPoolTests(unittest.TestCase):
         self.assertEqual(ch._consumer_work_pool._put_timeout,
                          DEFAULT_WORK_QUEUE_PUT_TIMEOUT)
 
+    def test_connection_rejects_invalid_put_timeout(self):
+        """
+        ThreadSafeConnection must validate its put timeout before connecting.
+
+        Validation happens ahead of SelectConnection construction, so a bad value raises without any
+        connection machinery or patching.
+        """
+        for bad in (None, 0, -1.0, float('nan')):
+            with self.assertRaises(ValueError):
+                ThreadSafeConnection(parameters='params',
+                                     work_queue_put_timeout=bad)
+
 
 class ThreadSafeChannelTests(unittest.TestCase):
 

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -104,6 +104,17 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool.shutdown(wait=True)
         pool.shutdown(wait=True)
 
+    def test_connection_params_propagate_to_channel_pool(self):
+        """Work-queue parameters passed to ThreadSafeChannel must reach its pool."""
+        raw_ch = MagicMock()
+        wrapper = MagicMock()
+        ch = ThreadSafeChannel(raw_ch,
+                               wrapper,
+                               work_queue_maxsize=7,
+                               work_queue_put_timeout=1.5)
+        self.assertEqual(ch._consumer_work_pool._queue.maxsize, 7)
+        self.assertEqual(ch._consumer_work_pool._put_timeout, 1.5)
+
 
 class ThreadSafeChannelTests(unittest.TestCase):
 
@@ -782,7 +793,12 @@ class ConsumerWorkPoolTests(unittest.TestCase):
     def test_pool_uses_single_worker(self):
         """The pool must use exactly one worker thread (for ordering)."""
         ch, _, _ = self._make_channel()
-        self.assertEqual(ch._consumer_work_pool._max_workers, 1)
+        pool = ch._consumer_work_pool
+        threads = []
+        for _ in range(5):
+            pool.submit(lambda: threads.append(threading.current_thread()))
+        pool.shutdown(wait=True)
+        self.assertEqual(len(set(threads)), 1)
 
     def test_callback_exception_is_logged(self):
         """Exceptions in delivery callbacks must be logged, not swallowed silently."""
@@ -1788,28 +1804,22 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             captured = []
 
             # Capture the pool reference before __init__ raises so we can
-            # assert it shut down.  We patch ThreadPoolExecutor to record
+            # assert it shut down.  We patch _BoundedWorkPool to record
             # the instance that __init__ created.
-            real_executor_cls = (__import__('concurrent.futures',
-                                            fromlist=['ThreadPoolExecutor'
-                                                     ]).ThreadPoolExecutor)
-
-            def capturing_executor(*a, **kw):
-                inst = real_executor_cls(*a, **kw)
+            def capturing_pool(*a, **kw):
+                inst = _BoundedWorkPool(*a, **kw)
                 captured.append(inst)
                 return inst
 
-            with patch(
-                    'pika.adapters.thread_safe_connection.'
-                    'concurrent.futures.ThreadPoolExecutor',
-                    side_effect=capturing_executor):
+            with patch('pika.adapters.thread_safe_connection._BoundedWorkPool',
+                       side_effect=capturing_pool):
                 with self.assertRaises(RuntimeError) as ctx:
                     ThreadSafeConnection(parameters='params')
             self.assertIs(ctx.exception, boom)
             self.assertEqual(len(captured), 1)
-            # The captured executor must be shut down.  shutdown(wait=True)
+            # The captured pool must be shut down.  shutdown(wait=True)
             # will be a no-op if already shut down, but submit() raises
-            # RuntimeError on a shut-down executor; use that as the probe.
+            # RuntimeError on a shut-down pool; use that as the probe.
             with self.assertRaises(RuntimeError):
                 captured[0].submit(lambda: None)
 
@@ -2249,12 +2259,11 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         mock_conn.add_on_connection_blocked_callback.assert_called_once()
 
     def test_blocked_callback_dispatches_on_worker_thread(self):
-        import concurrent.futures
         conn, mock_conn, mock_ioloop = self._make_connection()
         # Recreate the work pool because _make_connection lets _run_ioloop
         # exit, which shuts the pool down.
-        conn._connection_work_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix='pika-conn-test')
+        conn._connection_work_pool = _BoundedWorkPool(
+            maxsize=1000, put_timeout=None, thread_name='pika-conn-test')
         conn._connection_pool_shutdown = False
         callback_thread = []
         received = []
@@ -2313,10 +2322,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         mock_conn.add_on_connection_unblocked_callback.assert_not_called()
 
     def test_unblocked_callback_dispatches_on_worker_thread(self):
-        import concurrent.futures
         conn, mock_conn, mock_ioloop = self._make_connection()
-        conn._connection_work_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix='pika-conn-test')
+        conn._connection_work_pool = _BoundedWorkPool(
+            maxsize=1000, put_timeout=None, thread_name='pika-conn-test')
         conn._connection_pool_shutdown = False
         received = []
 
@@ -2368,10 +2376,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         """A blocked-listener exception must be logged, not silently lost on an unobserved
         Future.
         """
-        import concurrent.futures
         conn, mock_conn, mock_ioloop = self._make_connection()
-        conn._connection_work_pool = concurrent.futures.ThreadPoolExecutor(
-            max_workers=1, thread_name_prefix='pika-conn-test')
+        conn._connection_work_pool = _BoundedWorkPool(
+            maxsize=1000, put_timeout=None, thread_name='pika-conn-test')
         conn._connection_pool_shutdown = False
 
         def boom(connection, method_frame):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -4,7 +4,105 @@ import threading
 import unittest
 from unittest.mock import ANY, MagicMock, patch
 
-from pika.adapters.thread_safe_connection import ThreadSafeChannel, ThreadSafeConnection
+from pika.adapters.thread_safe_connection import (
+    ThreadSafeChannel,
+    ThreadSafeConnection,
+    _BoundedWorkPool,
+)
+from pika.exceptions import WorkQueueFullError
+
+
+class BoundedWorkPoolTests(unittest.TestCase):
+    """Tests for the bounded work queue backing the dispatch pools."""
+
+    def _make_blocked_pool(self, maxsize, put_timeout=None):
+        """Return (pool, release) where the pool's worker is stuck in its first work item until
+        *release* is set.
+        """
+        pool = _BoundedWorkPool(maxsize=maxsize,
+                                put_timeout=put_timeout,
+                                thread_name='test-pool')
+        release = threading.Event()
+        started = threading.Event()
+
+        def block():
+            started.set()
+            release.wait(timeout=5)
+
+        pool.submit(block)
+        self.assertTrue(started.wait(timeout=5))
+        return pool, release
+
+    def test_submit_with_timeout_raises_when_queue_stays_full(self):
+        """A submit() with put_timeout set must raise WorkQueueFullError when the queue stays
+        full.
+        """
+        pool, release = self._make_blocked_pool(maxsize=1, put_timeout=0.05)
+        try:
+            pool.submit(lambda: None)  # fills the queue
+            with self.assertRaises(WorkQueueFullError):
+                pool.submit(lambda: None)
+        finally:
+            release.set()
+            pool.shutdown(wait=True)
+
+    def test_submit_blocks_until_queue_has_space(self):
+        """A submit() on a full queue must block and proceed once the worker drains an item."""
+        pool, release = self._make_blocked_pool(maxsize=1)
+        pool.submit(lambda: None)  # fills the queue
+        submitted = threading.Event()
+
+        def blocked_submit():
+            pool.submit(lambda: None)
+            submitted.set()
+
+        producer = threading.Thread(target=blocked_submit, daemon=True)
+        producer.start()
+        # The producer must be stuck in put() while the queue is full...
+        self.assertFalse(submitted.wait(timeout=0.1))
+        # ...and proceed once the worker drains an item.
+        release.set()
+        self.assertTrue(submitted.wait(timeout=5))
+        producer.join(timeout=5)
+        pool.shutdown(wait=True)
+
+    def test_shutdown_drains_pending_work(self):
+        """Pool shutdown must let already-enqueued work finish before returning."""
+        pool, release = self._make_blocked_pool(maxsize=10)
+        done = []
+        for i in range(5):
+            pool.submit(done.append, i)
+        release.set()
+        pool.shutdown(wait=True)
+        self.assertEqual(done, list(range(5)))
+
+    def test_submit_after_shutdown_raises_runtime_error(self):
+        """A submit() on a shut-down pool must raise RuntimeError."""
+        pool = _BoundedWorkPool(maxsize=1,
+                                put_timeout=None,
+                                thread_name='test-pool')
+        pool.shutdown(wait=True)
+        with self.assertRaises(RuntimeError):
+            pool.submit(lambda: None)
+
+    def test_worker_thread_starts_lazily(self):
+        """The worker thread must not start until the first submit."""
+        pool = _BoundedWorkPool(maxsize=1,
+                                put_timeout=None,
+                                thread_name='test-pool')
+        self.assertIsNone(pool._thread)
+        pool.submit(lambda: None)
+        self.assertIsNotNone(pool._thread)
+        pool.shutdown(wait=True)
+
+    def test_shutdown_is_idempotent(self):
+        """Calling shutdown() multiple times must not raise."""
+        pool = _BoundedWorkPool(maxsize=1,
+                                put_timeout=None,
+                                thread_name='test-pool')
+        pool.submit(lambda: None)
+        pool.shutdown(wait=True)
+        pool.shutdown(wait=True)
 
 
 class ThreadSafeChannelTests(unittest.TestCase):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -5,6 +5,7 @@ import unittest
 from unittest.mock import ANY, MagicMock, patch
 
 from pika.adapters.thread_safe_connection import (
+    DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
     ThreadSafeChannel,
     ThreadSafeConnection,
     _BoundedWorkPool,
@@ -15,7 +16,9 @@ from pika.exceptions import WorkQueueFullError
 class BoundedWorkPoolTests(unittest.TestCase):
     """Tests for the bounded work queue backing the dispatch pools."""
 
-    def _make_blocked_pool(self, maxsize, put_timeout=None):
+    def _make_blocked_pool(self,
+                           maxsize,
+                           put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT):
         """Return (pool, release) where the pool's worker is stuck in its first work item until
         *release* is set.
         """
@@ -79,7 +82,7 @@ class BoundedWorkPoolTests(unittest.TestCase):
     def test_submit_after_shutdown_raises_runtime_error(self):
         """A submit() on a shut-down pool must raise RuntimeError."""
         pool = _BoundedWorkPool(maxsize=1,
-                                put_timeout=None,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
                                 thread_name='test-pool')
         pool.shutdown(wait=True)
         with self.assertRaises(RuntimeError):
@@ -88,7 +91,7 @@ class BoundedWorkPoolTests(unittest.TestCase):
     def test_worker_thread_starts_lazily(self):
         """The worker thread must not start until the first submit."""
         pool = _BoundedWorkPool(maxsize=1,
-                                put_timeout=None,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
                                 thread_name='test-pool')
         self.assertIsNone(pool._thread)
         pool.submit(lambda: None)
@@ -98,7 +101,7 @@ class BoundedWorkPoolTests(unittest.TestCase):
     def test_shutdown_is_idempotent(self):
         """Calling shutdown() multiple times must not raise."""
         pool = _BoundedWorkPool(maxsize=1,
-                                put_timeout=None,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
                                 thread_name='test-pool')
         pool.submit(lambda: None)
         pool.shutdown(wait=True)
@@ -111,9 +114,37 @@ class BoundedWorkPoolTests(unittest.TestCase):
         ch = ThreadSafeChannel(raw_ch,
                                wrapper,
                                work_queue_maxsize=7,
-                               work_queue_put_timeout=1.5)
+                               work_queue_put_timeout=45.0)
         self.assertEqual(ch._consumer_work_pool._queue.maxsize, 7)
-        self.assertEqual(ch._consumer_work_pool._put_timeout, 1.5)
+        self.assertEqual(ch._consumer_work_pool._put_timeout, 45.0)
+
+    def test_channel_rejects_none_put_timeout(self):
+        """ThreadSafeChannel must reject a None put timeout (would block the IOLoop forever)."""
+        with self.assertRaises(ValueError):
+            ThreadSafeChannel(MagicMock(),
+                              MagicMock(),
+                              work_queue_put_timeout=None)
+
+    def test_channel_rejects_non_positive_put_timeout(self):
+        """ThreadSafeChannel must reject a zero, negative, or NaN put timeout."""
+        for bad in (0, -1.0, float('nan')):
+            with self.assertRaises(ValueError):
+                ThreadSafeChannel(MagicMock(),
+                                  MagicMock(),
+                                  work_queue_put_timeout=bad)
+
+    def test_channel_accepts_small_positive_put_timeout(self):
+        """A positive override below the default must be accepted (no floor)."""
+        ch = ThreadSafeChannel(MagicMock(),
+                               MagicMock(),
+                               work_queue_put_timeout=5.0)
+        self.assertEqual(ch._consumer_work_pool._put_timeout, 5.0)
+
+    def test_channel_accepts_default_put_timeout(self):
+        """The default put timeout must satisfy its own validation."""
+        ch = ThreadSafeChannel(MagicMock(), MagicMock())
+        self.assertEqual(ch._consumer_work_pool._put_timeout,
+                         DEFAULT_WORK_QUEUE_PUT_TIMEOUT)
 
 
 class ThreadSafeChannelTests(unittest.TestCase):
@@ -2263,7 +2294,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         # Recreate the work pool because _make_connection lets _run_ioloop
         # exit, which shuts the pool down.
         conn._connection_work_pool = _BoundedWorkPool(
-            maxsize=1000, put_timeout=None, thread_name='pika-conn-test')
+            maxsize=1000,
+            put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+            thread_name='pika-conn-test')
         conn._connection_pool_shutdown = False
         callback_thread = []
         received = []
@@ -2324,7 +2357,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
     def test_unblocked_callback_dispatches_on_worker_thread(self):
         conn, mock_conn, mock_ioloop = self._make_connection()
         conn._connection_work_pool = _BoundedWorkPool(
-            maxsize=1000, put_timeout=None, thread_name='pika-conn-test')
+            maxsize=1000,
+            put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+            thread_name='pika-conn-test')
         conn._connection_pool_shutdown = False
         received = []
 
@@ -2378,7 +2413,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         """
         conn, mock_conn, mock_ioloop = self._make_connection()
         conn._connection_work_pool = _BoundedWorkPool(
-            maxsize=1000, put_timeout=None, thread_name='pika-conn-test')
+            maxsize=1000,
+            put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+            thread_name='pika-conn-test')
         conn._connection_pool_shutdown = False
 
         def boom(connection, method_frame):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -22,6 +22,7 @@ class SubmitOrTerminateTests(unittest.TestCase):
         """A normal submit must forward fn and args to the pool untouched."""
         pool = MagicMock()
         connection = MagicMock()
+        connection._error = None
         fn = object()
         _submit_or_terminate(pool, connection, 'dropped', fn, 'a', 'b')
         pool.submit.assert_called_once_with(fn, 'a', 'b')
@@ -33,6 +34,7 @@ class SubmitOrTerminateTests(unittest.TestCase):
         pool = MagicMock()
         pool.submit.side_effect = exc
         connection = MagicMock()
+        connection._error = None
         _submit_or_terminate(pool, connection, 'dropped', lambda: None)
         connection._terminate_stream.assert_called_once_with(exc)
 
@@ -41,8 +43,22 @@ class SubmitOrTerminateTests(unittest.TestCase):
         pool = MagicMock()
         pool.submit.side_effect = RuntimeError('pool shut down')
         connection = MagicMock()
+        connection._error = None
         with patch('pika.adapters.thread_safe_connection.LOGGER') as logger:
             _submit_or_terminate(pool, connection, 'dropped msg', lambda: None)
+        connection._terminate_stream.assert_not_called()
+        logger.debug.assert_called_once_with('dropped msg')
+
+    def test_skips_submit_when_teardown_already_underway(self):
+        """When connection._error is set, the work must be dropped without a pool submit or a repeat
+        teardown.
+        """
+        pool = MagicMock()
+        connection = MagicMock()
+        connection._error = WorkQueueFullError('already tearing down')
+        with patch('pika.adapters.thread_safe_connection.LOGGER') as logger:
+            _submit_or_terminate(pool, connection, 'dropped msg', lambda: None)
+        pool.submit.assert_not_called()
         connection._terminate_stream.assert_not_called()
         logger.debug.assert_called_once_with('dropped msg')
 
@@ -268,6 +284,9 @@ class ThreadSafeChannelTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_basic_publish_routes_through_add_callback_threadsafe(self):
@@ -845,6 +864,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_callback_runs_on_worker_thread_not_ioloop(self):
@@ -1351,6 +1373,9 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_queue_declare_raises_timeout_error(self):
@@ -1517,6 +1542,9 @@ class BlockingRPCPassthroughTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def _run_immediate_rpc(self, raw_method, *call_args, **call_kwargs):
@@ -1614,6 +1642,9 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_method_raise_propagates_to_caller(self):
@@ -1664,6 +1695,9 @@ class BasicGetTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_basic_get_returns_message_tuple(self):
@@ -1744,6 +1778,9 @@ class ChannelCloseErrorPathTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_close_propagates_broker_initiated_close_reason(self):
@@ -1789,6 +1826,9 @@ class CallbackRegistrationFailureTests(unittest.TestCase):
         wrapper._closed_reason = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_add_on_cancel_callback_logs_when_raw_register_raises(self):
@@ -1853,6 +1893,9 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             mock_conn.is_open = True
             mock_conn.is_closed = False
             mock_conn.is_closing = False
+            # A healthy connection has no pending error; _submit_or_terminate
+            # short-circuits when _error is set, so it must be None here.
+            mock_conn._error = None
 
             def fake_init(parameters, on_open_callback, on_open_error_callback,
                           on_close_callback):
@@ -2209,6 +2252,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
             mock_conn.is_open = True
             mock_conn.is_closed = False
             mock_conn.is_closing = False
+            # A healthy connection has no pending error; _submit_or_terminate
+            # short-circuits when _error is set, so it must be None here.
+            mock_conn._error = None
 
             # Capture the on_open_callback passed to SelectConnection
             # and call it immediately so _connected_event gets set.
@@ -2325,6 +2371,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
             mock_conn.is_open = True
             mock_conn.is_closed = False
             mock_conn.is_closing = False
+            # A healthy connection has no pending error; _submit_or_terminate
+            # short-circuits when _error is set, so it must be None here.
+            mock_conn._error = None
 
             def fake_init(parameters, on_open_callback, on_open_error_callback,
                           on_close_callback):
@@ -2741,6 +2790,9 @@ class ConnectionCloseFromIOLoopTests(unittest.TestCase):
             mock_conn.is_open = True
             mock_conn.is_closed = False
             mock_conn.is_closing = False
+            # A healthy connection has no pending error; _submit_or_terminate
+            # short-circuits when _error is set, so it must be None here.
+            mock_conn._error = None
 
             def fake_init(parameters, on_open_callback, on_open_error_callback,
                           on_close_callback):
@@ -2782,6 +2834,9 @@ class ConnectionEventRegistrationFailureTests(unittest.TestCase):
             mock_conn.is_open = True
             mock_conn.is_closed = False
             mock_conn.is_closing = False
+            # A healthy connection has no pending error; _submit_or_terminate
+            # short-circuits when _error is set, so it must be None here.
+            mock_conn._error = None
 
             def fake_init(parameters, on_open_callback, on_open_error_callback,
                           on_close_callback):
@@ -2823,6 +2878,9 @@ class ChannelOpenExceptionPathTests(unittest.TestCase):
             mock_conn.is_open = True
             mock_conn.is_closed = False
             mock_conn.is_closing = False
+            # A healthy connection has no pending error; _submit_or_terminate
+            # short-circuits when _error is set, so it must be None here.
+            mock_conn._error = None
 
             def fake_init(parameters, on_open_callback, on_open_error_callback,
                           on_close_callback):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -10,8 +10,41 @@ from pika.adapters.thread_safe_connection import (
     ThreadSafeChannel,
     ThreadSafeConnection,
     _BoundedWorkPool,
+    _submit_or_terminate,
 )
 from pika.exceptions import WorkQueueFullError
+
+
+class SubmitOrTerminateTests(unittest.TestCase):
+    """Tests for the _submit_or_terminate submit-wrapper helper."""
+
+    def test_submits_work_to_pool(self):
+        """A normal submit must forward fn and args to the pool untouched."""
+        pool = MagicMock()
+        connection = MagicMock()
+        fn = object()
+        _submit_or_terminate(pool, connection, 'dropped', fn, 'a', 'b')
+        pool.submit.assert_called_once_with(fn, 'a', 'b')
+        connection._terminate_stream.assert_not_called()
+
+    def test_overflow_terminates_connection_with_the_error(self):
+        """A WorkQueueFullError must tear the connection down with that error."""
+        exc = WorkQueueFullError('full')
+        pool = MagicMock()
+        pool.submit.side_effect = exc
+        connection = MagicMock()
+        _submit_or_terminate(pool, connection, 'dropped', lambda: None)
+        connection._terminate_stream.assert_called_once_with(exc)
+
+    def test_runtime_error_drops_work_without_terminating(self):
+        """A RuntimeError (pool shut down) must drop the work, not terminate."""
+        pool = MagicMock()
+        pool.submit.side_effect = RuntimeError('pool shut down')
+        connection = MagicMock()
+        with patch('pika.adapters.thread_safe_connection.LOGGER') as logger:
+            _submit_or_terminate(pool, connection, 'dropped msg', lambda: None)
+        connection._terminate_stream.assert_not_called()
+        logger.debug.assert_called_once_with('dropped msg')
 
 
 class BoundedWorkPoolTests(unittest.TestCase):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1,6 +1,7 @@
 """Tests for pika.adapters.thread_safe_connection."""
 
 import threading
+import time
 import unittest
 from unittest.mock import ANY, MagicMock, patch
 
@@ -104,6 +105,24 @@ class BoundedWorkPoolTests(unittest.TestCase):
 
         # Releasing the worker lets it drain and exit cleanly.
         release.set()
+        pool.shutdown(wait=True)
+
+    def test_worker_idles_then_processes_later_work(self):
+        """An idle worker must keep polling and still process work submitted after it goes idle."""
+        pool = _BoundedWorkPool(maxsize=10,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+                                thread_name='test-pool')
+        first = threading.Event()
+        pool.submit(first.set)
+        self.assertTrue(first.wait(timeout=5))
+
+        # Let the worker sit idle across several poll intervals so it takes the
+        # empty-queue-but-not-shutdown branch, then hand it more work.
+        time.sleep(pool._SHUTDOWN_POLL_INTERVAL * 3)
+
+        second = threading.Event()
+        pool.submit(second.set)
+        self.assertTrue(second.wait(timeout=5))
         pool.shutdown(wait=True)
 
     def test_shutdown_timeout_returns_false_when_worker_wedged(self):
@@ -728,6 +747,19 @@ class ThreadSafeChannelTests(unittest.TestCase):
         finally:
             release.set()
             ch._consumer_work_pool.shutdown(wait=True, timeout=5)
+
+    def test_channel_close_with_none_timeout_drains_unbounded(self):
+        """Close(timeout=None) must drain the pool with no bound (the None-budget branch)."""
+        ch, raw_ch, wrapper = self._make_channel()
+        raw_ch.is_closed = True  # immediate no-op handshake
+
+        def execute_immediately(cb):
+            cb()
+
+        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+
+        ch.close(timeout=None)
+        self.assertTrue(ch._pool_shutdown)
 
     def test_properties_delegate_to_raw_channel(self):
         ch, raw_ch, _wrapper = self._make_channel()
@@ -1893,6 +1925,68 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         conn.close(timeout=0.1)
 
         self.assertTrue(ch._pool_shutdown)
+
+    def test_force_stop_with_none_timeout_shuts_down_pools(self):
+        """Force-stop path with timeout=None must drain pools with an unbounded budget."""
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+        # First join returns with the thread still alive to enter the force
+        # path; after force-stop the second join sees it exited.
+        conn._ioloop_thread = MagicMock()
+        conn._ioloop_thread.is_alive.side_effect = [True, False]
+
+        ch = ThreadSafeChannel(MagicMock(), conn)
+        with conn._channel_waiters_lock:
+            conn._channels.append(ch)
+
+        conn.close(timeout=None)
+
+        self.assertTrue(ch._pool_shutdown)
+        self.assertTrue(conn._connection_pool_shutdown)
+
+    def test_shutdown_connection_pool_warns_when_worker_wedged(self):
+        """A wedged connection-event worker must be abandoned (not hang) with a warning logged."""
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+        # _make_connection runs the IOLoop tail, which already shut the
+        # connection pool down.  Replace it with a fresh pool wedged in a
+        # never-releasing callback and reset the guard so the shutdown runs.
+        release = threading.Event()
+        started = threading.Event()
+
+        def block():
+            started.set()
+            release.wait(timeout=5)
+
+        pool = _BoundedWorkPool(maxsize=10,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+                                thread_name='test-conn-pool')
+        conn._connection_work_pool = pool
+        conn._connection_pool_shutdown = False
+
+        try:
+            pool.submit(block)
+            self.assertTrue(started.wait(timeout=5))
+
+            done = threading.Event()
+
+            def do_shutdown():
+                with patch('pika.adapters.thread_safe_connection.LOGGER'
+                          ) as mock_logger:
+                    conn._shutdown_connection_pool(timeout=0.1)
+                    self.warned = mock_logger.warning.called
+                done.set()
+
+            shutter = threading.Thread(target=do_shutdown, daemon=True)
+            shutter.start()
+            self.assertTrue(
+                done.wait(timeout=5),
+                '_shutdown_connection_pool hung on a wedged worker')
+            shutter.join(timeout=5)
+            self.assertTrue(conn._connection_pool_shutdown)
+            self.assertTrue(self.warned,
+                            'expected a warning when abandoning the worker')
+        finally:
+            release.set()
+            pool.shutdown(wait=True, timeout=5)
 
     def test_init_raises_timeout_error(self):
         """Constructor must raise TimeoutError if connection is not established within the specified

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -106,6 +106,25 @@ class BoundedWorkPoolTests(unittest.TestCase):
         release.set()
         pool.shutdown(wait=True)
 
+    def test_shutdown_timeout_returns_false_when_worker_wedged(self):
+        """Shutdown(timeout) must return False and not hang when the worker will not exit."""
+        pool, release = self._make_blocked_pool(maxsize=1)
+        try:
+            # The worker is stuck in its first item, so it cannot observe the
+            # shutdown flag until released.  A short timeout must expire.
+            self.assertFalse(pool.shutdown(wait=True, timeout=0.1))
+            self.assertTrue(pool._thread.is_alive())
+        finally:
+            release.set()
+            self.assertTrue(pool.shutdown(wait=True, timeout=5))
+
+    def test_shutdown_timeout_returns_true_when_worker_exits(self):
+        """Shutdown(timeout) must return True once the worker drains and exits."""
+        pool, release = self._make_blocked_pool(maxsize=1)
+        release.set()
+        self.assertTrue(pool.shutdown(wait=True, timeout=5))
+        self.assertFalse(pool._thread.is_alive())
+
     def test_submit_after_shutdown_raises_runtime_error(self):
         """A submit() on a shut-down pool must raise RuntimeError."""
         pool = _BoundedWorkPool(maxsize=1,
@@ -670,6 +689,45 @@ class ThreadSafeChannelTests(unittest.TestCase):
         ch.abort(reply_code=320, reply_text='shutting down', timeout=5)
         # Verify the close path ran (work pool was shut down via close())
         self.assertTrue(ch._pool_shutdown)
+
+    def test_channel_close_honors_timeout_when_consumer_wedged(self):
+        """Close() must return within its timeout even if a delivery callback is wedged."""
+        ch, raw_ch, wrapper = self._make_channel()
+        raw_ch.is_closed = True  # make the close handshake an immediate no-op
+
+        def execute_immediately(cb):
+            cb()
+
+        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+
+        # Wedge the consumer worker in a never-releasing callback so the pool
+        # cannot drain and exit.
+        release = threading.Event()
+        started = threading.Event()
+
+        def block():
+            started.set()
+            release.wait(timeout=5)
+
+        try:
+            ch._consumer_work_pool.submit(block)
+            self.assertTrue(started.wait(timeout=5))
+
+            done = threading.Event()
+
+            def do_close():
+                ch.close(timeout=0.1)
+                done.set()
+
+            closer = threading.Thread(target=do_close, daemon=True)
+            closer.start()
+            self.assertTrue(done.wait(timeout=5),
+                            'close() hung on a wedged consumer worker')
+            closer.join(timeout=5)
+            self.assertTrue(ch._pool_shutdown)
+        finally:
+            release.set()
+            ch._consumer_work_pool.shutdown(wait=True, timeout=5)
 
     def test_properties_delegate_to_raw_channel(self):
         ch, raw_ch, _wrapper = self._make_channel()

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1,7 +1,6 @@
 """Tests for pika.adapters.thread_safe_connection."""
 
 import threading
-import time
 import unittest
 from unittest.mock import ANY, MagicMock, patch
 
@@ -162,17 +161,32 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool = _BoundedWorkPool(maxsize=10,
                                 put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
                                 thread_name='test-pool')
+
+        # Signal when the worker re-enters get() with an empty queue after the
+        # first item has run: that is the worker going idle, detected without
+        # a fixed sleep and without reaching into queue/condition internals.
+        idle = threading.Event()
         first = threading.Event()
-        pool.submit(first.set)
-        self.assertTrue(first.wait(timeout=5))
+        real_get = pool._queue.get
 
-        # Let the worker drain and block in get() on the empty queue, then hand
-        # it more work to prove the blocking get() wakes and processes it.
-        time.sleep(0.3)
+        def signaling_get(*args, **kwargs):
+            if first.is_set() and pool._queue.empty():
+                idle.set()
+            return real_get(*args, **kwargs)
 
-        second = threading.Event()
-        pool.submit(second.set)
-        self.assertTrue(second.wait(timeout=5))
+        with patch.object(pool._queue, 'get', side_effect=signaling_get):
+            pool.submit(first.set)
+            self.assertTrue(first.wait(timeout=5))
+            # The worker drains the first item, then blocks in get() on the
+            # empty queue; wait for that idle state deterministically.
+            self.assertTrue(idle.wait(timeout=5),
+                            'worker never went idle in get()')
+
+            # Handing it more work now proves the blocking get() wakes and
+            # processes work submitted after the worker went idle.
+            second = threading.Event()
+            pool.submit(second.set)
+            self.assertTrue(second.wait(timeout=5))
         pool.shutdown(wait=True)
 
     def test_shutdown_timeout_returns_false_when_worker_wedged(self):
@@ -202,6 +216,29 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool.shutdown(wait=True)
         with self.assertRaises(RuntimeError):
             pool.submit(lambda: None)
+
+    def test_submit_raises_when_shutdown_races_the_put(self):
+        """
+        A shutdown landing between the flag check and the put must reject the submit.
+
+        Otherwise the item lands in a queue whose worker has already drained empty and exited,
+        stranding the work with no exception to the caller. The put is made to flip the shutdown
+        flag as a side effect, standing in for a concurrent shutdown() that ran in that exact
+        window.
+        """
+        pool = _BoundedWorkPool(maxsize=10,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+                                thread_name='test-pool')
+        real_put = pool._queue.put
+
+        def put_then_shutdown(*args, **kwargs):
+            result = real_put(*args, **kwargs)
+            pool._shutdown = True
+            return result
+
+        with patch.object(pool._queue, 'put', side_effect=put_then_shutdown):
+            with self.assertRaises(RuntimeError):
+                pool.submit(lambda: None)
 
     def test_worker_thread_starts_lazily(self):
         """The worker thread must not start until the first submit."""
@@ -1967,6 +2004,89 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         # returns. Simulate that by calling it directly.
         conn._shutdown_all_consumer_pools()
         self.assertTrue(ch._pool_shutdown)
+
+    def test_bounded_sweep_signals_all_pools_before_joining_any(self):
+        """
+        The bounded sweep must signal every pool before it blocks joining the first.
+
+        Otherwise a wedged early channel's blocking join runs while later
+        channels have not been told to drain, so their workers only start
+        draining after the budget is already spent.  The invariant checked here
+        is order-based and deterministic: when the first (wedged) channel's
+        blocking join begins, every other channel's pool flag is already set.
+        """
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+
+        wedged = ThreadSafeChannel(MagicMock(), conn)
+        healthy = ThreadSafeChannel(MagicMock(), conn)
+        with conn._channel_waiters_lock:
+            conn._channels.extend([wedged, healthy])
+
+        release = threading.Event()
+        started = threading.Event()
+        self.addCleanup(release.set)
+
+        def block():
+            started.set()
+            release.wait(timeout=5)
+
+        # Wedge the first channel's worker so its blocking join stalls.
+        wedged._consumer_work_pool.submit(block)
+        self.assertTrue(started.wait(timeout=5))
+
+        # Record the healthy pool's flag state at the moment the wedged pool's
+        # blocking join (wait=True) begins.  With the up-front signal sweep it
+        # is already set; without it the healthy pool is still unsignalled.
+        real_shutdown = wedged._consumer_work_pool.shutdown
+        healthy_flag_at_wedged_join = []
+
+        def recording_shutdown(*args, **kwargs):
+            if kwargs.get('wait'):
+                healthy_flag_at_wedged_join.append(
+                    healthy._consumer_work_pool._shutdown)
+            return real_shutdown(*args, **kwargs)
+
+        with patch.object(wedged._consumer_work_pool,
+                          'shutdown',
+                          side_effect=recording_shutdown):
+            conn._shutdown_all_consumer_pools(timeout=0.2)
+
+        self.assertEqual(healthy_flag_at_wedged_join, [True])
+        self.assertTrue(healthy._pool_shutdown)
+        self.assertTrue(wedged._pool_shutdown)
+
+    def test_concurrent_channel_close_runs_shutdown_once(self):
+        """Two concurrent close() calls must not both run the pool join."""
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+        ch = ThreadSafeChannel(MagicMock(), conn)
+
+        calls = []
+        real_shutdown = ch._consumer_work_pool.shutdown
+
+        def counting_shutdown(*args, **kwargs):
+            calls.append(1)
+            return real_shutdown(*args, **kwargs)
+
+        with patch.object(ch._consumer_work_pool,
+                          'shutdown',
+                          side_effect=counting_shutdown):
+            barrier = threading.Barrier(2)
+
+            def do_shutdown():
+                barrier.wait(timeout=5)
+                ch._shutdown_pool()
+
+            threads = [
+                threading.Thread(target=do_shutdown, daemon=True)
+                for _ in range(2)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+        self.assertTrue(ch._pool_shutdown)
+        self.assertEqual(len(calls), 1)
 
     def test_ioloop_crash_shuts_down_channel_pools(self):
         """If the IOLoop crashes, all channel pools must be shut down."""

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -134,7 +134,8 @@ class BoundedWorkPoolTests(unittest.TestCase):
         Shutdown() must not block when the queue is full and the worker is wedged.
 
         The worker holds its first item while a second fills the single queue slot, so no slot is
-        free.  An in-band shutdown sentinel would block here; the flag-based shutdown must return
+        free.  The shutdown flag is set unconditionally and the wakeup sentinel is enqueued with
+        put_nowait, so a full queue drops the ping instead of blocking; shutdown must return
         promptly.
         """
         pool, release = self._make_blocked_pool(maxsize=1)
@@ -157,7 +158,7 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool.shutdown(wait=True)
 
     def test_worker_idles_then_processes_later_work(self):
-        """An idle worker must keep polling and still process work submitted after it goes idle."""
+        """An idle worker blocked in get() must still process work submitted after it goes idle."""
         pool = _BoundedWorkPool(maxsize=10,
                                 put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
                                 thread_name='test-pool')
@@ -165,9 +166,9 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool.submit(first.set)
         self.assertTrue(first.wait(timeout=5))
 
-        # Let the worker sit idle across several poll intervals so it takes the
-        # empty-queue-but-not-shutdown branch, then hand it more work.
-        time.sleep(pool._SHUTDOWN_POLL_INTERVAL * 3)
+        # Let the worker drain and block in get() on the empty queue, then hand
+        # it more work to prove the blocking get() wakes and processes it.
+        time.sleep(0.3)
 
         second = threading.Event()
         pool.submit(second.set)
@@ -220,6 +221,24 @@ class BoundedWorkPoolTests(unittest.TestCase):
         pool.submit(lambda: None)
         pool.shutdown(wait=True)
         pool.shutdown(wait=True)
+
+    def test_shutdown_from_worker_thread_does_not_join_itself(self):
+        """A work item that shuts its own pool down must not join the worker thread it runs on."""
+        pool = _BoundedWorkPool(maxsize=1,
+                                put_timeout=DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
+                                thread_name='test-pool')
+        result: list[bool] = []
+
+        def self_shutdown():
+            # RuntimeError('cannot join current thread') if shutdown() tried to
+            # join the worker from the worker itself.
+            result.append(pool.shutdown(wait=True))
+
+        pool.submit(self_shutdown)
+        pool._thread.join(timeout=5)
+        self.assertFalse(pool._thread.is_alive())
+        # shutdown() returned True (worker exits on its own) rather than raising.
+        self.assertEqual(result, [True])
 
     def test_connection_params_propagate_to_channel_pool(self):
         """Work-queue parameters passed to ThreadSafeChannel must reach its pool."""


### PR DESCRIPTION
## Proposed Changes
The `ThreadSafe*` adapters dispatch user callbacks on `ThreadPoolExecutor(max_workers=1)` pools. The executor's internal queue is unbounded, so a slow consumer callback under sustained delivery load grows it until the process runs out of memory.

This replaces each executor with a single worker thread reading from a `queue.Queue` bounded to 1000 items (same as the Java client's `WorkPool`). When the queue fills up, enqueueing blocks the IOLoop, which stops reading from the socket and lets TCP push back on the broker. Setting `work_queue_put_timeout` raises the new `WorkQueueFullError` instead of blocking forever. Both knobs are on `ThreadSafeConnection` and propagate to the per-channel pools; `work_queue_maxsize=0` gives the old unbounded behavior.

Shutdown semantics and the `except RuntimeError` call sites are unchanged, and the worker thread still starts lazily, so publish-only channels don't pay for one.

## Types of Changes

- [ ] Bugfix
- [x] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1600

## Further Comments

Blocking the IOLoop on a full queue is intentional, that's the back-pressure mechanism the issue asks for. It also means heartbeats stop while blocked, so the broker's heartbeat timeout caps how long a wedged consumer can hold the connection. `WorkQueueFullError` deliberately isn't a `RuntimeError` subclass, otherwise the dispatch sites would swallow it as the pool-shutdown signal and silently drop the event.
