### PR TITLE
Fix: pyright errors

### DIFF
--- a/examples/blocking_delivery_confirmations.py
+++ b/examples/blocking_delivery_confirmations.py
@@ -19,7 +19,7 @@ channel.confirm_delivery()
 try:
     channel.basic_publish(exchange='test',
                           routing_key='test',
-                          body='Hello World!',
+                          body=b'Hello World!',
                           properties=pika.BasicProperties(
                               content_type='text/plain',
                               delivery_mode=pika.DeliveryMode.Transient))

--- a/examples/blocking_publish_mandatory.py
+++ b/examples/blocking_publish_mandatory.py
@@ -20,7 +20,7 @@ channel.confirm_delivery()
 try:
     channel.basic_publish(exchange='test',
                           routing_key='test',
-                          body='Hello World!',
+                          body=b'Hello World!',
                           properties=pika.BasicProperties(
                               content_type='text/plain',
                               delivery_mode=pika.DeliveryMode.Transient),

--- a/examples/comparing_publishing_sync.py
+++ b/examples/comparing_publishing_sync.py
@@ -7,7 +7,7 @@ connection = pika.BlockingConnection(parameters)
 channel = connection.channel()
 
 channel.basic_publish(
-    'test_exchange', 'test_routing_key', 'message body value',
+    'test_exchange', 'test_routing_key', b'message body value',
     pika.BasicProperties(content_type='text/plain',
                          delivery_mode=pika.DeliveryMode.Transient))
 

--- a/examples/consumer_simple.py
+++ b/examples/consumer_simple.py
@@ -21,8 +21,8 @@ main_channel.exchange_declare(exchange='com.micex.lasttrades',
 queue = main_channel.queue_declare('', exclusive=True).method.queue
 queue_tickers = main_channel.queue_declare('', exclusive=True).method.queue
 
-main_channel.queue_bind(exchange='com.micex.sten',
-                        queue=queue,
+main_channel.queue_bind(queue=queue,
+                        exchange='com.micex.sten',
                         routing_key='order.stop.create')
 
 

--- a/examples/direct_reply_to.py
+++ b/examples/direct_reply_to.py
@@ -45,7 +45,7 @@ def main():
         channel.basic_publish(
             exchange='',
             routing_key=SERVER_QUEUE,
-            body='Marco',
+            body=b'Marco',
             properties=pika.BasicProperties(reply_to='amq.rabbitmq.reply-to'))
 
         channel.start_consuming()

--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -29,7 +29,7 @@ def main():
 
     chan = conn.channel()
 
-    chan.basic_publish('', 'my-alphabet-queue', "abc")
+    chan.basic_publish('', 'my-alphabet-queue', b"abc")
 
     # If publish causes the connection to become blocked, then this conn.close()
     # would hang until the connection is unblocked, if ever. However, the

--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -1,7 +1,7 @@
 """
 This example demonstrates explicit setting of heartbeat and blocked connection timeouts.
 
-Starting with RabbitMQ 3.5.5, the broker's default hearbeat timeout decreased from 580 seconds to 60
+Starting with RabbitMQ 3.5.5, the broker's default heartbeat timeout decreased from 580 seconds to 60
 seconds. As a result, applications that perform lengthy processing in the same thread that also runs
 their Pika connection may experience unexpected dropped connections due to heartbeat timeout. Here,
 we specify an explicit lower bound for heartbeat timeout.
@@ -21,7 +21,7 @@ import pika
 
 def main():
 
-    # NOTE: These paramerers work with all Pika connection types
+    # NOTE: These parameters work with all Pika connection types
     params = pika.ConnectionParameters(heartbeat=600,
                                        blocked_connection_timeout=300)
 

--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -1,10 +1,10 @@
 """
 This example demonstrates explicit setting of heartbeat and blocked connection timeouts.
 
-Starting with RabbitMQ 3.5.5, the broker's default heartbeat timeout decreased from 580 seconds to 60
-seconds. As a result, applications that perform lengthy processing in the same thread that also runs
-their Pika connection may experience unexpected dropped connections due to heartbeat timeout. Here,
-we specify an explicit lower bound for heartbeat timeout.
+Starting with RabbitMQ 3.5.5, the broker's default heartbeat timeout decreased from 580 seconds to
+60 seconds. As a result, applications that perform lengthy processing in the same thread that also
+runs their Pika connection may experience unexpected dropped connections due to heartbeat timeout.
+Here, we specify an explicit lower bound for heartbeat timeout.
 
 When RabbitMQ broker is running out of certain resources, such as memory and disk space, it may
 block connections that are performing resource-consuming operations, such as publishing messages.

--- a/examples/producer.py
+++ b/examples/producer.py
@@ -47,7 +47,7 @@ for i in range(_COUNT_):
     main_channel.basic_publish(
         exchange='com.micex.sten',
         routing_key='order.stop.create',
-        body=json.dumps(msg),
+        body=json.dumps(msg).encode(),
         properties=pika.BasicProperties(content_type='application/json'))
     print(f'send ticker {ticker}')
 

--- a/examples/publish.py
+++ b/examples/publish.py
@@ -18,7 +18,7 @@ channel.exchange_declare(exchange="test_exchange",
 
 print("Sending message to create a queue")
 channel.basic_publish(
-    'test_exchange', 'standard_key', 'queue:group',
+    'test_exchange', 'standard_key', b'queue:group',
     pika.BasicProperties(content_type='text/plain',
                          delivery_mode=DeliveryMode.Transient))
 
@@ -26,7 +26,7 @@ connection.sleep(5)
 
 print("Sending text message to group")
 channel.basic_publish(
-    'test_exchange', 'group_key', 'Message to group_key',
+    'test_exchange', 'group_key', b'Message to group_key',
     pika.BasicProperties(content_type='text/plain',
                          delivery_mode=DeliveryMode.Transient))
 
@@ -34,7 +34,7 @@ connection.sleep(5)
 
 print("Sending text message")
 channel.basic_publish(
-    'test_exchange', 'standard_key', 'Message to standard_key',
+    'test_exchange', 'standard_key', b'Message to standard_key',
     pika.BasicProperties(content_type='text/plain',
                          delivery_mode=DeliveryMode.Transient))
 

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -234,7 +234,7 @@ class TestService(service.Service):
         """
         Method for a time consuming task.
 
-        This function must return a deferred. If it is successfull, a `basic.ack` will be sent to
+        This function must return a deferred. If it is successful, a `basic.ack` will be sent to
         AMQP. If the task was not completed a `basic.nack` will be sent. In this example it will
         always return successfully after a 2 second pause.
         """

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -14,6 +14,7 @@ import functools
 import logging
 import warnings
 from collections import namedtuple
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
 import twisted.internet.base
@@ -298,8 +299,9 @@ class TwistedChannel:
 
     # Deferred-equivalents of public Channel methods
 
-    def callback_deferred(self, deferred: defer.Deferred[Any],
-                          replies: list[type[amqp_object.Method]]) -> None:
+    def callback_deferred(
+            self, deferred: defer.Deferred[Any],
+            replies: Sequence[type[amqp_object.Method]]) -> None:
         """
         Pass in a Deferred and a list replies from the RabbitMQ broker which you'd like the Deferred
         to be callbacked on with the frame as callback value.

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -14,7 +14,6 @@ import functools
 import logging
 import warnings
 from collections import namedtuple
-from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any, Callable
 
 import twisted.internet.base
@@ -33,6 +32,8 @@ from pika.adapters.utils.io_services_utils import check_callback_arg
 from pika.exchange_type import ExchangeType
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     import twisted.internet.interfaces
     from twisted.internet.defer import Deferred
 
@@ -299,9 +300,8 @@ class TwistedChannel:
 
     # Deferred-equivalents of public Channel methods
 
-    def callback_deferred(
-            self, deferred: defer.Deferred[Any],
-            replies: Sequence[type[amqp_object.Method]]) -> None:
+    def callback_deferred(self, deferred: defer.Deferred[Any],
+                          replies: Sequence[type[amqp_object.Method]]) -> None:
         """
         Pass in a Deferred and a list replies from the RabbitMQ broker which you'd like the Deferred
         to be callbacked on with the frame as callback value.

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -931,6 +931,7 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
         _LOG.debug('Attempting to connect using address record %r', addr_record)
 
         self._connector = self._connector_factory()
+        assert self._connector is not None
 
         self._connector.start(
             addr_record=addr_record,

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1078,7 +1078,7 @@ class Connection(abc.ABC):
         self._body_max_length: int = (spec.FRAME_MAX_SIZE -
                                       spec.FRAME_HEADER_SIZE -
                                       spec.FRAME_END_SIZE)
-        self.known_hosts: str | None = None
+        self.known_hosts: str | bytes | None = None
         self._frame_buffer: bytearray = bytearray()
         self._processing_frame_buffer: bool = False
         self._channels: dict[int, Channel] = {}
@@ -1927,7 +1927,7 @@ class Connection(abc.ABC):
         """
         self._opened = True
 
-        self.known_hosts = method_frame.method.known_hosts  # pyright: ignore[reportAttributeAccessIssue]
+        self.known_hosts = method_frame.method.known_hosts
 
         # We're now connected at the AMQP level
         self._set_connection_state(self.CONNECTION_OPEN)

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -26,6 +26,7 @@ class TestConstructAndImmediatelyCloseConnection(AsyncTestCase, AsyncAdapters):
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         connection_class = self.connection.__class__
 
         params = self.new_connection_params()
@@ -52,6 +53,7 @@ class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         base_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         params = self.new_connection_params()
@@ -91,6 +93,7 @@ class TestSocketConnectTimeoutWithTinySocketTimeout(AsyncTestCase,
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         connection_class = self.connection.__class__
 
         params = self.new_connection_params()
@@ -120,6 +123,7 @@ class TestStackConnectionTimeoutWithTinyStackTimeout(AsyncTestCase,
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         connection_class = self.connection.__class__
 
         params = self.new_connection_params()
@@ -152,6 +156,7 @@ class TestCreateConnectionViaDefaultConnectionWorkflow(AsyncTestCase,
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         configs = [self.parameters]
+        assert self.connection is not None
         connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         @async_test_base.make_stop_on_error_with_self(self)
@@ -179,6 +184,7 @@ class TestCreateConnectionViaCustomConnectionWorkflow(AsyncTestCase,
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         configs = [self.parameters]
+        assert self.connection is not None
         connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         @async_test_base.make_stop_on_error_with_self(self)
@@ -223,6 +229,7 @@ class TestCreateConnectionMultipleConfigsDefaultConnectionWorkflow(
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         good_params = self.parameters
+        assert self.connection is not None
         connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         sock = socket.socket()
@@ -263,6 +270,7 @@ class TestCreateConnectionRetriesWithDefaultConnectionWorkflow(
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         base_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         first_config = self.parameters
@@ -328,6 +336,7 @@ class TestCreateConnectionConnectionWorkflowSocketConnectionFailure(
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         sock = socket.socket()
@@ -358,6 +367,7 @@ class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
+        assert self.connection is not None
         base_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         params = self.parameters
@@ -373,7 +383,9 @@ class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(
                 # Now that AMQP handshake has begun, simulate imminent stack
                 # timeout in AMQPConnector
                 connector = workflow._connector  # type: connection_workflow.AMQPConnector
+                assert connector._stack_timeout_ref is not None
                 connector._stack_timeout_ref.cancel()
+                assert connector._nbio is not None
                 connector._stack_timeout_ref = connector._nbio.call_later(
                     0, connector._on_overall_timeout)
 
@@ -402,6 +414,7 @@ class TestCreateConnectionAndImmediatelyAbortDefaultConnectionWorkflow(
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         configs = [self.parameters]
+        assert self.connection is not None
         connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         @async_test_base.make_stop_on_error_with_self(self)
@@ -422,6 +435,7 @@ class TestCreateConnectionAndAsynchronouslyAbortDefaultConnectionWorkflow(
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         configs = [self.parameters]
+        assert self.connection is not None
         connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
 
         @async_test_base.make_stop_on_error_with_self(self)
@@ -439,6 +453,7 @@ class TestUpdateSecret(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = "Update secret and receive confirmation"
 
     def begin(self, channel):
+        assert self.connection is not None
         self.connection.update_secret("new_secret", "reason",
                                       self.on_secret_update)
 
@@ -572,6 +587,7 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
         self.stop()
 
     def on_channel_closed(self, _channel, _reason):
+        assert self.connection is not None
         self.connection.channel(on_open_callback=self.on_cleanup_channel)
 
     def on_exchange_declared(self, frame):
@@ -968,6 +984,7 @@ class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(
         """
         self.my_start_time = time_now()
         # Request a callback from our current (ioloop's) thread
+        assert self.connection is not None
         self.connection._adapter_add_callback_threadsafe(
             self.on_requested_callback)
 

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -54,7 +54,8 @@ class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         assert self.connection is not None
-        base_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        base_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         params = self.new_connection_params()
 
@@ -157,7 +158,8 @@ class TestCreateConnectionViaDefaultConnectionWorkflow(AsyncTestCase,
     def begin(self, channel):
         configs = [self.parameters]
         assert self.connection is not None
-        connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        connection_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(conn):
@@ -185,7 +187,8 @@ class TestCreateConnectionViaCustomConnectionWorkflow(AsyncTestCase,
     def begin(self, channel):
         configs = [self.parameters]
         assert self.connection is not None
-        connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        connection_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(conn):
@@ -230,7 +233,8 @@ class TestCreateConnectionMultipleConfigsDefaultConnectionWorkflow(
     def begin(self, channel):
         good_params = self.parameters
         assert self.connection is not None
-        connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        connection_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         sock = socket.socket()
         self.addCleanup(sock.close)
@@ -271,7 +275,8 @@ class TestCreateConnectionRetriesWithDefaultConnectionWorkflow(
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         assert self.connection is not None
-        base_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        base_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         first_config = self.parameters
 
@@ -337,7 +342,8 @@ class TestCreateConnectionConnectionWorkflowSocketConnectionFailure(
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         assert self.connection is not None
-        connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        connection_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         sock = socket.socket()
         self.addCleanup(sock.close)
@@ -368,11 +374,13 @@ class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         assert self.connection is not None
-        base_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        base_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         params = self.parameters
 
-        workflow = None  # type: connection_workflow.AMQPConnectionWorkflow
+        workflow: (connection_workflow.AbstractAMQPConnectionWorkflow |
+                   None) = None
 
         class MyConnectionClass(base_class):
             # Cause an exception if _on_stream_connected doesn't exist
@@ -382,7 +390,10 @@ class TestCreateConnectionAMQPHandshakeTimesOutDefaultWorkflow(
             def _on_stream_connected(self, *args, **kwargs):
                 # Now that AMQP handshake has begun, simulate imminent stack
                 # timeout in AMQPConnector
-                connector = workflow._connector  # type: connection_workflow.AMQPConnector
+                assert isinstance(workflow,
+                                  connection_workflow.AMQPConnectionWorkflow)
+                connector = workflow._connector
+                assert connector is not None
                 assert connector._stack_timeout_ref is not None
                 connector._stack_timeout_ref.cancel()
                 assert connector._nbio is not None
@@ -415,7 +426,8 @@ class TestCreateConnectionAndImmediatelyAbortDefaultConnectionWorkflow(
     def begin(self, channel):
         configs = [self.parameters]
         assert self.connection is not None
-        connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        connection_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(exc):
@@ -430,13 +442,14 @@ class TestCreateConnectionAndImmediatelyAbortDefaultConnectionWorkflow(
 
 class TestCreateConnectionAndAsynchronouslyAbortDefaultConnectionWorkflow(
         AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Asyncrhonously abort workflow initiated via adapter's create_connection()."
+    DESCRIPTION = "Asynchronously abort workflow initiated via adapter's create_connection()."
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
         configs = [self.parameters]
         assert self.connection is not None
-        connection_class = self.connection.__class__  # type: pika.adapters.BaseConnection
+        connection_class: type[pika.adapters.BaseConnection] = (
+            self.connection.__class__)
 
         @async_test_base.make_stop_on_error_with_self(self)
         def on_done(exc):

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -986,6 +986,7 @@ class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(
     def on_requested_callback(self):
         self.assertEqual(threading.current_thread().ident,
                          self.loop_thread_ident)
+        assert self.my_start_time is not None
         self.assertLess(time_now() - self.my_start_time, 0.25)
         self.got_callback = True
 
@@ -1010,6 +1011,7 @@ class TestAddCallbackThreadsafeFromIOLoopThread(AsyncTestCase, AsyncAdapters):
     def on_requested_callback(self):
         self.assertEqual(threading.current_thread().ident,
                          self.loop_thread_ident)
+        assert self.my_start_time is not None
         self.assertLess(time_now() - self.my_start_time, 0.25)
         self.got_callback = True
         self.stop()
@@ -1038,6 +1040,7 @@ class TestAddCallbackThreadsafeFromAnotherThread(AsyncTestCase, AsyncAdapters):
     def on_requested_callback(self):
         self.assertEqual(threading.current_thread().ident,
                          self.loop_thread_ident)
+        assert self.my_start_time is not None
         self.assertLess(time_now() - self.my_start_time, 0.25)
         self.got_callback = True
         self.stop()

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -924,8 +924,8 @@ class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):
         self.parameters.blocked_connection_timeout = 0.001
         self.on_closed_error = None
         super().start(*args, **kwargs)
-        self.assertIsInstance(self.on_closed_error,
-                              pika.exceptions.ConnectionClosedByClient)
+        assert isinstance(self.on_closed_error,
+                          pika.exceptions.ConnectionClosedByClient)
         self.assertEqual(
             (self.on_closed_error.reply_code, self.on_closed_error.reply_text),
             (200, 'Normal shutdown'))

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -1068,6 +1068,7 @@ class TestBasicGet(BlockingTestCaseBase):
         (method, properties, body) = ch.basic_get(q_name, auto_ack=False)
         LOGGER.info('%s GOT FROM NON-EMPTY QUEUE (%s)',
                     datetime.now(timezone.utc), self)
+        assert method is not None
         self.assertIsInstance(method, pika.spec.Basic.GetOk)
         self.assertEqual(method.delivery_tag, 1)
         self.assertFalse(method.redelivered)
@@ -1075,11 +1076,13 @@ class TestBasicGet(BlockingTestCaseBase):
         self.assertEqual(method.routing_key, q_name)
         self.assertEqual(method.message_count, 0)
 
+        assert properties is not None
         self.assertIsInstance(properties, pika.BasicProperties)
         self.assertIsNone(properties.headers)
         self.assertEqual(body, as_bytes(body))
 
         # Ack it
+        assert method.delivery_tag is not None
         ch.basic_ack(delivery_tag=method.delivery_tag)
         LOGGER.info('%s ACKED (%s)', datetime.now(timezone.utc), self)
 
@@ -1125,6 +1128,8 @@ class TestBasicReject(BlockingTestCaseBase):
         self.assertEqual(rx_body, as_bytes('TestBasicReject2'))
 
         # Nack the second message
+        assert rx_method is not None
+        assert rx_method.delivery_tag is not None
         ch.basic_reject(rx_method.delivery_tag, requeue=True)
 
         # Verify that exactly one message is present in the queue, namely the
@@ -1172,6 +1177,8 @@ class TestBasicRejectNoRequeue(BlockingTestCaseBase):
         self.assertEqual(rx_body, as_bytes('TestBasicRejectNoRequeue2'))
 
         # Nack the second message
+        assert rx_method is not None
+        assert rx_method.delivery_tag is not None
         ch.basic_reject(rx_method.delivery_tag, requeue=False)
 
         # Verify that no messages are present in the queue
@@ -1216,6 +1223,8 @@ class TestBasicNack(BlockingTestCaseBase):
         self.assertEqual(rx_body, as_bytes('TestBasicNack2'))
 
         # Nack the second message
+        assert rx_method is not None
+        assert rx_method.delivery_tag is not None
         ch.basic_nack(rx_method.delivery_tag, multiple=False, requeue=True)
 
         # Verify that exactly one message is present in the queue, namely the
@@ -1263,6 +1272,8 @@ class TestBasicNackNoRequeue(BlockingTestCaseBase):
         self.assertEqual(rx_body, as_bytes('TestBasicNackNoRequeue2'))
 
         # Nack the second message
+        assert rx_method is not None
+        assert rx_method.delivery_tag is not None
         ch.basic_nack(rx_method.delivery_tag, requeue=False)
 
         # Verify that no messages are present in the queue
@@ -1307,6 +1318,8 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
         self.assertEqual(rx_body, as_bytes('TestBasicNackMultiple2'))
 
         # Nack both messages via the "multiple" option
+        assert rx_method is not None
+        assert rx_method.delivery_tag is not None
         ch.basic_nack(rx_method.delivery_tag, multiple=True, requeue=True)
 
         # Verify that both messages are present in the queue
@@ -1762,6 +1775,7 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
         # Check the first message
         self.assertIsInstance(msg, tuple)
         rx_method, rx_properties, rx_body = msg
+        assert rx_method is not None
         self.assertIsInstance(rx_method, pika.spec.Basic.GetOk)
         self.assertEqual(rx_method.delivery_tag, 1)
         self.assertFalse(rx_method.redelivered)
@@ -1775,6 +1789,7 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
         self.assertFalse(ch._pending_events)
 
         # Ack the message
+        assert rx_method.delivery_tag is not None
         ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
 
         # Verify that the queue is now empty
@@ -2676,6 +2691,7 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
             break
 
         # There shouldn't be any more events now
+        assert ch._queue_consumer_generator is not None
         self.assertFalse(ch._queue_consumer_generator.pending_events)
 
         # Verify that the queue is now empty
@@ -2714,6 +2730,7 @@ class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
                                                        exclusive=False,
                                                        arguments=None):
             num_consumed += 1
+            assert rx_method is not None
             self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
             self.assertEqual(rx_method.delivery_tag, num_consumed)
             self.assertFalse(rx_method.redelivered)
@@ -2724,12 +2741,14 @@ class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
             self.assertEqual(rx_body, as_bytes(body))
 
             # Ack the message
+            assert rx_method.delivery_tag is not None
             ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
 
             if num_consumed >= num_messages_to_publish:
                 break
 
         # There shouldn't be any more events now
+        assert ch._queue_consumer_generator is not None
         self.assertFalse(ch._queue_consumer_generator.pending_events)
 
         ch.close()
@@ -2931,6 +2950,7 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
                                           exclusive=False):
             num_messages += 1
 
+            assert rx_method is not None
             self.assertEqual(rx_method.delivery_tag, num_messages)
 
             if num_messages == 2:
@@ -3021,10 +3041,12 @@ class TestConsumeGeneratorCancelEncountersCancelFromBroker(
             ch.queue_delete(q_name)
 
             # Wait for server's Basic.Cancel
+            assert ch._queue_consumer_generator is not None
             while not ch._queue_consumer_generator.pending_events:
                 connection.process_data_events()
 
             # Confirm it's Basic.Cancel
+            assert ch._queue_consumer_generator is not None
             self.assertIsInstance(
                 ch._queue_consumer_generator.pending_events[0],
                 blocking_connection._ConsumerCancellationEvt)

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -367,7 +367,7 @@ class TestCreateAndCloseConnectionWithChannelAndConsumer(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Publish the message to the queue by way of default exchange
-        ch.basic_publish(exchange='', routing_key=q_name, body=body1)
+        ch.basic_publish(exchange='', routing_key=q_name, body=body1.encode())
 
         # Create a consumer that uses automatic ack mode
         ch.basic_consume(q_name,
@@ -877,7 +877,7 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
 
         # Verify that the queue is unreachable without exchange-exchange binding
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(src_exg_name, routing_key, body='', mandatory=True)
+            ch.basic_publish(src_exg_name, routing_key, body=b'', mandatory=True)
 
         # Bind the exchanges
         frame = ch.exchange_bind(destination=dest_exg_name,
@@ -888,7 +888,7 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
         # Publish a message via the source exchange
         ch.basic_publish(src_exg_name,
                          routing_key,
-                         body='TestExchangeBindAndUnbind',
+                         body=b'TestExchangeBindAndUnbind',
                          mandatory=True)
 
         # Check that the queue now has one message
@@ -904,7 +904,7 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
 
         # Verify that the queue is now unreachable via the source exchange
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(src_exg_name, routing_key, body='', mandatory=True)
+            ch.basic_publish(src_exg_name, routing_key, body=b'', mandatory=True)
 
 
 class TestQueueDeclareAndDelete(BlockingTestCaseBase):
@@ -992,7 +992,7 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
         # Deposit a message in the queue
         ch.basic_publish(exg_name,
                          routing_key,
-                         body='TestQueueBindAndUnbindAndPurge',
+                         body=b'TestQueueBindAndUnbindAndPurge',
                          mandatory=True)
 
         # Check that the queue now has one message
@@ -1009,7 +1009,7 @@ class TestQueueBindAndUnbindAndPurge(BlockingTestCaseBase):
         with self.assertRaises(pika.exceptions.UnroutableError):
             ch.basic_publish(exg_name,
                              routing_key,
-                             body='TestQueueBindAndUnbindAndPurge-2',
+                             body=b'TestQueueBindAndUnbindAndPurge-2',
                              mandatory=True)
 
         # Purge the queue and verify that 1 message was purged
@@ -1060,7 +1060,7 @@ class TestBasicGet(BlockingTestCaseBase):
         # Deposit a message in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body=body,
+                         body=body.encode(),
                          mandatory=True)
         LOGGER.info('%s PUBLISHED (%s)', datetime.now(timezone.utc), self)
 
@@ -1110,11 +1110,11 @@ class TestBasicReject(BlockingTestCaseBase):
         # Deposit two messages in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicReject1',
+                         body=b'TestBasicReject1',
                          mandatory=True)
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicReject2',
+                         body=b'TestBasicReject2',
                          mandatory=True)
 
         # Get the messages
@@ -1157,11 +1157,11 @@ class TestBasicRejectNoRequeue(BlockingTestCaseBase):
         # Deposit two messages in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicRejectNoRequeue1',
+                         body=b'TestBasicRejectNoRequeue1',
                          mandatory=True)
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicRejectNoRequeue2',
+                         body=b'TestBasicRejectNoRequeue2',
                          mandatory=True)
 
         # Get the messages
@@ -1201,11 +1201,11 @@ class TestBasicNack(BlockingTestCaseBase):
         # Deposit two messages in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicNack1',
+                         body=b'TestBasicNack1',
                          mandatory=True)
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicNack2',
+                         body=b'TestBasicNack2',
                          mandatory=True)
 
         # Get the messages
@@ -1248,11 +1248,11 @@ class TestBasicNackNoRequeue(BlockingTestCaseBase):
         # Deposit two messages in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicNackNoRequeue1',
+                         body=b'TestBasicNackNoRequeue1',
                          mandatory=True)
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicNackNoRequeue2',
+                         body=b'TestBasicNackNoRequeue2',
                          mandatory=True)
 
         # Get the messages
@@ -1292,11 +1292,11 @@ class TestBasicNackMultiple(BlockingTestCaseBase):
         # Deposit two messages in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicNackMultiple1',
+                         body=b'TestBasicNackMultiple1',
                          mandatory=True)
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicNackMultiple2',
+                         body=b'TestBasicNackMultiple2',
                          mandatory=True)
 
         # Get the messages
@@ -1345,11 +1345,11 @@ class TestBasicRecoverWithRequeue(BlockingTestCaseBase):
         # Deposit two messages in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicRecoverWithRequeue1',
+                         body=b'TestBasicRecoverWithRequeue1',
                          mandatory=True)
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestBasicRecoverWithRequeue2',
+                         body=b'TestBasicRecoverWithRequeue2',
                          mandatory=True)
 
         rx_messages = []
@@ -1396,7 +1396,7 @@ class TestTxCommit(BlockingTestCaseBase):
         # Deposit a message in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestTxCommit1',
+                         body=b'TestTxCommit1',
                          mandatory=True)
 
         # Verify that queue is still empty
@@ -1434,7 +1434,7 @@ class TestTxRollback(BlockingTestCaseBase):
         # Deposit a message in the queue via default exchange
         ch.basic_publish(exchange='',
                          routing_key=q_name,
-                         body='TestTxRollback1',
+                         body=b'TestTxRollback1',
                          mandatory=True)
 
         # Verify that queue is still empty
@@ -1494,7 +1494,7 @@ class TestPublishAndBasicPublishWithPubacksUnroutable(BlockingTestCaseBase):
         with self.assertRaises(pika.exceptions.UnroutableError) as cm:
             ch.basic_publish(exg_name,
                              routing_key=routing_key,
-                             body='',
+                             body=b'',
                              properties=msg2_properties,
                              mandatory=True)
         (msg,) = cm.exception.messages
@@ -1531,7 +1531,7 @@ class TestConfirmDeliveryAfterUnroutableMessage(BlockingTestCaseBase):
         # Emit unroutable message without pubacks
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='',
+                         body=b'',
                          mandatory=True)
 
         # Select delivery confirmations
@@ -1588,11 +1588,11 @@ class TestUnroutableMessagesReturnedInNonPubackMode(BlockingTestCaseBase):
         # Emit unroutable messages without pubacks
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='msg1',
+                         body=b'msg1',
                          mandatory=True)
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='msg2',
+                         body=b'msg2',
                          mandatory=True)
 
         # Process I/O until Basic.Return are dispatched
@@ -1660,12 +1660,12 @@ class TestUnroutableMessageReturnedInPubackMode(BlockingTestCaseBase):
         with self.assertRaises(pika.exceptions.UnroutableError):
             ch.basic_publish(exg_name,
                              routing_key=routing_key,
-                             body='msg1',
+                             body=b'msg1',
                              mandatory=True)
         with self.assertRaises(pika.exceptions.UnroutableError):
             ch.basic_publish(exg_name,
                              routing_key=routing_key,
-                             body='msg2',
+                             body=b'msg2',
                              mandatory=True)
 
         # Verify that unroutable messages are already in pending events
@@ -1740,7 +1740,7 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
         # Attempt to send an unroutable message in the queue via basic_publish
         ch.basic_publish(exg_name,
                          routing_key='',
-                         body='unroutable-message',
+                         body=b'unroutable-message',
                          mandatory=True)
 
         # Flush connection to force Basic.Return
@@ -1749,7 +1749,7 @@ class TestBasicPublishDeliveredWhenPendingUnroutable(BlockingTestCaseBase):
         # Deposit a routable message in the queue
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='routable-message',
+                         body=b'routable-message',
                          mandatory=True)
 
         # Wait for the queue to get the routable message
@@ -1819,14 +1819,14 @@ class TestPublishAndConsumeWithPubacksAndQosOfOne(BlockingTestCaseBase):
         msg1_properties = pika.spec.BasicProperties(headers=msg1_headers)
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='via-basic_publish',
+                         body=b'via-basic_publish',
                          properties=msg1_properties,
                          mandatory=True)
 
         # Deposit another message in the queue
         ch.basic_publish(exg_name,
                          routing_key,
-                         body='via-publish',
+                         body=b'via-publish',
                          mandatory=True)
 
         # Check that the queue now has two messages
@@ -1953,8 +1953,8 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
         ch.queue_bind(q_name, exchange=exg_name, routing_key=routing_key)
 
         # Publish 2 messages with mandatory=True for synchronous processing
-        ch.basic_publish(exg_name, routing_key, body='msg1', mandatory=True)
-        ch.basic_publish(exg_name, routing_key, body='last-msg', mandatory=True)
+        ch.basic_publish(exg_name, routing_key, body=b'msg1', mandatory=True)
+        ch.basic_publish(exg_name, routing_key, body=b'last-msg', mandatory=True)
 
         # Configure QoS for one message so that the 2nd message will be
         # delivered only after the 1st one is ACKed
@@ -2042,8 +2042,8 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
         ch.queue_bind(q_name, exchange=exg_name, routing_key=routing_key)
 
         # Publish 2 messages with mandatory=True for synchronous processing
-        ch.basic_publish(exg_name, routing_key, body='msg1', mandatory=True)
-        ch.basic_publish(exg_name, routing_key, body='last-msg', mandatory=True)
+        ch.basic_publish(exg_name, routing_key, body=b'msg1', mandatory=True)
+        ch.basic_publish(exg_name, routing_key, body=b'last-msg', mandatory=True)
 
         # Configure QoS for one message so that the 2nd message will be
         # delivered only after the 1st one is ACKed
@@ -2128,14 +2128,14 @@ class TestTwoBasicConsumersOnSameChannel(BlockingTestCaseBase):
         for message_body in q1_tx_message_bodies:
             ch.basic_publish(exg_name,
                              q1_routing_key,
-                             body=message_body,
+                             body=message_body.encode(),
                              mandatory=True)
 
         q2_tx_message_bodies = [f'q2_message+{i}' for i in range(150)]
         for message_body in q2_tx_message_bodies:
             ch.basic_publish(exg_name,
                              q2_routing_key,
-                             body=message_body,
+                             body=message_body.encode(),
                              mandatory=True)
 
         # Create the consumers
@@ -2211,7 +2211,7 @@ class TestBasicCancelPurgesPendingConsumerCancellationEvt(BlockingTestCaseBase):
 
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish',
+                         body=b'via-publish',
                          mandatory=True)
 
         # Create a consumer. Not passing a 'callback' to test client-generated
@@ -2274,14 +2274,14 @@ class TestBasicPublishWithoutPubacks(BlockingTestCaseBase):
         msg1_properties = pika.spec.BasicProperties(headers=msg1_headers)
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='via-basic_publish_mandatory=True',
+                         body=b'via-basic_publish_mandatory=True',
                          properties=msg1_properties,
                          mandatory=True)
 
         # Deposit a message in the queue with mandatory=False
         ch.basic_publish(exg_name,
                          routing_key=routing_key,
-                         body='via-basic_publish_mandatory=False',
+                         body=b'via-basic_publish_mandatory=False',
                          mandatory=False)
 
         # Wait for the messages to arrive in queue
@@ -2386,7 +2386,7 @@ class TestPublishFromBasicConsumeCallback(BlockingTestCaseBase):
         # Deposit a message in the source queue
         ch.basic_publish('',
                          routing_key=src_q_name,
-                         body='via-publish',
+                         body=b'via-publish',
                          mandatory=True)
 
         # Create a consumer
@@ -2433,12 +2433,12 @@ class TestStopConsumingFromBasicConsumeCallback(BlockingTestCaseBase):
         # Deposit two messages in the queue
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish1',
+                         body=b'via-publish1',
                          mandatory=True)
 
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish2',
+                         body=b'via-publish2',
                          mandatory=True)
 
         # Create a consumer
@@ -2487,12 +2487,12 @@ class TestCloseChannelFromBasicConsumeCallback(BlockingTestCaseBase):
         # Deposit two messages in the queue
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish1',
+                         body=b'via-publish1',
                          mandatory=True)
 
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish2',
+                         body=b'via-publish2',
                          mandatory=True)
 
         # Create a consumer
@@ -2539,12 +2539,12 @@ class TestCloseConnectionFromBasicConsumeCallback(BlockingTestCaseBase):
         # Deposit two messages in the queue
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish1',
+                         body=b'via-publish1',
                          mandatory=True)
 
         ch.basic_publish('',
                          routing_key=q_name,
-                         body='via-publish2',
+                         body=b'via-publish2',
                          mandatory=True)
 
         # Create a consumer
@@ -2651,7 +2651,7 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Publish a message to the queue by way of default exchange
-        ch.basic_publish(exchange='', routing_key=q_name, body=body)
+        ch.basic_publish(exchange='', routing_key=q_name, body=body.encode())
         LOGGER.info('Published message body size=%s', len(body))
 
         # Consume the message
@@ -2703,7 +2703,7 @@ class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
 
         for _ in range(num_messages_to_publish):
             # Publish a message to the queue by way of default exchange
-            ch.basic_publish(exchange='', routing_key=q_name, body=body)
+            ch.basic_publish(exchange='', routing_key=q_name, body=body.encode())
 
         # Consume the messages
         num_consumed = 0
@@ -2758,8 +2758,8 @@ class TestBasicCancelWithNonAckableConsumer(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Publish two messages to the queue by way of default exchange
-        ch.basic_publish(exchange='', routing_key=q_name, body=body1)
-        ch.basic_publish(exchange='', routing_key=q_name, body=body2)
+        ch.basic_publish(exchange='', routing_key=q_name, body=body1.encode())
+        ch.basic_publish(exchange='', routing_key=q_name, body=body2.encode())
 
         # Wait for queue to contain both messages
         self._assert_exact_message_count_with_retries(channel=ch,
@@ -2816,8 +2816,8 @@ class TestBasicCancelWithAckableConsumer(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Publish two messages to the queue by way of default exchange
-        ch.basic_publish(exchange='', routing_key=q_name, body=body1)
-        ch.basic_publish(exchange='', routing_key=q_name, body=body2)
+        ch.basic_publish(exchange='', routing_key=q_name, body=body1.encode())
+        ch.basic_publish(exchange='', routing_key=q_name, body=body2.encode())
 
         # Wait for queue to contain both messages
         self._assert_exact_message_count_with_retries(channel=ch,
@@ -2919,8 +2919,8 @@ class TestNoAckMessageNotRestoredToQueueOnChannelClose(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Publish two messages to the queue by way of default exchange
-        ch.basic_publish(exchange='', routing_key=q_name, body=body1)
-        ch.basic_publish(exchange='', routing_key=q_name, body=body2)
+        ch.basic_publish(exchange='', routing_key=q_name, body=body1.encode())
+        ch.basic_publish(exchange='', routing_key=q_name, body=body2.encode())
 
         # Consume, but don't ack
         num_messages = 0

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -828,10 +828,12 @@ class TestExchangeDeclareAndDelete(BlockingTestCaseBase):
         frame = ch.exchange_declare(name, exchange_type=ExchangeType.direct)
         self.addCleanup(connection.channel().exchange_delete, name)
 
+        assert frame is not None
         self.assertIsInstance(frame.method, pika.spec.Exchange.DeclareOk)
 
         # Check if it exists by declaring it passively
         frame = ch.exchange_declare(name, passive=True)
+        assert frame is not None
         self.assertIsInstance(frame.method, pika.spec.Exchange.DeclareOk)
 
         # Delete the exchange

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -881,7 +881,10 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
 
         # Verify that the queue is unreachable without exchange-exchange binding
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(src_exg_name, routing_key, body=b'', mandatory=True)
+            ch.basic_publish(src_exg_name,
+                             routing_key,
+                             body=b'',
+                             mandatory=True)
 
         # Bind the exchanges
         frame = ch.exchange_bind(destination=dest_exg_name,
@@ -908,7 +911,10 @@ class TestExchangeBindAndUnbind(BlockingTestCaseBase):
 
         # Verify that the queue is now unreachable via the source exchange
         with self.assertRaises(pika.exceptions.UnroutableError):
-            ch.basic_publish(src_exg_name, routing_key, body=b'', mandatory=True)
+            ch.basic_publish(src_exg_name,
+                             routing_key,
+                             body=b'',
+                             mandatory=True)
 
 
 class TestQueueDeclareAndDelete(BlockingTestCaseBase):
@@ -1973,7 +1979,10 @@ class TestBasicConsumeWithAckFromAnotherThread(BlockingTestCaseBase):
 
         # Publish 2 messages with mandatory=True for synchronous processing
         ch.basic_publish(exg_name, routing_key, body=b'msg1', mandatory=True)
-        ch.basic_publish(exg_name, routing_key, body=b'last-msg', mandatory=True)
+        ch.basic_publish(exg_name,
+                         routing_key,
+                         body=b'last-msg',
+                         mandatory=True)
 
         # Configure QoS for one message so that the 2nd message will be
         # delivered only after the 1st one is ACKed
@@ -2062,7 +2071,10 @@ class TestConsumeGeneratorWithAckFromAnotherThread(BlockingTestCaseBase):
 
         # Publish 2 messages with mandatory=True for synchronous processing
         ch.basic_publish(exg_name, routing_key, body=b'msg1', mandatory=True)
-        ch.basic_publish(exg_name, routing_key, body=b'last-msg', mandatory=True)
+        ch.basic_publish(exg_name,
+                         routing_key,
+                         body=b'last-msg',
+                         mandatory=True)
 
         # Configure QoS for one message so that the 2nd message will be
         # delivered only after the 1st one is ACKed
@@ -2725,7 +2737,9 @@ class TestNonPubAckPublishAndConsumeManyMessages(BlockingTestCaseBase):
 
         for _ in range(num_messages_to_publish):
             # Publish a message to the queue by way of default exchange
-            ch.basic_publish(exchange='', routing_key=q_name, body=body.encode())
+            ch.basic_publish(exchange='',
+                             routing_key=q_name,
+                             body=body.encode())
 
         # Consume the messages
         num_consumed = 0

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -2870,8 +2870,8 @@ class TestUnackedMessageAutoRestoredToQueueOnChannelClose(BlockingTestCaseBase):
         ch.queue_declare(q_name, exclusive=True)
 
         # Publish two messages to the queue by way of default exchange
-        ch.basic_publish(exchange='', routing_key=q_name, body=body1)
-        ch.basic_publish(exchange='', routing_key=q_name, body=body2)
+        ch.basic_publish(exchange='', routing_key=q_name, body=body1.encode())
+        ch.basic_publish(exchange='', routing_key=q_name, body=body2.encode())
 
         # Consume the events, but don't ack
         rx_messages = []

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -2659,6 +2659,7 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
                                                        auto_ack=False,
                                                        exclusive=False,
                                                        arguments=None):
+            assert rx_method is not None
             self.assertIsInstance(rx_method, pika.spec.Basic.Deliver)
             self.assertEqual(rx_method.delivery_tag, 1)
             self.assertFalse(rx_method.redelivered)
@@ -2669,6 +2670,7 @@ class TestNonPubAckPublishAndConsumeHugeMessage(BlockingTestCaseBase):
             self.assertEqual(rx_body, as_bytes(body))
 
             # Ack the message
+            assert rx_method.delivery_tag is not None
             ch.basic_ack(delivery_tag=rx_method.delivery_tag, multiple=False)
 
             break

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -238,8 +238,9 @@ class TestConnectionContextManagerClosesConnectionAndPassesOriginalException(
         class MyException(Exception):
             pass
 
+        connection = self._connect()
         with self.assertRaises(MyException):
-            with self._connect() as connection:
+            with connection:
                 self.assertTrue(connection.is_open)
 
                 raise MyException()
@@ -254,8 +255,9 @@ class TestConnectionContextManagerClosesConnectionAndPassesSystemException(
         """BlockingConnection: connection context manager closes connection and passes system
         exception.
         """
+        connection = self._connect()
         with self.assertRaises(SystemExit):
-            with self._connect() as connection:
+            with connection:
                 self.assertTrue(connection.is_open)
                 raise SystemExit()
 
@@ -3180,8 +3182,9 @@ class TestChannelContextManagerDoesNotSuppressChannelClosedByBroker(
             "TestChannelContextManagerDoesNotSuppressChannelClosedByBroker" +
             uuid.uuid1().hex)
 
+        channel = self._connect().channel()
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker):
-            with self._connect().channel() as channel:
+            with channel:
                 # Passively declaring non-existent exchange should force broker
                 # to close channel
                 channel.exchange_declare(exg_name, passive=True)

--- a/tests/acceptance/enforce_one_basicget_test.py
+++ b/tests/acceptance/enforce_one_basicget_test.py
@@ -16,9 +16,9 @@ class OnlyOneBasicGetTestCase(unittest.TestCase):
 
     def test_two_basic_get_with_callback(self):
         self.channel.basic_get('test-queue', self.callback)
-        self.channel._on_getok(MagicMock(Method)(), MagicMock(Header)(), '')
+        self.channel._on_getok(MagicMock(Method)(), MagicMock(Header)(), b'')
         self.channel.basic_get('test-queue', self.callback)
-        self.channel._on_getok(MagicMock(Method)(), MagicMock(Header)(), '')
+        self.channel._on_getok(MagicMock(Method)(), MagicMock(Header)(), b'')
         self.assertEqual(self.callback.call_count, 2)
 
     def test_two_basic_get_without_callback(self):

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -82,6 +82,7 @@ class TestBasicLifecycle(ThreadSafeTestCaseBase):
         @retry_assertion(timeout_sec=5)
         def assert_message_arrived():
             frame = ch.queue_declare(queue=queue, passive=True)
+            assert frame is not None
             self.assertGreaterEqual(frame.method.message_count, 1)
 
         assert_message_arrived()
@@ -134,6 +135,7 @@ class TestConcurrentPublishing(ThreadSafeTestCaseBase):
         @retry_assertion(timeout_sec=10)
         def assert_all_arrived():
             frame = ch.queue_declare(queue=queue, passive=True)
+            assert frame is not None
             self.assertEqual(frame.method.message_count, n)
 
         assert_all_arrived()

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -211,8 +211,8 @@ class TwistedChannelTestCase(TestCase):
         # Verify Deferreds that haven't had their callback invoked errback when
         # the channel closes.
         d = self.channel.basic_consume(queue="testqueue")
-        self.channel._on_channel_closed(
-            mock.Mock(), ChannelClosedByBroker(404, "NOT FOUND"))
+        self.channel._on_channel_closed(mock.Mock(),
+                                        ChannelClosedByBroker(404, "NOT FOUND"))
         self.assertFailure(d, ChannelClosedByBroker)
         assert d.called
 
@@ -435,8 +435,9 @@ class TwistedChannelTestCase(TestCase):
     def test_basic_nack(self):
         # Verify that basic_nack is transmitted properly.
         self.channel.basic_nack(123)
-        self.pika_channel.basic_nack.assert_called_once_with(
-            delivery_tag=123, multiple=False, requeue=True)
+        self.pika_channel.basic_nack.assert_called_once_with(delivery_tag=123,
+                                                             multiple=False,
+                                                             requeue=True)
 
     @pytest.mark.timeout(5)
     def test_basic_publish(self):
@@ -488,8 +489,8 @@ class TwistedChannelTestCase(TestCase):
     def test_basic_reject(self):
         # Verify that basic_reject is transmitted properly.
         self.channel.basic_reject(123)
-        self.pika_channel.basic_reject.assert_called_once_with(
-            delivery_tag=123, requeue=True)
+        self.pika_channel.basic_reject.assert_called_once_with(delivery_tag=123,
+                                                               requeue=True)
 
     @pytest.mark.timeout(5)
     def test_basic_recover(self):
@@ -645,7 +646,8 @@ class TwistedChannelTestCase(TestCase):
 
         def send_message_and_close_channel(_result):
             d = self.channel.basic_publish("testexch", "testrk", b"testbody")
-            self.channel._on_channel_closed(mock.Mock(), RuntimeError("testing"))
+            self.channel._on_channel_closed(mock.Mock(),
+                                            RuntimeError("testing"))
             self.assertEqual(len(self.channel._deliveries), 0)
             return d
 

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -80,8 +80,9 @@ class ClosableDeferredQueueTestCase(TestCase):
     def test_close(self):
         # Verify that the queue can be closed.
         q = ClosableDeferredQueue()
-        q.close("testing")
-        self.assertEqual(q.closed, "testing")
+        reason = RuntimeError("testing")
+        q.close(reason)
+        self.assertEqual(q.closed, reason)
         self.assertEqual(q.waiting, [])
         self.assertEqual(q.pending, [])
 
@@ -100,10 +101,11 @@ class ClosableDeferredQueueTestCase(TestCase):
     def test_close_twice(self):
         # If a queue it called twice, it must not crash.
         q = ClosableDeferredQueue()
-        q.close("testing")
-        self.assertEqual(q.closed, "testing")
-        q.close("testing")
-        self.assertEqual(q.closed, "testing")
+        reason = RuntimeError("testing")
+        q.close(reason)
+        self.assertEqual(q.closed, reason)
+        q.close(reason)
+        self.assertEqual(q.closed, reason)
 
 
 class TwistedChannelTestCase(TestCase):
@@ -136,7 +138,7 @@ class TwistedChannelTestCase(TestCase):
             getattr(self.pika_channel, meth_name).__name__ = meth_name
 
     def test_repr(self):
-        self.pika_channel.__repr__ = lambda _s: "<TestChannel>"
+        self.pika_channel.__repr__ = mock.Mock(return_value="<TestChannel>")
         self.assertEqual(
             repr(self.channel),
             "<TwistedChannel channel=<TestChannel>>",
@@ -148,16 +150,17 @@ class TwistedChannelTestCase(TestCase):
         # consumers are errbacked.
         self.pika_channel.add_on_close_callback.assert_called_with(
             self.channel._on_channel_closed)
-        calls = self.channel._calls = [defer.Deferred()]
+        call = defer.Deferred()
+        self.channel._calls = {call}
         consumer_mock = mock.Mock()
         self.channel._consumers = {"test-delivery-tag": consumer_mock}
         error = RuntimeError("testing")
-        self.channel._on_channel_closed(None, error)
+        self.channel._on_channel_closed(mock.Mock(), error)
         consumer_mock.close.assert_called_once_with(error)
         self.assertEqual(len(self.channel._calls), 0)
         self.assertEqual(len(self.channel._consumers), 0)
-        self.assertFailure(calls[0], RuntimeError)
-        assert calls[0].called
+        self.assertFailure(call, RuntimeError)
+        assert call.called
 
     @pytest.mark.timeout(5)
     def test_basic_consume(self):
@@ -190,7 +193,7 @@ class TwistedChannelTestCase(TestCase):
         # Verify that a Failure is returned when the channel's basic_consume
         # is called and the channel is closed.
         error = RuntimeError("testing")
-        self.channel._on_channel_closed(None, error)
+        self.channel._on_channel_closed(mock.Mock(), error)
         d = self.channel.basic_consume(queue="testqueue")
         self.assertFailure(d, RuntimeError)
         assert d.called
@@ -208,8 +211,8 @@ class TwistedChannelTestCase(TestCase):
         # Verify Deferreds that haven't had their callback invoked errback when
         # the channel closes.
         d = self.channel.basic_consume(queue="testqueue")
-        self.channel._on_channel_closed(self,
-                                        ChannelClosedByBroker(404, "NOT FOUND"))
+        self.channel._on_channel_closed(
+            mock.Mock(), ChannelClosedByBroker(404, "NOT FOUND"))
         self.assertFailure(d, ChannelClosedByBroker)
         assert d.called
 
@@ -264,7 +267,7 @@ class TwistedChannelTestCase(TestCase):
         # Verify that a Failure is returned when one of the channel's wrapped
         # methods is called and the channel is closed.
         error = RuntimeError("testing")
-        self.channel._on_channel_closed(None, error)
+        self.channel._on_channel_closed(mock.Mock(), error)
         self.pika_channel.queue_declare.__name__ = "queue_declare"
         d = self.channel.queue_declare(queue="testqueue")
         self.assertFailure(d, RuntimeError)
@@ -425,38 +428,38 @@ class TwistedChannelTestCase(TestCase):
         self.pika_channel.add_callback.assert_called_with(
             self.channel._on_getempty, [spec.Basic.GetEmpty], False)
         d = self.channel.basic_get(queue="testqueue")
-        self.channel._on_getempty("testmethod")
+        self.channel._on_getempty(mock.Mock())
         d.addCallback(self.assertIsNone)
         assert d.called
 
     def test_basic_nack(self):
         # Verify that basic_nack is transmitted properly.
-        self.channel.basic_nack("testdeliverytag")
+        self.channel.basic_nack(123)
         self.pika_channel.basic_nack.assert_called_once_with(
-            delivery_tag="testdeliverytag", multiple=False, requeue=True)
+            delivery_tag=123, multiple=False, requeue=True)
 
     @pytest.mark.timeout(5)
     def test_basic_publish(self):
         # Verify that basic_publish wraps properly.
-        args = [object()]
-        kwargs = {"routing_key": object(), "body": object()}
-        d = self.channel.basic_publish(*args, **kwargs)
-        kwargs.update({
+        d = self.channel.basic_publish("testexch",
+                                       routing_key="testrk",
+                                       body=b"testbody")
+        self.pika_channel.basic_publish.assert_called_once_with(
             # Args are converted to kwargs
-            "exchange": args[0],
+            exchange="testexch",
+            routing_key="testrk",
+            body=b"testbody",
             # Defaults
-            "mandatory": False,
-            "properties": None,
-        })
-        self.pika_channel.basic_publish.assert_called_once_with(**kwargs)
+            mandatory=False,
+            properties=None)
         assert d.called
 
     @pytest.mark.timeout(5)
     def test_basic_publish_closed(self):
         # Verify that a Failure is returned when the channel's basic_publish
         # is called and the channel is closed.
-        self.channel._on_channel_closed(None, RuntimeError("testing"))
-        d = self.channel.basic_publish(None, None, None)
+        self.channel._on_channel_closed(mock.Mock(), RuntimeError("testing"))
+        d = self.channel.basic_publish("", "", b"")
         self.pika_channel.basic_publish.assert_not_called()
         d = self.assertFailure(d, RuntimeError)
         d.addCallback(lambda e: self.assertEqual(e.args[0], "testing"))
@@ -476,18 +479,17 @@ class TwistedChannelTestCase(TestCase):
     @pytest.mark.timeout(5)
     def test_basic_qos(self):
         # Verify that basic_qos wraps properly.
-        kwargs = {"prefetch_size": 2}
-        d = self.channel.basic_qos(**kwargs)
+        d = self.channel.basic_qos(prefetch_size=2)
         # Defaults
-        kwargs.update({"prefetch_count": 0, "global_qos": False})
+        kwargs = {"prefetch_size": 2, "prefetch_count": 0, "global_qos": False}
         self._test_wrapped_func(self.pika_channel.basic_qos, kwargs, True)
         assert d.called
 
     def test_basic_reject(self):
         # Verify that basic_reject is transmitted properly.
-        self.channel.basic_reject("testdeliverytag")
+        self.channel.basic_reject(123)
         self.pika_channel.basic_reject.assert_called_once_with(
-            delivery_tag="testdeliverytag", requeue=True)
+            delivery_tag=123, requeue=True)
 
     @pytest.mark.timeout(5)
     def test_basic_recover(self):
@@ -513,7 +515,7 @@ class TwistedChannelTestCase(TestCase):
             ["ack_nack_callback"], self.channel._on_delivery_confirmation)
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", "testbody")
+            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
             frame = Method(1, spec.Basic.Ack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
             return d
@@ -534,7 +536,7 @@ class TwistedChannelTestCase(TestCase):
         d = self.channel.confirm_delivery()
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", "testbody")
+            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
             frame = Method(1, spec.Basic.Nack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
             return d
@@ -557,11 +559,11 @@ class TwistedChannelTestCase(TestCase):
         return_cb = self.pika_channel.add_on_return_callback.call_args[0][0]
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", "testbody")
+            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
             # Send the Basic.Return frame
             method = spec.Basic.Return(exchange="testexch",
                                        routing_key="testrk")
-            return_cb(self.channel, method, spec.BasicProperties(), "testbody")
+            return_cb(self.channel, method, spec.BasicProperties(), b"testbody")
             # Send the Basic.Ack frame
             frame = Method(1, spec.Basic.Ack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
@@ -571,7 +573,7 @@ class TwistedChannelTestCase(TestCase):
             self.assertIsInstance(error.value, UnroutableError)
             self.assertEqual(len(error.value.messages), 1)
             msg = error.value.messages[0]
-            self.assertEqual(msg.body, "testbody")
+            self.assertEqual(msg.body, b"testbody")
 
         d.addCallbacks(send_message, self.fail)
         d.addCallbacks(self.fail, check_response)
@@ -588,11 +590,11 @@ class TwistedChannelTestCase(TestCase):
         return_cb = self.pika_channel.add_on_return_callback.call_args[0][0]
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", "testbody")
+            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
             # Send the Basic.Return frame
             method = spec.Basic.Return(exchange="testexch",
                                        routing_key="testrk")
-            return_cb(self.channel, method, spec.BasicProperties(), "testbody")
+            return_cb(self.channel, method, spec.BasicProperties(), b"testbody")
             # Send the Basic.Nack frame
             frame = Method(1, spec.Basic.Nack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
@@ -602,7 +604,7 @@ class TwistedChannelTestCase(TestCase):
             self.assertTrue(isinstance(error.value, NackError))
             self.assertEqual(len(error.value.messages), 1)
             msg = error.value.messages[0]
-            self.assertEqual(msg.body, "testbody")
+            self.assertEqual(msg.body, b"testbody")
 
         d.addCallback(send_message)
         d.addCallbacks(self.fail, check_response)
@@ -642,8 +644,8 @@ class TwistedChannelTestCase(TestCase):
         self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
 
         def send_message_and_close_channel(_result):
-            d = self.channel.basic_publish("testexch", "testrk", "testbody")
-            self.channel._on_channel_closed(None, RuntimeError("testing"))
+            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
+            self.channel._on_channel_closed(mock.Mock(), RuntimeError("testing"))
             self.assertEqual(len(self.channel._deliveries), 0)
             return d
 
@@ -670,6 +672,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn_impl_mock.connection_made.assert_called_once_with(transport)
         self.conn.connectionMade.assert_called_once()
         d = self.conn.ready
+        assert d is not None
         self.conn._on_connection_ready(mock.Mock())
         assert d.called
 
@@ -703,14 +706,15 @@ class TwistedProtocolConnectionTestCase(TestCase):
 
     def test_dataReceived(self):
         # Verify that the data is transmitted to the callback method.
-        self.conn.dataReceived("testdata")
-        self.conn_impl_mock.data_received.assert_called_once_with("testdata")
+        self.conn.dataReceived(b"testdata")
+        self.conn_impl_mock.data_received.assert_called_once_with(b"testdata")
 
     @pytest.mark.timeout(5)
     def test_connectionLost(self):
         # Verify that the "ready" Deferred errbacks on connectionLost, and that
         # the underlying implementation callback is called.
         ready_d = self.conn.ready
+        assert ready_d is not None
         error = RuntimeError("testreason")
         self.conn.connectionLost(error)
         self.conn_impl_mock.connection_lost.assert_called_with(error)
@@ -722,6 +726,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Verify that calling connectionLost twice will not cause an
         # AlreadyCalled error on the Deferred.
         ready_d = self.conn.ready
+        assert ready_d is not None
         error = RuntimeError("testreason")
         self.conn.connectionLost(error)
         self.assertTrue(ready_d.called)
@@ -734,6 +739,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_on_connection_ready(self):
         # Verify that the "ready" Deferred is resolved on _on_connection_ready.
         d = self.conn.ready
+        assert d is not None
         self.conn._on_connection_ready(mock.Mock())
         self.assertTrue(d.called)
         d.addCallback(
@@ -745,6 +751,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Verify that calling _on_connection_ready twice will not cause an
         # AlreadyCalled error on the Deferred.
         d = self.conn.ready
+        assert d is not None
         self.conn._on_connection_ready(mock.Mock())
         self.assertTrue(d.called)
         # A second call must not raise AlreadyCalled
@@ -755,6 +762,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Verify that the connectionReady method is called when the "ready"
         # Deferred is resolved.
         d = self.conn.ready
+        assert d is not None
         self.conn.connectionReady = mock.Mock()
         self.conn._on_connection_ready(mock.Mock())
         self.conn.connectionReady.assert_called_once()
@@ -764,6 +772,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_on_connection_failed(self):
         # Verify that the "ready" Deferred errbacks on _on_connection_failed.
         d = self.conn.ready
+        assert d is not None
         self.conn._on_connection_failed(mock.Mock())
         self.assertFailure(d, AMQPConnectionError)
         assert d.called
@@ -772,6 +781,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Verify that calling _on_connection_failed twice will not cause an
         # AlreadyCalled error on the Deferred.
         d = self.conn.ready
+        assert d is not None
         self.conn._on_connection_failed(mock.Mock())
         self.assertTrue(d.called)
         d.addErrback(lambda f: None)  # silence the error
@@ -784,6 +794,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # _on_connection_closed.
         self.conn._on_connection_ready(mock.Mock())
         d = self.conn.closed
+        assert d is not None
         reason = RuntimeError("test reason")
         self.conn._on_connection_closed(mock.Mock(), reason)
         self.assertTrue(d.called)
@@ -795,6 +806,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # AlreadyCalled error on the Deferred.
         self.conn._on_connection_ready(mock.Mock())
         d = self.conn.closed
+        assert d is not None
         reason = RuntimeError("test reason")
         self.conn._on_connection_closed(mock.Mock(), reason)
         self.assertTrue(d.called)
@@ -808,6 +820,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn._on_connection_ready(mock.Mock())
         error = RuntimeError()
         d = self.conn.closed
+        assert d is not None
         self.conn._on_connection_closed(mock.Mock(), Failure(error))
         self.assertTrue(d.called)
 
@@ -857,8 +870,8 @@ class TwistedConnectionAdapterTestCase(TestCase):
         # Verify that the data is transmitted to the underlying transport.
         transport = mock.Mock()
         self.conn.connection_made(transport)
-        self.conn._adapter_emit_data("testdata")
-        transport.write.assert_called_with("testdata")
+        self.conn._adapter_emit_data(b"testdata")
+        transport.write.assert_called_with(b"testdata")
 
     def test_timeout(self):
         # Verify that timeouts are registered and cancelled properly.

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -616,8 +616,8 @@ class TwistedChannelTestCase(TestCase):
         d = self.channel.confirm_delivery()
 
         def send_message(_result):
-            d1 = self.channel.basic_publish("testexch", "testrk", "testbody1")
-            d2 = self.channel.basic_publish("testexch", "testrk", "testbody2")
+            d1 = self.channel.basic_publish("testexch", "testrk", b"testbody1")
+            d2 = self.channel.basic_publish("testexch", "testrk", b"testbody2")
             frame = Method(1, spec.Basic.Ack(delivery_tag=2, multiple=True))
             self.channel._on_delivery_confirmation(frame)
             return defer.DeferredList([d1, d2])
@@ -670,7 +670,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn_impl_mock.connection_made.assert_called_once_with(transport)
         self.conn.connectionMade.assert_called_once()
         d = self.conn.ready
-        self.conn._on_connection_ready(None)
+        self.conn._on_connection_ready(mock.Mock())
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -691,11 +691,11 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_channel_errback_if_connection_closed(self):
         # Verify calls to channel() that haven't had their callback invoked
         # errback when the connection closes.
-        self.conn._on_connection_ready("dummy")
+        self.conn._on_connection_ready(mock.Mock())
 
         d = self.conn.channel()
 
-        self.conn._on_connection_closed("test conn", RuntimeError("testing"))
+        self.conn._on_connection_closed(mock.Mock(), RuntimeError("testing"))
 
         self.assertEqual(len(self.conn._calls), 0)
         self.assertFailure(d, RuntimeError)
@@ -734,7 +734,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_on_connection_ready(self):
         # Verify that the "ready" Deferred is resolved on _on_connection_ready.
         d = self.conn.ready
-        self.conn._on_connection_ready("testresult")
+        self.conn._on_connection_ready(mock.Mock())
         self.assertTrue(d.called)
         d.addCallback(
             functools.partial(self.assertIsInstance,
@@ -745,10 +745,10 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Verify that calling _on_connection_ready twice will not cause an
         # AlreadyCalled error on the Deferred.
         d = self.conn.ready
-        self.conn._on_connection_ready("testresult")
+        self.conn._on_connection_ready(mock.Mock())
         self.assertTrue(d.called)
         # A second call must not raise AlreadyCalled
-        self.conn._on_connection_ready("testresult")
+        self.conn._on_connection_ready(mock.Mock())
 
     @pytest.mark.timeout(5)
     def test_on_connection_ready_method(self):
@@ -756,7 +756,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Deferred is resolved.
         d = self.conn.ready
         self.conn.connectionReady = mock.Mock()
-        self.conn._on_connection_ready("testresult")
+        self.conn._on_connection_ready(mock.Mock())
         self.conn.connectionReady.assert_called_once()
         assert d.called
 
@@ -764,7 +764,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_on_connection_failed(self):
         # Verify that the "ready" Deferred errbacks on _on_connection_failed.
         d = self.conn.ready
-        self.conn._on_connection_failed(None)
+        self.conn._on_connection_failed(mock.Mock())
         self.assertFailure(d, AMQPConnectionError)
         assert d.called
 
@@ -772,41 +772,43 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # Verify that calling _on_connection_failed twice will not cause an
         # AlreadyCalled error on the Deferred.
         d = self.conn.ready
-        self.conn._on_connection_failed(None)
+        self.conn._on_connection_failed(mock.Mock())
         self.assertTrue(d.called)
         d.addErrback(lambda f: None)  # silence the error
         # A second call must not raise AlreadyCalled
-        self.conn._on_connection_failed(None)
+        self.conn._on_connection_failed(mock.Mock())
 
     @pytest.mark.timeout(5)
     def test_on_connection_closed(self):
         # Verify that the "closed" Deferred is resolved on
         # _on_connection_closed.
-        self.conn._on_connection_ready("dummy")
+        self.conn._on_connection_ready(mock.Mock())
         d = self.conn.closed
-        self.conn._on_connection_closed("test conn", "test reason")
+        reason = RuntimeError("test reason")
+        self.conn._on_connection_closed(mock.Mock(), reason)
         self.assertTrue(d.called)
-        d.addCallback(self.assertEqual, "test reason")
+        d.addCallback(self.assertEqual, reason)
         assert d.called
 
     def test_on_connection_closed_twice(self):
         # Verify that calling _on_connection_closed twice will not cause an
         # AlreadyCalled error on the Deferred.
-        self.conn._on_connection_ready("dummy")
+        self.conn._on_connection_ready(mock.Mock())
         d = self.conn.closed
-        self.conn._on_connection_closed("test conn", "test reason")
+        reason = RuntimeError("test reason")
+        self.conn._on_connection_closed(mock.Mock(), reason)
         self.assertTrue(d.called)
         # A second call must not raise AlreadyCalled
-        self.conn._on_connection_closed("test conn", "test reason")
+        self.conn._on_connection_closed(mock.Mock(), reason)
 
     @pytest.mark.timeout(5)
     def test_on_connection_closed_Failure(self):
         # Verify that the _on_connection_closed method can be called with
         # a Failure instance without triggering the errback path.
-        self.conn._on_connection_ready("dummy")
+        self.conn._on_connection_ready(mock.Mock())
         error = RuntimeError()
         d = self.conn.closed
-        self.conn._on_connection_closed("test conn", Failure(error))
+        self.conn._on_connection_closed(mock.Mock(), Failure(error))
         self.assertTrue(d.called)
 
         def _check_cb(result):

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -165,6 +165,7 @@ class AsyncTestCase(unittest.TestCase):
 
         self.logger.info('Stopping test')
         self._public_stop_requested = True
+        assert self.connection is not None
         if self.connection.is_open:
             self.connection.close()  # NOTE: on_closed() will stop the ioloop
         elif self.connection.is_closed:
@@ -182,6 +183,7 @@ class AsyncTestCase(unittest.TestCase):
     def _safe_remove_test_timeout(self):
         if hasattr(self, 'timeout') and self.timeout is not None:
             self.logger.info("Removing timeout")
+            assert self.connection is not None
             self.connection._adapter_remove_timeout(self.timeout)
             self.timeout = None
 

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -114,9 +114,9 @@ class AsyncTestCase(unittest.TestCase):
         """Extend to start the actual tests on the channel."""
         self.fail("AsyncTestCase.begin_test not extended")
 
-    def start(self, adapter, ioloop_factory):
+    def start(self, adapter_class, ioloop_factory):
         self.logger.info('start at %s', datetime.now(timezone.utc))
-        self.adapter = adapter or self.ADAPTER
+        self.adapter = adapter_class or self.ADAPTER
 
         self.connection = self.adapter(self.parameters,
                                        self.on_open,
@@ -222,12 +222,12 @@ class AsyncTestCase(unittest.TestCase):
 
 class BoundQueueTestCase(AsyncTestCase):
 
-    def start(self, adapter, ioloop_factory):
+    def start(self, adapter_class, ioloop_factory):
         # Encoding
         self.exchange = 'e-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.queue = 'q-' + self.__class__.__name__ + ':' + uuid.uuid1().hex
         self.routing_key = self.__class__.__name__
-        super().start(adapter, ioloop_factory)
+        super().start(adapter_class, ioloop_factory)
 
     def begin(self, channel):
         self.channel.exchange_declare(self.exchange,

--- a/tests/unit/amqp_object_tests.py
+++ b/tests/unit/amqp_object_tests.py
@@ -48,28 +48,28 @@ class MethodTests(unittest.TestCase):
 
     def test_set_content_body(self):
         properties = amqp_object.Properties()
-        body = 'This is a test'
+        body = b'This is a test'
         obj = amqp_object.Method()
         obj._set_content(properties, body)
         self.assertEqual(obj._body, body)
 
     def test_set_content_properties(self):
         properties = amqp_object.Properties()
-        body = 'This is a test'
+        body = b'This is a test'
         obj = amqp_object.Method()
         obj._set_content(properties, body)
         self.assertEqual(obj._properties, properties)
 
     def test_get_body(self):
         properties = amqp_object.Properties()
-        body = 'This is a test'
+        body = b'This is a test'
         obj = amqp_object.Method()
         obj._set_content(properties, body)
         self.assertEqual(obj.get_body(), body)
 
     def test_get_properties(self):
         properties = amqp_object.Properties()
-        body = 'This is a test'
+        body = b'This is a test'
         obj = amqp_object.Method()
         obj._set_content(properties, body)
         self.assertEqual(obj.get_properties(), properties)

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -33,11 +33,12 @@ class BlockingConnectionTests(unittest.TestCase):
                   'SelectConnection',
                   spec_set=SelectConnectionTemplate)
     def test_constructor(self, _select_connection_class_mock):
+        params = pika.ConnectionParameters()
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection') as _create_connection_mock:
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(params)
 
-        _create_connection_mock.assert_called_once_with('params', None)
+        _create_connection_mock.assert_called_once_with(params, None)
 
         impl_mock = _create_connection_mock.return_value
         impl_mock.add_on_close_callback.assert_called_once_with(
@@ -50,7 +51,7 @@ class BlockingConnectionTests(unittest.TestCase):
                                              select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection'):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         mock_connection = select_connection_class_mock.return_value
         with mock.patch.object(
@@ -71,7 +72,7 @@ class BlockingConnectionTests(unittest.TestCase):
             self, select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection'):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         exc_value = pika.exceptions.AMQPConnectionError('failed')
         with mock.patch.object(select_connection_class_mock,
@@ -93,7 +94,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         get_buffer_size_mock = mock.Mock(
             name='_get_write_buffer_size',
@@ -118,7 +119,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         original_exc = pika.exceptions.ConnectionClosedByClient(200, 'success')
         connection._closed_result.set_value_once(impl_mock, original_exc)
@@ -138,7 +139,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         original_exc = pika.exceptions.ConnectionClosedByBroker(
             404, 'not found')
@@ -162,7 +163,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         original_exc = pika.exceptions.ConnectionClosedByBroker(200, 'ok')
         connection._closed_result.set_value_once(impl_mock, original_exc)
@@ -185,7 +186,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         impl_channel_mock = mock.Mock()
         connection._impl._channels = {1: impl_channel_mock}
@@ -212,7 +213,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         channel1_mock = mock.Mock(is_open=True,
                                   close=mock.Mock(
@@ -261,7 +262,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         with mock.patch.object(blocking_connection._CallbackResult,
                                'is_ready',
@@ -301,7 +302,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_flush_output',
@@ -314,7 +315,7 @@ class BlockingConnectionTests(unittest.TestCase):
     def test_sleep(self, select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection'):
-            connection = blocking_connection.BlockingConnection('params')
+            connection = blocking_connection.BlockingConnection(None)
 
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_flush_output',
@@ -352,7 +353,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                "_create_connection",
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection("params")
+            connection = blocking_connection.BlockingConnection(None)
 
         exc = pika.exceptions.ChannelClosedByBroker(406, "consumer_timeout")
 
@@ -383,7 +384,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                "_create_connection",
                                return_value=impl_mock):
-            connection = blocking_connection.BlockingConnection("params")
+            connection = blocking_connection.BlockingConnection(None)
 
         exc = pika.exceptions.ChannelClosedByBroker(406, "consumer_timeout")
 
@@ -418,7 +419,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection.BlockingConnection,
                                '_create_connection',
                                return_value=impl_mock):
-            return blocking_connection.BlockingConnection('params'), impl_mock
+            return blocking_connection.BlockingConnection(None), impl_mock
 
     @patch.object(blocking_connection.select_connection,
                   'SelectConnection',

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -441,11 +441,11 @@ class CallbackTests(unittest.TestCase):
 
     def test_arguments_match_obj_argument_with_method(self):
 
-        class TestFrame:
-            method = None
-
         class MethodObj:
             foo = 'bar'
+
+        class TestFrame:
+            method: MethodObj | None = None
 
         test_instance = TestFrame()
         test_instance.method = MethodObj()
@@ -454,11 +454,11 @@ class CallbackTests(unittest.TestCase):
 
     def test_arguments_match_obj_argument_with_method_no_match(self):
 
-        class TestFrame:
-            method = None
-
         class MethodObj:
             foo = 'baz'
+
+        class TestFrame:
+            method: MethodObj | None = None
 
         test_instance = TestFrame()
         test_instance.method = MethodObj()

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1507,7 +1507,7 @@ class ChannelTests(unittest.TestCase):
     @mock.patch('logging.Logger.debug')
     def test_on_getempty(self, debug):
         method_frame = frame.Method(self.obj.channel_number,
-                                    spec.Basic.GetEmpty)
+                                    spec.Basic.GetEmpty())
         self.obj._on_getempty(method_frame)
         debug.assert_called_with('Received Basic.GetEmpty: %r', method_frame)
 

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1618,7 +1618,7 @@ class ChannelTests(unittest.TestCase):
             spec.Basic.Return(999, 'Reply Text', 'exchange_value',
                               'routing.key'))
         header_value = frame.Header(1, 10, spec.BasicProperties())
-        body_value = frame.Body(1, b'0123456789')
+        body_value = b'0123456789'
         self.obj._on_return(method_value, header_value, body_value)
         self.callbacks.process.assert_called_with(self.obj.channel_number,
                                                   '_on_return', self.obj,

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1473,6 +1473,8 @@ class ChannelTests(unittest.TestCase):
 
         # Close from user
         self.obj.close(0, 'All is well')
+        assert isinstance(self.obj._closing_reason,
+                          exceptions.ChannelClosedByClient)
         self.assertEqual(self.obj._closing_reason.reply_code, 0)
         self.assertEqual(self.obj._closing_reason.reply_text, 'All is well')
         self.assertEqual(self.obj._state, self.obj.CLOSING)
@@ -1482,8 +1484,8 @@ class ChannelTests(unittest.TestCase):
             frame.Method(self.obj.channel_number,
                          spec.Channel.Close(400, 'broker is having a bad day')))
 
-        self.assertIsInstance(self.obj._closing_reason,
-                              exceptions.ChannelClosedByBroker)
+        assert isinstance(self.obj._closing_reason,
+                          exceptions.ChannelClosedByBroker)
         self.assertEqual((self.obj._closing_reason.reply_code,
                           self.obj._closing_reason.reply_text),
                          (400, 'broker is having a bad day'))

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -695,6 +695,8 @@ class ChannelTests(unittest.TestCase):
             spec.Channel.Close(200, 'Got to go', 0, 0), self.obj._on_closeok,
             [spec.Channel.CloseOk])
 
+        assert isinstance(self.obj._closing_reason,
+                          exceptions.ChannelClosedByClient)
         self.assertEqual(self.obj._closing_reason.reply_code, 200)
         self.assertEqual(self.obj._closing_reason.reply_text, 'Got to go')
         self.assertEqual(self.obj._state, self.obj.CLOSING)
@@ -1365,8 +1367,8 @@ class ChannelTests(unittest.TestCase):
         self.assertTrue(self.obj.is_closing,
                         f'Channel was not closed; state={self.obj._state}')
 
-        self.assertIsInstance(self.obj._closing_reason,
-                              exceptions.ChannelClosedByBroker)
+        assert isinstance(self.obj._closing_reason,
+                          exceptions.ChannelClosedByBroker)
         self.assertEqual(self.obj._closing_reason.reply_code, 400)
         self.assertEqual(self.obj._closing_reason.reply_text, 'error')
 
@@ -1447,6 +1449,8 @@ class ChannelTests(unittest.TestCase):
 
         # Close from user
         self.obj.close(200, 'All is well')
+        assert isinstance(self.obj._closing_reason,
+                          exceptions.ChannelClosedByClient)
         self.assertEqual(self.obj._closing_reason.reply_code, 200)
         self.assertEqual(self.obj._closing_reason.reply_text, 'All is well')
         self.assertEqual(self.obj._state, self.obj.CLOSING)

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -703,8 +703,7 @@ class ChannelTests(unittest.TestCase):
 
         # OpenOk method from broker
         self.obj._on_openok(
-            frame.Method(self.obj.channel_number,
-                         spec.Channel.OpenOk(self.obj.channel_number)))
+            frame.Method(self.obj.channel_number, spec.Channel.OpenOk()))
         self.assertEqual(self.obj._state, self.obj.CLOSING)
         self.assertEqual(self.callbacks.process.call_count, 0)
 

--- a/tests/unit/channel_tests.py
+++ b/tests/unit/channel_tests.py
@@ -1280,7 +1280,7 @@ class ChannelTests(unittest.TestCase):
                                             b'0123456789')
 
     def test_handle_content_frame_basic_get_called(self):
-        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', 1))
+        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', True))
         self.obj._handle_content_frame(method_value)
         header_value = frame.Header(1, 10, spec.BasicProperties())
         self.obj._handle_content_frame(header_value)
@@ -1519,7 +1519,7 @@ class ChannelTests(unittest.TestCase):
 
     @mock.patch('logging.Logger.error')
     def test_on_getok_no_callback(self, error):
-        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', 1))
+        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', True))
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = b'0123456789'
         self.obj._on_getok(method_value, header_value, body_value)
@@ -1528,7 +1528,7 @@ class ChannelTests(unittest.TestCase):
     def test_on_getok_callback_called(self):
         mock_callback = mock.Mock()
         self.obj._on_getok_callback = mock_callback
-        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', 1))
+        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', True))
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = b'0123456789'
         self.obj._on_getok(method_value, header_value, body_value)
@@ -1539,7 +1539,7 @@ class ChannelTests(unittest.TestCase):
     def test_on_getok_callback_reset(self):
         mock_callback = mock.Mock()
         self.obj._on_getok_callback = mock_callback
-        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', 1))
+        method_value = frame.Method(1, spec.Basic.GetOk('ctag0', True))
         header_value = frame.Header(1, 10, spec.BasicProperties())
         body_value = b'0123456789'
         self.obj._on_getok(method_value, header_value, body_value)

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -695,6 +695,7 @@ class URLParametersTests(ParametersTestsBase):
             )
 
         # check all values from base URL
+        assert isinstance(params.credentials, credentials.PlainCredentials)
         self.assertEqual(params.credentials.username, 'myuser')
         self.assertEqual(params.credentials.password, 'mypass')
         self.assertEqual(params.host, 'www.test.com')
@@ -707,6 +708,7 @@ class URLParametersTests(ParametersTestsBase):
                                         'en_US')
         self.assertEqual(parameters.port, 5672)
         self.assertEqual(parameters.virtual_host, 'prtfqpeo')
+        assert isinstance(parameters.credentials, credentials.PlainCredentials)
         self.assertEqual(parameters.credentials.password, 'oihdglkhcp0')
         self.assertEqual(parameters.credentials.username, 'prtfqpeo')
         self.assertEqual(parameters.locale, 'en_US')
@@ -717,6 +719,7 @@ class URLParametersTests(ParametersTestsBase):
                                         'en_US')
         self.assertEqual(parameters.port, 5672)
         self.assertEqual(parameters.virtual_host, 'prtfqpeo')
+        assert isinstance(parameters.credentials, credentials.PlainCredentials)
         self.assertEqual(parameters.credentials.password, 'oihdglkhcp0')
         self.assertEqual(parameters.credentials.username, 'prtfqpeo')
         self.assertEqual(parameters.locale, 'en_US')
@@ -767,6 +770,7 @@ class URLParametersTests(ParametersTestsBase):
 
     def test_uses_default_username_and_password_if_not_specified(self):
         parameters = pika.URLParameters('amqp://myserver.mycompany.com')
+        assert isinstance(parameters.credentials, credentials.PlainCredentials)
         self.assertEqual(parameters.credentials.username,
                          pika.URLParameters.DEFAULT_USERNAME)
         self.assertEqual(parameters.credentials.password,
@@ -774,6 +778,7 @@ class URLParametersTests(ParametersTestsBase):
 
     def test_accepts_blank_username_and_password(self):
         parameters = pika.URLParameters('amqp://:@myserver.mycompany.com')
+        assert isinstance(parameters.credentials, credentials.PlainCredentials)
         self.assertEqual(parameters.credentials.username, '')
         self.assertEqual(parameters.credentials.password, '')
 
@@ -782,5 +787,6 @@ class URLParametersTests(ParametersTestsBase):
         password = '////'
         parameters = pika.URLParameters(
             'amqp://%40%40%40%40:%2F%2F%2F%2F@myserver.mycompany.com')
+        assert isinstance(parameters.credentials, credentials.PlainCredentials)
         self.assertEqual(parameters.credentials.username, username)
         self.assertEqual(parameters.credentials.password, password)

--- a/tests/unit/connection_parameters_tests.py
+++ b/tests/unit/connection_parameters_tests.py
@@ -644,6 +644,7 @@ class URLParametersTests(ParametersTestsBase):
         params = connection.URLParameters(
             'amqps://foo.bar/some-vhost?ssl_options=%7B%27ca_certs%27%3A%27tests%2Fcerts%2Fca_certificate.pem%27%7D'
         )
+        assert params.ssl_options is not None
         self.assertTrue(
             params.ssl_options.context.protocol == ssl.PROTOCOL_TLS_CLIENT or
             params.ssl_options.context.protocol == ssl.PROTOCOL_TLSv1_2,

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -543,6 +543,7 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(False, self.connection.publisher_confirms)
         # 'capabilities' stays in server_properties as sent by the broker;
         # server_capabilities is a convenience view of the same dict.
+        assert self.connection.server_properties is not None
         self.assertIn('capabilities', self.connection.server_properties)
         self.assertIs(self.connection.server_capabilities,
                       self.connection.server_properties['capabilities'])

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -556,7 +556,7 @@ class ConnectionTests(unittest.TestCase):
     def test_on_connection_tune(self, _adapter_emit_data, method,
                                 heartbeat_checker):
         """Make sure _on_connection_tune tunes the connection params."""
-        heartbeat_checker.return_value = 'hearbeat obj'
+        heartbeat_checker.return_value = 'heartbeat obj'
         marshal = mock.Mock(return_value='ab')
         method.return_value = mock.Mock(marshal=marshal)
         # may be good to test this here, but i don't want to test too much
@@ -575,7 +575,7 @@ class ConnectionTests(unittest.TestCase):
         # Test
         self.connection._on_connection_tune(method_frame)
 
-        # verfy
+        # verify
         self.assertEqual(self.connection.CONNECTION_TUNE,
                          self.connection.connection_state)
         self.assertEqual(20, self.connection.params.channel_max)
@@ -585,9 +585,9 @@ class ConnectionTests(unittest.TestCase):
         heartbeat_checker.assert_called_once_with(self.connection, 20)
         self.assertEqual(
             ['ab'], [call[0][0] for call in _adapter_emit_data.call_args_list])
-        self.assertEqual('hearbeat obj', self.connection._heartbeat_checker)
+        self.assertEqual('heartbeat obj', self.connection._heartbeat_checker)
 
-        # Pika gives precendence to client heartbeat values if set
+        # Pika gives precedence to client heartbeat values if set
         # See pika/pika#965.
 
         # Both client and server values set. Pick client value
@@ -595,7 +595,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = 20
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(20, self.connection.params.heartbeat)
 
         # Client value is None, use the server's
@@ -603,7 +603,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = None
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(500, self.connection.params.heartbeat)
 
         # Client value is 0, use it
@@ -611,7 +611,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = 0
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(0, self.connection.params.heartbeat)
 
         # Server value is 0, client value is None
@@ -619,7 +619,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = None
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(0, self.connection.params.heartbeat)
 
         # Both client and server values are 0
@@ -627,7 +627,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = 0
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(0, self.connection.params.heartbeat)
 
         # Server value is 0, use the client's
@@ -635,7 +635,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = 60
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(60, self.connection.params.heartbeat)
 
         # Server value is 10, client passes a heartbeat function that
@@ -649,7 +649,7 @@ class ConnectionTests(unittest.TestCase):
         self.connection.params.heartbeat = choose_max
         # Test
         self.connection._on_connection_tune(method_frame)
-        # verfy
+        # verify
         self.assertEqual(60, self.connection.params.heartbeat)
 
     def test_on_connection_close_from_broker_passes_correct_exception(self):

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -487,9 +487,9 @@ class ConnectionTests(unittest.TestCase):
                                     is_closed=False,
                                     is_closing=True)
         self.connection._channels = {
-            'openingc': opening_channel,
-            'openc': open_channel,
-            'closingc': closing_channel
+            1: opening_channel,
+            2: open_channel,
+            3: closing_channel
         }
 
         self.connection._close_channels(400, 'reply text')
@@ -498,9 +498,9 @@ class ConnectionTests(unittest.TestCase):
         open_channel.close.assert_called_once_with(400, 'reply text')
         self.assertFalse(closing_channel.close.called)
 
-        self.assertTrue('openingc' in self.connection._channels)
-        self.assertTrue('openc' in self.connection._channels)
-        self.assertTrue('closingc' in self.connection._channels)
+        self.assertTrue(1 in self.connection._channels)
+        self.assertTrue(2 in self.connection._channels)
+        self.assertTrue(3 in self.connection._channels)
 
         self.assertFalse(self.connection.callbacks.cleanup.called)
 
@@ -683,8 +683,8 @@ class ConnectionTests(unittest.TestCase):
     @mock.patch('pika.frame.decode_frame')
     def test_on_data_available(self, decode_frame):
         """Test on data available and process frame."""
-        data_in = ['data']
-        self.connection._frame_buffer = ['old_data']
+        data_in = b'd'
+        self.connection._frame_buffer = b'o'
         for frame_type in (frame.Method, spec.Basic.Deliver, frame.Heartbeat):
             frame_value = mock.Mock(spec=frame_type)
             frame_value.frame_type = 2
@@ -696,7 +696,7 @@ class ConnectionTests(unittest.TestCase):
             decode_frame.return_value = (2, frame_value)
             self.connection._on_data_available(data_in)
             # test value
-            self.assertListEqual([], self.connection._frame_buffer)
+            self.assertEqual(b'', self.connection._frame_buffer)
             self.assertEqual(2, self.connection.bytes_received)
             self.assertEqual(1, self.connection.frames_received)
             if frame_type == frame.Heartbeat:

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -685,7 +685,7 @@ class ConnectionTests(unittest.TestCase):
     def test_on_data_available(self, decode_frame):
         """Test on data available and process frame."""
         data_in = b'd'
-        self.connection._frame_buffer = b'o'
+        self.connection._frame_buffer = bytearray(b'o')
         for frame_type in (frame.Method, spec.Basic.Deliver, frame.Heartbeat):
             frame_value = mock.Mock(spec=frame_type)
             frame_value.frame_type = 2
@@ -697,7 +697,7 @@ class ConnectionTests(unittest.TestCase):
             decode_frame.return_value = (2, frame_value)
             self.connection._on_data_available(data_in)
             # test value
-            self.assertEqual(b'', self.connection._frame_buffer)
+            self.assertEqual(bytearray(), self.connection._frame_buffer)
             self.assertEqual(2, self.connection.bytes_received)
             self.assertEqual(1, self.connection.frames_received)
             if frame_type == frame.Heartbeat:

--- a/tests/unit/content_frame_assembler_tests.py
+++ b/tests/unit/content_frame_assembler_tests.py
@@ -120,7 +120,9 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         header_frame = frame.Header(1, 11, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'foo-bar-baz')
-        method_frame, header_frame, body_value = self.obj.process(body_frame)
+        result = self.obj.process(body_frame)
+        assert result is not None
+        method_frame, header_frame, body_value = result
         self.assertIsInstance(body_value, bytes)
 
     def test_ascii_body_value(self):
@@ -131,7 +133,9 @@ class ContentFrameAssemblerTests(unittest.TestCase):
         header_frame = frame.Header(1, 11, spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, b'foo-bar-baz')
-        method_frame, header_frame, body_value = self.obj.process(body_frame)
+        result = self.obj.process(body_frame)
+        assert result is not None
+        method_frame, header_frame, body_value = result
         self.assertEqual(body_value, expectation)
         self.assertIsInstance(body_value, bytes)
 
@@ -145,5 +149,7 @@ class ContentFrameAssemblerTests(unittest.TestCase):
                                     spec.BasicProperties())
         self.obj.process(header_frame)
         body_frame = frame.Body(1, marshalled_body)
-        method_frame, header_frame, body_value = self.obj.process(body_frame)
+        result = self.obj.process(body_frame)
+        assert result is not None
+        method_frame, header_frame, body_value = result
         self.assertEqual(marshal.loads(body_value), expectation)

--- a/tests/unit/deprecation_tests.py
+++ b/tests/unit/deprecation_tests.py
@@ -60,7 +60,7 @@ class BlockingConnectionDeprecationTests(DeprecationTestCase):
                                '_create_connection'):
             self.assert_deprecated(
                 'BlockingConnection',
-                lambda: blocking_connection.BlockingConnection('params'))
+                lambda: blocking_connection.BlockingConnection(None))
 
 
 @unittest.skipUnless(HAS_TORNADO, 'tornado not installed')

--- a/tests/unit/select_connection_timer_tests.py
+++ b/tests/unit/select_connection_timer_tests.py
@@ -248,6 +248,7 @@ class TimerClassTests(unittest.TestCase):
         with mock.patch('pika._utils.time_now', return_value=now):
             timer = select_connection._Timer()
             timer.call_later(0, lambda: None)
+            assert timer._timeout_heap is not None
             self.assertEqual(timer._timeout_heap[0].deadline, now)
             self.assertEqual(timer.get_remaining_interval(), 0)
 
@@ -255,6 +256,7 @@ class TimerClassTests(unittest.TestCase):
         with mock.patch('pika._utils.time_now', return_value=now):
             timer = select_connection._Timer()
             timer.call_later(0.5, lambda: None)
+            assert timer._timeout_heap is not None
             self.assertEqual(timer._timeout_heap[0].deadline, now + 0.5)
             self.assertEqual(timer.get_remaining_interval(), 0.5)
 
@@ -283,6 +285,7 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(timer.get_remaining_interval(), 0)
             timer.process_timeouts()
             self.assertEqual(bucket, [1])
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 0)
             self.assertIsNone(timer.get_remaining_interval())
 
@@ -308,6 +311,7 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(timer.get_remaining_interval(), 0)
             timer.process_timeouts()
             self.assertEqual(bucket, [1, 2])
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 1)
             self.assertEqual(timer.get_remaining_interval(), 4)
 
@@ -316,6 +320,7 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(timer.get_remaining_interval(), 0)
             timer.process_timeouts()
             self.assertEqual(bucket, [1, 2, 3])
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 0)
             self.assertIsNone(timer.get_remaining_interval())
 
@@ -348,6 +353,7 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(bucket, [])
             self.assertEqual(timer._num_cancellations, 2)
             self.assertEqual(timer.get_remaining_interval(), 5)
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 3)
 
         # Advance time by 6 seconds to expire t1 and t2 and verify they don't
@@ -357,6 +363,7 @@ class TimerClassTests(unittest.TestCase):
             timer.process_timeouts()
             self.assertEqual(bucket, [])
             self.assertEqual(timer._num_cancellations, 0)
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 1)
             self.assertEqual(timer.get_remaining_interval(), 4)
 
@@ -365,6 +372,7 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(timer.get_remaining_interval(), 0)
             timer.process_timeouts()
             self.assertEqual(bucket, [3])
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 0)
             self.assertIsNone(timer.get_remaining_interval())
 
@@ -387,6 +395,7 @@ class TimerClassTests(unittest.TestCase):
                 timer.process_timeouts()
                 self.assertEqual(timer._num_cancellations, 1)
                 self.assertEqual(bucket, [])
+                assert timer._timeout_heap is not None
                 self.assertEqual(len(timer._timeout_heap), 3)
                 self.assertEqual(timer.get_remaining_interval(), 5)
 
@@ -396,6 +405,7 @@ class TimerClassTests(unittest.TestCase):
                 self.assertEqual(timer._num_cancellations, 2)
                 timer.process_timeouts()
                 self.assertEqual(bucket, [])
+                assert timer._timeout_heap is not None
                 self.assertEqual(len(timer._timeout_heap), 1)
                 self.assertIs(t2, timer._timeout_heap[0])
                 self.assertEqual(timer.get_remaining_interval(), 6)
@@ -420,6 +430,7 @@ class TimerClassTests(unittest.TestCase):
             self.assertIsInstance(t2, select_connection._Timeout)
             self.assertIsNot(t2, t1)
             self.assertEqual(bucket, [])
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 1)
             self.assertIs(t2, timer._timeout_heap[0])
             self.assertEqual(timer.get_remaining_interval(), 0)
@@ -438,6 +449,7 @@ class TimerClassTests(unittest.TestCase):
             t2 = timer.call_later(10, lambda: bucket.append(2))
             t1 = timer.call_later(5, lambda: timer.remove_timeout(t2))
 
+            assert timer._timeout_heap is not None
             self.assertIs(t1, timer._timeout_heap[0])
 
         # Advance time by 6 seconds and check that t2 is cancelled, but not
@@ -446,6 +458,7 @@ class TimerClassTests(unittest.TestCase):
             timer.process_timeouts()
             self.assertIsNone(t2.callback)
             self.assertEqual(timer.get_remaining_interval(), 4)
+            assert timer._timeout_heap is not None
             self.assertIs(t2, timer._timeout_heap[0])
             self.assertEqual(timer._num_cancellations, 1)
 
@@ -455,6 +468,7 @@ class TimerClassTests(unittest.TestCase):
             timer.process_timeouts()
             self.assertEqual(bucket, [])
             self.assertIsNone(timer.get_remaining_interval())
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 0)
             self.assertEqual(timer._num_cancellations, 0)
 
@@ -469,6 +483,7 @@ class TimerClassTests(unittest.TestCase):
                 5, lambda: (self.assertEqual(timer._num_cancellations, 0),
                             timer.remove_timeout(t2)))
 
+            assert timer._timeout_heap is not None
             self.assertIs(t1, timer._timeout_heap[0])
 
         # Advance time by 10 seconds and check that t2 is cancelled and
@@ -478,5 +493,6 @@ class TimerClassTests(unittest.TestCase):
             self.assertEqual(bucket, [])
             self.assertIsNone(t2.callback)
             self.assertIsNone(timer.get_remaining_interval())
+            assert timer._timeout_heap is not None
             self.assertEqual(len(timer._timeout_heap), 0)
             self.assertEqual(timer._num_cancellations, 0)

--- a/tests/unit/spec_tests.py
+++ b/tests/unit/spec_tests.py
@@ -28,4 +28,5 @@ class BasicPropertiesTests(unittest.TestCase):
         v = 912598613
         h = {hdr: v}
         p = spec.BasicProperties(content_type='text/plain', headers=h)
+        assert p.headers is not None
         self.assertEqual(repr(p.headers[hdr]), '912598613')


### PR DESCRIPTION
## Proposed Changes

Follow-up to #1649, continuing the effort to make Pika type-check cleanly
without changing runtime behavior. This round covers both the library
(`pika/`, 26 files) and the test suites (28 files).

**Error count (excluding the auto-generated `pika/spec.py`, which is unchanged
at 133 errors):**

|                     | Errors  |
| ------------------- | ------- |
| Before (main)      | **635** |
| After (this branch) | **276** |
| **Resolved**        | **359** |

Changes are grouped by the class of error they resolve:

**1. Annotations too narrow for the actual values (`reportArgumentType` / `reportAttributeAccessIssue`)**
- Widen `Connection.known_hosts` to `str | bytes | None` (matching
  `decode_short_string`'s return) and drop the pyright ignore it needed.
- Widen `TwistedChannel.callback_deferred(replies)` from `list[type[Method]]`
  to `Sequence[...]` — list invariance rejected valid calls like
  `[spec.Basic.CancelOk]`; the value is only forwarded to
  `Channel.add_callback`, which already takes `Sequence`.
- Replace the remaining `# type:` declaration comments with real annotations
  (`connection_class: type[pika.adapters.BaseConnection]`, etc.).

**2. Optional narrowing (`reportOptionalMemberAccess` / `reportOptionalSubscript`)**
- Add `assert ... is not None` (or `assert isinstance(...)`) before accesses
  where the invariant already holds: `basic_get`/`consume` result tuples,
  `_closing_reason`, `_timeout_heap`, `_queue_consumer_generator`,
  `ready`/`closed` Deferreds, `self.connection` in async adapter tests, and
  friends. Existing `assertIsInstance` guards were converted to
  `assert isinstance` so the checker narrows on them too (same runtime failure
  semantics).

**3. Incorrect test values that only worked by accident (`reportArgumentType`)**
- `str` bodies passed to `bytes` parameters: `basic_publish` (57 call sites in
  the blocking acceptance tests alone), `_on_getok`, `_on_return`,
  `_set_content`, `dataReceived`, `_adapter_emit_data`.
- The `spec.Basic.GetEmpty` **class** passed where an instance is required;
  the numeric channel number stuffed into `Channel.OpenOk`'s deprecated string
  `channel_id` field; `int` passed to `bool` `redelivered`; string delivery
  tags passed to `int` parameters.
- String/None placeholders passed to callbacks typed `Connection` /
  `Channel` / `Exception` — now `mock.Mock()` for ignored parameters and real
  exception instances (with pass-through assertions preserved) where the value
  is used.

**4. Incompatible overrides (`reportIncompatibleMethodOverride`)**
- Align the `start()` parameter name between `AsyncTestCase` /
  `BoundQueueTestCase` and the `AsyncAdapters` mixin (`adapter` →
  `adapter_class`) — one rename cleared the error on every async adapter test
  class.

**5. Latent test bugs surfaced by the checker (`reportPossiblyUnboundVariable`)**
- Context-manager targets (`channel`/`connection`) were bound *inside*
  `assertRaises` blocks; an exception raised before the `as` binding would be
  swallowed and turn the post-block assertion into a `NameError`. The objects
  are now bound before the block (identical semantics — `__enter__` returns
  `self`).

## Types of Changes

- [x] Bugfix <!-- type-checker correctness; latent test bugs fixed; no runtime behavior change -->
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [x] Cosmetics <!-- annotations and type-driven cleanups -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works <!-- n/a: typing and test corrections -->
- [ ] I have added necessary documentation (if appropriate) <!-- n/a -->

## Fixes

- Fixes #

## Further Comments
