### PR TITLE
Optimization: Eliminate quadratic copying in inbound frame buffer

### DIFF
--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1079,7 +1079,8 @@ class Connection(abc.ABC):
                                       spec.FRAME_HEADER_SIZE -
                                       spec.FRAME_END_SIZE)
         self.known_hosts: str | None = None
-        self._frame_buffer: bytes = b''
+        self._frame_buffer: bytearray = bytearray()
+        self._processing_frame_buffer: bool = False
         self._channels: dict[int, Channel] = {}
 
         self._init_connection_state()
@@ -1126,7 +1127,8 @@ class Connection(abc.ABC):
         self.server_properties = None
 
         # Inbound buffer for decoding frames
-        self._frame_buffer = b''
+        self._frame_buffer = bytearray()
+        self._processing_frame_buffer = False
 
         # Dict of open channels
         self._channels = {}
@@ -2063,14 +2065,36 @@ class Connection(abc.ABC):
 
         :param data_in: The data that is available to read
         """
-        self._frame_buffer += data_in
+        buffer = self._frame_buffer
+        buffer += data_in
 
-        while self._frame_buffer:
-            consumed_count, frame_value = self._read_frame()
-            if not frame_value:
-                return
-            self._trim_frame_buffer(consumed_count)
-            self._process_frame(frame_value)
+        if self._processing_frame_buffer:
+            # Re-entrant call: a frame callback caused more data to be read.
+            # The data was appended above; the outer invocation's loop will
+            # decode it, since trimming mid-loop would corrupt its offset.
+            return
+
+        # Decode frames by walking an offset and trim the buffer once per data
+        # event; trimming (copying) the buffer after every frame is quadratic
+        # when one read contains many frames.
+        self._processing_frame_buffer = True
+        offset = 0
+        try:
+            while offset < len(buffer):
+                consumed_count, frame_value = frame.decode_frame(buffer, offset)
+                if not frame_value:
+                    break
+                offset += consumed_count
+                self.bytes_received += consumed_count
+                self._process_frame(frame_value)
+                if self._frame_buffer is not buffer:
+                    # A frame callback reset the connection state (e.g. stream
+                    # terminated); leftover data is no longer relevant.
+                    return
+        finally:
+            self._processing_frame_buffer = False
+            if offset and self._frame_buffer is buffer:
+                del buffer[:offset]
 
     def _terminate_stream(self, error: Exception | None) -> None:
         """
@@ -2245,11 +2269,6 @@ class Connection(abc.ABC):
         # If the frame has a channel number beyond the base channel, deliver it
         elif frame_value.channel_number > 0:
             self._deliver_frame_to_channel(frame_value)
-
-    def _read_frame(
-            self) -> tuple[int, frame.Frame | frame.ProtocolHeader | None]:
-        """Try and read from the frame buffer and decode a frame."""
-        return frame.decode_frame(self._frame_buffer)
 
     def _remove_callbacks(
             self, channel_number: int,
@@ -2428,16 +2447,6 @@ class Connection(abc.ABC):
         # now would break them.
         self.server_capabilities = self.server_properties.get(
             'capabilities', {})
-
-    def _trim_frame_buffer(self, byte_count: int) -> None:
-        """
-        Trim the leading N bytes off the frame buffer and increment the counter that keeps track of
-        how many bytes have been read/used from the socket.
-
-        :param byte_count: The number of bytes consumed
-        """
-        self._frame_buffer = self._frame_buffer[byte_count:]
-        self.bytes_received += byte_count
 
     def _output_marshaled_frames(self,
                                  marshaled_frames: Sequence[bytes]) -> None:

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -190,19 +190,22 @@ class ProtocolHeader(amqp_object.AMQPObject):
                                      self.revision)
 
 
-def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
+def decode_frame(data_in: bytes | bytearray,
+                 offset: int = 0) -> tuple[int, Frame | ProtocolHeader | None]:
     """
     Receives raw socket data and attempts to turn it into a frame.
 
-    Returns the number of bytes consumed from the stream and the frame.
+    Returns the number of bytes consumed from the stream starting at ``offset`` and the frame.
 
     :param data_in: The raw data stream
+    :param offset: Offset into ``data_in`` at which the frame starts
     :raises: pika.exceptions.InvalidFrameError
     """
     # Look to see if it's a protocol header frame
     try:
-        if data_in[0:4] == b'AMQP':
-            major, minor, revision = struct.unpack_from('BBB', data_in, 5)
+        if data_in[offset:offset + 4] == b'AMQP':
+            major, minor, revision = struct.unpack_from('BBB', data_in,
+                                                        offset + 5)
             return 8, ProtocolHeader(major, minor, revision)
     except (IndexError, struct.error):
         return 0, None
@@ -210,7 +213,7 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
     # Get the Frame Type, Channel Number and Frame Size
     try:
         (frame_type, channel_number,
-         frame_size) = struct.unpack('>BHL', data_in[0:7])
+         frame_size) = struct.unpack_from('>BHL', data_in, offset)
     except struct.error:
         return 0, None
 
@@ -218,15 +221,22 @@ def decode_frame(data_in: bytes) -> tuple[int, Frame | ProtocolHeader | None]:
     frame_end = spec.FRAME_HEADER_SIZE + frame_size + spec.FRAME_END_SIZE
 
     # We don't have all of the frame yet
-    if frame_end > len(data_in):
+    if offset + frame_end > len(data_in):
         return 0, None
 
     # The Frame termination chr is wrong
-    if data_in[frame_end - 1:frame_end] != bytes((spec.FRAME_END,)):
+    if data_in[offset + frame_end - 1] != spec.FRAME_END:
         raise exceptions.InvalidFrameError("Invalid FRAME_END marker")
 
-    # Get the raw frame data
-    frame_data = data_in[spec.FRAME_HEADER_SIZE:frame_end - 1]
+    # Get the raw frame data as immutable bytes. For large payloads copy via
+    # memoryview, which avoids a bytearray input's extra intermediate copy;
+    # for small frames a plain slice is cheaper than memoryview setup.
+    data_start = offset + spec.FRAME_HEADER_SIZE
+    data_end = offset + frame_end - 1
+    if frame_size > 1024:
+        frame_data = bytes(memoryview(data_in)[data_start:data_end])
+    else:
+        frame_data = bytes(data_in[data_start:data_end])
 
     if frame_type == spec.FRAME_METHOD:
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -15,6 +15,14 @@ _MethodT = TypeVar('_MethodT', bound=amqp_object.Method)
 
 _FRAME_END_BYTE = bytes((spec.FRAME_END,))
 
+# Payload size (bytes) above which decode_frame copies the frame body via a
+# memoryview rather than a plain slice. For a bytearray input a plain slice
+# makes an intermediate bytearray before the bytes() copy; a memoryview skips
+# that second allocation, which pays off only once the payload is large. Below
+# this threshold the memoryview setup costs more than the slice it replaces.
+# The crossover was measured empirically; see PR #1653.
+_MEMORYVIEW_COPY_THRESHOLD = 1024
+
 
 class Frame(amqp_object.AMQPObject):
     """
@@ -233,7 +241,7 @@ def decode_frame(data_in: bytes | bytearray,
     # for small frames a plain slice is cheaper than memoryview setup.
     data_start = offset + spec.FRAME_HEADER_SIZE
     data_end = offset + frame_end - 1
-    if frame_size > 1024:
+    if frame_size > _MEMORYVIEW_COPY_THRESHOLD:
         frame_data = bytes(memoryview(data_in)[data_start:data_end])
     else:
         frame_data = bytes(data_in[data_start:data_end])

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -703,6 +703,67 @@ class ConnectionTests(unittest.TestCase):
                 self.assertTrue(
                     self.connection._heartbeat_checker.received.called)
 
+    def test_on_data_available_reentrant_call_defers_to_outer_loop(self):
+        """A frame callback that re-enters `_on_data_available` (e.g. a blocking call that pumps the
+        ioloop) must only append: the outer loop owns the offset and consumes the appended data,
+        since trimming mid-loop would corrupt that offset.
+        """
+        heartbeat = frame.Heartbeat().marshal()
+        processed = []
+        reentered = []
+
+        def process_frame(frame_value):
+            processed.append(frame_value)
+            # Re-enter once, as if a callback pumped the ioloop and more
+            # data arrived while the outer invocation is still running.
+            if not reentered:
+                reentered.append(True)
+                self.assertTrue(self.connection._processing_frame_buffer)
+                self.connection._on_data_available(heartbeat)
+
+        self.connection._frame_buffer = bytearray()
+        self.connection.bytes_received = 0
+        with mock.patch.object(self.connection,
+                               '_process_frame',
+                               side_effect=process_frame):
+            self.connection._on_data_available(heartbeat + heartbeat)
+
+        # Two frames in the initial event plus the one appended re-entrantly,
+        # all decoded by the single outer loop.
+        self.assertEqual(3, len(processed))
+        self.assertEqual(3 * len(heartbeat), self.connection.bytes_received)
+        # Buffer fully consumed and trimmed exactly once, by the outer call.
+        self.assertEqual(bytearray(), self.connection._frame_buffer)
+        self.assertFalse(self.connection._processing_frame_buffer)
+
+    def test_on_data_available_state_reset_mid_loop_drops_stale_data(self):
+        """If a frame callback resets connection state, rebinding `_frame_buffer` (as
+        `_init_connection_state` does on stream termination), the loop stops and the stale tail of
+        the old buffer is neither processed nor trimmed onto the fresh buffer.
+        """
+        heartbeat = frame.Heartbeat().marshal()
+        fresh_buffer = bytearray()
+        processed = []
+
+        def process_frame(frame_value):
+            processed.append(frame_value)
+            # Simulate _init_connection_state binding a brand-new buffer.
+            self.connection._frame_buffer = fresh_buffer
+
+        self.connection._frame_buffer = bytearray()
+        with mock.patch.object(self.connection,
+                               '_process_frame',
+                               side_effect=process_frame):
+            self.connection._on_data_available(heartbeat + heartbeat)
+
+        # Only the first frame is processed; the second is abandoned with the
+        # old buffer when state resets.
+        self.assertEqual(1, len(processed))
+        # The fresh buffer is left untouched: no stale bytes trimmed into it.
+        self.assertIs(fresh_buffer, self.connection._frame_buffer)
+        self.assertEqual(bytearray(), self.connection._frame_buffer)
+        self.assertFalse(self.connection._processing_frame_buffer)
+
     def test_add_on_connection_blocked_callback(self):
         blocked_buffer = []
         self.connection.add_on_connection_blocked_callback(


### PR DESCRIPTION
## Problem

`Connection._frame_buffer` was an immutable `bytes` object with two quadratic behaviors on the hot receive path:

1. **Per-frame trim.** `_on_data_available()` re-sliced the entire remaining buffer after *every* decoded frame (`self._frame_buffer = self._frame_buffer[byte_count:]`). When one data event contains many frames — bursts of small deliveries, publisher confirms — this is O(frames × buffer size) memcpy per event. The native adapters' 4 KiB read cap bounds it, but the Twisted adapter passes framework-sized chunks (typically 64 KiB) straight through, and the cost grows quadratically with read size.
2. **Accumulation.** While waiting for a complete frame, each read did `self._frame_buffer += data_in`, copying the whole buffer every time. A 128 KiB body frame (default `frame_max`) arriving via 4 KiB reads gets copied ~32 times — roughly 16x write amplification on every large-message frame, on all adapters.

## Change

- `_frame_buffer` is now a `bytearray`: appends are amortized O(1), and the consumed prefix is trimmed **once per data event** (`del buffer[:offset]`) instead of after every frame.
- `frame.decode_frame()` accepts an optional `offset` and parses with `struct.unpack_from` instead of slicing, so `_on_data_available()` walks an offset through the buffer. Existing callers are unaffected (`offset` defaults to 0).
- Frame payloads are copied out as immutable `bytes`: via `memoryview` for payloads > 1 KiB (avoids the bytearray double-copy) and plain slicing for small frames (memoryview setup costs more than it saves there — measured both).
- Two edge cases are handled explicitly in `_on_data_available()`: a re-entrant call only appends (the outer loop consumes the data, since trimming mid-loop would corrupt its offset), and a callback that resets connection state mid-loop (e.g. stream termination → `_init_connection_state()`) is detected by buffer identity so stale data is dropped.
- `bytes_received` accounting (used by heartbeat) is unchanged: still incremented per consumed frame.
- `_read_frame()` and `_trim_frame_buffer()` are removed (private, now unused).

## Benchmarks

Two benchmarks, run on `main` vs this branch — 4 interleaved rounds per side, medians reported. All highlighted gains hold in worst-round vs best-round comparisons; rows marked *parity* are within the ±9% run-to-run noise band.

**Frame-processing benchmark** — pre-marshaled `Basic.Deliver` streams fed into a real `Connection` + `Channel` + `ContentFrameAssembler` pipeline (isolates client CPU from broker/network). Read-chunk size models the adapter: 4 KiB = select/blocking/asyncio (`_MAX_RECV_BYTES`), 64 KiB = Twisted, 1 MiB = large coalesced reads.

| msg size | read chunk (adapter) | before | after | speedup |
|---:|---|---:|---:|---:|
| 100 B | 4 KiB (select/blocking/asyncio) | 219k msg/s | 219k msg/s | parity |
| 100 B | 64 KiB (Twisted) | 168k msg/s | 221k msg/s | **1.32x** |
| 100 B | 1 MiB (stress) | 39k msg/s | 221k msg/s | **5.7x** |
| 1 KiB | 64 KiB | 162k msg/s | 211k msg/s | **1.30x** |
| 1 KiB | 1 MiB | 38k msg/s | 211k msg/s | **5.5x** |
| 16 KiB | 64 KiB | 140k msg/s | 170k msg/s | **1.22x** |
| 16 KiB | 1 MiB | 35k msg/s | 172k msg/s | **4.9x** |
| 1 MiB | 4 KiB | 2,500 MiB/s | 5,800 MiB/s | **2.3x** |
| 1 MiB | 64 KiB | 6,800 MiB/s | 8,750 MiB/s | **1.28x** |
| 1 MiB | 1 MiB | 3,200 MiB/s | 7,150 MiB/s | **2.3x** |

Before the fix, throughput *dropped* as reads grew (224k → 172k → 40k msg/s for 100 B messages) — the signature of the quadratic trim. After, it is flat across read sizes. The 1 MiB rows show the accumulation fix.

**Live-broker benchmark** — `BlockingConnection` draining a pre-filled queue from a local RabbitMQ, `auto_ack`, best-of-3 per round.

| scenario | before | after | change |
|---|---:|---:|---:|
| 200 B × 100,000 | 173.8k msg/s | 174.9k msg/s | parity |
| 16 KiB × 20,000 | 54.0k msg/s | 53.9k msg/s | parity |
| 1 MiB × 512 | 972 msg/s (972 MiB/s) | 1,242 msg/s (1,242 MiB/s) | **+28%** |

The blocking adapter's small/medium results are parity as predicted (its 4 KiB read cap already bounded the trim cost); the large-message gain (+28% in every round, ranges never overlapping) comes from the accumulation fix. The Twisted adapter, with no read cap, gets the 64 KiB-column gains above.

## Reproducing

Both benchmarks are standalone scripts (collapsed below). Save them anywhere inside the repo checkout as `utils/bench/bench_e2e.py` and `utils/bench/bench_real_broker.py` (they locate the pika package relative to their own path), then compare branches:

```bash
git switch main
python3 utils/bench/bench_e2e.py before           # no broker needed
python3 -W ignore utils/bench/bench_real_broker.py   # needs RabbitMQ on localhost:5672

git switch <this-branch>
python3 utils/bench/bench_e2e.py after
python3 -W ignore utils/bench/bench_real_broker.py
```

<details>
<summary><code>bench_e2e.py</code> — frame-processing benchmark (no broker required)</summary>

```python
"""End-to-end benchmark of pika's inbound frame processing.

Drives Connection._on_data_available with pre-marshaled Basic.Deliver message
streams through a real Channel + ContentFrameAssembler, simulating each
adapter's read-chunk behavior:
  - 4 KiB reads  : SelectConnection / BlockingConnection / asyncio adapter
  - 64 KiB reads : Twisted adapter (framework-sized chunks)
  - 1 MiB reads  : stress case (large coalesced reads)

Usage: python bench_e2e.py <label>   # writes results_<label>.json
"""
import gc
import json
import os
import statistics
import sys
import time
from unittest import mock

_HERE = os.path.dirname(os.path.abspath(__file__))
sys.path.insert(0, os.path.dirname(os.path.dirname(_HERE)))

import pika.channel as channel_mod
import pika.connection as connection_mod
import pika.frame as frame_mod
import pika.spec as spec
from pika._utils import override


class BenchConnection(connection_mod.Connection):
    """Concrete Connection with no-op adapter hooks."""

    @override
    def _adapter_connect_stream(self):
        pass

    @override
    def _adapter_disconnect_stream(self):
        pass

    @override
    def _adapter_call_later(self, delay, callback):
        return object()

    @override
    def _adapter_remove_timeout(self, timeout_id):
        pass

    @override
    def _adapter_add_callback_threadsafe(self, callback):
        pass

    @override
    def _adapter_emit_data(self, data):
        pass


BODY_MAX = (spec.FRAME_MAX_SIZE - spec.FRAME_HEADER_SIZE -
            spec.FRAME_END_SIZE)
CTAG = 'ctag0'


def build_stream(msg_size, n_messages):
    """Marshal n_messages deliveries of msg_size bytes into one byte stream."""
    props = spec.BasicProperties(delivery_mode=1)
    body = bytes(range(256)) * (msg_size // 256) + b'x' * (msg_size % 256)
    assert len(body) == msg_size
    pieces = []
    for i in range(n_messages):
        method = spec.Basic.Deliver(consumer_tag=CTAG,
                                    delivery_tag=i + 1,
                                    exchange='bench',
                                    routing_key='rk')
        pieces.append(frame_mod.Method(1, method).marshal())
        pieces.append(frame_mod.Header(1, msg_size, props).marshal())
        for start in range(0, msg_size, BODY_MAX):
            pieces.append(
                frame_mod.Body(1, body[start:start + BODY_MAX]).marshal())
    return b''.join(pieces)


def make_connection(counter):
    with mock.patch.object(BenchConnection, '_adapter_connect_stream'):
        conn = BenchConnection(internal_connection_workflow=False)
    conn._set_connection_state(connection_mod.Connection.CONNECTION_OPEN)
    conn._opened = True

    ch = channel_mod.Channel(conn, 1, lambda c: None)
    ch._state = channel_mod.Channel.OPEN

    def on_message(chan, method, properties, body):
        counter[0] += 1
        counter[1] += len(body)

    ch._consumers[CTAG] = on_message
    conn._channels[1] = ch
    return conn


def run_once(stream_chunks, expected_msgs, expected_bytes):
    counter = [0, 0]
    conn = make_connection(counter)
    on_data = conn._on_data_available
    gc.collect()
    gc.disable()
    t0 = time.perf_counter()
    for chunk in stream_chunks:
        on_data(chunk)
    dt = time.perf_counter() - t0
    gc.enable()
    assert counter[0] == expected_msgs, (counter, expected_msgs)
    assert counter[1] == expected_bytes, (counter, expected_bytes)
    return dt


def main():
    label = sys.argv[1] if len(sys.argv) > 1 else 'run'

    # (message size, total payload target)
    sizes = [
        (100, 4 * 2**20),
        (1024, 8 * 2**20),
        (16 * 1024, 16 * 2**20),
        (1 * 2**20, 32 * 2**20),
    ]
    chunk_sizes = [
        ('4KiB (select/asyncio/blocking)', 4096),
        ('64KiB (twisted)', 65536),
        ('1MiB (stress)', 2**20),
    ]
    repeats = 5

    results = []
    for msg_size, total in sizes:
        n_messages = max(1, total // msg_size)
        stream = build_stream(msg_size, n_messages)
        for chunk_label, chunk in chunk_sizes:
            chunks = [
                stream[i:i + chunk] for i in range(0, len(stream), chunk)
            ]
            times = [
                run_once(chunks, n_messages, n_messages * msg_size)
                for _ in range(repeats)
            ]
            best = min(times)
            med = statistics.median(times)
            row = {
                'msg_size': msg_size,
                'n_messages': n_messages,
                'stream_bytes': len(stream),
                'chunk': chunk,
                'chunk_label': chunk_label,
                'best_s': best,
                'median_s': med,
                'msgs_per_s': n_messages / med,
                'mib_per_s': len(stream) / med / 2**20,
            }
            results.append(row)
            print(f"msg={msg_size:>8}B chunk={chunk_label:<32} "
                  f"median={med * 1000:8.1f}ms  "
                  f"{row['msgs_per_s']:>10.0f} msg/s  "
                  f"{row['mib_per_s']:8.1f} MiB/s")

    out = os.path.join(_HERE, f'results_{label}.json')
    with open(out, 'w') as f:
        json.dump(results, f, indent=2)
    print(f'wrote {out}')


if __name__ == '__main__':
    main()
```

</details>

<details>
<summary><code>bench_real_broker.py</code> — live-broker drain benchmark</summary>

```python
"""Real-broker consume throughput: publish N messages, time draining them
with BlockingConnection (4 KiB reads path)."""
import os
import sys
import time

sys.path.insert(
    0,
    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
import pika

SCENARIOS = [
    (200, 100000),         # 200 B x 100k
    (16 * 1024, 20000),    # 16 KiB x 20k
    (1024 * 1024, 512),    # 1 MiB x 512
]
REPEATS = 3

conn = pika.BlockingConnection(pika.ConnectionParameters('localhost'))
ch = conn.channel()
ch.confirm_delivery()

for size, count in SCENARIOS:
    body = b'z' * size
    times = []
    for _ in range(REPEATS):
        q = ch.queue_declare(queue='', exclusive=True).method.queue
        for _ in range(count):
            ch.basic_publish(exchange='', routing_key=str(q), body=body)

        got = 0
        t0 = time.perf_counter()
        for _method, _props, msg in ch.consume(str(q), auto_ack=True):
            got += 1
            if got == count:
                break
        times.append(time.perf_counter() - t0)
        ch.cancel()
        ch.queue_delete(str(q))
    dt = min(times)
    total_mib = size * count / 2**20
    print(f"msg={size:>8}B x{count:<6} drain(best of {REPEATS})={dt:6.2f}s  "
          f"{count / dt:>9.0f} msg/s  {total_mib / dt:8.1f} MiB/s")

conn.close()
```

</details>

## Compatibility notes

- `decode_frame()` keeps full backward compatibility for existing callers (positional `bytes`, `offset` defaults to 0). Two observable differences for anyone calling it directly: consumed-count is relative to `offset`, and payloads are always returned as `bytes` even for `bytearray` input.
- `Connection._frame_buffer` changes type from `bytes` to `bytearray` (private attribute).