### PR TITLE
Build the release dist once and add a TestPyPI test mode

### DIFF
--- a/.ci/smoke_test.py
+++ b/.ci/smoke_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Post-release smoke test for the published pika wheel.
+
+Run against a live broker after installing pika from PyPI to prove the
+distributed package can open a connection, declare a queue, publish a
+message, and read it back. Exits 0 on success, non-zero on any failure.
+
+This lives under .ci/ rather than examples/ or tests/ so it is not picked
+up by pytest, yapf, or ruff globs, and so it exercises the *installed*
+package rather than the source tree.
+
+Usage:
+    python .ci/smoke_test.py [amqp_url]
+
+The broker URL is taken from the first argument, then the
+PIKA_SMOKE_AMQP_URL environment variable, then a localhost default.
+"""
+
+import os
+import sys
+
+import pika
+
+DEFAULT_URL = 'amqp://guest:guest@localhost:5672/%2F'
+QUEUE = 'pika-smoke-test'
+BODY = b'pika smoke test'
+
+
+def main() -> int:
+    url = (sys.argv[1] if len(sys.argv) > 1 else
+           os.environ.get('PIKA_SMOKE_AMQP_URL', DEFAULT_URL))
+    print(f'pika {pika.__version__}: connecting to {url}')
+
+    connection = pika.BlockingConnection(pika.URLParameters(url))
+    try:
+        channel = connection.channel()
+        channel.queue_declare(queue=QUEUE, auto_delete=True)
+        channel.basic_publish(exchange='', routing_key=QUEUE, body=BODY)
+
+        method, _properties, body = channel.basic_get(queue=QUEUE,
+                                                       auto_ack=True)
+        if method is None:
+            print('smoke test FAILED: no message returned by basic_get')
+            return 1
+        if body != BODY:
+            print(f'smoke test FAILED: expected {BODY!r}, got {body!r}')
+            return 1
+    finally:
+        connection.close()
+
+    print('smoke test PASSED')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,22 @@ name: release
 on:
   workflow_dispatch:
     inputs:
+      mode:
+        description: 'What to do'
+        required: true
+        type: choice
+        default: release
+        options:
+          # release:    bump, tag, publish X.Y.Z to PyPI, GitHub Release
+          # prerelease: bump, tag, publish X.Y.Z<tag> to PyPI (pip skips it
+          #             unless --pre or pinned), GitHub Release
+          # test:       publish a throwaway X.Y.Z.dev<run> to TestPyPI; no
+          #             commit, tag, or GitHub Release. Repeatable.
+          # dry-run:    compute the version and build, but publish nothing
+          - release
+          - prerelease
+          - test
+          - dry-run
       bump:
         description: 'Version bump type'
         required: true
@@ -11,21 +27,11 @@ on:
           - patch
           - minor
           - major
-      prerelease:
-        description: 'Mark as pre-release (publishes to TestPyPI)'
-        required: false
-        type: boolean
-        default: false
       prerelease_tag:
-        description: 'Pre-release suffix (e.g. b1, rc1). Required when prerelease is true.'
+        description: 'Pre-release suffix (e.g. b1, rc1). Required when mode is prerelease.'
         required: false
         type: string
         default: ''
-      dry_run:
-        description: 'Compute and bump the version but do not commit, tag, or publish'
-        required: false
-        type: boolean
-        default: false
 
 # Serialize releases so two near-simultaneous dispatches cannot race on the
 # version bump.
@@ -38,7 +44,7 @@ permissions:
 
 jobs:
   release:
-    name: Bump version and tag
+    name: Bump version and build
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -51,6 +57,10 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.14'
+
       - name: Configure git
         run: |
           git config user.name "github-actions[bot]"
@@ -58,20 +68,25 @@ jobs:
 
       - name: Validate inputs
         env:
-          PRERELEASE: ${{ inputs.prerelease }}
+          MODE: ${{ inputs.mode }}
           PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
         run: |
-          if [ "$PRERELEASE" = "true" ] && [ -z "$PRERELEASE_TAG" ]; then
-            echo "::error::prerelease_tag is required when prerelease is true (e.g. b1, rc1)"
+          if [ "$MODE" = "prerelease" ] && [ -z "$PRERELEASE_TAG" ]; then
+            echo "::error::prerelease_tag is required when mode is prerelease (e.g. b1, rc1)"
+            exit 1
+          fi
+          if [ "$MODE" != "prerelease" ] && [ -n "$PRERELEASE_TAG" ]; then
+            echo "::error::prerelease_tag is only valid when mode is prerelease"
             exit 1
           fi
 
       - name: Compute new version
         id: version
         env:
+          MODE: ${{ inputs.mode }}
           BUMP: ${{ inputs.bump }}
-          PRERELEASE: ${{ inputs.prerelease }}
           PRERELEASE_TAG: ${{ inputs.prerelease_tag }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           current=$(sed -nE 's/^version = "([^"]+)".*/\1/p' pyproject.toml)
           echo "current=$current" >> "$GITHUB_OUTPUT"
@@ -85,16 +100,24 @@ jobs:
           esac
 
           new_version="${major}.${minor}.${patch}"
-          if [ "$PRERELEASE" = "true" ]; then
-            if ! echo "$PRERELEASE_TAG" | grep -qE '^[a-zA-Z0-9]+$'; then
-              echo "::error::prerelease_tag must be alphanumeric (e.g. b1, rc1)"
-              exit 1
-            fi
-            new_version="${new_version}${PRERELEASE_TAG}"
-          fi
+          case "$MODE" in
+            prerelease)
+              if ! echo "$PRERELEASE_TAG" | grep -qE '^[a-zA-Z0-9]+$'; then
+                echo "::error::prerelease_tag must be alphanumeric (e.g. b1, rc1)"
+                exit 1
+              fi
+              new_version="${new_version}${PRERELEASE_TAG}"
+              ;;
+            # A throwaway .devN build keyed on the run number: valid PEP 440,
+            # sorts below the real X.Y.Z, and unique per run so TestPyPI's
+            # immutable-version rule never bites on repeated test publishes.
+            test)
+              new_version="${new_version}.dev${RUN_NUMBER}"
+              ;;
+          esac
 
           echo "new=$new_version" >> "$GITHUB_OUTPUT"
-          echo "Bumping $current -> $new_version"
+          echo "Bumping $current -> $new_version (mode: $MODE)"
 
       - name: Update version
         env:
@@ -103,8 +126,26 @@ jobs:
           sed -i "s/^version = \".*\"/version = \"$NEW_VERSION\"/" pyproject.toml
           sed -i "s/^__version__ = ['\"].*['\"]/__version__ = '$NEW_VERSION'/" pika/__init__.py
 
+      # Build once, before mutating main, so a broken build aborts the release
+      # before any commit or tag. Every downstream publish consumes this exact
+      # artifact rather than rebuilding, so the bytes tested are the bytes
+      # shipped. Runs in all modes, including dry-run, so a dry run validates
+      # that the project still builds.
+      - name: Build distribution
+        run: |
+          python -m pip install build twine --upgrade
+          python -m build --sdist --wheel --outdir dist/ .
+          twine check dist/*
+
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
       - name: Commit, tag, and push
-        if: ${{ !inputs.dry_run }}
+        if: ${{ inputs.mode == 'release' || inputs.mode == 'prerelease' }}
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
@@ -114,7 +155,7 @@ jobs:
           git push origin HEAD:${{ github.ref }} --follow-tags
 
       - name: Verify tag exists on remote
-        if: ${{ !inputs.dry_run }}
+        if: ${{ inputs.mode == 'release' || inputs.mode == 'prerelease' }}
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
@@ -122,80 +163,121 @@ jobs:
             || { echo "::error::Tag $NEW_VERSION not found on remote after push"; exit 1; }
 
       - name: Dry-run summary
-        if: ${{ inputs.dry_run }}
+        if: ${{ inputs.mode == 'dry-run' }}
         env:
           NEW_VERSION: ${{ steps.version.outputs.new }}
         run: |
           echo "::notice::Dry run - would release pika $NEW_VERSION (no commit, tag, or publish)"
           git --no-pager diff
 
-  # The PyPI publish jobs MUST live in this top-level workflow: PyPI trusted
-  # publishing matches the OIDC job_workflow_ref claim against the configured
-  # workflow filename and rejects tokens minted inside a reusable workflow.
+  # The publish jobs only download and publish the artifact built by the
+  # release job; they never rebuild, so the bytes tested are the bytes
+  # shipped. Authentication uses the PYPI_API_TOKEN / TEST_PYPI_API_TOKEN
+  # repository secrets rather than trusted publishing, so the API token is
+  # exposed only to the publish jobs, not to the build.
   publish-pypi:
     name: Publish to PyPI
     needs: release
-    if: ${{ !inputs.prerelease && !inputs.dry_run }}
+    if: ${{ inputs.mode == 'release' || inputs.mode == 'prerelease' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     environment:
       name: pypi
       url: https://pypi.org/project/pika/${{ needs.release.outputs.version }}/
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Download distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ needs.release.outputs.version }}
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.14'
-
-      - name: Build
-        run: |
-          python -m pip install build twine --upgrade
-          python -m build --sdist --wheel --outdir dist/ .
-          twine check dist/*
+          name: dist
+          path: dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}
+          # Attestations require trusted publishing; with token auth they
+          # must be disabled explicitly or the action errors.
+          attestations: false
 
   publish-test-pypi:
     name: Publish to TestPyPI
     needs: release
-    if: ${{ inputs.prerelease && !inputs.dry_run }}
+    if: ${{ inputs.mode == 'test' }}
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     environment:
       name: testpypi
       url: https://test.pypi.org/project/pika/${{ needs.release.outputs.version }}/
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Download distribution artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          ref: ${{ needs.release.outputs.version }}
-
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
-        with:
-          python-version: '3.14'
-
-      - name: Build
-        run: |
-          python -m pip install build twine --upgrade
-          python -m build --sdist --wheel --outdir dist/ .
-          twine check dist/*
+          name: dist
+          path: dist/
 
       - name: Publish to TestPyPI
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          # Attestations require trusted publishing; with token auth they
+          # must be disabled explicitly or the action errors.
+          attestations: false
+
+  smoke-test:
+    name: Smoke-test the published wheel
+    needs: [release, publish-pypi, publish-test-pypi]
+    # Run for whichever publish actually happened. This is skipped for
+    # dry-run (neither publish ran) and fires for the one publish job whose
+    # index received the wheel.
+    if: >-
+      always() && needs.release.result == 'success' &&
+      (needs.publish-pypi.result == 'success' ||
+       needs.publish-test-pypi.result == 'success')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.14'
+
+      - name: Start RabbitMQ
+        run: ./.ci/linux/gha-setup.sh
+
+      - name: Install pika and smoke-test
+        env:
+          NEW_VERSION: ${{ needs.release.outputs.version }}
+          # The TestPyPI index when the test publish ran, else empty (real
+          # PyPI). pika has no runtime dependencies, so installing from the
+          # TestPyPI index needs no fallback index for dependency resolution.
+          INDEX_URL: ${{ needs.publish-test-pypi.result == 'success' && 'https://test.pypi.org/simple/' || '' }}
+        run: |
+          python -m venv smoke-venv
+          pip_args=()
+          if [ -n "$INDEX_URL" ]
+          then
+            pip_args+=(--index-url "$INDEX_URL")
+          fi
+          # PyPI/TestPyPI are eventually consistent: a fresh install can 404
+          # for a minute or two right after publish. Retry until the
+          # just-published version installs, up to ~5 minutes.
+          attempt=0
+          until smoke-venv/bin/pip install "${pip_args[@]}" "pika==$NEW_VERSION"
+          do
+            attempt=$((attempt + 1))
+            if (( attempt >= 20 ))
+            then
+              echo "::error::pika $NEW_VERSION not installable after $attempt attempts"
+              exit 1
+            fi
+            echo "pika $NEW_VERSION not available yet; retrying in 15s (attempt $attempt)"
+            sleep 15
+          done
+          smoke-venv/bin/python .ci/smoke_test.py
 
   github-release:
     name: Create GitHub Release
-    needs: [release, publish-pypi, publish-test-pypi]
-    if: always() && (needs.publish-pypi.result == 'success' || needs.publish-test-pypi.result == 'success')
+    needs: [release, publish-pypi]
+    if: ${{ inputs.mode == 'release' || inputs.mode == 'prerelease' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -209,7 +291,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release.outputs.version }}
-          IS_PRERELEASE: ${{ inputs.prerelease }}
+          IS_PRERELEASE: ${{ inputs.mode == 'prerelease' }}
         run: |
           PRERELEASE_FLAG=""
           if [ "$IS_PRERELEASE" = "true" ]; then

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 
 Trigger the release workflow from GitHub Actions UI or CLI:
 
+The workflow takes a `mode` (default `release`) and a `bump`:
+
 ```bash
 # Patch release (1.4.0 -> 1.4.1)
 gh workflow run release.yaml -f bump=patch
@@ -14,24 +16,42 @@ gh workflow run release.yaml -f bump=minor
 # Major release (1.4.0 -> 2.0.0)
 gh workflow run release.yaml -f bump=major
 
-# Pre-release to TestPyPI (1.4.0 -> 1.5.0b1)
-gh workflow run release.yaml -f bump=minor -f prerelease=true -f prerelease_tag=b1
+# Pre-release to PyPI (1.4.0 -> 1.5.0b1); pip skips it unless --pre or pinned
+gh workflow run release.yaml -f mode=prerelease -f bump=minor -f prerelease_tag=b1
 
-# Dry run (compute and bump the version, but do not commit, tag, or publish)
-gh workflow run release.yaml -f bump=patch -f dry_run=true
+# Test release to TestPyPI (1.4.0 -> 1.5.0.devN); throwaway, repeatable
+gh workflow run release.yaml -f mode=test -f bump=minor
+
+# Dry run (compute the version and build, but publish nothing)
+gh workflow run release.yaml -f mode=dry-run -f bump=patch
 ```
+
+### Modes
+
+| `mode`       | Version         | Commit + tag | Publishes to | GitHub Release |
+|--------------|-----------------|--------------|--------------|----------------|
+| `release`    | `X.Y.Z`         | yes          | PyPI         | yes            |
+| `prerelease` | `X.Y.Z<tag>`    | yes          | PyPI         | yes (marked)   |
+| `test`       | `X.Y.Z.dev<run>`| no           | TestPyPI     | no             |
+| `dry-run`    | `X.Y.Z`         | no           | nothing      | no             |
+
+A pre-release goes to real PyPI: per PEP 440, `pip install pika` skips it
+unless the user passes `--pre` or pins the exact version. A test release
+uses a `.devN` version keyed on the workflow run number, so it is unique per
+run and never collides with TestPyPI's immutable-version rule.
 
 ### What happens
 
 The entire flow lives in a single `release.yaml` workflow:
 
-1. The `release` job bumps the version in `pyproject.toml` and `pika/__init__.py`, then commits, tags, and pushes
-2. The `publish-pypi` / `publish-test-pypi` job builds the distribution and publishes via PyPI trusted publishing (OIDC, no tokens). Regular versions go to PyPI; pre-releases (`prerelease=true`) go to TestPyPI
-3. The `github-release` job creates a GitHub Release with notes auto-generated from merged PRs (`--generate-notes`, grouped per `.github/release.yml`)
+1. The `release` job bumps the version in `pyproject.toml` and `pika/__init__.py`, builds the distribution once (`twine check` included), and uploads it as an artifact. For `release`/`prerelease` it also commits, tags, and pushes. The build runs before any commit, so a broken build aborts the release before `main` is mutated
+2. The `publish-pypi` / `publish-test-pypi` job downloads that artifact and publishes it, authenticating with the `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` repository secrets. Downstream jobs never rebuild, so the bytes tested are the bytes shipped
+3. The `smoke-test` job installs the just-published wheel from the matching index and runs `.ci/smoke_test.py` against a live broker (see Post-release verification)
+4. The `github-release` job creates a GitHub Release with notes auto-generated from merged PRs (`--generate-notes`, grouped per `.github/release.yml`)
 
-A `dry_run=true` dispatch stops after computing the version and prints the diff — nothing is committed, tagged, or published.
+A `dry-run` dispatch computes the version and builds the artifact, then stops - nothing is committed, tagged, or published.
 
-> The publish jobs deliberately live in this top-level workflow rather than a reusable one: PyPI trusted publishing matches the OIDC `job_workflow_ref` claim against the configured workflow filename and rejects tokens minted inside a reusable workflow.
+> Building in the `release` job and publishing from separate jobs is the pattern the `gh-action-pypi-publish` maintainers recommend: the build runs without access to the publishing secret, which is exposed only to the `publish-pypi` / `publish-test-pypi` jobs.
 
 ### PR label categories
 
@@ -44,17 +64,20 @@ Release notes are grouped by PR labels (configured in `.github/release.yml`):
 | `documentation`, `docs`  | Documentation            |
 | everything else          | Other changes            |
 
-### Setup: trusted publishing
+### Setup: publishing credentials
 
-PyPI trusted publishing must be configured for this to work. On PyPI:
+The publish jobs authenticate with API tokens stored as repository secrets:
 
-1. Go to the pika project settings on pypi.org
-2. Add a new "trusted publisher" for GitHub Actions
-3. Set repository to `pika/pika`, workflow to `release.yaml`, environment to `pypi`
-4. Repeat on test.pypi.org with environment `testpypi`
+- `PYPI_API_TOKEN` - an upload token for the pika project on pypi.org
+- `TEST_PYPI_API_TOKEN` - an upload token for the pika project on test.pypi.org
 
-Also create the `pypi` and `testpypi` GitHub environments (repo Settings →
-Environments) so the publish jobs can request the OIDC token.
+Create each token under the account's settings on the respective index
+(scoped to the pika project), then add it under repo Settings → Secrets and
+variables → Actions.
+
+The publish jobs also reference the `pypi` and `testpypi` GitHub environments
+(repo Settings → Environments). They can be empty; add required reviewers
+there if you want to gate publishing behind an approval.
 
 ### Setup: branch protection
 
@@ -64,15 +87,18 @@ bypass the relevant rules (or the push step will fail).
 
 ## Post-release verification
 
-After the release is published:
+The `smoke-test` job in `release.yaml` runs automatically after
+`publish-pypi` for every release: it starts RabbitMQ, waits for
+the just-released version to become installable from PyPI, installs it into
+a clean virtualenv, and runs `.ci/smoke_test.py` (connect, declare, publish,
+get). A failing smoke test fails the release run, so a broken wheel is caught
+loudly rather than shipped silently.
 
-1. Check PyPI: `https://pypi.org/project/pika/<version>/`
-2. Test the release:
+To reproduce the smoke test locally:
 
-    ```bash
-    docker run --pull always --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:4-management-alpine
-    cd examples
-    python -m venv venv && source ./venv/bin/activate
-    pip install pika==<version>
-    python ./asynchronous_publisher_example.py
-    ```
+```bash
+docker run --pull always --detach --rm --publish 5672:5672 --publish 15672:15672 rabbitmq:4-management-alpine
+python -m venv venv && source ./venv/bin/activate
+pip install pika==<version>
+python .ci/smoke_test.py
+```


### PR DESCRIPTION
## Summary

Automates the release process end to end and removes a class of release bug. The publish step previously rebuilt the distribution in each publish job, so the bytes tested were not guaranteed to be the bytes shipped, and there was no way to rehearse a release without mutating `main`. Post-release verification was also fully manual (check PyPI, then hand-run an example against a local broker).

## Changes

### Build once, publish the same bytes

- The `release` job builds the distribution once, before any commit, and hands it to the publish jobs as an artifact. A broken build now aborts before `main` is touched, and every publisher installs the identical bytes. This is the separation `gh-action-pypi-publish` recommends: the build runs without the publishing secret, which is exposed only to the publish jobs.

### A single `mode` input with a new test mode

- Replace the `prerelease` / `dry_run` boolean inputs with one `mode` choice (`release`, `prerelease`, `test`, `dry-run`) so illegal combinations are unrepresentable.
- Add `mode=test`: publishes a throwaway `X.Y.Z.dev<run_number>` to TestPyPI without committing, tagging, or creating a GitHub Release. The run-number-keyed `.devN` version is unique per run, so TestPyPI's immutable-version rule never blocks a repeat, making releases fully rehearsable.
- Pre-releases (e.g. `1.5.0b1`) publish to real PyPI, not TestPyPI. Per PEP 440, `pip install pika` skips them unless the user passes `--pre` or pins the exact version.

### Automated post-release smoke test

- Add a `smoke-test` job that installs the just-published wheel from the matching index (TestPyPI for `test`, PyPI otherwise), retrying to absorb index eventual-consistency, then runs `.ci/smoke_test.py` against a live broker started via the existing `.ci/linux/gha-setup.sh`. A broken wheel now fails the release run instead of shipping silently. Installing from TestPyPI needs no fallback index because pika has no runtime dependencies.
- Add `.ci/smoke_test.py`: a `BlockingConnection` round-trip (connect, declare, publish, get) that exercises the installed package rather than the source tree. It lives under `.ci/` so pytest, yapf, and ruff globs do not pick it up.

### Docs and housekeeping

- Publish with the `PYPI_API_TOKEN` / `TEST_PYPI_API_TOKEN` repository secrets rather than trusted publishing. PEP 740 attestations are disabled because they require OIDC.
- Rewrite RELEASE.md: document the four modes, the build-once/artifact hand-off, the automatic smoke test, and the publishing-credentials setup. The old post-release recipe pointed at `asynchronous_publisher_example.py`, which never self-terminates.
- Pin `actions/upload-artifact` and `actions/download-artifact` to their release SHAs.
- Add a `CLAUDE.md` symlink to `AGENTS.md` so the project guidelines load under both names.

## What is still manual (and why)

- Generating the PyPI / TestPyPI API tokens and storing them as repository secrets: external web consoles.
- One-time branch-protection bypass for `github-actions[bot]`: a security control better left to a documented click-through than a script.

## Testing

- `actionlint` passes on `release.yaml`; `ruff` passes on `.ci/smoke_test.py` and the script parses under `ast`.
- Each of the four modes was traced through the job graph to confirm the correct jobs run and the smoke test targets the right index.
- The smoke job reuses the RabbitMQ provisioning already proven by the test matrix. The first real dispatch exercises the full path end to end; a `mode=test` dispatch can rehearse it against TestPyPI beforehand.
