### PR TITLE
Fix ruff 0.16.0 `RUF036` and `ISC004` violations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,17 @@ examples/               # usage examples
   is in `pyproject.toml` under `[tool.docformatter]`. Run
   `hatch run docfmt-check`.
 - **Linter:** [ruff](https://docs.astral.sh/ruff/). Configuration is in
-  `pyproject.toml` under `[tool.ruff]`. Run `hatch run lint`.
+  `pyproject.toml` under `[tool.ruff]`. `hatch run lint` applies fixes
+  (`ruff check --fix`); `hatch run lint-check` only reports (this is what
+  CI runs). Verify with `lint-check`, not `lint`, so you read the same
+  result CI will.
+- **Do not pin the ruff version.** Ruff is intentionally left unpinned so
+  CI always installs the latest release. When ruff stabilizes a new rule,
+  CI surfaces the violations immediately and we fix them, keeping the
+  codebase current with ruff's evolving idioms. A CI lint failure after a
+  ruff release is this mechanism working as intended, not a regression to
+  suppress. Fix the flagged code; never add a version pin to make the
+  failure go away.
 - **Type checking:** [mypy](https://mypy-lang.org/). Configuration is in
   `mypy.ini`. Run `hatch run typecheck`.
 - Use single quotes for strings unless the string contains a single quote.

--- a/pika/adapters/asyncio_connection.py
+++ b/pika/adapters/asyncio_connection.py
@@ -23,14 +23,14 @@ class AsyncioConnection(base_connection.BaseConnection):
     def __init__(
             self,
             parameters: connection.Parameters | None = None,
-            on_open_callback: None |
-        (Callable[[connection.Connection], None]) = None,
-            on_open_error_callback: None |
-        (Callable[[connection.Connection, BaseException], None]) = None,
-            on_close_callback: None |
-        (Callable[[connection.Connection, BaseException], None]) = None,
-            custom_ioloop: None |
-        (asyncio.AbstractEventLoop | nbio_interface.AbstractIOServices) = None,
+            on_open_callback: Callable[[connection.Connection], None] |
+        None = None,
+            on_open_error_callback: Callable[
+                [connection.Connection, BaseException], None] | None = None,
+            on_close_callback: Callable[[connection.Connection, BaseException],
+                                        None] | None = None,
+            custom_ioloop: asyncio.AbstractEventLoop |
+        nbio_interface.AbstractIOServices | None = None,
             internal_connection_workflow: bool = True) -> None:
         """
         Create a new instance of the AsyncioConnection class, connecting to RabbitMQ automatically.
@@ -78,8 +78,8 @@ class AsyncioConnection(base_connection.BaseConnection):
         on_done: Callable[[(connection.Connection |
                             connection_workflow.AMQPConnectorException)], None],
         custom_ioloop: asyncio.AbstractEventLoop | None = None,
-        workflow: None |
-        (connection_workflow.AbstractAMQPConnectionWorkflow) = None
+        workflow: connection_workflow.AbstractAMQPConnectionWorkflow |
+        None = None
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """
         :param connection_configs: One or more connection parameter objects

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -27,16 +27,16 @@ class BaseConnection(connection.Connection):
     This class abstracts I/O loop and transport services from pika core.
     """
 
-    def __init__(self,
-                 parameters: connection.Parameters | None,
-                 on_open_callback: None |
-                 (Callable[[connection.Connection], None]),
-                 on_open_error_callback: None |
-                 (Callable[[connection.Connection, BaseException], None]),
-                 on_close_callback: None |
-                 (Callable[[connection.Connection, BaseException], None]),
-                 nbio: nbio_interface.AbstractIOServices,
-                 internal_connection_workflow: bool = True) -> None:
+    def __init__(
+            self,
+            parameters: connection.Parameters | None,
+            on_open_callback: Callable[[connection.Connection], None] | None,
+            on_open_error_callback: Callable[
+                [connection.Connection, BaseException], None] | None,
+            on_close_callback: Callable[[connection.Connection, BaseException],
+                                        None] | None,
+            nbio: nbio_interface.AbstractIOServices,
+            internal_connection_workflow: bool = True) -> None:
         """
         Create a new instance of the Connection object.
 
@@ -65,8 +65,7 @@ class BaseConnection(connection.Connection):
 
         self._nbio: nbio_interface.AbstractIOServices = nbio
 
-        self._connection_workflow: None | (
-            connection_workflow.AbstractAMQPConnectionWorkflow) = None
+        self._connection_workflow: connection_workflow.AbstractAMQPConnectionWorkflow | None = None
         self._transport: nbio_interface.AbstractStreamTransport | None = None
 
         self._got_eof: bool = False  # transport indicated EOF (connection reset)
@@ -105,8 +104,8 @@ class BaseConnection(connection.Connection):
         on_done: Callable[[(connection.Connection |
                             connection_workflow.AMQPConnectorException)], None],
         custom_ioloop: Any | None = None,
-        workflow: None |
-        (connection_workflow.AbstractAMQPConnectionWorkflow) = None
+        workflow: connection_workflow.AbstractAMQPConnectionWorkflow |
+        None = None
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """
         Asynchronously create a connection to an AMQP broker using the given configurations.

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -346,8 +346,8 @@ class BlockingConnection:
 
     def __init__(
             self,
-            parameters: None | (pika.connection.Parameters |
-                                Sequence[pika.connection.Parameters]) = None,
+            parameters: pika.connection.Parameters |
+        Sequence[pika.connection.Parameters] | None = None,
             _impl_class: select_connection.SelectConnection | None = None
     ) -> None:
         """
@@ -445,8 +445,8 @@ class BlockingConnection:
 
     def _create_connection(
         self,
-        configs: None | (pika.connection.Parameters |
-                         Sequence[pika.connection.Parameters]) = None,
+        configs: pika.connection.Parameters |
+        Sequence[pika.connection.Parameters] | None = None,
         impl_class: select_connection.SelectConnection | None = None
     ) -> select_connection.SelectConnection:
         """
@@ -1154,12 +1154,11 @@ class _ConsumerInfo:
         self,
         consumer_tag: str,
         auto_ack: bool,
-        on_message_callback: None | (Callable[[
+        on_message_callback: Callable[[
             BlockingChannel, pika.spec.Basic.Deliver, pika.spec.
             BasicProperties, bytes
-        ], None]) = None,
-        alternate_event_sink: None |
-        (Callable[[_ChannelPendingEvt], None]) = None
+        ], None] | None = None,
+        alternate_event_sink: Callable[[_ChannelPendingEvt], None] | None = None
     ) -> None:
         """
         NOTE: exactly one of callback/alternate_event_sink musts be non-None.
@@ -1289,8 +1288,7 @@ class BlockingChannel:
 
         # Queue consumer generator generator info of type
         # _QueueConsumerGeneratorInfo created by BlockingChannel.consume
-        self._queue_consumer_generator: None | (
-            _QueueConsumerGeneratorInfo) = None
+        self._queue_consumer_generator: _QueueConsumerGeneratorInfo | None = None
 
         # Whether RabbitMQ delivery confirmation has been enabled
         self._delivery_confirmation = False
@@ -1731,12 +1729,11 @@ class BlockingChannel:
         exclusive: bool,
         consumer_tag: str | None,
         arguments: dict[str, Any] | None = None,
-        on_message_callback: None | (Callable[[
+        on_message_callback: Callable[[
             BlockingChannel, pika.spec.Basic.Deliver, pika.spec.
             BasicProperties, bytes
-        ], None]) = None,
-        alternate_event_sink: None |
-        (Callable[[_ChannelPendingEvt], None]) = None
+        ], None] | None = None,
+        alternate_event_sink: Callable[[_ChannelPendingEvt], None] | None = None
     ) -> str:
         """
         The low-level implementation used by `basic_consume` and `consume`.
@@ -1765,9 +1762,9 @@ class BlockingChannel:
             consumer_tag is already present.
         """
         if (on_message_callback is None) == (alternate_event_sink is None):
-            raise ValueError(
-                ('exactly one of on_message_callback/alternate_event_sink must '
-                 'be non-None', on_message_callback, alternate_event_sink))
+            raise ValueError(((
+                'exactly one of on_message_callback/alternate_event_sink must '
+                'be non-None'), on_message_callback, alternate_event_sink))
 
         if not consumer_tag:
             # Need a consumer tag to register consumer info before sending

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -42,19 +42,18 @@ class GeventConnection(BaseConnection):
     An async selector-based connection which integrates with Gevent.
     """
 
-    def __init__(self,
-                 parameters: connection.Parameters | None = None,
-                 on_open_callback: None |
-                 (Callable[[connection.Connection], None]) = None,
-                 on_open_error_callback: None |
-                 (Callable[[connection.Connection, BaseException],
-                           None]) = None,
-                 on_close_callback: None |
-                 (Callable[[connection.Connection, BaseException],
-                           None]) = None,
-                 custom_ioloop: None |
-                 (gevent._interfaces.ILoop | AbstractIOServices) = None,
-                 internal_connection_workflow: bool = True) -> None:
+    def __init__(
+            self,
+            parameters: connection.Parameters | None = None,
+            on_open_callback: Callable[[connection.Connection], None] |
+        None = None,
+            on_open_error_callback: Callable[
+                [connection.Connection, BaseException], None] | None = None,
+            on_close_callback: Callable[[connection.Connection, BaseException],
+                                        None] | None = None,
+            custom_ioloop: gevent._interfaces.ILoop | AbstractIOServices |
+        None = None,
+            internal_connection_workflow: bool = True) -> None:
         """
         Create a new GeventConnection instance and connect to RabbitMQ on Gevent's event-loop.
 
@@ -112,8 +111,8 @@ class GeventConnection(BaseConnection):
         on_done: Callable[[(connection.Connection |
                             connection_workflow.AMQPConnectorException)], None],
         custom_ioloop: gevent._interfaces.ILoop | None = None,
-        workflow: None |
-        (connection_workflow.AbstractAMQPConnectionWorkflow) = None
+        workflow: connection_workflow.AbstractAMQPConnectionWorkflow |
+        None = None
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """
         :param connection_configs: One or more connection parameter objects

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -88,19 +88,18 @@ class SelectConnection(BaseConnection):
     the given platform.
     """
 
-    def __init__(self,
-                 parameters: connection.Parameters | None = None,
-                 on_open_callback: None |
-                 (Callable[[connection.Connection], None]) = None,
-                 on_open_error_callback: None |
-                 (Callable[[connection.Connection, BaseException],
-                           None]) = None,
-                 on_close_callback: None |
-                 (Callable[[connection.Connection, BaseException],
-                           None]) = None,
-                 custom_ioloop: None |
-                 (nbio_interface.AbstractIOServices | IOLoop) = None,
-                 internal_connection_workflow: bool = True) -> None:
+    def __init__(
+            self,
+            parameters: connection.Parameters | None = None,
+            on_open_callback: Callable[[connection.Connection], None] |
+        None = None,
+            on_open_error_callback: Callable[
+                [connection.Connection, BaseException], None] | None = None,
+            on_close_callback: Callable[[connection.Connection, BaseException],
+                                        None] | None = None,
+            custom_ioloop: nbio_interface.AbstractIOServices | IOLoop |
+        None = None,
+            internal_connection_workflow: bool = True) -> None:
         """
         Create a new instance of the Connection object.
 
@@ -144,8 +143,8 @@ class SelectConnection(BaseConnection):
         on_done: Callable[[(connection.Connection |
                             connection_workflow.AMQPConnectorException)], None],
         custom_ioloop: Any | None = None,
-        workflow: None |
-        (connection_workflow.AbstractAMQPConnectionWorkflow) = None
+        workflow: connection_workflow.AbstractAMQPConnectionWorkflow |
+        None = None
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """
         :param connection_configs: One or more connection parameter objects

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -22,19 +22,18 @@ LOGGER = logging.getLogger(__name__)
 class TornadoConnection(base_connection.BaseConnection):
     """The TornadoConnection runs on the Tornado IOLoop."""
 
-    def __init__(self,
-                 parameters: connection.Parameters | None = None,
-                 on_open_callback: None |
-                 (Callable[[connection.Connection], None]) = None,
-                 on_open_error_callback: None |
-                 (Callable[[connection.Connection, BaseException],
-                           None]) = None,
-                 on_close_callback: None |
-                 (Callable[[connection.Connection, BaseException],
-                           None]) = None,
-                 custom_ioloop: None |
-                 (ioloop.IOLoop | nbio_interface.AbstractIOServices) = None,
-                 internal_connection_workflow: bool = True) -> None:
+    def __init__(
+            self,
+            parameters: connection.Parameters | None = None,
+            on_open_callback: Callable[[connection.Connection], None] |
+        None = None,
+            on_open_error_callback: Callable[
+                [connection.Connection, BaseException], None] | None = None,
+            on_close_callback: Callable[[connection.Connection, BaseException],
+                                        None] | None = None,
+            custom_ioloop: ioloop.IOLoop | nbio_interface.AbstractIOServices |
+        None = None,
+            internal_connection_workflow: bool = True) -> None:
         """
         Create a new instance of the TornadoConnection class, connecting to RabbitMQ automatically.
 
@@ -88,8 +87,8 @@ class TornadoConnection(base_connection.BaseConnection):
         on_done: Callable[[(connection.Connection |
                             connection_workflow.AMQPConnectorException)], None],
         custom_ioloop: Any | None = None,
-        workflow: None |
-        (connection_workflow.AbstractAMQPConnectionWorkflow) = None
+        workflow: connection_workflow.AbstractAMQPConnectionWorkflow |
+        None = None
     ) -> connection_workflow.AbstractAMQPConnectionWorkflow:
         """
         :param connection_configs: One or more connection parameter objects

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -55,8 +55,8 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         super().__init__(size, backlog)
 
     @override
-    def put(self, obj: Any) -> None | (  # type: ignore[override]
-            defer.Deferred[Any]):
+    def put(  # type: ignore[override]
+            self, obj: Any) -> defer.Deferred[Any] | None:
         """
         Like the original :meth:`DeferredQueue.put` method, but returns an errback if the queue is
         closed.
@@ -1064,12 +1064,12 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
 
     def __init__(self,
                  parameters: pika.connection.Parameters | None,
-                 on_open_callback: None |
-                 (Callable[[pika.connection.Connection], Any]),
-                 on_open_error_callback: None |
-                 (Callable[[pika.connection.Connection, Exception], Any]),
-                 on_close_callback: None |
-                 (Callable[[pika.connection.Connection, Exception], Any]),
+                 on_open_callback: Callable[[pika.connection.Connection], Any] |
+                 None,
+                 on_open_error_callback: Callable[
+                     [pika.connection.Connection, Exception], Any] | None,
+                 on_close_callback: Callable[
+                     [pika.connection.Connection, Exception], Any] | None,
                  custom_reactor: Any = None) -> None:
         super().__init__(parameters=parameters,
                          on_open_callback=on_open_callback,
@@ -1078,9 +1078,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
                          internal_connection_workflow=False)
 
         self._reactor = custom_reactor or reactor
-        self._transport: None | (
-            twisted.internet.interfaces.ITransport
-        ) = None  # to be provided by `connection_made()`
+        self._transport: twisted.internet.interfaces.ITransport | None = None  # to be provided by `connection_made()`
 
     @override
     def _adapter_call_later(self, delay: float,

--- a/pika/adapters/utils/connection_workflow.py
+++ b/pika/adapters/utils/connection_workflow.py
@@ -156,11 +156,9 @@ class AMQPConnector:
         self._on_done: Callable[[pika.connection.Connection | BaseException],
                                 None] | None = None
         # TCP connection timeout
-        self._tcp_timeout_ref: None | (
-            nbio_interface.AbstractTimerReference) = None
+        self._tcp_timeout_ref: nbio_interface.AbstractTimerReference | None = None
         # Overall TCP/[SSL]/AMQP timeout
-        self._stack_timeout_ref: None | (
-            nbio_interface.AbstractTimerReference) = None
+        self._stack_timeout_ref: nbio_interface.AbstractTimerReference | None = None
         # Current task
         self._task_ref: nbio_interface.AbstractIOReference | None = None
         self._sock: socket.socket | None = None
@@ -666,10 +664,10 @@ class AMQPConnectionWorkflow(AbstractAMQPConnectionWorkflow):
 
         self._connector: AMQPConnector | None = None
 
-        self._task_ref: None | (
+        self._task_ref: (
             nbio_interface.AbstractTimerReference |
-            nbio_interface.AbstractIOReference
-        ) = None  # current cancelable asynchronous task or timer
+            nbio_interface.AbstractIOReference |
+            None) = None  # current cancelable asynchronous task or timer
         self._addrinfo_iter: Iterator[ADDRESS_INFO] | None = None
 
         # Exceptions from all failed connection attempts in this workflow

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -283,12 +283,12 @@ class _AsyncSocketConnector:
         _LOGGER.debug('_AsyncSocketConnector._report_completion(%r); %s',
                       result, self._sock)
 
-        assert isinstance(result, (BaseException, type(None))), (
+        assert isinstance(result, (BaseException, type(None))), ((
             '_AsyncSocketConnector._report_completion() expected exception or '
-            'None as result.', result)
-        assert self._state == self._STATE_ACTIVE, (
+            'None as result.'), result)
+        assert self._state == self._STATE_ACTIVE, ((
             '_AsyncSocketConnector._report_completion() expected '
-            '_STATE_NOT_STARTED', self._state)
+            '_STATE_NOT_STARTED'), self._state)
 
         self._state = self._STATE_COMPLETED
         self._cleanup()
@@ -422,16 +422,15 @@ class _AsyncStreamConnector:
 
         self._nbio: (nbio_interface.AbstractFileDescriptorIOServices |
                      None) = nbio
-        self._protocol_factory: None | (
-            Callable[[],
-                     nbio_interface.AbstractStreamProtocol]) = protocol_factory
+        self._protocol_factory: Callable[
+            [], nbio_interface.AbstractStreamProtocol] | None = protocol_factory
         self._sock: socket.socket | None = sock
         self._ssl_context: ssl.SSLContext | None = ssl_context
         self._server_hostname: str | None = server_hostname
-        self._on_done: None | (Callable[[(
+        self._on_done: Callable[[
             tuple[nbio_interface.AbstractStreamTransport,
-                  nbio_interface.AbstractStreamProtocol] | BaseException)],
-                                        None]) = on_done
+                  nbio_interface.AbstractStreamProtocol] | BaseException
+        ], None] | None = on_done
 
         self._state = self._STATE_NOT_STARTED
         self._watching_socket = False
@@ -479,9 +478,9 @@ class _AsyncStreamConnector:
         """Kick off the workflow."""
         _LOGGER.debug('_AsyncStreamConnector.start(); %s', self._sock)
 
-        assert self._state == self._STATE_NOT_STARTED, (
+        assert self._state == self._STATE_NOT_STARTED, ((
             '_AsyncStreamConnector.start() expected '
-            '_STATE_NOT_STARTED', self._state)
+            '_STATE_NOT_STARTED'), self._state)
 
         self._state = self._STATE_ACTIVE
 
@@ -512,9 +511,9 @@ class _AsyncStreamConnector:
 
     @_log_exceptions
     def _report_completion(
-        self, result: None |
-        (BaseException | tuple[nbio_interface.AbstractStreamTransport,
-                               nbio_interface.AbstractStreamProtocol])
+        self, result: BaseException |
+        tuple[nbio_interface.AbstractStreamTransport,
+              nbio_interface.AbstractStreamProtocol] | None
     ) -> None:
         """
         Advance to COMPLETED state, cancel async operation(s), and invoke user's completion
@@ -526,12 +525,12 @@ class _AsyncStreamConnector:
         _LOGGER.debug('_AsyncStreamConnector._report_completion(%r); %s',
                       result, self._sock)
 
-        assert isinstance(result, (BaseException, tuple)), (
+        assert isinstance(result, (BaseException, tuple)), ((
             '_AsyncStreamConnector._report_completion() expected exception or '
-            'tuple as result.', result, self._state)
-        assert self._state == self._STATE_ACTIVE, (
+            'tuple as result.'), result, self._state)
+        assert self._state == self._STATE_ACTIVE, ((
             '_AsyncStreamConnector._report_completion() expected '
-            '_STATE_ACTIVE', self._state)
+            '_STATE_ACTIVE'), self._state)
 
         self._state = self._STATE_COMPLETED
 
@@ -943,9 +942,9 @@ class _AsyncTransportBase(AbstractStreamTransport):
             'asynchronous transport shutdown: state=%s; error=%r; %s',
             self._state, error, self._sock)
 
-        assert self._state != self._STATE_COMPLETED, (
+        assert self._state != self._STATE_COMPLETED, ((
             '_AsyncTransportBase._initate_abort() expected '
-            'non-_STATE_COMPLETED', self._state)
+            'non-_STATE_COMPLETED'), self._state)
 
         if self._state == self._STATE_COMPLETED:
             return
@@ -969,9 +968,9 @@ class _AsyncTransportBase(AbstractStreamTransport):
             # Connection failed
 
             if self._state != self._STATE_ACTIVE:
-                assert self._state == self._STATE_ABORTED_BY_USER, (
+                assert self._state == self._STATE_ABORTED_BY_USER, ((
                     '_AsyncTransportBase._initate_abort() expected '
-                    '_STATE_ABORTED_BY_USER', self._state)
+                    '_STATE_ABORTED_BY_USER'), self._state)
                 return
 
             self._state = self._STATE_FAILED
@@ -1001,9 +1000,9 @@ class _AsyncTransportBase(AbstractStreamTransport):
 
         if error is not None and self._state != self._STATE_FAILED:
             # Priority is given to user-initiated abort notification
-            assert self._state == self._STATE_ABORTED_BY_USER, (
+            assert self._state == self._STATE_ABORTED_BY_USER, ((
                 '_AsyncTransportBase._connection_lost_notify_async() '
-                'expected _STATE_ABORTED_BY_USER', self._state)
+                'expected _STATE_ABORTED_BY_USER'), self._state)
             return
 
         # Inform protocol
@@ -1142,9 +1141,9 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
         assert self._sock is not None
 
         # We shouldn't be getting called with empty tx buffers
-        assert self._tx_buffers, (
+        assert self._tx_buffers, ((
             '_AsyncPlaintextTransport._on_socket_writable() called, '
-            'but _tx_buffers is empty.', self._state)
+            'but _tx_buffers is empty.'), self._state)
 
         try:
             # Transmit buffered data to remote socket
@@ -1377,15 +1376,15 @@ class _AsyncSSLTransport(_AsyncTransportBase):
         else:
             # No exception, so everything must have been written to the socket
             assert not self._tx_buffers, (
-                '_AsyncSSLTransport._produce(): no exception from parent '
-                'class, but data remains in _tx_buffers.',
+                ('_AsyncSSLTransport._produce(): no exception from parent '
+                 'class, but data remains in _tx_buffers.'),
                 len(self._tx_buffers))
 
         # Update producer registration
         if self._tx_buffers:
-            assert next_produce_on_writable is not None, (
+            assert next_produce_on_writable is not None, ((
                 '_AsyncSSLTransport._produce(): next_produce_on_writable is '
-                'still None', self._state)
+                'still None'), self._state)
 
             if next_produce_on_writable:
                 if not self._ssl_writable_action:
@@ -1412,16 +1411,16 @@ class _AsyncSSLTransport(_AsyncTransportBase):
             if self._ssl_readable_action == self._produce:
                 self._nbio.remove_reader(self._sock.fileno())
                 self._ssl_readable_action = None
-                assert self._ssl_writable_action != self._produce, (
+                assert self._ssl_writable_action != self._produce, ((
                     '_AsyncSSLTransport._produce(): with empty tx_buffers, '
                     'writable_action cannot be _produce when readable is '
-                    '_produce', self._state)
+                    '_produce'), self._state)
             else:
                 # NOTE: can't use identity check, it fails for instance methods
                 assert self._ssl_writable_action == self._produce, (
-                    '_AsyncSSLTransport._produce(): with empty tx_buffers, '
-                    'expected writable_action as _produce when readable_action '
-                    'is not _produce', 'writable_action:',
+                    ('_AsyncSSLTransport._produce(): with empty tx_buffers, '
+                     'expected writable_action as _produce when readable_action '
+                     'is not _produce'), 'writable_action:',
                     self._ssl_writable_action, 'readable_action:',
                     self._ssl_readable_action, 'state:', self._state)
                 self._ssl_writable_action = None

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -118,7 +118,7 @@ class Channel:
         self._on_flowok_callback: Callable[..., Any] | None = None
         self._on_getok_callback: Callable[..., Any] | None = None
         self._on_ack_nack_callback: _OnAckNackCallback | None = None
-        self._on_openok_callback: None | (Callable[..., Any]) = on_open_callback
+        self._on_openok_callback: Callable[..., Any] | None = on_open_callback
         self._state: int = self.CLOSED
 
         # We save the closing reason exception to be passed to on-channel-close
@@ -415,9 +415,9 @@ class Channel:
 
         self._consumers[consumer_tag] = on_message_callback
 
-        rpc_callback: None | (
-            Callable[...,
-                     Any]) = self._on_eventok if callback is None else callback
+        rpc_callback: Callable[
+            ...,
+            Any] | None = self._on_eventok if callback is None else callback
 
         self._rpc(
             spec.Basic.Consume(queue=queue,
@@ -1429,9 +1429,9 @@ class Channel:
         self,
         method: amqp_object.Method,
         callback: Callable[..., Any] | None = None,
-        acceptable_replies: None |
-        (Sequence[(type[amqp_object.Method] |
-                   tuple[type[amqp_object.Method], dict[str, Any]])]) = None
+        acceptable_replies: Sequence[type[amqp_object.Method] |
+                                     tuple[type[amqp_object.Method],
+                                           dict[str, Any]]] | None = None
     ) -> None:
         """
         Make a synchronous channel RPC call for a synchronous method frame.
@@ -1536,8 +1536,7 @@ class Channel:
     def _send_method(
             self,
             method: amqp_object.Method,
-            content: None | (tuple[spec.BasicProperties, bytes]) = None
-    ) -> None:
+            content: tuple[spec.BasicProperties, bytes] | None = None) -> None:
         """
         Shortcut wrapper to send a method through our connection, passing in the channel number.
 

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -107,8 +107,7 @@ class Parameters:
             pika.credentials.PlainCredentials |
             pika.credentials.ExternalCredentials) = self.DEFAULT_CREDENTIALS
         self._frame_max: int = 0
-        self._heartbeat: None | (int |
-                                 Callable[[Connection, float], int]) = None
+        self._heartbeat: int | Callable[[Connection, float], int] | None = None
         self._host: str = ''
         self._locale: str = ''
         self._port: int = 0
@@ -327,7 +326,8 @@ class Parameters:
 
     @heartbeat.setter
     def heartbeat(
-        self, value: None | (int | Callable[[Connection, float], int])) -> None:
+            self,
+            value: int | Callable[[Connection, float], int] | None) -> None:
         """
         :param value: Controls AMQP heartbeat timeout negotiation
             during connection tuning. An integer value always overrides the value
@@ -559,8 +559,8 @@ class ConnectionParameters(Parameters):
                      pika.credentials.ExternalCredentials)] = _DEFAULT,
                  channel_max: DefaultT[int] = _DEFAULT,
                  frame_max: DefaultT[int] = _DEFAULT,
-                 heartbeat: DefaultT[None | (int | Callable[[Connection, float],
-                                                            int])] = _DEFAULT,
+                 heartbeat: DefaultT[int | Callable[[Connection, float], int] |
+                                     None] = _DEFAULT,
                  ssl_options: DefaultT[SSLOptions | None] = _DEFAULT,
                  connection_attempts: DefaultT[int] = _DEFAULT,
                  retry_delay: DefaultT[float] = _DEFAULT,
@@ -1005,10 +1005,10 @@ class Connection(abc.ABC):
     def __init__(self,
                  parameters: Parameters | None = None,
                  on_open_callback: Callable[[Connection], Any] | None = None,
-                 on_open_error_callback: None |
-                 (Callable[[Connection, Exception], Any]) = None,
-                 on_close_callback: None |
-                 (Callable[[Connection, Exception], Any]) = None,
+                 on_open_error_callback: Callable[[Connection, Exception],
+                                                  Any] | None = None,
+                 on_close_callback: Callable[[Connection, Exception], Any] |
+                 None = None,
                  internal_connection_workflow: bool = True) -> None:
         """
         Connection initialization expects an object that has implemented the Parameters class and a
@@ -1050,7 +1050,7 @@ class Connection(abc.ABC):
         # Used to hold timer if configured for Connection.Blocked timeout
         self._blocked_conn_timer: object = None
 
-        self._heartbeat_checker: None | (pika.heartbeat.HeartbeatChecker) = None
+        self._heartbeat_checker: pika.heartbeat.HeartbeatChecker | None = None
 
         # Set our configuration options
         if parameters is not None:
@@ -1342,7 +1342,7 @@ class Connection(abc.ABC):
     def channel(
             self,
             channel_number: int | None = None,
-            on_open_callback: None | (Callable[[Channel], Any]) = None
+            on_open_callback: Callable[[Channel], Any] | None = None
     ) -> Channel:
         """
         Create a new channel with the next available channel number or pass in a channel number to
@@ -1372,8 +1372,8 @@ class Connection(abc.ABC):
         self,
         new_secret: str,
         reason: str,
-        callback: None |
-        (Callable[[frame.Method[spec.Connection.UpdateSecretOk]], Any]) = None
+        callback: Callable[[frame.Method[spec.Connection.UpdateSecretOk]],
+                           Any] | None = None
     ) -> None:
         """RabbitMQ AMQP extension - This method updates the secret used to authenticate this connection.
         It is used when secrets have an expiration date and need to be renewed, like OAuth 2 tokens.
@@ -2288,7 +2288,7 @@ class Connection(abc.ABC):
         channel_number: int,
         method: amqp_object.Method,
         callback: Callable[..., Any] | None = None,
-        acceptable_replies: None | (Sequence[type[amqp_object.Method]]) = None
+        acceptable_replies: Sequence[type[amqp_object.Method]] | None = None
     ) -> None:
         """
         Make an RPC call for the given callback, channel number and method.
@@ -2374,8 +2374,7 @@ class Connection(abc.ABC):
             self,
             channel_number: int,
             method: amqp_object.Method,
-            content: None | (tuple[spec.BasicProperties, bytes]) = None
-    ) -> None:
+            content: tuple[spec.BasicProperties, bytes] | None = None) -> None:
         """
         Constructs a RPC method frame and then sends it to the broker.
 


### PR DESCRIPTION
## Summary

Ruff 0.16.0 stabilized two rules that were preview-only in earlier releases, so `hatch run lint-check` (and CI) now flag 71 pre-existing violations across the adapters and core connection code. Because ruff is intentionally left unpinned, any push against the newer ruff fails the lint job until these are fixed.

This PR clears all 71 violations. Every change is cosmetic or structural with no behavior change.

## Changes

- `RUF036` (57): reorder type-annotation unions so `None` comes last, e.g. `None | (int | X)` becomes `int | X | None`. Union types are commutative, so these are purely cosmetic.
- `ISC004` (14): wrap the implicitly-concatenated message strings in `assert`/`raise` tuple arguments in their own parentheses, preserving the tuple-as-message structure (the concatenation is intentional line-wrapping of long messages, not a missing comma).
- Restore the `# type: ignore[override]` on `ClosableDeferredQueue.put` that the `RUF036` autofix dropped when it rewrote that line; mypy caught the regression.
- Document in `AGENTS.md` that ruff is deliberately unpinned so CI stays current with newly-stabilized rules, that a lint failure after a ruff release is expected and should be fixed rather than pinned away, and that `lint-check` (not `lint`) mirrors CI.

## Testing

`hatch run unit` (875 passed, 21 skipped), `typecheck`, `lint-check`, `fmt-check`, and `docfmt-check` all pass locally on ruff 0.16.0.
