### PR TITLE
Add Ruff quote style (`Q`)

### DIFF
--- a/examples/async_as_callback.py
+++ b/examples/async_as_callback.py
@@ -36,7 +36,7 @@ class Headers(BaseModel):
     priority: Priority
     task_type: str | None = None
 
-    @validator("priority", pre=True)
+    @validator('priority', pre=True)
     def _convert_priority(self, value):
         return Priority[value]
 
@@ -52,11 +52,11 @@ class RabbitMQConfig(BaseModel):
 class BasicPikaClient:
 
     def __init__(self):
-        self.username = "username"
-        self.password = "password"
-        self.host = "localhost"
+        self.username = 'username'
+        self.password = 'password'
+        self.host = 'localhost'
         self.port = 5672
-        self.protocol = "amqp"
+        self.protocol = 'amqp'
 
         self._init_connection_parameters()
         self._connect()
@@ -80,13 +80,13 @@ class BasicPikaClient:
         self.parameters = pika.ConnectionParameters(
             self.host,
             int(self.port),
-            "/",
+            '/',
             self.credentials,
         )
-        if self.protocol == "amqps":
+        if self.protocol == 'amqps':
             # SSL Context for TLS configuration of Amazon MQ for RabbitMQ
             ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
-            ssl_context.set_ciphers("ECDHE+AESGCM:!ECDSA")
+            ssl_context.set_ciphers('ECDHE+AESGCM:!ECDSA')
             self.parameters.ssl_options = pika.SSLOptions(context=ssl_context)
 
     def check_connection(self):
@@ -102,17 +102,17 @@ class BasicPikaClient:
                       exclusive: bool = False,
                       max_priority: int = 10):
         self.check_connection()
-        logger.debug("Trying to declare queue(%s)...", queue_name)
+        logger.debug('Trying to declare queue(%s)...', queue_name)
         self.channel.queue_declare(
             queue=queue_name,
             exclusive=exclusive,
             durable=True,
-            arguments={"x-max-priority": max_priority},
+            arguments={'x-max-priority': max_priority},
         )
 
     def declare_exchange(self,
                          exchange_name: str,
-                         exchange_type: str = "direct"):
+                         exchange_type: str = 'direct'):
         self.check_connection()
         self.channel.exchange_declare(exchange=exchange_name,
                                       exchange_type=exchange_type)
@@ -132,8 +132,8 @@ class BasicPikaClient:
 
 class BasicMessageSender(BasicPikaClient):
 
-    def encode_message(self, body: dict, encoding_type: str = "bytes"):
-        if encoding_type == "bytes":
+    def encode_message(self, body: dict, encoding_type: str = 'bytes'):
+        if encoding_type == 'bytes':
             return msgpack.packb(body)
         raise NotImplementedError
 
@@ -156,7 +156,7 @@ class BasicMessageSender(BasicPikaClient):
             ),
         )
         logger.debug(
-            "Sent message. Exchange: %s, Routing Key: %s, Body: %s",
+            'Sent message. Exchange: %s, Routing Key: %s, Body: %s',
             exchange_name,
             routing_key,
             body[:128],
@@ -178,16 +178,16 @@ class BasicMessageReceiver(BasicPikaClient):
         method_frame, header_frame, body = self.channel.basic_get(
             queue=queue_name, auto_ack=auto_ack)
         if method_frame:
-            logger.debug("%s, %s, %s", method_frame, header_frame, body)
+            logger.debug('%s, %s, %s', method_frame, header_frame, body)
             return method_frame, header_frame, body
-        logger.debug("No message returned")
+        logger.debug('No message returned')
         return None
 
     def consume_messages(self, queue, callback):
         self.check_connection()
         self.channel_tag = self.channel.basic_consume(
             queue=queue, on_message_callback=callback, auto_ack=True)
-        logger.debug(" [*] Waiting for messages. To exit press CTRL+C")
+        logger.debug(' [*] Waiting for messages. To exit press CTRL+C')
         self.channel.start_consuming()
 
     def cancel_consumer(self):
@@ -195,7 +195,7 @@ class BasicMessageReceiver(BasicPikaClient):
             self.channel.basic_cancel(self.channel_tag)
             self.channel_tag = None
         else:
-            logger.error("Do not cancel a non-existing job")
+            logger.error('Do not cancel a non-existing job')
 
 
 class MyConsumer(BasicMessageReceiver):
@@ -203,7 +203,7 @@ class MyConsumer(BasicMessageReceiver):
     @sync
     async def consume(self, channel, method, properties, body):
         body = self.decode_message(body=body)
-        _file_content = await self._download_image(img_url=body["url"])
+        _file_content = await self._download_image(img_url=body['url'])
         # consume message logic ...
 
     async def _download_image(self, img_url):
@@ -213,13 +213,13 @@ class MyConsumer(BasicMessageReceiver):
 
 def create_consumer():
     worker = MyConsumer()
-    worker.declare_queue(queue_name="myqueue")
-    worker.declare_exchange(exchange_name="myexchange")
-    worker.bind_queue(exchange_name="myexchange",
-                      queue_name="myqueue",
-                      routing_key="randomkey")
-    worker.consume_messages(queue="myqueue", callback=worker.consume)
+    worker.declare_queue(queue_name='myqueue')
+    worker.declare_exchange(exchange_name='myexchange')
+    worker.bind_queue(exchange_name='myexchange',
+                      queue_name='myqueue',
+                      routing_key='randomkey')
+    worker.consume_messages(queue='myqueue', callback=worker.consume)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     create_consumer()

--- a/examples/basic_publisher_threaded.py
+++ b/examples/basic_publisher_threaded.py
@@ -15,8 +15,8 @@ import pika
 from pika.adapters.thread_safe_connection import ThreadSafeConnection
 from pika.exchange_type import ExchangeType
 
-LOG_FORMAT = ("%(levelname) -10s %(asctime)s %(name) -30s %(funcName) "
-              "-35s %(lineno) -5d: %(message)s")
+LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
+              '-35s %(lineno) -5d: %(message)s')
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO, format=LOG_FORMAT)
 

--- a/examples/blocking_consume_tls.py
+++ b/examples/blocking_consume_tls.py
@@ -7,11 +7,11 @@ context.check_hostname = False
 context.verify_mode = False
 
 parameters = pika.ConnectionParameters(
-    host="serverhostname.com",
+    host='serverhostname.com',
     port=5671,
     heartbeat=150,
     ssl_options=pika.SSLOptions(context),
-    virtual_host="rwgvqgbl",
+    virtual_host='rwgvqgbl',
     channel_max=10,
     credentials=pika.PlainCredentials('rwgvqgbl', 'password'),
     client_properties={

--- a/examples/blocking_delivery_confirmations.py
+++ b/examples/blocking_delivery_confirmations.py
@@ -7,7 +7,7 @@ connection = pika.BlockingConnection()
 channel = connection.channel()
 
 # Declare the queue
-channel.queue_declare(queue="test",
+channel.queue_declare(queue='test',
                       durable=True,
                       exclusive=False,
                       auto_delete=False)

--- a/examples/blocking_publish_mandatory.py
+++ b/examples/blocking_publish_mandatory.py
@@ -8,7 +8,7 @@ connection = pika.BlockingConnection()
 channel = connection.channel()
 
 # Declare the queue
-channel.queue_declare(queue="test",
+channel.queue_declare(queue='test',
                       durable=True,
                       exclusive=False,
                       auto_delete=False)

--- a/examples/heartbeat_and_blocked_timeouts.py
+++ b/examples/heartbeat_and_blocked_timeouts.py
@@ -29,7 +29,7 @@ def main():
 
     chan = conn.channel()
 
-    chan.basic_publish('', 'my-alphabet-queue', b"abc")
+    chan.basic_publish('', 'my-alphabet-queue', b'abc')
 
     # If publish causes the connection to become blocked, then this conn.close()
     # would hang until the connection is unblocked, if ever. However, the

--- a/examples/long_running_publisher.py
+++ b/examples/long_running_publisher.py
@@ -10,11 +10,11 @@ class Publisher(threading.Thread):
         super().__init__(*args, **kwargs)
         self.daemon = True
         self.is_running = True
-        self.name = "Publisher"
-        self.queue = "downstream_queue"
+        self.name = 'Publisher'
+        self.queue = 'downstream_queue'
 
-        credentials = PlainCredentials("guest", "guest")
-        parameters = ConnectionParameters("localhost", credentials=credentials)
+        credentials = PlainCredentials('guest', 'guest')
+        parameters = ConnectionParameters('localhost', credentials=credentials)
         self.connection = BlockingConnection(parameters)
         self.channel = self.connection.channel()
         self.channel.queue_declare(queue=self.queue, exclusive=True)
@@ -24,28 +24,28 @@ class Publisher(threading.Thread):
             self.connection.process_data_events(time_limit=1)
 
     def _publish(self, message):
-        self.channel.basic_publish("", self.queue, body=message.encode())
+        self.channel.basic_publish('', self.queue, body=message.encode())
 
     def publish(self, message):
         self.connection.add_callback_threadsafe(lambda: self._publish(message))
 
     def stop(self):
-        print("Stopping...")
+        print('Stopping...')
         self.is_running = False
         # Wait until all the data events have been processed
         self.connection.process_data_events(time_limit=1)
         if self.connection.is_open:
             self.connection.close()
-        print("Stopped")
+        print('Stopped')
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     publisher = Publisher()
     publisher.start()
     try:
         for i in range(9999):
-            msg = f"Message {i}"
-            print(f"Publishing: {msg!r}")
+            msg = f'Message {i}'
+            print(f'Publishing: {msg!r}')
             publisher.publish(msg)
             sleep(1)
     except KeyboardInterrupt:

--- a/examples/publish.py
+++ b/examples/publish.py
@@ -10,13 +10,13 @@ credentials = pika.PlainCredentials('guest', 'guest')
 parameters = pika.ConnectionParameters('localhost', credentials=credentials)
 connection = pika.BlockingConnection(parameters)
 channel = connection.channel()
-channel.exchange_declare(exchange="test_exchange",
+channel.exchange_declare(exchange='test_exchange',
                          exchange_type=ExchangeType.direct,
                          passive=False,
                          durable=True,
                          auto_delete=False)
 
-print("Sending message to create a queue")
+print('Sending message to create a queue')
 channel.basic_publish(
     'test_exchange', 'standard_key', b'queue:group',
     pika.BasicProperties(content_type='text/plain',
@@ -24,7 +24,7 @@ channel.basic_publish(
 
 connection.sleep(5)
 
-print("Sending text message to group")
+print('Sending text message to group')
 channel.basic_publish(
     'test_exchange', 'group_key', b'Message to group_key',
     pika.BasicProperties(content_type='text/plain',
@@ -32,7 +32,7 @@ channel.basic_publish(
 
 connection.sleep(5)
 
-print("Sending text message")
+print('Sending text message')
 channel.basic_publish(
     'test_exchange', 'standard_key', b'Message to standard_key',
     pika.BasicProperties(content_type='text/plain',

--- a/examples/tls_mutual_authentication.py
+++ b/examples/tls_mutual_authentication.py
@@ -12,11 +12,11 @@ context = ssl.create_default_context(cafile=str(_certs / 'ca_certificate.pem'))
 context.verify_mode = ssl.CERT_REQUIRED
 context.load_cert_chain(str(_certs / 'client_certificate.pem'),
                         str(_certs / 'client_key.pem'))
-ssl_options = pika.SSLOptions(context, "localhost")
+ssl_options = pika.SSLOptions(context, 'localhost')
 conn_params = pika.ConnectionParameters(port=5671, ssl_options=ssl_options)
 
 with pika.BlockingConnection(conn_params) as conn:
     ch = conn.channel()
-    ch.queue_declare("foobar")
-    ch.basic_publish("", "foobar", b"Hello, world!")
-    print(ch.basic_get("foobar"))
+    ch.queue_declare('foobar')
+    ch.basic_publish('', 'foobar', b'Hello, world!')
+    print(ch.basic_get('foobar'))

--- a/examples/tls_mutual_authentication_twisted.py
+++ b/examples/tls_mutual_authentication_twisted.py
@@ -15,7 +15,7 @@ def publish(connection):
         routing_key='hello.world',
         body='Hello World!',
     )
-    print("published")
+    print('published')
 
 
 def connection_ready(conn):
@@ -36,7 +36,7 @@ with _certs.joinpath('client_certificate.pem').open() as fd:
 client_keypair = ssl.PrivateCertificate.loadPEM(client_key + client_cert)
 
 context_factory = ssl.optionsForClientTLS(
-    "localhost",
+    'localhost',
     trustRoot=ca_cert,
     clientCertificate=client_keypair,
 )
@@ -44,7 +44,7 @@ params = ConnectionParameters(credentials=ExternalCredentials())
 cc = protocol.ClientCreator(reactor,
                             twisted_connection.TwistedProtocolConnection,
                             params)
-deferred = cc.connectSSL("localhost", 5671, context_factory)
+deferred = cc.connectSSL('localhost', 5671, context_factory)
 deferred.addCallback(connection_ready)
 deferred.addCallback(publish)
 reactor.run()

--- a/examples/tls_server_authentication.py
+++ b/examples/tls_server_authentication.py
@@ -6,15 +6,15 @@ import pika
 logging.basicConfig(level=logging.INFO)
 
 context = ssl.create_default_context(
-    cafile="/Users/me/tls-gen/basic/result/ca_certificate.pem")
+    cafile='/Users/me/tls-gen/basic/result/ca_certificate.pem')
 context.verify_mode = ssl.CERT_REQUIRED
-context.load_cert_chain("/Users/me/tls-gen/result/client_certificate.pem",
-                        "/Users/me/tls-gen/result/client_key.pem")
-ssl_options = pika.SSLOptions(context, "localhost")
+context.load_cert_chain('/Users/me/tls-gen/result/client_certificate.pem',
+                        '/Users/me/tls-gen/result/client_key.pem')
+ssl_options = pika.SSLOptions(context, 'localhost')
 conn_params = pika.ConnectionParameters(port=5671, ssl_options=ssl_options)
 
 with pika.BlockingConnection(conn_params) as conn:
     ch = conn.channel()
-    print(ch.queue_declare("sslq"))
-    ch.basic_publish("", "sslq", b"abc")
-    print(ch.basic_get("sslq"))
+    print(ch.queue_declare('sslq'))
+    ch.basic_publish('', 'sslq', b'abc')
+    print(ch.basic_get('sslq'))

--- a/examples/twisted_service.py
+++ b/examples/twisted_service.py
@@ -214,13 +214,13 @@ class PikaFactory(protocol.ReconnectingClientFactory):
             self.client.read(exchange, routing_key, callback)
 
 
-application = service.Application("pikaapplication")
+application = service.Application('pikaapplication')
 
 ps = PikaService(
-    pika.ConnectionParameters(host="localhost",
-                              virtual_host="/",
+    pika.ConnectionParameters(host='localhost',
+                              virtual_host='/',
                               credentials=pika.PlainCredentials(
-                                  "guest", "guest")))
+                                  'guest', 'guest')))
 ps.setServiceParent(application)
 
 
@@ -238,18 +238,18 @@ class TestService(service.Service):
         AMQP. If the task was not completed a `basic.nack` will be sent. In this example it will
         always return successfully after a 2 second pause.
         """
-        return task.deferLater(reactor, 2, lambda: log.msg("task completed"))
+        return task.deferLater(reactor, 2, lambda: log.msg('task completed'))
 
     def respond(self, msg):
         self.amqp.send_message('foobar', 'response', msg[3])
 
     def startService(self):
-        amqp_service = self.parent.getServiceNamed("amqp")
+        amqp_service = self.parent.getServiceNamed('amqp')
         self.amqp = amqp_service.getFactory()
-        self.amqp.read_messages("foobar", "request1", self.respond)
-        self.amqp.read_messages("foobar", "request2", self.respond)
-        self.amqp.read_messages("foobar", "request3", self.respond)
-        self.amqp.read_messages("foobar", "task", self.task)
+        self.amqp.read_messages('foobar', 'request1', self.respond)
+        self.amqp.read_messages('foobar', 'request2', self.respond)
+        self.amqp.read_messages('foobar', 'request3', self.respond)
+        self.amqp.read_messages('foobar', 'task', self.task)
 
 
 ts = TestService()

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -134,7 +134,7 @@ class _CallbackResult:
             self._values = (self._value_class(*args, **kwargs),)
         except Exception:
             LOGGER.error(
-                "set_value_once failed: value_class=%r; args=%r; kwargs=%r",
+                'set_value_once failed: value_class=%r; args=%r; kwargs=%r',
                 self._value_class, args, kwargs)
             raise
 
@@ -149,7 +149,7 @@ class _CallbackResult:
             value = self._value_class(*args, **kwargs)
         except Exception:
             LOGGER.error(
-                "append_element failed: value_class=%r; args=%r; kwargs=%r",
+                'append_element failed: value_class=%r; args=%r; kwargs=%r',
                 self._value_class, args, kwargs)
             raise
 
@@ -365,11 +365,11 @@ class BlockingConnection:
         :raises RuntimeError:
         """
         warnings.warn(
-            "BlockingConnection is deprecated and will be removed in Pika 2.0. "
-            "Use ThreadSafeConnection instead, which runs its own IOLoop on a "
-            "background thread and provides a thread-safe blocking API that "
-            "does not stall heartbeats on slow message processing. See "
-            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            'BlockingConnection is deprecated and will be removed in Pika 2.0. '
+            'Use ThreadSafeConnection instead, which runs its own IOLoop on a '
+            'background thread and provides a thread-safe blocking API that '
+            'does not stall heartbeats on slow message processing. See '
+            'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,
             stacklevel=2,
         )
@@ -1330,7 +1330,7 @@ class BlockingChannel:
                                 replies=[pika.spec.Basic.GetEmpty],
                                 one_shot=False)
 
-        LOGGER.info("Created channel=%s", self.channel_number)
+        LOGGER.info('Created channel=%s', self.channel_number)
 
     def __int__(self) -> int:
         """
@@ -1431,9 +1431,9 @@ class BlockingChannel:
         assert isinstance(properties, pika.spec.BasicProperties), (properties)
 
         LOGGER.warning(
-            "Published message was returned: _delivery_confirmation=%s; "
-            "channel=%s; method=%r; properties=%r; body_size=%d; "
-            "body_prefix=%.255r", self._delivery_confirmation,
+            'Published message was returned: _delivery_confirmation=%s; '
+            'channel=%s; method=%r; properties=%r; body_size=%d; '
+            'body_prefix=%.255r', self._delivery_confirmation,
             channel.channel_number, method, properties,
             len(body) if body is not None else None, body)
 
@@ -1587,7 +1587,7 @@ class BlockingChannel:
 
     def close(self,
               reply_code: int = 0,
-              reply_text: str = "Normal shutdown") -> None:
+              reply_text: str = 'Normal shutdown') -> None:
         """
         Will invoke a clean shutdown of the channel with the AMQP Broker.
 
@@ -1847,8 +1847,8 @@ class BlockingChannel:
             consumer_info = self._consumer_infos[consumer_tag]
         except KeyError:
             LOGGER.warning(
-                "User is attempting to cancel an unknown consumer=%s; "
-                "already cancelled by user or broker?", consumer_tag)
+                'User is attempting to cancel an unknown consumer=%s; '
+                'already cancelled by user or broker?', consumer_tag)
             return []
 
         try:
@@ -2274,7 +2274,7 @@ class BlockingChannel:
                     evt = get_ok_result.value
                     return evt.method, evt.properties, evt.body
                 assert self._basic_getempty_result, (
-                    "wait completed without GetOk and GetEmpty")
+                    'wait completed without GetOk and GetEmpty')
                 return None, None, None
 
     def basic_publish(self,

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -77,10 +77,10 @@ class GeventConnection(BaseConnection):
             connection workflow via the `create_connection()` factory
         """
         warnings.warn(
-            "GeventConnection is deprecated and will be removed in Pika 2.0. "
-            "Use ThreadSafeConnection instead, which works with any framework "
-            "including Gevent. See "
-            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            'GeventConnection is deprecated and will be removed in Pika 2.0. '
+            'Use ThreadSafeConnection instead, which works with any framework '
+            'including Gevent. See '
+            'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,
             stacklevel=2,
         )
@@ -195,7 +195,7 @@ class _TSafeCallbackQueue:
             callback = self._queue.get_nowait()
         except queue.Empty:
             # Should never happen.
-            LOGGER.warning("Callback queue was empty.")
+            LOGGER.warning('Callback queue was empty.')
         else:
             # Read the byte from the pipe so the event doesn't re-fire.
             os.read(self._read_fd, 1)
@@ -287,14 +287,14 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
         """
         if gevent.get_hub() == self._hub:
             # We're in the main thread; just add the callback.
-            LOGGER.debug("Adding callback from main thread")
+            LOGGER.debug('Adding callback from main thread')
             self._hub.loop.run_callback(
                 callback)  # pyright: ignore[reportOptionalMemberAccess]
         else:
             # This isn't the main thread and Gevent's hub/loop don't provide
             # any thread-safety so enqueue the callback for it to be registered
             # in the main thread.
-            LOGGER.debug("Adding callback from another thread")
+            LOGGER.debug('Adding callback from another thread')
             callback = functools.partial(
                 self._hub.loop.run_callback, callback
             )  # pyright: ignore[reportAssignmentType, reportOptionalMemberAccess]
@@ -481,7 +481,7 @@ class _GeventAddressResolver:
         if self._greenlet is None:
             self._greenlet = gevent.spawn_raw(self._resolve)
         else:
-            LOGGER.warning("_GeventAddressResolver already started")
+            LOGGER.warning('_GeventAddressResolver already started')
 
     def cancel(self) -> bool:
         """Cancel the pending resolver."""

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -291,7 +291,7 @@ class _Timer:
         :raises ValueError, TypeError
         """
         if self._timeout_heap is None:
-            raise ValueError("Timeout closed before call")
+            raise ValueError('Timeout closed before call')
 
         if delay < 0:
             raise ValueError(
@@ -449,8 +449,8 @@ class IOLoop(AbstractSelectorIOLoop):
         poller: _PollerBase | None = None
 
         kwargs: POLLER_PARAMS = {
-            "get_wait_seconds": get_wait_seconds,
-            "process_timeouts": process_timeouts
+            'get_wait_seconds': get_wait_seconds,
+            'process_timeouts': process_timeouts
         }
 
         if hasattr(select, 'epoll'):
@@ -723,7 +723,7 @@ class _PollerBase(abc.ABC):
             except Exception as err:
                 # There's nothing sensible to do here, we'll exit the interrupt
                 # loop after POLL_TIMEOUT secs in worst case anyway.
-                LOGGER.warning("Failed to send interrupt to poller: %s", err)
+                LOGGER.warning('Failed to send interrupt to poller: %s', err)
                 raise
 
     def _get_max_wait(self) -> float:
@@ -1304,7 +1304,7 @@ class PollPoller(_PollerBase):
     def _uninit_poller(self) -> None:
         """Notify the implementation to release the poller resource."""
         if self._poll is not None:
-            if hasattr(self._poll, "close"):
+            if hasattr(self._poll, 'close'):
                 self._poll.close(
                 )  # pyright: ignore[reportAttributeAccessIssue]
 

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -58,10 +58,10 @@ class TornadoConnection(base_connection.BaseConnection):
             connection workflow via the `create_connection()` factory
         """
         warnings.warn(
-            "TornadoConnection is deprecated and will be removed in Pika 2.0. "
-            "Use ThreadSafeConnection instead, which works with any framework "
-            "including Tornado. See "
-            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            'TornadoConnection is deprecated and will be removed in Pika 2.0. '
+            'Use ThreadSafeConnection instead, which works with any framework '
+            'including Tornado. See '
+            'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -100,8 +100,8 @@ class ClosableDeferredQueue(defer.DeferredQueue):
         self.pending = []
 
 
-ReceivedMessage = namedtuple("ReceivedMessage",
-                             ["channel", "method", "properties", "body"])
+ReceivedMessage = namedtuple('ReceivedMessage',
+                             ['channel', 'method', 'properties', 'body'])
 
 
 class TwistedChannel:
@@ -215,8 +215,8 @@ class TwistedChannel:
         :param _method_frame: Method frame from Basic.Get response (unused)
         """
         if self._basic_get_deferred is None:
-            LOGGER.warning("Got Basic.GetEmpty but no Basic.Get calls "
-                           "were pending.")
+            LOGGER.warning('Got Basic.GetEmpty but no Basic.Get calls '
+                           'were pending.')
             return
         self._basic_get_deferred.callback(None)
 
@@ -512,7 +512,7 @@ class TwistedChannel:
             self._basic_get_deferred = None
             return result
 
-        d = self._wrap_channel_method("basic_get")(queue=queue,
+        d = self._wrap_channel_method('basic_get')(queue=queue,
                                                    auto_ack=auto_ack)
         d.addCallback(create_namedtuple)
         d.addBoth(cleanup_attribute)
@@ -613,7 +613,7 @@ class TwistedChannel:
         :param global_qos: Should the QoS apply to all channels on the connection.
         :returns: Deferred that fires on the Basic.QosOk response
         """
-        return self._wrap_channel_method("basic_qos")(
+        return self._wrap_channel_method('basic_qos')(
             prefetch_size=prefetch_size,
             prefetch_count=prefetch_count,
             global_qos=global_qos,
@@ -645,11 +645,11 @@ class TwistedChannel:
             an alternative subscriber.
         :returns: Deferred that fires on the Basic.RecoverOk response
         """
-        return self._wrap_channel_method("basic_recover")(requeue=requeue)
+        return self._wrap_channel_method('basic_recover')(requeue=requeue)
 
     def close(self,
               reply_code: int = 0,
-              reply_text: str = "Normal shutdown") -> None:
+              reply_text: str = 'Normal shutdown') -> None:
         """
         Invoke a graceful shutdown of the channel with the AMQP Broker.
 
@@ -683,7 +683,7 @@ class TwistedChannel:
         def set_delivery_confirmation(result):
             self._delivery_confirmation = True
             self._delivery_message_id = 0
-            LOGGER.debug("Delivery confirmation enabled.")
+            LOGGER.debug('Delivery confirmation enabled.')
             return result
 
         d.addCallback(set_delivery_confirmation)
@@ -708,7 +708,7 @@ class TwistedChannel:
         """
         delivery_tag = method_frame.method.delivery_tag
         if delivery_tag not in self._deliveries:
-            LOGGER.error("Delivery tag %s not found in the pending deliveries",
+            LOGGER.error('Delivery tag %s not found in the pending deliveries',
                          delivery_tag)
             return
         if method_frame.method.multiple:
@@ -763,9 +763,9 @@ class TwistedChannel:
         assert isinstance(properties, spec.BasicProperties), properties
 
         LOGGER.warning(
-            "Published message was returned: _delivery_confirmation=%s; "
-            "channel=%s; method=%r; properties=%r; body_size=%d; "
-            "body_prefix=%.255r", self._delivery_confirmation,
+            'Published message was returned: _delivery_confirmation=%s; '
+            'channel=%s; method=%r; properties=%r; body_size=%d; '
+            'body_prefix=%.255r', self._delivery_confirmation,
             channel.channel_number, method, properties,
             len(body) if body is not None else None, body)
 
@@ -790,7 +790,7 @@ class TwistedChannel:
         :raises ValueError:
         :returns: Deferred that fires on the Exchange.BindOk response
         """
-        return self._wrap_channel_method("exchange_bind")(
+        return self._wrap_channel_method('exchange_bind')(
             destination=destination,
             source=source,
             routing_key=routing_key,
@@ -828,7 +828,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Exchange.DeclareOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("exchange_declare")(
+        return self._wrap_channel_method('exchange_declare')(
             exchange=exchange,
             exchange_type=exchange_type,
             passive=passive,
@@ -849,7 +849,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Exchange.DeleteOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("exchange_delete")(
+        return self._wrap_channel_method('exchange_delete')(
             exchange=exchange,
             if_unused=if_unused,
         )
@@ -870,7 +870,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Exchange.UnbindOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("exchange_unbind")(
+        return self._wrap_channel_method('exchange_unbind')(
             destination=destination,
             source=source,
             routing_key=routing_key,
@@ -890,7 +890,7 @@ class TwistedChannel:
         :returns: Deferred that fires with the channel flow state
         :raises ValueError:
         """
-        return self._wrap_channel_method("flow")(active=active)
+        return self._wrap_channel_method('flow')(active=active)
 
     def open(self) -> None:
         """Open the channel."""
@@ -912,7 +912,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Queue.BindOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("queue_bind")(
+        return self._wrap_channel_method('queue_bind')(
             queue=queue,
             exchange=exchange,
             routing_key=routing_key,
@@ -947,7 +947,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Queue.DeclareOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("queue_declare")(
+        return self._wrap_channel_method('queue_declare')(
             queue=queue,
             passive=passive,
             durable=durable,
@@ -980,7 +980,7 @@ class TwistedChannel:
                     self._queue_name_to_consumer_tags.get(queue_name, set())):
                 self._consumers[consumer_tag].close(
                     exceptions.ConsumerCancelled(
-                        f"Queue {queue_name} was deleted."))
+                        f'Queue {queue_name} was deleted.'))
                 del self._consumers[consumer_tag]
                 self._queue_name_to_consumer_tags[queue_name].remove(
                     consumer_tag)
@@ -996,7 +996,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Queue.PurgeOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("queue_purge")(queue=queue)
+        return self._wrap_channel_method('queue_purge')(queue=queue)
 
     def queue_unbind(
             self,
@@ -1014,7 +1014,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Queue.UnbindOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("queue_unbind")(
+        return self._wrap_channel_method('queue_unbind')(
             queue=queue,
             exchange=exchange,
             routing_key=routing_key,
@@ -1028,7 +1028,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Tx.CommitOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("tx_commit")()
+        return self._wrap_channel_method('tx_commit')()
 
     def tx_rollback(self) -> defer.Deferred[Any]:
         """
@@ -1037,7 +1037,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Tx.RollbackOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("tx_rollback")()
+        return self._wrap_channel_method('tx_rollback')()
 
     def tx_select(self) -> defer.Deferred[Any]:
         """
@@ -1049,7 +1049,7 @@ class TwistedChannel:
         :returns: Deferred that fires on the Tx.SelectOk response
         :raises ValueError:
         """
-        return self._wrap_channel_method("tx_select")()
+        return self._wrap_channel_method('tx_select')()
 
 
 class _TwistedConnectionAdapter(pika.connection.Connection):
@@ -1194,10 +1194,10 @@ class TwistedProtocolConnection(protocol.Protocol):
                  parameters: pika.connection.ConnectionParameters | None = None,
                  custom_reactor: Any = None) -> None:
         warnings.warn(
-            "TwistedProtocolConnection is deprecated and will be removed in "
-            "Pika 2.0. Use ThreadSafeConnection instead, which works with any "
-            "framework including Twisted. See "
-            "https://pika.github.io/pika/modules/adapters/thread_safe/",
+            'TwistedProtocolConnection is deprecated and will be removed in '
+            'Pika 2.0. Use ThreadSafeConnection instead, which works with any '
+            'framework including Twisted. See '
+            'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,
             stacklevel=2,
         )

--- a/pika/adapters/utils/io_services_utils.py
+++ b/pika/adapters/utils/io_services_utils.py
@@ -1116,8 +1116,8 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
             else:
                 _LOGGER.exception(
                     '_AsyncBaseTransport._consume() failed, aborting '
-                    'connection: error=%r; sock=%s; Caller\'s stack:\n%s',
-                    error, self._sock,
+                    "connection: error=%r; sock=%s; Caller's stack:\n%s", error,
+                    self._sock,
                     ''.join(traceback.format_exception(*sys.exc_info())))
                 self._initiate_abort(error)
         else:
@@ -1155,8 +1155,8 @@ class _AsyncPlaintextTransport(_AsyncTransportBase):
             else:
                 _LOGGER.exception(
                     '_AsyncBaseTransport._produce() failed, aborting '
-                    'connection: error=%r; sock=%s; Caller\'s stack:\n%s',
-                    error, self._sock,
+                    "connection: error=%r; sock=%s; Caller's stack:\n%s", error,
+                    self._sock,
                     ''.join(traceback.format_exception(*sys.exc_info())))
                 self._initiate_abort(error)
         else:
@@ -1293,8 +1293,8 @@ class _AsyncSSLTransport(_AsyncTransportBase):
             else:
                 _LOGGER.exception(
                     '_AsyncBaseTransport._consume() failed, aborting '
-                    'connection: error=%r; sock=%s; Caller\'s stack:\n%s',
-                    error, self._sock,
+                    "connection: error=%r; sock=%s; Caller's stack:\n%s", error,
+                    self._sock,
                     ''.join(traceback.format_exception(*sys.exc_info())))
                 raise  # let outer catch block abort the transport
         else:
@@ -1369,8 +1369,8 @@ class _AsyncSSLTransport(_AsyncTransportBase):
             else:
                 _LOGGER.exception(
                     '_AsyncBaseTransport._produce() failed, aborting '
-                    'connection: error=%r; sock=%s; Caller\'s stack:\n%s',
-                    error, self._sock,
+                    "connection: error=%r; sock=%s; Caller's stack:\n%s", error,
+                    self._sock,
                     ''.join(traceback.format_exception(*sys.exc_info())))
                 raise  # let outer catch block abort the transport
         else:

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -286,7 +286,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         if callbacks.reader is None:
             assert callbacks.writer is not None
-            LOGGER.debug('remove_reader(%s) reader wasn\'t set Wr', fd)
+            LOGGER.debug("remove_reader(%s) reader wasn't set Wr", fd)
             return False
 
         callbacks.reader = None
@@ -351,7 +351,7 @@ class SelectorIOServicesAdapter(io_services_utils.SocketConnectionMixin,
 
         if callbacks.writer is None:
             assert callbacks.reader is not None
-            LOGGER.debug('remove_writer(%s) writer wasn\'t set Rd', fd)
+            LOGGER.debug("remove_writer(%s) writer wasn't set Rd", fd)
             return False
 
         callbacks.writer = None

--- a/pika/amqp_object.py
+++ b/pika/amqp_object.py
@@ -20,8 +20,8 @@ class AMQPObject:
             if getattr(self.__class__, key, None) != value:
                 items.append(f'{key}={value}')
         if not items:
-            return f"<{self.NAME}>"
-        return f"<{self.NAME}({sorted(items)})>"
+            return f'<{self.NAME}>'
+        return f'<{self.NAME}({sorted(items)})>'
 
     @override
     def __eq__(self, other: object) -> bool:
@@ -63,7 +63,7 @@ class Method(AMQPObject):
 
     def encode(self) -> list[bytes]:
         """Encode the method into a binary format."""
-        raise NotImplementedError("Subclasses must implement this method")
+        raise NotImplementedError('Subclasses must implement this method')
 
     def decode(self, encoded: bytes, offset: int = 0) -> Method:
         """
@@ -72,7 +72,7 @@ class Method(AMQPObject):
         :param encoded: The encoded method data
         :param offset: The offset to start decoding from
         """
-        raise NotImplementedError("Subclasses must implement this method")
+        raise NotImplementedError('Subclasses must implement this method')
 
 
 class Properties(AMQPObject):

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -33,12 +33,12 @@ _OnConfirmDeliveryCallback = Callable[[frame.Method[spec.Confirm.SelectOk]],
                                       None]
 _OnBasicConsumeCallback = Callable[[frame.Method[spec.Basic.ConsumeOk]], None]
 _OnBasicGetCallback = Callable[
-    ["Channel", spec.Basic.GetOk, spec.BasicProperties, bytes], None]
+    ['Channel', spec.Basic.GetOk, spec.BasicProperties, bytes], None]
 _OnBasicRecoverCallback = Callable[[frame.Method[spec.Basic.RecoverOk]], None]
 _OnBasicQosCallback = Callable[[frame.Method[spec.Basic.QosOk]], None]
 _OnBasicCancelCallback = Callable[[frame.Method[spec.Basic.CancelOk]], None]
 _OnCancelCallback = Callable[[frame.Method[spec.Basic.Cancel]], Any]
-_OnCloseCallback = Callable[["Channel", Exception], None]
+_OnCloseCallback = Callable[['Channel', Exception], None]
 _OnExchangeBindCallback = Callable[[frame.Method[spec.Exchange.BindOk]], None]
 _OnExchangeDeclareCallback = Callable[[frame.Method[spec.Exchange.DeclareOk]],
                                       None]
@@ -48,15 +48,15 @@ _OnExchangeUnbindCallback = Callable[[frame.Method[spec.Exchange.UnbindOk]],
                                      None]
 _OnFlowCallback = Callable[[bool], None]
 _OnMessageCallback = Callable[
-    ["Channel", spec.Basic.Deliver, spec.BasicProperties, bytes], None]
-_OnOpenCallback = Callable[["Channel"], None]
+    ['Channel', spec.Basic.Deliver, spec.BasicProperties, bytes], None]
+_OnOpenCallback = Callable[['Channel'], None]
 _OnQueueBindCallback = Callable[[frame.Method[spec.Queue.BindOk]], None]
 _OnQueueDeclareCallback = Callable[[frame.Method[spec.Queue.DeclareOk]], None]
 _OnQueueDeleteCallback = Callable[[frame.Method[spec.Queue.DeleteOk]], None]
 _OnQueuePurgeCallback = Callable[[frame.Method[spec.Queue.PurgeOk]], None]
 _OnQueueUnbindCallback = Callable[[frame.Method[spec.Queue.UnbindOk]], None]
 _OnReturnCallback = Callable[
-    ["Channel", spec.Basic.Return, spec.BasicProperties, bytes], None]
+    ['Channel', spec.Basic.Return, spec.BasicProperties, bytes], None]
 _OnTxCommitCallback = Callable[[spec.Tx.CommitOk], None]
 _OnTxRollbackCallback = Callable[[spec.Tx.RollbackOk], None]
 _OnTxSelectCallback = Callable[[spec.Tx.SelectOk], None]
@@ -606,7 +606,7 @@ class Channel:
 
     def close(self,
               reply_code: int = 0,
-              reply_text: str = "Normal shutdown") -> None:
+              reply_text: str = 'Normal shutdown') -> None:
         """
         Invoke a graceful shutdown of the channel with the AMQP Broker.
 
@@ -1381,7 +1381,7 @@ class Channel:
 
         :param method_frame: The method frame received
         """
-        LOGGER.debug("Confirm.SelectOk Received: %r", method_frame)
+        LOGGER.debug('Confirm.SelectOk Received: %r', method_frame)
 
     def _on_synchronous_complete(self,
                                  _method_frame_unused: frame.Method) -> None:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -42,7 +42,7 @@ if TYPE_CHECKING:
     from pika import amqp_object
     from pika.channel import Channel
 
-PRODUCT = "Pika Python Client Library"
+PRODUCT = 'Pika Python Client Library'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1429,7 +1429,7 @@ class Connection(abc.ABC):
 
         # Transition to closing
         self._set_connection_state(self.CONNECTION_CLOSING)
-        LOGGER.info("Closing connection (%s): %r", reply_code, reply_text)
+        LOGGER.info('Closing connection (%s): %r', reply_code, reply_text)
 
         if not self._opened:
             # It was opening, but not fully open yet, so we won't attempt

--- a/pika/credentials.py
+++ b/pika/credentials.py
@@ -94,7 +94,7 @@ class PlainCredentials:
     def erase_credentials(self) -> None:
         """Called by Connection when it no longer needs the credentials."""
         if self.erase_on_connect:
-            LOGGER.info("Erasing stored credential values")
+            LOGGER.info('Erasing stored credential values')
             self.username = None
             self.password = None
 

--- a/pika/diagnostic_utils.py
+++ b/pika/diagnostic_utils.py
@@ -59,7 +59,7 @@ def create_log_exception_decorator(logger: logging.Logger) -> Callable[[F], F]:
                 return func(*args, **kwargs)
             except Exception:
                 logger.exception(
-                    'Wrapped func exited with exception. Caller\'s stack:\n%s',
+                    "Wrapped func exited with exception. Caller's stack:\n%s",
                     ''.join(traceback.format_exception(*sys.exc_info())))
                 raise
 

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -253,7 +253,7 @@ class UnroutableError(AMQPChannelError):
         """
         :param messages: Sequence of returned unroutable messages
         """
-        super().__init__(f"{len(messages)} unroutable message(s) returned")
+        super().__init__(f'{len(messages)} unroutable message(s) returned')
 
         self.messages = messages
 
@@ -274,7 +274,7 @@ class NackError(AMQPChannelError):
         """
         :param messages: Sequence of returned unroutable messages
         """
-        super().__init__(f"{len(messages)} message(s) NACKed")
+        super().__init__(f'{len(messages)} message(s) NACKed')
 
         self.messages = messages
 

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -234,7 +234,7 @@ def decode_frame(data_in: bytes | bytearray,
 
     # The Frame termination chr is wrong
     if data_in[offset + frame_end - 1] != spec.FRAME_END:
-        raise exceptions.InvalidFrameError("Invalid FRAME_END marker")
+        raise exceptions.InvalidFrameError('Invalid FRAME_END marker')
 
     # Get the raw frame data as immutable bytes. For large payloads copy via
     # memoryview, which avoids a bytearray input's extra intermediate copy;
@@ -284,4 +284,4 @@ def decode_frame(data_in: bytes | bytearray,
         # Return the amount of data and a Heartbeat frame
         return frame_end, Heartbeat()
 
-    raise exceptions.InvalidFrameError(f"Unknown frame type: {frame_type}")
+    raise exceptions.InvalidFrameError(f'Unknown frame type: {frame_type}')

--- a/pika/heartbeat.py
+++ b/pika/heartbeat.py
@@ -17,7 +17,7 @@ class HeartbeatChecker:
     details.
     """
 
-    _STALE_CONNECTION = "No activity or too many missed heartbeats in the last %i seconds"
+    _STALE_CONNECTION = 'No activity or too many missed heartbeats in the last %i seconds'
 
     def __init__(self, connection, timeout) -> None:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ extend-exclude = [
 [tool.ruff.format]
 quote-style = "single"
 
+[tool.ruff.lint.flake8-quotes]
+inline-quotes = "single"
+
 [tool.ruff.lint]
 select = [
     "E",    # pycodestyle errors
@@ -87,6 +90,7 @@ select = [
     "PGH",  # pygrep-hooks: blanket type-ignore / eval
     "FA",   # flake8-future-annotations: use `from __future__ import annotations`
     "TC",   # flake8-type-checking: guard type-only imports behind TYPE_CHECKING
+    "Q",    # flake8-quotes: enforce consistent string quote usage
 ]
 
 ignore = [

--- a/tests/acceptance/async_adapter_tests.py
+++ b/tests/acceptance/async_adapter_tests.py
@@ -15,14 +15,14 @@ from tests.base.async_test_base import AsyncAdapters, AsyncTestCase, BoundQueueT
 
 
 class TestA_Connect(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Connect, open channel and disconnect"
+    DESCRIPTION = 'Connect, open channel and disconnect'
 
     def begin(self, channel):
         self.stop()
 
 
 class TestConstructAndImmediatelyCloseConnection(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Construct and immediately close connection."
+    DESCRIPTION = 'Construct and immediately close connection.'
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
@@ -49,7 +49,7 @@ class TestConstructAndImmediatelyCloseConnection(AsyncTestCase, AsyncAdapters):
 
 
 class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Close connection during AMQP handshake."
+    DESCRIPTION = 'Close connection during AMQP handshake.'
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
@@ -90,7 +90,7 @@ class TestCloseConnectionDuringAMQPHandshake(AsyncTestCase, AsyncAdapters):
 
 class TestSocketConnectTimeoutWithTinySocketTimeout(AsyncTestCase,
                                                     AsyncAdapters):
-    DESCRIPTION = "Force socket.connect() timeout with very tiny socket_timeout."
+    DESCRIPTION = 'Force socket.connect() timeout with very tiny socket_timeout.'
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
@@ -120,7 +120,7 @@ class TestSocketConnectTimeoutWithTinySocketTimeout(AsyncTestCase,
 
 class TestStackConnectionTimeoutWithTinyStackTimeout(AsyncTestCase,
                                                      AsyncAdapters):
-    DESCRIPTION = "Force stack bring-up timeout with very tiny stack_timeout."
+    DESCRIPTION = 'Force stack bring-up timeout with very tiny stack_timeout.'
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
@@ -463,11 +463,11 @@ class TestCreateConnectionAndAsynchronouslyAbortDefaultConnectionWorkflow(
 
 
 class TestUpdateSecret(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Update secret and receive confirmation"
+    DESCRIPTION = 'Update secret and receive confirmation'
 
     def begin(self, channel):
         assert self.connection is not None
-        self.connection.update_secret("new_secret", "reason",
+        self.connection.update_secret('new_secret', 'reason',
                                       self.on_secret_update)
 
     def on_secret_update(self, frame):
@@ -476,7 +476,7 @@ class TestUpdateSecret(AsyncTestCase, AsyncAdapters):
 
 
 class TestConfirmSelect(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Receive confirmation of Confirm.Select"
+    DESCRIPTION = 'Receive confirmation of Confirm.Select'
 
     def begin(self, channel):
         channel.confirm_delivery(ack_nack_callback=self.ack_nack_callback,
@@ -497,11 +497,11 @@ class TestBlockingNonBlockingBlockingRPCWontStall(AsyncTestCase, AsyncAdapters):
 
     def begin(self, channel):
         # Queue declaration params table: queue name, nowait value
-        self._expected_queue_params = (("blocking-non-blocking-stall-check-" +
+        self._expected_queue_params = (('blocking-non-blocking-stall-check-' +
                                         uuid.uuid1().hex, False),
-                                       ("blocking-non-blocking-stall-check-" +
+                                       ('blocking-non-blocking-stall-check-' +
                                         uuid.uuid1().hex, True),
-                                       ("blocking-non-blocking-stall-check-" +
+                                       ('blocking-non-blocking-stall-check-' +
                                         uuid.uuid1().hex, False))
 
         self._declared_queue_names = []
@@ -529,7 +529,7 @@ class TestBlockingNonBlockingBlockingRPCWontStall(AsyncTestCase, AsyncAdapters):
 
 
 class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Consume and cancel"
+    DESCRIPTION = 'Consume and cancel'
 
     def begin(self, channel):
         self.queue_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
@@ -556,7 +556,7 @@ class TestConsumeCancel(AsyncTestCase, AsyncAdapters):
 
 
 class TestExchangeDeclareAndDelete(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Create and delete and exchange"
+    DESCRIPTION = 'Create and delete and exchange'
 
     X_TYPE = ExchangeType.direct
 
@@ -580,7 +580,7 @@ class TestExchangeDeclareAndDelete(AsyncTestCase, AsyncAdapters):
 
 
 class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "should close chan: re-declared exchange w/ diff params"
+    DESCRIPTION = 'should close chan: re-declared exchange w/ diff params'
 
     X_TYPE1 = ExchangeType.direct
     X_TYPE2 = ExchangeType.topic
@@ -613,13 +613,13 @@ class TestExchangeRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
 
     def on_bad_result(self, frame):
         self.channel.exchange_delete(self.name)
-        raise AssertionError("Should not have received an Exchange.DeclareOk")
+        raise AssertionError('Should not have received an Exchange.DeclareOk')
 
 
 class TestNoDeadlockWhenClosingChannelWithPendingBlockedRequestsAndConcurrentChannelCloseFromBroker(
         AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = ("No deadlock when closing a channel with pending blocked "
-                   "requests and concurrent Channel.Close from broker.")
+    DESCRIPTION = ('No deadlock when closing a channel with pending blocked '
+                   'requests and concurrent Channel.Close from broker.')
 
     # To observe the behavior that this is testing, comment out this line
     # in pika/channel.py - _on_close:
@@ -647,12 +647,12 @@ class TestNoDeadlockWhenClosingChannelWithPendingBlockedRequestsAndConcurrentCha
         self.stop()
 
     def on_bad_result(self, exch_name, frame):
-        self.fail("Should not have received an Exchange.DeclareOk")
+        self.fail('Should not have received an Exchange.DeclareOk')
 
 
 class TestClosingAChannelPermitsBlockedRequestToComplete(
         AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Closing a channel permits blocked requests to complete."
+    DESCRIPTION = 'Closing a channel permits blocked requests to complete.'
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
@@ -687,7 +687,7 @@ class TestClosingAChannelPermitsBlockedRequestToComplete(
 
 
 class TestQueueUnnamedDeclareAndDelete(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Create and delete an unnamed queue"
+    DESCRIPTION = 'Create and delete an unnamed queue'
 
     @async_test_base.stop_on_error_in_async_test_case_method
     def begin(self, channel):
@@ -712,7 +712,7 @@ class TestQueueUnnamedDeclareAndDelete(AsyncTestCase, AsyncAdapters):
 
 
 class TestQueueNamedDeclareAndDelete(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Create and delete a named queue"
+    DESCRIPTION = 'Create and delete a named queue'
 
     def begin(self, channel):
         self._q_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
@@ -737,7 +737,7 @@ class TestQueueNamedDeclareAndDelete(AsyncTestCase, AsyncAdapters):
 
 
 class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Should close chan: re-declared queue w/ diff params"
+    DESCRIPTION = 'Should close chan: re-declared queue w/ diff params'
 
     def begin(self, channel):
         self._q_name = self.__class__.__name__ + ':' + uuid.uuid1().hex
@@ -764,11 +764,11 @@ class TestQueueRedeclareWithDifferentValues(AsyncTestCase, AsyncAdapters):
 
     def on_bad_result(self, frame):
         self.channel.queue_delete(self._q_name)
-        raise AssertionError("Should not have received a Queue.DeclareOk")
+        raise AssertionError('Should not have received a Queue.DeclareOk')
 
 
 class TestTX1_Select(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Receive confirmation of Tx.Select"
+    DESCRIPTION = 'Receive confirmation of Tx.Select'
 
     def begin(self, channel):
         channel.tx_select(callback=self.on_complete)
@@ -779,7 +779,7 @@ class TestTX1_Select(AsyncTestCase, AsyncAdapters):
 
 
 class TestTX2_Commit(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Start a transaction, and commit it"
+    DESCRIPTION = 'Start a transaction, and commit it'
 
     def begin(self, channel):
         channel.tx_select(callback=self.on_selectok)
@@ -794,7 +794,7 @@ class TestTX2_Commit(AsyncTestCase, AsyncAdapters):
 
 
 class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Close the channel: commit without a TX"
+    DESCRIPTION = 'Close the channel: commit without a TX'
 
     def begin(self, channel):
         self.channel.add_on_close_callback(self.on_channel_closed)
@@ -808,11 +808,11 @@ class TestTX2_CommitFailure(AsyncTestCase, AsyncAdapters):
 
     @staticmethod
     def on_commitok(frame):
-        raise AssertionError("Should not have received a Tx.CommitOk")
+        raise AssertionError('Should not have received a Tx.CommitOk')
 
 
 class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Start a transaction, then rollback"
+    DESCRIPTION = 'Start a transaction, then rollback'
 
     def begin(self, channel):
         channel.tx_select(callback=self.on_selectok)
@@ -827,7 +827,7 @@ class TestTX3_Rollback(AsyncTestCase, AsyncAdapters):
 
 
 class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Close the channel: rollback without a TX"
+    DESCRIPTION = 'Close the channel: rollback without a TX'
 
     def begin(self, channel):
         self.channel.add_on_close_callback(self.on_channel_closed)
@@ -838,15 +838,15 @@ class TestTX3_RollbackFailure(AsyncTestCase, AsyncAdapters):
 
     @staticmethod
     def on_commitok(frame):
-        raise AssertionError("Should not have received a Tx.RollbackOk")
+        raise AssertionError('Should not have received a Tx.RollbackOk')
 
 
 class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):
-    DESCRIPTION = "Publish a message and consume it"
+    DESCRIPTION = 'Publish a message and consume it'
 
     def on_ready(self, frame):
         self.ctag = self.channel.basic_consume(self.queue, self.on_message)
-        self.msg_body = f"{self.__class__.__name__}: {time_now()}"
+        self.msg_body = f'{self.__class__.__name__}: {time_now()}'
         self.channel.basic_publish(self.exchange, self.routing_key,
                                    self.msg_body)
 
@@ -862,11 +862,11 @@ class TestZ_PublishAndConsume(BoundQueueTestCase, AsyncAdapters):
 
 
 class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
-    DESCRIPTION = "Publish a big message and consume it"
+    DESCRIPTION = 'Publish a big message and consume it'
 
     @staticmethod
     def _get_msg_body():
-        return '\n'.join([f"{i}" for i in range(2097152)])
+        return '\n'.join([f'{i}' for i in range(2097152)])
 
     def on_ready(self, frame):
         self.ctag = self.channel.basic_consume(self.queue, self.on_message)
@@ -886,10 +886,10 @@ class TestZ_PublishAndConsumeBig(BoundQueueTestCase, AsyncAdapters):
 
 
 class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):
-    DESCRIPTION = "Publish a message and get it"
+    DESCRIPTION = 'Publish a message and get it'
 
     def on_ready(self, frame):
-        self.msg_body = f"{self.__class__.__name__}: {time_now()}"
+        self.msg_body = f'{self.__class__.__name__}: {time_now()}'
         self.channel.basic_publish(self.exchange, self.routing_key,
                                    self.msg_body)
         self.channel.basic_get(self.queue, self.on_get)
@@ -902,7 +902,7 @@ class TestZ_PublishAndGet(BoundQueueTestCase, AsyncAdapters):
 
 
 class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Unknown vhost results in ProbableAccessDeniedError."
+    DESCRIPTION = 'Unknown vhost results in ProbableAccessDeniedError.'
 
     def start(self, *args, **kwargs):
         self.parameters.virtual_host = str(uuid.uuid4())
@@ -921,7 +921,7 @@ class TestZ_AccessDenied(AsyncTestCase, AsyncAdapters):
 
 
 class TestBlockedConnectionTimesOut(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Verify that blocked connection terminates on timeout"
+    DESCRIPTION = 'Verify that blocked connection terminates on timeout'
 
     def start(self, *args, **kwargs):
         self.parameters.blocked_connection_timeout = 0.001
@@ -947,7 +947,7 @@ class TestBlockedConnectionTimesOut(AsyncTestCase, AsyncAdapters):
 
 
 class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Verify that blocked-unblocked connection closes normally"
+    DESCRIPTION = 'Verify that blocked-unblocked connection closes normally'
 
     def start(self, *args, **kwargs):
         self.parameters.blocked_connection_timeout = 0.001
@@ -988,7 +988,7 @@ class TestBlockedConnectionUnblocks(AsyncTestCase, AsyncAdapters):
 class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(
         AsyncTestCase, AsyncAdapters):
     DESCRIPTION = (
-        "Test _adapter_add_callback_threadsafe request before ioloop starts.")
+        'Test _adapter_add_callback_threadsafe request before ioloop starts.')
 
     def _run_ioloop(self, *args, **kwargs):
         """We intercept this method from AsyncTestCase in order to call
@@ -1023,7 +1023,7 @@ class TestAddCallbackThreadsafeRequestBeforeIOLoopStarts(
 
 class TestAddCallbackThreadsafeFromIOLoopThread(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = (
-        "Test _adapter_add_callback_threadsafe request from same thread.")
+        'Test _adapter_add_callback_threadsafe request from same thread.')
 
     def start(self, *args, **kwargs):
         self.loop_thread_ident = threading.current_thread().ident
@@ -1049,7 +1049,7 @@ class TestAddCallbackThreadsafeFromIOLoopThread(AsyncTestCase, AsyncAdapters):
 
 class TestAddCallbackThreadsafeFromAnotherThread(AsyncTestCase, AsyncAdapters):
     DESCRIPTION = (
-        "Test _adapter_add_callback_threadsafe request from another thread.")
+        'Test _adapter_add_callback_threadsafe request from another thread.')
 
     def start(self, *args, **kwargs):
         self.loop_thread_ident = threading.current_thread().ident
@@ -1077,7 +1077,7 @@ class TestAddCallbackThreadsafeFromAnotherThread(AsyncTestCase, AsyncAdapters):
 
 
 class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Test ioloop.stop() before ioloop starts causes ioloop to exit quickly."
+    DESCRIPTION = 'Test ioloop.stop() before ioloop starts causes ioloop to exit quickly.'
 
     def _run_ioloop(self, *args, **kwargs):
         """We intercept this method from AsyncTestCase in order to call ioloop.stop() before
@@ -1102,7 +1102,7 @@ class TestIOLoopStopBeforeIOLoopStarts(AsyncTestCase, AsyncAdapters):
 
 class TestViabilityOfMultipleTimeoutsWithSameDeadlineAndCallback(
         AsyncTestCase, AsyncAdapters):
-    DESCRIPTION = "Test viability of multiple timeouts with same deadline and callback"
+    DESCRIPTION = 'Test viability of multiple timeouts with same deadline and callback'
 
     def begin(self, channel):
         timer1 = channel.connection._adapter_call_later(0, self.on_my_timer)

--- a/tests/acceptance/blocking_adapter_test.py
+++ b/tests/acceptance/blocking_adapter_test.py
@@ -154,7 +154,7 @@ class TestCreateConnectionFromTwoConfigsFirstUnreachable(BlockingTestCaseBase):
 
         sock.close()
 
-        bad_params = pika.URLParameters(PARAMS_URL_TEMPLATE % {"port": port})
+        bad_params = pika.URLParameters(PARAMS_URL_TEMPLATE % {'port': port})
         good_params = pika.URLParameters(DEFAULT_URL)
 
         with self._connect_params([bad_params, good_params]) as connection:
@@ -178,7 +178,7 @@ class TestCreateConnectionFromTwoUnreachableConfigs(BlockingTestCaseBase):
 
         sock.close()
 
-        bad_params = pika.URLParameters(PARAMS_URL_TEMPLATE % {"port": port})
+        bad_params = pika.URLParameters(PARAMS_URL_TEMPLATE % {'port': port})
 
         with self.assertRaises(pika.exceptions.AMQPConnectionError):
             self._connect_params([bad_params, bad_params])
@@ -292,7 +292,7 @@ class TestUpdateSecret(BlockingTestCaseBase):
         channel = connection.channel()
 
         # Update secret
-        connection.update_secret("new_secret", "reason")
+        connection.update_secret('new_secret', 'reason')
 
         # Now check is_open/is_closed on channel and connection
         self.assertTrue(channel.is_open)
@@ -311,7 +311,7 @@ class TestUpdateSecretOnClosedRaisesWrongState(BlockingTestCaseBase):
 
         # Attempt to update secret
         with self.assertRaises(pika.exceptions.ConnectionWrongStateError):
-            connection.update_secret("new_secret", "reason")
+            connection.update_secret('new_secret', 'reason')
 
         # Now check is_open/is_closed on channel and connection
         self.assertFalse(connection.is_open)
@@ -325,11 +325,11 @@ class TestUpdateSecretExpectsStrings(BlockingTestCaseBase):
 
         # Attempt to update secret with integer as new_secret
         with self.assertRaises(AssertionError):
-            connection.update_secret(1, "reason")
+            connection.update_secret(1, 'reason')
 
         # Attempt to update secret with integer as reason
         with self.assertRaises(AssertionError):
-            connection.update_secret("new_secret", 1)
+            connection.update_secret('new_secret', 1)
 
 
 class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
@@ -342,7 +342,7 @@ class TestInvalidExchangeTypeRaisesConnectionClosed(BlockingTestCaseBase):
         connection = self._connect()
         ch = connection.channel()
 
-        exg_name = ("TestInvalidExchangeTypeRaisesConnectionClosed_" +
+        exg_name = ('TestInvalidExchangeTypeRaisesConnectionClosed_' +
                     uuid.uuid1().hex)
 
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
@@ -408,7 +408,7 @@ class TestSuddenBrokerDisconnectBeforeChannel(BlockingTestCaseBase):
                            local_linger_args=(1, 0)) as fwd:
 
             self.connection = self._connect(PARAMS_URL_TEMPLATE %
-                                            {"port": fwd.server_address[1]})
+                                            {'port': fwd.server_address[1]})
 
         # Once outside the context, the connection is broken
 
@@ -430,7 +430,7 @@ class TestNoAccessToConnectionAfterConnectionLost(BlockingTestCaseBase):
                            local_linger_args=(1, 0)) as fwd:
 
             self.connection = self._connect(PARAMS_URL_TEMPLATE %
-                                            {"port": fwd.server_address[1]})
+                                            {'port': fwd.server_address[1]})
 
         # Once outside the context, the connection is broken
 
@@ -463,7 +463,7 @@ class TestConnectWithDownedBroker(BlockingTestCaseBase):
 
         with self.assertRaises(pika.exceptions.AMQPConnectionError):
             self.connection = self._connect(PARAMS_URL_TEMPLATE %
-                                            {"port": port})
+                                            {'port': port})
 
 
 class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
@@ -485,7 +485,7 @@ class TestDisconnectDuringConnectionStart(BlockingTestCaseBase):
                 return super()._on_connection_start(*args, **kwargs)
 
         with self.assertRaises(pika.exceptions.ProbableAuthenticationError):
-            self._connect(PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
+            self._connect(PARAMS_URL_TEMPLATE % {'port': fwd.server_address[1]},
                           impl_class=MySelectConnection)
 
 
@@ -507,7 +507,7 @@ class TestDisconnectDuringConnectionTune(BlockingTestCaseBase):
                 return super()._on_connection_tune(*args, **kwargs)
 
         with self.assertRaises(pika.exceptions.ProbableAccessDeniedError):
-            self._connect(PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
+            self._connect(PARAMS_URL_TEMPLATE % {'port': fwd.server_address[1]},
                           impl_class=MySelectConnection)
 
 
@@ -530,7 +530,7 @@ class TestDisconnectDuringConnectionProtocol(BlockingTestCaseBase):
                 return super()._on_stream_connected(*args, **kwargs)
 
         with self.assertRaises(pika.exceptions.IncompatibleProtocolError):
-            self._connect(PARAMS_URL_TEMPLATE % {"port": fwd.server_address[1]},
+            self._connect(PARAMS_URL_TEMPLATE % {'port': fwd.server_address[1]},
                           impl_class=MySelectConnection)
 
 
@@ -824,7 +824,7 @@ class TestExchangeDeclareAndDelete(BlockingTestCaseBase):
 
         ch = connection.channel()
 
-        name = "TestExchangeDeclareAndDelete_" + uuid.uuid1().hex
+        name = 'TestExchangeDeclareAndDelete_' + uuid.uuid1().hex
 
         # Declare a new exchange
         frame = ch.exchange_declare(name, exchange_type=ExchangeType.direct)
@@ -956,7 +956,7 @@ class TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed(
         ch = connection.channel()
 
         q_name = (
-            "TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed_q_" +
+            'TestPassiveQueueDeclareOfUnknownQueueRaisesChannelClosed_q_' +
             uuid.uuid1().hex)
 
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
@@ -1479,7 +1479,7 @@ class TestBasicConsumeFromUnknownQueueRaisesChannelClosed(BlockingTestCaseBase):
         connection = self._connect()
         ch = connection.channel()
 
-        q_name = ("TestBasicConsumeFromUnknownQueueRaisesChannelClosed_q_" +
+        q_name = ('TestBasicConsumeFromUnknownQueueRaisesChannelClosed_q_' +
                   uuid.uuid1().hex)
 
         with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as ex_cm:
@@ -3193,7 +3193,7 @@ class TestChannelContextManagerDoesNotSuppressChannelClosedByBroker(
         exception.
         """
         exg_name = (
-            "TestChannelContextManagerDoesNotSuppressChannelClosedByBroker" +
+            'TestChannelContextManagerDoesNotSuppressChannelClosedByBroker' +
             uuid.uuid1().hex)
 
         channel = self._connect().channel()

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -103,7 +103,7 @@ class TestRunWithStopFromThreadsafeCallback(AsyncServicesTestBase,
         self.assertEqual(bucket, ['I was called'])
 
 
-@unittest.skipIf(pika._utils.ON_WINDOWS, "Windows timing is too precise")
+@unittest.skipIf(pika._utils.ON_WINDOWS, 'Windows timing is too precise')
 class TestCallLaterDoesNotCallAheadOfTime(AsyncServicesTestBase,
                                           IOServicesTestStubs):
 
@@ -178,7 +178,7 @@ class TestCallLaterCancelledDoesNotCallBack(AsyncServicesTestBase,
 
 class SocketWatcherTestBase(AsyncServicesTestBase):
 
-    WatcherActivity = collections.namedtuple("io_services_test_WatcherActivity",
+    WatcherActivity = collections.namedtuple('io_services_test_WatcherActivity',
                                              ['readable', 'writable'])
 
     def _check_socket_watchers_fired(self, sock, expected):

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -46,7 +46,7 @@ class TestCase(unittest.TestCase):
 
         def _cb(ignore):
             raise self.failureException(
-                f"did not catch an error, instead got {ignore!r}")
+                f'did not catch an error, instead got {ignore!r}')
 
         def _eb(failure):
             if failure.check(*expectedFailures):
@@ -63,24 +63,24 @@ class ClosableDeferredQueueTestCase(TestCase):
     def test_put_closed(self):
         # Verify that the .put() method errbacks when the queue is closed.
         q = ClosableDeferredQueue()
-        q.closed = RuntimeError("testing")
+        q.closed = RuntimeError('testing')
         d = self.assertFailure(q.put(None), RuntimeError)
-        d.addCallback(lambda e: self.assertEqual(e.args[0], "testing"))
+        d.addCallback(lambda e: self.assertEqual(e.args[0], 'testing'))
         assert d.called
 
     @pytest.mark.timeout(5)
     def test_get_closed(self):
         # Verify that the .get() method errbacks when the queue is closed.
         q = ClosableDeferredQueue()
-        q.closed = RuntimeError("testing")
+        q.closed = RuntimeError('testing')
         d = self.assertFailure(q.get(), RuntimeError)
-        d.addCallback(lambda e: self.assertEqual(e.args[0], "testing"))
+        d.addCallback(lambda e: self.assertEqual(e.args[0], 'testing'))
         assert d.called
 
     def test_close(self):
         # Verify that the queue can be closed.
         q = ClosableDeferredQueue()
-        reason = RuntimeError("testing")
+        reason = RuntimeError('testing')
         q.close(reason)
         self.assertEqual(q.closed, reason)
         self.assertEqual(q.waiting, [])
@@ -91,7 +91,7 @@ class ClosableDeferredQueueTestCase(TestCase):
         # queue is closed.
         q = ClosableDeferredQueue()
         d = q.get()
-        q.close(RuntimeError("testing"))
+        q.close(RuntimeError('testing'))
         self.assertTrue(q.closed)
         self.assertEqual(q.waiting, [])
         self.assertEqual(q.pending, [])
@@ -101,7 +101,7 @@ class ClosableDeferredQueueTestCase(TestCase):
     def test_close_twice(self):
         # If a queue it called twice, it must not crash.
         q = ClosableDeferredQueue()
-        reason = RuntimeError("testing")
+        reason = RuntimeError('testing')
         q.close(reason)
         self.assertEqual(q.closed, reason)
         q.close(reason)
@@ -115,33 +115,33 @@ class TwistedChannelTestCase(TestCase):
         self.channel = TwistedChannel(self.pika_channel)
         # This is only needed on Python2 for functools.wraps to work.
         wrapped = (
-            "basic_cancel",
-            "basic_get",
-            "basic_qos",
-            "basic_recover",
-            "exchange_bind",
-            "exchange_unbind",
-            "exchange_declare",
-            "exchange_delete",
-            "confirm_delivery",
-            "flow",
-            "queue_bind",
-            "queue_declare",
-            "queue_delete",
-            "queue_purge",
-            "queue_unbind",
-            "tx_commit",
-            "tx_rollback",
-            "tx_select",
+            'basic_cancel',
+            'basic_get',
+            'basic_qos',
+            'basic_recover',
+            'exchange_bind',
+            'exchange_unbind',
+            'exchange_declare',
+            'exchange_delete',
+            'confirm_delivery',
+            'flow',
+            'queue_bind',
+            'queue_declare',
+            'queue_delete',
+            'queue_purge',
+            'queue_unbind',
+            'tx_commit',
+            'tx_rollback',
+            'tx_select',
         )
         for meth_name in wrapped:
             getattr(self.pika_channel, meth_name).__name__ = meth_name
 
     def test_repr(self):
-        self.pika_channel.__repr__ = mock.Mock(return_value="<TestChannel>")
+        self.pika_channel.__repr__ = mock.Mock(return_value='<TestChannel>')
         self.assertEqual(
             repr(self.channel),
-            "<TwistedChannel channel=<TestChannel>>",
+            '<TwistedChannel channel=<TestChannel>>',
         )
 
     @pytest.mark.timeout(5)
@@ -153,8 +153,8 @@ class TwistedChannelTestCase(TestCase):
         call = defer.Deferred()
         self.channel._calls = {call}
         consumer_mock = mock.Mock()
-        self.channel._consumers = {"test-delivery-tag": consumer_mock}
-        error = RuntimeError("testing")
+        self.channel._consumers = {'test-delivery-tag': consumer_mock}
+        error = RuntimeError('testing')
         self.channel._on_channel_closed(mock.Mock(), error)
         consumer_mock.close.assert_called_once_with(error)
         self.assertEqual(len(self.channel._calls), 0)
@@ -165,11 +165,11 @@ class TwistedChannelTestCase(TestCase):
     @pytest.mark.timeout(5)
     def test_basic_consume(self):
         # Verify that the basic_consume method works properly.
-        d = self.channel.basic_consume(queue="testqueue")
+        d = self.channel.basic_consume(queue='testqueue')
         self.pika_channel.basic_consume.assert_called_once()
         kwargs = self.pika_channel.basic_consume.call_args_list[0][1]
-        self.assertEqual(kwargs["queue"], "testqueue")
-        on_message = kwargs["on_message_callback"]
+        self.assertEqual(kwargs['queue'], 'testqueue')
+        on_message = kwargs['on_message_callback']
 
         def check_cb(result):
             queue, _consumer_tag = result
@@ -177,24 +177,24 @@ class TwistedChannelTestCase(TestCase):
             queue_get_d = queue.get()
             queue_get_d.addCallback(
                 self.assertEqual,
-                (self.channel, "testmethod", "testprops", "testbody"))
+                (self.channel, 'testmethod', 'testprops', 'testbody'))
             # Simulate reception of a message
-            on_message("testchan", "testmethod", "testprops", "testbody")
+            on_message('testchan', 'testmethod', 'testprops', 'testbody')
             return queue_get_d
 
         d.addCallback(check_cb)
         # Simulate a ConsumeOk from the server
-        frame = Method(1, spec.Basic.ConsumeOk(consumer_tag="testconsumertag"))
-        kwargs["callback"](frame)
+        frame = Method(1, spec.Basic.ConsumeOk(consumer_tag='testconsumertag'))
+        kwargs['callback'](frame)
         assert d.called
 
     @pytest.mark.timeout(5)
     def test_basic_consume_while_closed(self):
         # Verify that a Failure is returned when the channel's basic_consume
         # is called and the channel is closed.
-        error = RuntimeError("testing")
+        error = RuntimeError('testing')
         self.channel._on_channel_closed(mock.Mock(), error)
-        d = self.channel.basic_consume(queue="testqueue")
+        d = self.channel.basic_consume(queue='testqueue')
         self.assertFailure(d, RuntimeError)
         assert d.called
 
@@ -203,16 +203,16 @@ class TwistedChannelTestCase(TestCase):
         # Verify that a Failure is returned when the channel's basic_consume
         # method fails.
         self.pika_channel.basic_consume.side_effect = RuntimeError()
-        d = self.channel.basic_consume(queue="testqueue")
+        d = self.channel.basic_consume(queue='testqueue')
         self.assertFailure(d, RuntimeError)
         assert d.called
 
     def test_basic_consume_errback_on_close(self):
         # Verify Deferreds that haven't had their callback invoked errback when
         # the channel closes.
-        d = self.channel.basic_consume(queue="testqueue")
+        d = self.channel.basic_consume(queue='testqueue')
         self.channel._on_channel_closed(mock.Mock(),
-                                        ChannelClosedByBroker(404, "NOT FOUND"))
+                                        ChannelClosedByBroker(404, 'NOT FOUND'))
         self.assertFailure(d, ChannelClosedByBroker)
         assert d.called
 
@@ -221,17 +221,17 @@ class TwistedChannelTestCase(TestCase):
         # Verify that the consumers are cleared when a queue is deleted.
         queue_obj = mock.Mock()
         self.channel._consumers = {
-            "test-delivery-tag": queue_obj,
+            'test-delivery-tag': queue_obj,
         }
-        self.channel._queue_name_to_consumer_tags["testqueue"] = {
-            "test-delivery-tag"
+        self.channel._queue_name_to_consumer_tags['testqueue'] = {
+            'test-delivery-tag'
         }
         self.channel._calls = set()
-        self.pika_channel.queue_delete.__name__ = "queue_delete"
-        d = self.channel.queue_delete(queue="testqueue")
+        self.pika_channel.queue_delete.__name__ = 'queue_delete'
+        d = self.channel.queue_delete(queue='testqueue')
         self.pika_channel.queue_delete.assert_called_once()
         call_kw = self.pika_channel.queue_delete.call_args_list[0][1]
-        self.assertEqual(call_kw["queue"], "testqueue")
+        self.assertEqual(call_kw['queue'], 'testqueue')
 
         def check(_):
             self.assertEqual(len(self.channel._consumers), 0)
@@ -250,26 +250,26 @@ class TwistedChannelTestCase(TestCase):
     def test_wrapped_method(self):
         # Verify that the wrapped method is called and the result is properly
         # transmitted via the Deferred.
-        self.pika_channel.queue_declare.__name__ = "queue_declare"
-        d = self.channel.queue_declare(queue="testqueue")
+        self.pika_channel.queue_declare.__name__ = 'queue_declare'
+        d = self.channel.queue_declare(queue='testqueue')
         self.pika_channel.queue_declare.assert_called_once()
         call_kw = self.pika_channel.queue_declare.call_args_list[0][1]
-        self.assertIn("queue", call_kw)
-        self.assertEqual(call_kw["queue"], "testqueue")
-        self.assertIn("callback", call_kw)
-        self.assertTrue(callable(call_kw["callback"]))
-        call_kw["callback"]("testresult")
-        d.addCallback(self.assertEqual, "testresult")
+        self.assertIn('queue', call_kw)
+        self.assertEqual(call_kw['queue'], 'testqueue')
+        self.assertIn('callback', call_kw)
+        self.assertTrue(callable(call_kw['callback']))
+        call_kw['callback']('testresult')
+        d.addCallback(self.assertEqual, 'testresult')
         assert d.called
 
     @pytest.mark.timeout(5)
     def test_wrapped_method_while_closed(self):
         # Verify that a Failure is returned when one of the channel's wrapped
         # methods is called and the channel is closed.
-        error = RuntimeError("testing")
+        error = RuntimeError('testing')
         self.channel._on_channel_closed(mock.Mock(), error)
-        self.pika_channel.queue_declare.__name__ = "queue_declare"
-        d = self.channel.queue_declare(queue="testqueue")
+        self.pika_channel.queue_declare.__name__ = 'queue_declare'
+        d = self.channel.queue_declare(queue='testqueue')
         self.assertFailure(d, RuntimeError)
         assert d.called
 
@@ -277,20 +277,20 @@ class TwistedChannelTestCase(TestCase):
     def test_wrapped_method_multiple_args(self):
         # Verify that multiple arguments to the callback are properly converted
         # to a tuple for the Deferred's result.
-        self.pika_channel.queue_declare.__name__ = "queue_declare"
-        d = self.channel.queue_declare(queue="testqueue")
+        self.pika_channel.queue_declare.__name__ = 'queue_declare'
+        d = self.channel.queue_declare(queue='testqueue')
         call_kw = self.pika_channel.queue_declare.call_args_list[0][1]
-        call_kw["callback"]("testresult-1", "testresult-2")
-        d.addCallback(self.assertEqual, ("testresult-1", "testresult-2"))
+        call_kw['callback']('testresult-1', 'testresult-2')
+        d.addCallback(self.assertEqual, ('testresult-1', 'testresult-2'))
         assert d.called
 
     @pytest.mark.timeout(5)
     def test_wrapped_method_failure(self):
         # Verify that exceptions are properly handled in wrapped methods.
-        error = RuntimeError("testing")
-        self.pika_channel.queue_declare.__name__ = "queue_declare"
+        error = RuntimeError('testing')
+        self.pika_channel.queue_declare.__name__ = 'queue_declare'
         self.pika_channel.queue_declare.side_effect = error
-        d = self.channel.queue_declare(queue="testqueue")
+        d = self.channel.queue_declare(queue='testqueue')
         self.assertFailure(d, RuntimeError)
         assert d.called
 
@@ -303,16 +303,16 @@ class TwistedChannelTestCase(TestCase):
     def test_passthrough(self):
         # Check the simple attribute passthroughs
         attributes = (
-            "channel_number",
-            "connection",
-            "is_closed",
-            "is_closing",
-            "is_open",
-            "flow_active",
-            "consumer_tags",
+            'channel_number',
+            'connection',
+            'is_closed',
+            'is_closing',
+            'is_open',
+            'flow_active',
+            'consumer_tags',
         )
         for name in attributes:
-            value = f"testvalue-{name}"
+            value = f'testvalue-{name}'
             setattr(self.pika_channel, name, value)
             self.assertEqual(getattr(self.channel, name), value)
 
@@ -328,27 +328,27 @@ class TwistedChannelTestCase(TestCase):
         cb = mock.Mock()
         self.channel.add_on_return_callback(cb)
         self.pika_channel.add_on_return_callback.assert_called_once()
-        self.pika_channel.add_on_return_callback.call_args[0][0]("testchannel",
-                                                                 "testmethod",
-                                                                 "testprops",
-                                                                 "testbody")
+        self.pika_channel.add_on_return_callback.call_args[0][0]('testchannel',
+                                                                 'testmethod',
+                                                                 'testprops',
+                                                                 'testbody')
         cb.assert_called_once()
         self.assertEqual(len(cb.call_args[0]), 1)
         self.assertEqual(cb.call_args[0][0],
-                         (self.channel, "testmethod", "testprops", "testbody"))
+                         (self.channel, 'testmethod', 'testprops', 'testbody'))
 
     @pytest.mark.timeout(5)
     def test_basic_cancel(self):
         # Verify that basic_cancels calls clean up the consumer queue.
         queue_obj = mock.Mock()
         queue_obj_2 = mock.Mock()
-        self.channel._consumers["test-consumer"] = queue_obj
-        self.channel._consumers["test-consumer-2"] = queue_obj_2
+        self.channel._consumers['test-consumer'] = queue_obj
+        self.channel._consumers['test-consumer-2'] = queue_obj_2
         self.channel._queue_name_to_consumer_tags.update({
-            "testqueue": {"test-consumer"},
-            "testqueue-2": {"test-consumer-2"},
+            'testqueue': {'test-consumer'},
+            'testqueue-2': {'test-consumer-2'},
         })
-        d = self.channel.basic_cancel("test-consumer")
+        d = self.channel.basic_cancel('test-consumer')
 
         def check(result):
             self.assertTrue(isinstance(result, Method))
@@ -358,26 +358,26 @@ class TwistedChannelTestCase(TestCase):
             self.assertEqual(len(self.channel._consumers), 1)
             queue_obj_2.close.assert_not_called()
             self.assertEqual(
-                self.channel._queue_name_to_consumer_tags["testqueue"], set())
+                self.channel._queue_name_to_consumer_tags['testqueue'], set())
 
         d.addCallback(check)
         self.pika_channel.basic_cancel.assert_called_once()
-        self.pika_channel.basic_cancel.call_args[1]["callback"](Method(
-            1, spec.Basic.CancelOk(consumer_tag="test-consumer")))
+        self.pika_channel.basic_cancel.call_args[1]['callback'](Method(
+            1, spec.Basic.CancelOk(consumer_tag='test-consumer')))
         assert d.called
 
     @pytest.mark.timeout(5)
     def test_basic_cancel_no_consumer(self):
         # Verify that basic_cancel does not crash if there is no consumer.
-        d = self.channel.basic_cancel("test-consumer")
+        d = self.channel.basic_cancel('test-consumer')
 
         def check(result):
             self.assertTrue(isinstance(result, Method))
 
         d.addCallback(check)
         self.pika_channel.basic_cancel.assert_called_once()
-        self.pika_channel.basic_cancel.call_args[1]["callback"](Method(
-            1, spec.Basic.CancelOk(consumer_tag="test-consumer")))
+        self.pika_channel.basic_cancel.call_args[1]['callback'](Method(
+            1, spec.Basic.CancelOk(consumer_tag='test-consumer')))
         assert d.called
 
     def test_consumer_cancelled_by_broker(self):
@@ -385,49 +385,49 @@ class TwistedChannelTestCase(TestCase):
         self.pika_channel.add_on_cancel_callback.assert_called_with(
             self.channel._on_consumer_cancelled_by_broker)
         queue_obj = mock.Mock()
-        self.channel._consumers["test-consumer"] = queue_obj
-        self.channel._queue_name_to_consumer_tags["testqueue"] = {
-            "test-consumer"
+        self.channel._consumers['test-consumer'] = queue_obj
+        self.channel._queue_name_to_consumer_tags['testqueue'] = {
+            'test-consumer'
         }
         self.channel._on_consumer_cancelled_by_broker(
-            Method(1, spec.Basic.Cancel(consumer_tag="test-consumer")))
+            Method(1, spec.Basic.Cancel(consumer_tag='test-consumer')))
         queue_obj.close.assert_called_once()
         self.assertTrue(
             isinstance(queue_obj.close.call_args[0][0], ConsumerCancelled))
         self.assertEqual(self.channel._consumers, {})
-        self.assertEqual(self.channel._queue_name_to_consumer_tags["testqueue"],
+        self.assertEqual(self.channel._queue_name_to_consumer_tags['testqueue'],
                          set())
 
     @pytest.mark.timeout(5)
     def test_basic_get(self):
         # Verify that the basic_get method works properly.
-        d = self.channel.basic_get(queue="testqueue")
+        d = self.channel.basic_get(queue='testqueue')
         self.pika_channel.basic_get.assert_called_once()
         kwargs = self.pika_channel.basic_get.call_args_list[0][1]
-        self.assertEqual(kwargs["queue"], "testqueue")
+        self.assertEqual(kwargs['queue'], 'testqueue')
 
         def check_cb(result):
             self.assertEqual(
-                result, (self.channel, "testmethod", "testprops", "testbody"))
+                result, (self.channel, 'testmethod', 'testprops', 'testbody'))
 
         d.addCallback(check_cb)
         # Simulate reception of a message
-        kwargs["callback"]("testchannel", "testmethod", "testprops", "testbody")
+        kwargs['callback']('testchannel', 'testmethod', 'testprops', 'testbody')
         assert d.called
 
     def test_basic_get_twice(self):
         # Verify that the basic_get method raises the proper exception when
         # called twice.
-        self.channel.basic_get(queue="testqueue")
+        self.channel.basic_get(queue='testqueue')
         self.assertRaises(DuplicateGetOkCallback, self.channel.basic_get,
-                          "testqueue")
+                          'testqueue')
 
     @pytest.mark.timeout(5)
     def test_basic_get_empty(self):
         # Verify that the basic_get method works when the queue is empty.
         self.pika_channel.add_callback.assert_called_with(
             self.channel._on_getempty, [spec.Basic.GetEmpty], False)
-        d = self.channel.basic_get(queue="testqueue")
+        d = self.channel.basic_get(queue='testqueue')
         self.channel._on_getempty(mock.Mock())
         d.addCallback(self.assertIsNone)
         assert d.called
@@ -442,14 +442,14 @@ class TwistedChannelTestCase(TestCase):
     @pytest.mark.timeout(5)
     def test_basic_publish(self):
         # Verify that basic_publish wraps properly.
-        d = self.channel.basic_publish("testexch",
-                                       routing_key="testrk",
-                                       body=b"testbody")
+        d = self.channel.basic_publish('testexch',
+                                       routing_key='testrk',
+                                       body=b'testbody')
         self.pika_channel.basic_publish.assert_called_once_with(
             # Args are converted to kwargs
-            exchange="testexch",
-            routing_key="testrk",
-            body=b"testbody",
+            exchange='testexch',
+            routing_key='testrk',
+            body=b'testbody',
             # Defaults
             mandatory=False,
             properties=None)
@@ -459,11 +459,11 @@ class TwistedChannelTestCase(TestCase):
     def test_basic_publish_closed(self):
         # Verify that a Failure is returned when the channel's basic_publish
         # is called and the channel is closed.
-        self.channel._on_channel_closed(mock.Mock(), RuntimeError("testing"))
-        d = self.channel.basic_publish("", "", b"")
+        self.channel._on_channel_closed(mock.Mock(), RuntimeError('testing'))
+        d = self.channel.basic_publish('', '', b'')
         self.pika_channel.basic_publish.assert_not_called()
         d = self.assertFailure(d, RuntimeError)
-        d.addCallback(lambda e: self.assertEqual(e.args[0], "testing"))
+        d.addCallback(lambda e: self.assertEqual(e.args[0], 'testing'))
         assert d.called
 
     def _test_wrapped_func(self, func, kwargs, do_callback=False):
@@ -471,18 +471,18 @@ class TwistedChannelTestCase(TestCase):
         call_kw = {
             key: value
             for key, value in func.call_args[1].items()
-            if key != "callback"
+            if key != 'callback'
         }
         self.assertEqual(kwargs, call_kw)
         if do_callback:
-            func.call_args[1]["callback"](do_callback)
+            func.call_args[1]['callback'](do_callback)
 
     @pytest.mark.timeout(5)
     def test_basic_qos(self):
         # Verify that basic_qos wraps properly.
         d = self.channel.basic_qos(prefetch_size=2)
         # Defaults
-        kwargs = {"prefetch_size": 2, "prefetch_count": 0, "global_qos": False}
+        kwargs = {'prefetch_size': 2, 'prefetch_count': 0, 'global_qos': False}
         self._test_wrapped_func(self.pika_channel.basic_qos, kwargs, True)
         assert d.called
 
@@ -497,14 +497,14 @@ class TwistedChannelTestCase(TestCase):
         # Verify that basic_recover wraps properly.
         d = self.channel.basic_recover()
         self._test_wrapped_func(self.pika_channel.basic_recover,
-                                {"requeue": False}, True)
+                                {'requeue': False}, True)
         assert d.called
 
     def test_close(self):
         # Verify that close wraps properly.
         self.channel.close()
         self.pika_channel.close.assert_called_once_with(
-            reply_code=0, reply_text="Normal shutdown")
+            reply_code=0, reply_text='Normal shutdown')
 
     @pytest.mark.timeout(5)
     def test_confirm_delivery(self):
@@ -513,10 +513,10 @@ class TwistedChannelTestCase(TestCase):
         self.pika_channel.confirm_delivery.assert_called_once()
         self.assertEqual(
             self.pika_channel.confirm_delivery.call_args[1]
-            ["ack_nack_callback"], self.channel._on_delivery_confirmation)
+            ['ack_nack_callback'], self.channel._on_delivery_confirmation)
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
+            d = self.channel.basic_publish('testexch', 'testrk', b'testbody')
             frame = Method(1, spec.Basic.Ack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
             return d
@@ -527,7 +527,7 @@ class TwistedChannelTestCase(TestCase):
         d.addCallback(send_message)
         d.addCallback(check_response)
         # Simulate Confirm.SelectOk
-        self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
+        self.pika_channel.confirm_delivery.call_args[1]['callback'](None)
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -537,7 +537,7 @@ class TwistedChannelTestCase(TestCase):
         d = self.channel.confirm_delivery()
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
+            d = self.channel.basic_publish('testexch', 'testrk', b'testbody')
             frame = Method(1, spec.Basic.Nack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
             return d
@@ -549,7 +549,7 @@ class TwistedChannelTestCase(TestCase):
         d.addCallback(send_message)
         d.addCallbacks(self.fail, check_response)
         # Simulate Confirm.SelectOk
-        self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
+        self.pika_channel.confirm_delivery.call_args[1]['callback'](None)
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -560,11 +560,11 @@ class TwistedChannelTestCase(TestCase):
         return_cb = self.pika_channel.add_on_return_callback.call_args[0][0]
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
+            d = self.channel.basic_publish('testexch', 'testrk', b'testbody')
             # Send the Basic.Return frame
-            method = spec.Basic.Return(exchange="testexch",
-                                       routing_key="testrk")
-            return_cb(self.channel, method, spec.BasicProperties(), b"testbody")
+            method = spec.Basic.Return(exchange='testexch',
+                                       routing_key='testrk')
+            return_cb(self.channel, method, spec.BasicProperties(), b'testbody')
             # Send the Basic.Ack frame
             frame = Method(1, spec.Basic.Ack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
@@ -574,12 +574,12 @@ class TwistedChannelTestCase(TestCase):
             self.assertIsInstance(error.value, UnroutableError)
             self.assertEqual(len(error.value.messages), 1)
             msg = error.value.messages[0]
-            self.assertEqual(msg.body, b"testbody")
+            self.assertEqual(msg.body, b'testbody')
 
         d.addCallbacks(send_message, self.fail)
         d.addCallbacks(self.fail, check_response)
         # Simulate Confirm.SelectOk
-        self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
+        self.pika_channel.confirm_delivery.call_args[1]['callback'](None)
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -591,11 +591,11 @@ class TwistedChannelTestCase(TestCase):
         return_cb = self.pika_channel.add_on_return_callback.call_args[0][0]
 
         def send_message(_result):
-            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
+            d = self.channel.basic_publish('testexch', 'testrk', b'testbody')
             # Send the Basic.Return frame
-            method = spec.Basic.Return(exchange="testexch",
-                                       routing_key="testrk")
-            return_cb(self.channel, method, spec.BasicProperties(), b"testbody")
+            method = spec.Basic.Return(exchange='testexch',
+                                       routing_key='testrk')
+            return_cb(self.channel, method, spec.BasicProperties(), b'testbody')
             # Send the Basic.Nack frame
             frame = Method(1, spec.Basic.Nack(delivery_tag=1))
             self.channel._on_delivery_confirmation(frame)
@@ -605,11 +605,11 @@ class TwistedChannelTestCase(TestCase):
             self.assertTrue(isinstance(error.value, NackError))
             self.assertEqual(len(error.value.messages), 1)
             msg = error.value.messages[0]
-            self.assertEqual(msg.body, b"testbody")
+            self.assertEqual(msg.body, b'testbody')
 
         d.addCallback(send_message)
         d.addCallbacks(self.fail, check_response)
-        self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
+        self.pika_channel.confirm_delivery.call_args[1]['callback'](None)
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -619,8 +619,8 @@ class TwistedChannelTestCase(TestCase):
         d = self.channel.confirm_delivery()
 
         def send_message(_result):
-            d1 = self.channel.basic_publish("testexch", "testrk", b"testbody1")
-            d2 = self.channel.basic_publish("testexch", "testrk", b"testbody2")
+            d1 = self.channel.basic_publish('testexch', 'testrk', b'testbody1')
+            d2 = self.channel.basic_publish('testexch', 'testrk', b'testbody2')
             frame = Method(1, spec.Basic.Ack(delivery_tag=2, multiple=True))
             self.channel._on_delivery_confirmation(frame)
             return defer.DeferredList([d1, d2])
@@ -633,7 +633,7 @@ class TwistedChannelTestCase(TestCase):
 
         d.addCallback(send_message)
         d.addCallback(check_response)
-        self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
+        self.pika_channel.confirm_delivery.call_args[1]['callback'](None)
         assert d.called
 
     @pytest.mark.timeout(5)
@@ -642,12 +642,12 @@ class TwistedChannelTestCase(TestCase):
         # the channel closes.
         d = self.channel.confirm_delivery()
         # Simulate Confirm.SelectOk
-        self.pika_channel.confirm_delivery.call_args[1]["callback"](None)
+        self.pika_channel.confirm_delivery.call_args[1]['callback'](None)
 
         def send_message_and_close_channel(_result):
-            d = self.channel.basic_publish("testexch", "testrk", b"testbody")
+            d = self.channel.basic_publish('testexch', 'testrk', b'testbody')
             self.channel._on_channel_closed(mock.Mock(),
-                                            RuntimeError("testing"))
+                                            RuntimeError('testing'))
             self.assertEqual(len(self.channel._deliveries), 0)
             return d
 
@@ -700,7 +700,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
 
         d = self.conn.channel()
 
-        self.conn._on_connection_closed(mock.Mock(), RuntimeError("testing"))
+        self.conn._on_connection_closed(mock.Mock(), RuntimeError('testing'))
 
         self.assertEqual(len(self.conn._calls), 0)
         self.assertFailure(d, RuntimeError)
@@ -708,8 +708,8 @@ class TwistedProtocolConnectionTestCase(TestCase):
 
     def test_dataReceived(self):
         # Verify that the data is transmitted to the callback method.
-        self.conn.dataReceived(b"testdata")
-        self.conn_impl_mock.data_received.assert_called_once_with(b"testdata")
+        self.conn.dataReceived(b'testdata')
+        self.conn_impl_mock.data_received.assert_called_once_with(b'testdata')
 
     @pytest.mark.timeout(5)
     def test_connectionLost(self):
@@ -717,7 +717,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # the underlying implementation callback is called.
         ready_d = self.conn.ready
         assert ready_d is not None
-        error = RuntimeError("testreason")
+        error = RuntimeError('testreason')
         self.conn.connectionLost(error)
         self.conn_impl_mock.connection_lost.assert_called_with(error)
         self.assertIsNone(self.conn.ready)
@@ -729,7 +729,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         # AlreadyCalled error on the Deferred.
         ready_d = self.conn.ready
         assert ready_d is not None
-        error = RuntimeError("testreason")
+        error = RuntimeError('testreason')
         self.conn.connectionLost(error)
         self.assertTrue(ready_d.called)
         ready_d.addErrback(lambda f: None)  # silence the error
@@ -797,7 +797,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn._on_connection_ready(mock.Mock())
         d = self.conn.closed
         assert d is not None
-        reason = RuntimeError("test reason")
+        reason = RuntimeError('test reason')
         self.conn._on_connection_closed(mock.Mock(), reason)
         self.assertTrue(d.called)
         d.addCallback(self.assertEqual, reason)
@@ -809,7 +809,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn._on_connection_ready(mock.Mock())
         d = self.conn.closed
         assert d is not None
-        reason = RuntimeError("test reason")
+        reason = RuntimeError('test reason')
         self.conn._on_connection_closed(mock.Mock(), reason)
         self.assertTrue(d.called)
         # A second call must not raise AlreadyCalled
@@ -830,7 +830,7 @@ class TwistedProtocolConnectionTestCase(TestCase):
             self.assertEqual(result, error)
 
         def _check_eb(_failure):
-            self.fail("The errback path should not have been triggered")
+            self.fail('The errback path should not have been triggered')
 
         d.addCallbacks(_check_cb, _check_eb)
         assert d.called
@@ -838,11 +838,11 @@ class TwistedProtocolConnectionTestCase(TestCase):
     def test_close(self):
         # Verify that the close method is properly wrapped.
         self.conn_impl_mock.is_closed = False
-        self.conn.closed = "TESTING"
+        self.conn.closed = 'TESTING'
         value = self.conn.close()
-        self.assertEqual(value, "TESTING")
+        self.assertEqual(value, 'TESTING')
         self.conn_impl_mock.close.assert_called_once_with(
-            200, "Normal shutdown")
+            200, 'Normal shutdown')
 
     def test_close_twice(self):
         # Verify that the close method is only transmitted when open.
@@ -872,8 +872,8 @@ class TwistedConnectionAdapterTestCase(TestCase):
         # Verify that the data is transmitted to the underlying transport.
         transport = mock.Mock()
         self.conn.connection_made(transport)
-        self.conn._adapter_emit_data(b"testdata")
-        transport.write.assert_called_with(b"testdata")
+        self.conn._adapter_emit_data(b'testdata')
+        transport.write.assert_called_with(b'testdata')
 
     def test_timeout(self):
         # Verify that timeouts are registered and cancelled properly.
@@ -905,7 +905,7 @@ class TwistedConnectionAdapterTestCase(TestCase):
         # Verify that the correct callback is called and that the
         # attributes are reinitialized.
         self.conn._on_stream_terminated = mock.Mock()
-        error = Failure(RuntimeError("testreason"))
+        error = Failure(RuntimeError('testreason'))
         self.conn.connection_lost(error)
         self.conn._on_stream_terminated.assert_called_with(error.value)
         self.assertIsNone(self.conn._transport)
@@ -922,7 +922,7 @@ class TwistedConnectionAdapterTestCase(TestCase):
 
     def test_data_received(self):
         # Verify that the received data is forwarded to the Connection.
-        data = b"test data"
+        data = b'test data'
         self.conn._on_data_available = mock.Mock()
         self.conn.data_received(data)
         self.conn._on_data_available.assert_called_once_with(data)

--- a/tests/base/async_test_base.py
+++ b/tests/base/async_test_base.py
@@ -72,7 +72,7 @@ def enable_tls():
 
 
 class AsyncTestCase(unittest.TestCase):
-    DESCRIPTION = ""
+    DESCRIPTION = ''
     ADAPTER = None
     TIMEOUT = TEST_TIMEOUT
 
@@ -107,12 +107,12 @@ class AsyncTestCase(unittest.TestCase):
     def shortDescription(self):
         method_desc = super().shortDescription()
         if self.DESCRIPTION:
-            return f"{self.DESCRIPTION} ({method_desc})"
+            return f'{self.DESCRIPTION} ({method_desc})'
         return method_desc
 
     def begin(self, channel) -> None:
         """Extend to start the actual tests on the channel."""
-        self.fail("AsyncTestCase.begin_test not extended")
+        self.fail('AsyncTestCase.begin_test not extended')
 
     def start(self, adapter_class, ioloop_factory):
         self.logger.info('start at %s', datetime.now(timezone.utc))
@@ -182,7 +182,7 @@ class AsyncTestCase(unittest.TestCase):
 
     def _safe_remove_test_timeout(self):
         if hasattr(self, 'timeout') and self.timeout is not None:
-            self.logger.info("Removing timeout")
+            self.logger.info('Removing timeout')
             assert self.connection is not None
             self.connection._adapter_remove_timeout(self.timeout)
             self.timeout = None
@@ -190,7 +190,7 @@ class AsyncTestCase(unittest.TestCase):
     def _stop(self):
         if hasattr(self, 'connection') and self.connection is not None:
             self._safe_remove_test_timeout()
-            self.logger.info("Stopping ioloop")
+            self.logger.info('Stopping ioloop')
             self.connection._nbio.stop()
 
     def on_closed(self, connection, error):
@@ -297,28 +297,28 @@ class AsyncAdapters:
 
     @unittest.skipIf(
         not hasattr(select, 'poll') or not hasattr(select.poll(), 'modify'),
-        "poll not supported")
+        'poll not supported')
     @run_test_in_thread_with_timeout
     def test_with_select_poll(self):
         """SelectConnection:poll."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='poll'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
-    @unittest.skipIf(not hasattr(select, 'epoll'), "epoll not supported")
+    @unittest.skipIf(not hasattr(select, 'epoll'), 'epoll not supported')
     @run_test_in_thread_with_timeout
     def test_with_select_epoll(self):
         """SelectConnection:epoll."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='epoll'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
-    @unittest.skipIf(not hasattr(select, 'kqueue'), "kqueue not supported")
+    @unittest.skipIf(not hasattr(select, 'kqueue'), 'kqueue not supported')
     @run_test_in_thread_with_timeout
     def test_with_select_kqueue(self):
         """SelectConnection:kqueue."""
         with mock.patch.multiple(select_connection, SELECT_TYPE='kqueue'):
             self.start(adapters.SelectConnection, select_connection.IOLoop)
 
-    @unittest.skipIf(pika._utils.ON_WINDOWS, "Windows not supported")
+    @unittest.skipIf(pika._utils.ON_WINDOWS, 'Windows not supported')
     @run_test_in_thread_with_timeout
     def test_with_gevent(self):
         """GeventConnection."""

--- a/tests/misc/forward_server.py
+++ b/tests/misc/forward_server.py
@@ -24,7 +24,7 @@ def buffer(object_, offset, size):
 
 def _trace(fmt, *args):
     """Format and output the text to stderr."""
-    print((fmt % args) + "\n", end="", file=sys.stderr)
+    print((fmt % args) + '\n', end='', file=sys.stderr)
 
 
 class ForwardServer:
@@ -77,7 +77,7 @@ class ForwardServer:
                  remote_addr,
                  remote_addr_family=socket.AF_INET,
                  remote_socket_type=socket.SOCK_STREAM,
-                 server_addr=("127.0.0.1", 0),
+                 server_addr=('127.0.0.1', 0),
                  server_addr_family=socket.AF_INET,
                  server_socket_type=socket.SOCK_STREAM,
                  local_linger_args=None):
@@ -135,7 +135,7 @@ class ForwardServer:
 
         NOTE: undefined before server starts and after it shuts down
         """
-        assert self._server_addr_family is not None, "Not in context"
+        assert self._server_addr_family is not None, 'Not in context'
 
         return self._server_addr_family
 
@@ -147,7 +147,7 @@ class ForwardServer:
 
         NOTE: undefined before server starts and after it shuts down
         """
-        assert self._server_addr is not None, "Not in context"
+        assert self._server_addr is not None, 'Not in context'
 
         return self._server_addr
 
@@ -174,20 +174,20 @@ class ForwardServer:
 
         :returns: self
         """
-        mp_ctx = multiprocessing.get_context("spawn")
+        mp_ctx = multiprocessing.get_context('spawn')
         queue = mp_ctx.Queue()
 
         self._subproc = mp_ctx.Process(
             target=_run_server,
             kwargs={
-                "local_addr": self._server_addr,
-                "local_addr_family": self._server_addr_family,
-                "local_socket_type": self._server_socket_type,
-                "local_linger_args": self._local_linger_args,
-                "remote_addr": self._remote_addr,
-                "remote_addr_family": self._remote_addr_family,
-                "remote_socket_type": self._remote_socket_type,
-                "queue": queue
+                'local_addr': self._server_addr,
+                'local_addr_family': self._server_addr_family,
+                'local_socket_type': self._server_socket_type,
+                'local_linger_args': self._local_linger_args,
+                'remote_addr': self._remote_addr,
+                'remote_addr_family': self._remote_addr_family,
+                'remote_socket_type': self._remote_socket_type,
+                'queue': queue
             })
         self._subproc.daemon = True
         self._subproc.start()
@@ -200,7 +200,7 @@ class ForwardServer:
         except Exception:
             try:
                 self._logger.exception(
-                    "Failed while waiting for local socket info")
+                    'Failed while waiting for local socket info')
                 # Preserve primary exception and traceback
                 raise
             finally:
@@ -210,7 +210,7 @@ class ForwardServer:
                 except Exception:
                     # Suppress secondary exception in favor of the primary
                     self._logger.exception(
-                        "Emergency subprocess shutdown failed")
+                        'Emergency subprocess shutdown failed')
 
         return self
 
@@ -222,14 +222,14 @@ class ForwardServer:
         ForwardServer. start()/stop() are alternatives to the context manager
         use case and are mutually exclusive with it.
         """
-        self._logger.info("ForwardServer STOPPING")
+        self._logger.info('ForwardServer STOPPING')
 
         try:
             self._subproc.terminate()
             self._subproc.join(timeout=self._SUBPROC_TIMEOUT)
             if self._subproc.is_alive():
                 self._logger.error(
-                    "ForwardServer failed to terminate, killing it")
+                    'ForwardServer failed to terminate, killing it')
                 os.kill(self._subproc.pid)
                 self._subproc.join(timeout=self._SUBPROC_TIMEOUT)
                 assert not self._subproc.is_alive(), self._subproc
@@ -237,7 +237,7 @@ class ForwardServer:
             # Log subprocess's exit code; NOTE: negative signal.SIGTERM (usually
             # -15) is normal on POSIX systems - it corresponds to SIGTERM
             exit_code = self._subproc.exitcode
-            self._logger.info("ForwardServer terminated with exitcode=%s",
+            self._logger.info('ForwardServer terminated with exitcode=%s',
                               exit_code)
         finally:
             self._subproc = None
@@ -361,7 +361,7 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                 type=self._remote_socket_type,
                 proto=socket.IPPROTO_IP)
             remote_dest_sock.connect(self._remote_addr)
-            _trace("%s _TCPHandler connected to remote %s",
+            _trace('%s _TCPHandler connected to remote %s',
                    datetime.now(timezone.utc), remote_dest_sock.getpeername())
         else:
             # Echo set-up
@@ -403,7 +403,7 @@ class _TCPHandler(socketserver.StreamRequestHandler):
         """Forward from src_sock to dest_sock."""
         src_peername = src_sock.getpeername()
 
-        _trace("%s forwarding from %s to %s", datetime.now(timezone.utc),
+        _trace('%s forwarding from %s to %s', datetime.now(timezone.utc),
                src_peername, dest_sock.getpeername())
         try:
             # NOTE: python 2.6 doesn't support bytearray with recv_into, so
@@ -411,7 +411,7 @@ class _TCPHandler(socketserver.StreamRequestHandler):
             # array instance isn't shared across threads. See
             # https://bugs.python.org/issue7827 and
             # groups.google.com/forum/#!topic/comp.lang.python/M6Pqr-KUjQw
-            rx_buf = array.array("B", [0] * self._SOCK_RX_BUF_SIZE)
+            rx_buf = array.array('B', [0] * self._SOCK_RX_BUF_SIZE)
 
             while True:
                 try:
@@ -421,17 +421,17 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                         continue
                     if exc.errno == errno.ECONNRESET:
                         # Source peer forcibly closed connection
-                        _trace("%s errno.ECONNRESET from %s",
+                        _trace('%s errno.ECONNRESET from %s',
                                datetime.now(timezone.utc), src_peername)
                         break
-                    _trace("%s Unexpected errno=%s from %s\n%s",
+                    _trace('%s Unexpected errno=%s from %s\n%s',
                            datetime.now(timezone.utc), exc.errno, src_peername,
-                           "".join(traceback.format_stack()))
+                           ''.join(traceback.format_stack()))
                     raise
 
                 if not nbytes:
                     # Source input EOF
-                    _trace("%s EOF on %s", datetime.now(timezone.utc),
+                    _trace('%s EOF on %s', datetime.now(timezone.utc),
                            src_peername)
                     break
 
@@ -441,27 +441,27 @@ class _TCPHandler(socketserver.StreamRequestHandler):
                     if exc.errno == errno.EPIPE:
                         # Destination peer closed its end of the connection
                         _trace(
-                            "%s Destination peer %s closed its end of "
-                            "the connection: errno.EPIPE",
+                            '%s Destination peer %s closed its end of '
+                            'the connection: errno.EPIPE',
                             datetime.now(timezone.utc), dest_sock.getpeername())
                         break
                     if exc.errno == errno.ECONNRESET:
                         # Destination peer forcibly closed connection
                         _trace(
-                            "%s Destination peer %s forcibly closed "
-                            "connection: errno.ECONNRESET",
+                            '%s Destination peer %s forcibly closed '
+                            'connection: errno.ECONNRESET',
                             datetime.now(timezone.utc), dest_sock.getpeername())
                         break
-                    _trace("%s Unexpected errno=%s in sendall to %s\n%s",
+                    _trace('%s Unexpected errno=%s in sendall to %s\n%s',
                            datetime.now(timezone.utc), exc.errno,
                            dest_sock.getpeername(),
-                           "".join(traceback.format_stack()))
+                           ''.join(traceback.format_stack()))
                     raise
         except Exception:
-            _trace("forward failed\n%s", "".join(traceback.format_exc()))
+            _trace('forward failed\n%s', ''.join(traceback.format_exc()))
             raise
         finally:
-            _trace("%s done forwarding from %s", datetime.now(timezone.utc),
+            _trace('%s done forwarding from %s', datetime.now(timezone.utc),
                    src_peername)
             try:
                 # Let source peer know we're done receiving
@@ -482,13 +482,13 @@ def echo(port=0):
         connection
     """
     lsock = socket.socket()
-    lsock.bind(("", port))
+    lsock.bind(('', port))
     lsock.listen(1)
-    _trace("Listening on sockname=%s", lsock.getsockname())
+    _trace('Listening on sockname=%s', lsock.getsockname())
 
     sock, remote_addr = lsock.accept()
     try:
-        _trace("Connection from peer=%s", remote_addr)
+        _trace('Connection from peer=%s', remote_addr)
         while True:
             try:
                 data = sock.recv(4 * 1024)

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -54,7 +54,7 @@ def retry_assertion(timeout_sec, retry_interval_sec=0.1):
                     if (now - start_time) > timeout_sec:
                         logging.exception(
                             'Exceeded retry timeout of %s sec in %s attempts '
-                            'with func %r. Caller\'s stack:\n%s', timeout_sec,
+                            "with func %r. Caller's stack:\n%s", timeout_sec,
                             num_attempts, func,
                             ''.join(traceback.format_stack()))
                         raise

--- a/tests/unit/amqp_object_tests.py
+++ b/tests/unit/amqp_object_tests.py
@@ -23,10 +23,10 @@ class AMQPObjectTests(unittest.TestCase):
         b = amqp_object.AMQPObject()
         self.assertEqual(a, b)
 
-        setattr(a, "a_property", "test")
+        setattr(a, 'a_property', 'test')
         self.assertNotEqual(a, b)
 
-        setattr(b, "a_property", "test")
+        setattr(b, 'a_property', 'test')
         self.assertEqual(a, b)
 
 

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -249,7 +249,7 @@ class BlockingConnectionTests(unittest.TestCase):
         impl_mock.close.assert_called_once_with(200, 'text')
 
     @unittest.skipIf(sys.version_info < (3, 8),
-                     "mock args differ on 3.7 and earlier")
+                     'mock args differ on 3.7 and earlier')
     @patch.object(blocking_connection.select_connection,
                   'SelectConnection',
                   spec_set=SelectConnectionTemplate)
@@ -267,7 +267,7 @@ class BlockingConnectionTests(unittest.TestCase):
         with mock.patch.object(blocking_connection._CallbackResult,
                                'is_ready',
                                return_value=True):
-            connection.update_secret("new_secret", "reason")
+            connection.update_secret('new_secret', 'reason')
 
         if sys.version_info < (3, 8):
             args_0 = select_connection_class_mock.return_value.update_secret.call_args[
@@ -284,8 +284,8 @@ class BlockingConnectionTests(unittest.TestCase):
             args_len = len(select_connection_class_mock.return_value.
                            update_secret.call_args.args)
 
-        self.assertEqual(args_0, "new_secret")
-        self.assertEqual(args_1, "reason")
+        self.assertEqual(args_0, 'new_secret')
+        self.assertEqual(args_1, 'reason')
         self.assertEqual(args_len, 3)
 
     @patch.object(blocking_connection.select_connection,
@@ -343,7 +343,7 @@ class BlockingConnectionTests(unittest.TestCase):
         self.assertIs(unblocked_buffer[0], frame)
 
     @patch.object(blocking_connection.select_connection,
-                  "SelectConnection",
+                  'SelectConnection',
                   spec_set=SelectConnectionTemplate)
     def test_process_data_events_raises_on_channel_closed_by_broker(
             self, select_connection_class_mock):
@@ -351,29 +351,29 @@ class BlockingConnectionTests(unittest.TestCase):
         impl_mock.is_closed = False
 
         with mock.patch.object(blocking_connection.BlockingConnection,
-                               "_create_connection",
+                               '_create_connection',
                                return_value=impl_mock):
             connection = blocking_connection.BlockingConnection(None)
 
-        exc = pika.exceptions.ChannelClosedByBroker(406, "consumer_timeout")
+        exc = pika.exceptions.ChannelClosedByBroker(406, 'consumer_timeout')
 
         impl_channel_mock = mock.Mock()
         impl_channel_mock.channel_number = 1
         channel = blocking_connection.BlockingChannel(impl_channel_mock,
                                                       connection)
 
-        with mock.patch.object(channel, "_cleanup"):
+        with mock.patch.object(channel, '_cleanup'):
             channel._on_channel_closed(impl_channel_mock, exc)
 
-        with mock.patch.object(connection, "_flush_output"):
+        with mock.patch.object(connection, '_flush_output'):
             with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
                 connection.process_data_events(time_limit=0)
 
             self.assertEqual(cm.exception.reply_code, 406)
-            self.assertEqual(cm.exception.reply_text, "consumer_timeout")
+            self.assertEqual(cm.exception.reply_text, 'consumer_timeout')
 
     @patch.object(blocking_connection.select_connection,
-                  "SelectConnection",
+                  'SelectConnection',
                   spec_set=SelectConnectionTemplate)
     def test_process_data_events_raises_after_full_channel_cleanup(
             self, select_connection_class_mock):
@@ -382,29 +382,29 @@ class BlockingConnectionTests(unittest.TestCase):
         impl_mock._channels = {}
 
         with mock.patch.object(blocking_connection.BlockingConnection,
-                               "_create_connection",
+                               '_create_connection',
                                return_value=impl_mock):
             connection = blocking_connection.BlockingConnection(None)
 
-        exc = pika.exceptions.ChannelClosedByBroker(406, "consumer_timeout")
+        exc = pika.exceptions.ChannelClosedByBroker(406, 'consumer_timeout')
 
         impl_channel_mock = mock.Mock()
         impl_channel_mock.channel_number = 1
         channel = blocking_connection.BlockingChannel(impl_channel_mock,
                                                       connection)
 
-        with mock.patch.object(channel, "_cleanup"):
+        with mock.patch.object(channel, '_cleanup'):
             channel._on_channel_closed(impl_channel_mock, exc)
 
         impl_mock._channels.pop(1, None)
         impl_channel_mock._cookie = None
 
-        with mock.patch.object(connection, "_flush_output"):
+        with mock.patch.object(connection, '_flush_output'):
             with self.assertRaises(pika.exceptions.ChannelClosedByBroker) as cm:
                 connection.process_data_events(time_limit=0)
 
             self.assertEqual(cm.exception.reply_code, 406)
-            self.assertEqual(cm.exception.reply_text, "consumer_timeout")
+            self.assertEqual(cm.exception.reply_text, 'consumer_timeout')
 
     @staticmethod
     def _make_open_connection(select_connection_class_mock):

--- a/tests/unit/compat_tests.py
+++ b/tests/unit/compat_tests.py
@@ -6,20 +6,20 @@ import pika._utils
 class UtilsTests(unittest.TestCase):
 
     def test_get_linux_version_normal(self):
-        self.assertEqual(pika._utils.get_linux_version("4.11.0-2-amd64"),
+        self.assertEqual(pika._utils.get_linux_version('4.11.0-2-amd64'),
                          (4, 11, 0))
 
     def test_get_linux_version_short(self):
-        self.assertEqual(pika._utils.get_linux_version("4.11.0"), (4, 11, 0))
+        self.assertEqual(pika._utils.get_linux_version('4.11.0'), (4, 11, 0))
 
     def test_get_linux_version_gcp(self):
-        self.assertEqual(pika._utils.get_linux_version("4.4.64+"), (4, 4, 64))
+        self.assertEqual(pika._utils.get_linux_version('4.4.64+'), (4, 4, 64))
 
     def test_to_digit(self):
-        self.assertEqual(pika._utils.to_digit("64"), 64)
+        self.assertEqual(pika._utils.to_digit('64'), 64)
 
     def test_to_digit_with_plus_sign(self):
-        self.assertEqual(pika._utils.to_digit("64+"), 64)
+        self.assertEqual(pika._utils.to_digit('64+'), 64)
 
     def test_to_digit_with_dot(self):
-        self.assertEqual(pika._utils.to_digit("64."), 64)
+        self.assertEqual(pika._utils.to_digit('64.'), 64)

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -261,7 +261,7 @@ class ExceptionTests(unittest.TestCase):
     def test_unsupported_amqp_field_exception_repr(self):
         self.assertEqual(
             repr(exceptions.UnsupportedAMQPFieldException('kind', 42)),
-            'UnsupportedAMQPFieldException: Unsupported field kind <class \'int\'>'
+            "UnsupportedAMQPFieldException: Unsupported field kind <class 'int'>"
         )
 
     def test_channel_error_repr(self):

--- a/tests/unit/select_connection_ioloop_tests.py
+++ b/tests/unit/select_connection_ioloop_tests.py
@@ -36,24 +36,24 @@ POLLPRI = getattr(select, 'POLLPRI', 0) or 2
 
 def _trace_stderr(fmt, *args):
     """Format and output the text to stderr."""
-    print((fmt % args) + "\n", end="", file=sys.stderr)
+    print((fmt % args) + '\n', end='', file=sys.stderr)
 
 
 def _fd_events_to_str(events):
     str_events = f'{events}: '
 
     if events & POLLIN:
-        str_events += "In."
+        str_events += 'In.'
     if events & POLLOUT:
-        str_events += "Out."
+        str_events += 'Out.'
     if events & POLLERR:
-        str_events += "Err."
+        str_events += 'Err.'
     if events & POLLHUP:
-        str_events += "Hup."
+        str_events += 'Hup.'
     if events & POLLNVAL:
-        str_events += "Inval."
+        str_events += 'Inval.'
     if events & POLLPRI:
-        str_events += "Pri."
+        str_events += 'Pri.'
 
     remainig_events = events & ~(POLLIN | POLLOUT | POLLERR | POLLHUP |
                                  POLLNVAL | POLLPRI)
@@ -445,7 +445,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
 
         Implementation is subclass's responsibility.
         """
-        self.fail("IOLoopSocketBase.connected not extended")
+        self.fail('IOLoopSocketBase.connected not extended')
 
     def do_read(self, fd_, events):
         """Read from fd and check the received content."""
@@ -459,7 +459,7 @@ class IOLoopSocketBaseSelect(IOLoopBaseTest):
 
         This is a stub. Real implementation is subclass's responsibility
         """
-        self.fail("IOLoopSocketBase.verify_message not extended")
+        self.fail('IOLoopSocketBase.verify_message not extended')
 
     def on_timeout(self):
         """Called when stuck waiting for connection to close."""
@@ -577,7 +577,7 @@ class IOLoopEintrTestCaseSelect(IOLoopBaseTest):
         mechanism and another.
         """
         if threading.current_thread() is not threading.main_thread():
-            self.skipTest("signal.signal() requires the main thread")
+            self.skipTest('signal.signal() requires the main thread')
 
         is_resumable_mock.side_effect = is_resumable_raw
 


### PR DESCRIPTION
## Proposed Changes

`CLAUDE.md` documents a single-quote string convention, but nothing enforced it and the codebase had drifted. This adds the linter rule that enforces it and applies the mechanical conversion.

Worth calling out why `[tool.ruff.format] quote-style = "single"` was not already doing this job: it configures `ruff format`, which this project does not use (yapf is the formatter), so it was inert. The `Q` rules are linter rules and read `[tool.ruff.lint.flake8-quotes] inline-quotes`, which defaults to `double`. Enabling `Q` without that section would have had ruff rewriting single quotes into double ones, the opposite of the intended convention.

Two commits, kept separate so the mechanical churn is easy to skip while reviewing: one adds `Q` to the rule selection and sets `inline-quotes = "single"`, the other is pure `ruff check --fix` output.

Docstrings are untouched, since `docstring-quotes` and `multiline-quotes` keep their `double` defaults, so PEP 257 style is preserved and `docformatter` is unaffected. Strings containing a single quote keep their double quotes via the `avoid-escape` default, matching the carve-out in `CLAUDE.md`.

## Types of Changes

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [x] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

## Further Comments