### PR TITLE
Upload coverage to Codecov once after all tests finish

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,2 @@
 [run]
 omit = pika/spec.py
-relative_files = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 omit = pika/spec.py
+relative_files = true

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -20,9 +20,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      CODECOV_TOKEN:
-        required: false
 
 jobs:
   build-windows:
@@ -72,14 +69,13 @@ jobs:
           python -m pip install hatch ${{ inputs.legacy && '"virtualenv<21.0.0"' || '' }}
       - name: Test with pytest
         run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          disable_search: true
-          flags: windows-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
-          fail_ci_if_error: false
+          name: coverage-windows-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
+          path: coverage.xml
+          retention-days: 7
+          if-no-files-found: error
 
   build-linux:
     name: build/test on ${{ inputs.ubuntu-runner }} py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
@@ -102,14 +98,13 @@ jobs:
           python -m pip install hatch ${{ inputs.legacy && '"virtualenv<21.0.0"' || '' }}
       - name: Test with pytest
         run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          disable_search: true
-          flags: linux-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
-          fail_ci_if_error: false
+          name: coverage-linux-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
+          path: coverage.xml
+          retention-days: 7
+          if-no-files-found: error
 
   build-macos:
     name: build/test on ${{ inputs.macos-runner }} py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
@@ -134,11 +129,10 @@ jobs:
           python -m pip install hatch ${{ inputs.legacy && '"virtualenv<21.0.0"' || '' }}
       - name: Test with pytest
         run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          disable_search: true
-          flags: macos-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
-          fail_ci_if_error: false
+          name: coverage-macos-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
+          path: coverage.xml
+          retention-days: 7
+          if-no-files-found: error

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   docs:
     uses: ./.github/workflows/docs.yaml
@@ -19,8 +23,6 @@ jobs:
       ubuntu-runner: ubuntu-latest
       macos-runner: macos-latest
       legacy: false
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-legacy:
     uses: ./.github/workflows/_test.yaml
@@ -29,8 +31,29 @@ jobs:
       ubuntu-runner: ubuntu-22.04
       macos-runner: macos-15-intel
       legacy: true
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  coverage:
+    name: upload coverage to Codecov
+    runs-on: ubuntu-latest
+    needs: [test-modern, test-legacy]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: coverage-*
+          path: coverage
+      - name: Verify coverage reports were collected
+        run: |
+          count=$(find coverage -name coverage.xml | wc -l)
+          echo "collected $count coverage reports"
+          test "$count" -gt 0
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          directory: ./coverage
+          fail_ci_if_error: false
 
   tests-passed:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,3 @@
-codecov:
-  notify:
-    wait_for_ci: true
-
 coverage:
   status:
     patch:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,6 @@ force-one-line-summary = false
 [tool.hatch.envs.default]
 dependencies = [
     "coverage",
-    "codecov",
     "docformatter",
     "gevent",
     "pytest>=7.0.0",


### PR DESCRIPTION
## Problem

The `codecov/patch` status and the Codecov PR comment appear long before CI has finished, computed from a fraction of the test matrix, and then change as the rest of the run completes.

Two causes:

1. **Every matrix job uploaded separately.** Codecov notifies as soon as the first upload is processed, then re-notifies on each subsequent one. The matrix produces 48 uploads (`test-modern` 5 Python x 3 OS x 2 TLS, plus `test-legacy` 3 x 3 x 2), so the first report to land triggered the status.
2. **`wait_for_ci: true` was inert.** It gates on the commit's CI statuses, but on a PR branch every workflow here fires only via `pull_request`, so the check runs attach to the merge commit. `codecov-action` attributes coverage to the PR head commit. Codecov polls the head commit, finds no pending checks, and concludes CI is done.

## Changes

Each matrix job now publishes `coverage.xml` as an artifact rather than uploading it. A new `coverage` job runs after both test workflows, downloads all reports, and makes one Codecov upload. One upload, one notification, sent only after every test job has finished.

`after_n_builds` was the other candidate fix, but it would have made the notification depend on 48 independent jobs, any one of which could die before its upload and strand the counter permanently. Gating on the job graph is deterministic.

Also in this PR:

- A guard step between download and upload fails the job if no reports were collected. With a single upload point and `fail_ci_if_error: false`, a bad artifact pattern would otherwise pass green and silent.
- A concurrency group on `main.yaml`. There wasn't one, so three pushes in quick succession ran three complete 48-job matrices at once. `cancel-in-progress` is an expression rather than a bare `true` so that superseded PR runs are cancelled while pushes to `main` queue, keeping coverage for every commit on the default branch.
- `retention-days: 7` on the artifacts, so re-running a failed `coverage` job the next day still finds its inputs. Reports are ~225K each and public repos are not billed for artifact storage.
- The `codecov` dependency is dropped from the default hatch environment. It is the deprecated Python uploader and nothing invokes it; uploads go through `codecov/codecov-action`, which fetches its own.

## Notes for reviewers

**Flags are gone.** A single upload carries one flag set, so the per-OS and per-Python breakdown is no longer available and the existing flags on the Codecov dashboard will go stale. Coverage is now a union across platforms, which means a line exercised on Linux but never on Windows reads as covered. Restoring flags is possible by fanning the `coverage` job across an OS matrix and setting `after_n_builds` to match, at the cost of reintroducing a multi-way counter. Happy to do that in a follow-up if the platform split is worth keeping.

**`coverage` is deliberately not in `tests-passed`.** Codecov upload flakiness should not block merges, and the guard step surfaces the silent-empty case in the job's own log.

**The flag table in the Codecov comment is a transitional artifact.** Every row shows `?`, meaning no data for that flag on this branch. The comparison base is a commit on `main`, which still carries all 48 flags from the old per-job uploads. It confirms the change worked, and it also confirms carryforward is off, so stale flag data is not leaking into the merged coverage. The table goes away once `main` itself carries a flagless report.

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes