### PR TITLE
fix: Stop the getaddrinfo acceptance tests from depending on live DNS

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -26,6 +26,7 @@ jobs:
     name: build/test on windows-latest py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
     runs-on: windows-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
         test-tls: [true, false]
@@ -81,6 +82,7 @@ jobs:
     name: build/test on ${{ inputs.ubuntu-runner }} py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
     runs-on: ${{ inputs.ubuntu-runner }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
         test-tls: [true, false]
@@ -110,6 +112,7 @@ jobs:
     name: build/test on ${{ inputs.macos-runner }} py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
     runs-on: ${{ inputs.macos-runner }}
     strategy:
+      fail-fast: false
       matrix:
         python-version: ${{ fromJSON(inputs.python-versions) }}
         test-tls: [true, false]

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -1,11 +1,14 @@
 """Tests of nbio_interface.AbstractIOServices adaptations."""
 
 import collections
+import contextlib
 import errno
 import logging
 import os
 import socket
+import threading
 import unittest
+from unittest import mock
 
 import pika._utils
 from pika.adapters.utils import nbio_interface
@@ -403,8 +406,49 @@ class TestSocketWatchersAfterLocalPeerShutsReadWrite(SocketWatcherTestBase,
         self._check_socket_watchers_fired(s1, expected)
 
 
-class TestGetaddrinfoWWWGoogleDotComPort80(AsyncServicesTestBase,
-                                           IOServicesTestStubs):
+@contextlib.contextmanager
+def _failing_resolver():
+    """
+    Patch `socket.getaddrinfo()` to fail as if the host did not exist.
+
+    A name that does not resolve cannot be obtained without the network, not even under the
+    `.invalid` TLD reserved by RFC 6761, because the stub resolver still sends the query and waits
+    for `NXDOMAIN`. Patching `socket.getaddrinfo()` covers every adaptation under test, since both
+    `selector_ioloop_adapter._AddressResolver` and asyncio's `loop.getaddrinfo()` bottom out in it.
+    """
+
+    def getaddrinfo_failure(*args, **kwargs):
+        raise socket.gaierror(socket.EAI_NONAME, 'Name or service not known')
+
+    with mock.patch.object(socket, 'getaddrinfo', getaddrinfo_failure):
+        yield
+
+
+@contextlib.contextmanager
+def _blocked_resolver():
+    """
+    Patch `socket.getaddrinfo()` to block until the context manager exits.
+
+    The cancellation tests need a lookup that is still pending when they cancel it. Blocking the
+    resolver removes the race with a lookup that completes first, and keeps an abandoned lookup from
+    outliving the test in a resolver thread.
+    """
+    released = threading.Event()
+
+    def getaddrinfo_blocked(*args, **kwargs):
+        released.wait()
+        # Every caller cancels the lookup, so nothing observes this result
+        return []
+
+    try:
+        with mock.patch.object(socket, 'getaddrinfo', getaddrinfo_blocked):
+            yield
+    finally:
+        released.set()
+
+
+class TestGetaddrinfoLocalhostPort80(AsyncServicesTestBase,
+                                     IOServicesTestStubs):
 
     def start(self):
         # provided by IOServicesTestStubs mixin
@@ -416,7 +460,11 @@ class TestGetaddrinfoWWWGoogleDotComPort80(AsyncServicesTestBase,
             result_bucket.append(result)
             nbio.stop()
 
-        ref = nbio.getaddrinfo('www.google.com',
+        # NOTE: this is the one lookup we let reach the system resolver, so that
+        # argument forwarding and the result's shape stay covered end to end.
+        # `localhost` resolves from the hosts file, so no network is needed; an
+        # IP address literal would skip name resolution altogether.
+        ref = nbio.getaddrinfo('localhost',
                                80,
                                socktype=socket.SOCK_STREAM,
                                on_done=on_done)
@@ -426,8 +474,7 @@ class TestGetaddrinfoWWWGoogleDotComPort80(AsyncServicesTestBase,
         self.assertEqual(len(result_bucket), 1)
 
         result = result_bucket[0]
-        self.logger.debug('TestGetaddrinfoWWWGoogleDotComPort80: result=%r',
-                          result)
+        self.logger.debug('TestGetaddrinfoLocalhostPort80: result=%r', result)
         self.assertIsInstance(result, list)
         self.assertEqual(len(result[0]), 5)
 
@@ -461,16 +508,19 @@ class TestGetaddrinfoNonExistentHost(AsyncServicesTestBase,
             result_bucket.append(result)
             nbio.stop()
 
-        ref = nbio.getaddrinfo('www.google.comSSS',
-                               80,
-                               socktype=socket.SOCK_STREAM,
-                               proto=socket.IPPROTO_TCP,
-                               on_done=on_done)
+        with _failing_resolver():
+            ref = nbio.getaddrinfo('no-such-host.invalid',
+                                   80,
+                                   socktype=socket.SOCK_STREAM,
+                                   proto=socket.IPPROTO_TCP,
+                                   on_done=on_done)
 
-        nbio.run()
+            nbio.run()
 
         self.assertEqual(len(result_bucket), 1)
 
+        # The failure must be reported as the value passed to `on_done`, not
+        # raised out of the resolver's thread or loop callback
         result = result_bucket[0]
         self.assertIsInstance(result, socket.gaierror)
 
@@ -481,12 +531,6 @@ class TestGetaddrinfoCancelBeforeLoopRun(AsyncServicesTestBase,
                                          IOServicesTestStubs):
 
     def start(self):
-        # NOTE: this test elicits an occasional asyncio
-        # `RuntimeError: Event loop is closed` message on the terminal,
-        # presumably when the `getaddrinfo()` executing in the thread pool
-        # finally completes and attempts to set the value on the future, but
-        # our cleanup logic will have closed the loop before then.
-
         # Provided by IOServicesTestStubs mixin
         nbio = self.create_nbio()
 
@@ -495,15 +539,16 @@ class TestGetaddrinfoCancelBeforeLoopRun(AsyncServicesTestBase,
         def on_done(result):
             on_done_bucket.append(result)
 
-        ref = nbio.getaddrinfo('www.google.com',
-                               80,
-                               socktype=socket.SOCK_STREAM,
-                               on_done=on_done)
+        with _blocked_resolver():
+            ref = nbio.getaddrinfo('localhost',
+                                   80,
+                                   socktype=socket.SOCK_STREAM,
+                                   on_done=on_done)
 
-        self.assertEqual(ref.cancel(), True)
+            self.assertEqual(ref.cancel(), True)
 
-        nbio.add_callback_threadsafe(nbio.stop)
-        nbio.run()
+            nbio.add_callback_threadsafe(nbio.stop)
+            nbio.run()
 
         self.assertFalse(on_done_bucket)
 
@@ -512,12 +557,6 @@ class TestGetaddrinfoCancelAfterLoopRun(AsyncServicesTestBase,
                                         IOServicesTestStubs):
 
     def start(self):
-        # NOTE: this test elicits an occasional asyncio
-        # `RuntimeError: Event loop is closed` message on the terminal,
-        # presumably when the `getaddrinfo()` executing in the thread pool
-        # finally completes and attempts to set the value on the future, but
-        # our cleanup logic will have closed the loop before then.
-
         # Provided by IOServicesTestStubs mixin
         nbio = self.create_nbio()
 
@@ -528,11 +567,6 @@ class TestGetaddrinfoCancelAfterLoopRun(AsyncServicesTestBase,
                 'Unexpected completion of cancelled getaddrinfo()')
             on_done_bucket.append(result)
 
-        # NOTE: there is some probability that getaddrinfo() will have completed
-        # and added its completion reporting callback quickly, so we add our
-        # cancellation callback before requesting getaddrinfo() in order to
-        # avoid the race condition wehreby it invokes our completion callback
-        # before we had a chance to cancel it.
         cancel_result_bucket = []
 
         def cancel_and_stop_from_loop():
@@ -540,14 +574,18 @@ class TestGetaddrinfoCancelAfterLoopRun(AsyncServicesTestBase,
             cancel_result_bucket.append(getaddr_ref.cancel())
             nbio.stop()
 
-        nbio.add_callback_threadsafe(cancel_and_stop_from_loop)
+        with _blocked_resolver():
+            # NOTE: the blocked resolver keeps the lookup pending, but we still
+            # add the cancellation callback before requesting getaddrinfo() so
+            # that the reference is cancelled from the loop's own thread.
+            nbio.add_callback_threadsafe(cancel_and_stop_from_loop)
 
-        getaddr_ref = nbio.getaddrinfo('www.google.com',
-                                       80,
-                                       socktype=socket.SOCK_STREAM,
-                                       on_done=on_done)
+            getaddr_ref = nbio.getaddrinfo('localhost',
+                                           80,
+                                           socktype=socket.SOCK_STREAM,
+                                           on_done=on_done)
 
-        nbio.run()
+            nbio.run()
 
         self.assertEqual(cancel_result_bucket, [True])
 

--- a/tests/acceptance/io_services_tests.py
+++ b/tests/acceptance/io_services_tests.py
@@ -14,6 +14,11 @@ import pika._utils
 from pika.adapters.utils import nbio_interface
 from tests.misc.forward_server import ForwardServer
 from tests.stubs.io_services_test_stubs import IOServicesTestStubs
+from tests.wrappers.threaded_test_wrapper import DEFAULT_TEST_TIMEOUT
+
+# Upper bound on how long `_blocked_resolver()` blocks a lookup. Longer than the per-test timeout,
+# so only a test that has already been abandoned can reach it.
+_BLOCKED_RESOLVER_MAX_WAIT = DEFAULT_TEST_TIMEOUT * 2
 
 
 class AsyncServicesTestBase(unittest.TestCase):
@@ -432,11 +437,18 @@ def _blocked_resolver():
     The cancellation tests need a lookup that is still pending when they cancel it. Blocking the
     resolver removes the race with a lookup that completes first, and keeps an abandoned lookup from
     outliving the test in a resolver thread.
+
+    The wait is bounded so that the stub cannot outlive its test even if the context manager is
+    never exited. `run_in_thread_with_timeout` abandons the thread running `start()` on timeout,
+    which would otherwise leave `socket.getaddrinfo()` patched for every later test in the process
+    and hang interpreter exit, because `concurrent.futures` joins the asyncio executor thread that
+    the stub is parked in. Cleanup unwinds the abandoned loop first, so this bound is only a
+    backstop; it exceeds the test timeout so a passing test never reaches it.
     """
     released = threading.Event()
 
     def getaddrinfo_blocked(*args, **kwargs):
-        released.wait()
+        released.wait(timeout=_BLOCKED_RESOLVER_MAX_WAIT)
         # Every caller cancels the lookup, so nothing observes this result
         return []
 

--- a/tests/acceptance/thread_safe_bounded_queue_test.py
+++ b/tests/acceptance/thread_safe_bounded_queue_test.py
@@ -12,7 +12,6 @@ timeout even with a wedged consumer (Finding 2), and a merely-slow consumer that
 keeps pace does NOT trip overflow (the back-pressure negative control).
 """
 
-import logging
 import threading
 import time
 import unittest
@@ -21,9 +20,7 @@ import uuid
 import pika
 from pika.adapters.thread_safe_connection import ThreadSafeConnection
 from pika.exceptions import WorkQueueFullError
-from tests.misc.test_utils import retry_assertion
-
-LOGGER = logging.getLogger(__name__)
+from tests.misc.test_utils import retry_assertion, safe_close
 
 DEFAULT_PARAMS = pika.ConnectionParameters(
     host='127.0.0.1',
@@ -39,16 +36,8 @@ class ThreadSafeBoundedQueueTestCaseBase(unittest.TestCase):
 
     def _connect(self, **kwargs):
         conn = ThreadSafeConnection(DEFAULT_PARAMS, **kwargs)
-        self.addCleanup(self._safe_close, conn)
+        self.addCleanup(safe_close, conn, timeout=BLOCKING_CALL_TIMEOUT)
         return conn
-
-    @staticmethod
-    def _safe_close(conn):
-        try:
-            conn.close(timeout=BLOCKING_CALL_TIMEOUT)
-        except Exception:
-            # Best-effort teardown; must not mask the test's own result.
-            LOGGER.exception('Best-effort cleanup close() failed for %r', conn)
 
     @staticmethod
     def _unique_queue():

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -9,7 +9,6 @@ Each test covers a scenario that unit tests with mocks cannot: real socket I/O,
 real AMQP frame exchange, and real concurrent threads.
 """
 
-import logging
 import threading
 import unittest
 import uuid
@@ -17,9 +16,7 @@ import uuid
 import pika
 from pika.adapters.thread_safe_connection import ThreadSafeChannel, ThreadSafeConnection
 from tests.misc.forward_server import ForwardServer
-from tests.misc.test_utils import retry_assertion
-
-LOGGER = logging.getLogger(__name__)
+from tests.misc.test_utils import retry_assertion, safe_close
 
 DEFAULT_PARAMS = pika.ConnectionParameters(
     host='127.0.0.1',
@@ -35,16 +32,8 @@ class ThreadSafeTestCaseBase(unittest.TestCase):
 
     def _connect(self, parameters=None):
         conn = ThreadSafeConnection(parameters or DEFAULT_PARAMS)
-        self.addCleanup(self._safe_close, conn)
+        self.addCleanup(safe_close, conn)
         return conn
-
-    @staticmethod
-    def _safe_close(conn):
-        try:
-            conn.close()
-        except Exception:
-            # Best-effort teardown; must not mask the test's own result.
-            LOGGER.exception('Best-effort cleanup close() failed for %r', conn)
 
     @staticmethod
     def _unique_queue():
@@ -234,7 +223,7 @@ class TestBrokerDropBlockedInChannel(ThreadSafeTestCaseBase):
             credentials=pika.PlainCredentials('guest', 'guest'),
         )
         conn = ThreadSafeConnection(params)
-        self.addCleanup(self._safe_close, conn)
+        self.addCleanup(safe_close, conn)
 
         # Intercept add_callback_threadsafe so channel() registers its waiter
         # but the channel never actually opens before we drop the connection.
@@ -293,7 +282,7 @@ class TestBrokerDropBlockedInQueueDeclare(ThreadSafeTestCaseBase):
             credentials=pika.PlainCredentials('guest', 'guest'),
         )
         conn = ThreadSafeConnection(params)
-        self.addCleanup(self._safe_close, conn)
+        self.addCleanup(safe_close, conn)
 
         # Open the channel before intercepting so we get a real channel object.
         ch = conn.channel()

--- a/tests/misc/test_utils.py
+++ b/tests/misc/test_utils.py
@@ -10,6 +10,27 @@ import pika._utils
 LOGGER = logging.getLogger(__name__)
 
 
+def safe_close(closeable, *args, **kwargs):
+    """
+    Close `closeable` from cleanup, logging rather than raising on failure.
+
+    Teardown registered via `addCleanup()` reports its exceptions as test errors, so a failing
+    close() masks the result of the test that registered it. Best-effort closing keeps the test's
+    own outcome, passing or failing, as the thing that gets reported.
+
+    Callers that can distinguish an expected teardown failure from a real one should catch that
+    narrow type themselves instead of reaching for this.
+
+    :param closeable: object whose `close()` is to be called.
+    :param args: positional args to pass to `close()`.
+    :param kwargs: keyword args to pass to `close()`.
+    """
+    try:
+        closeable.close(*args, **kwargs)
+    except Exception:
+        LOGGER.exception('Best-effort cleanup close() failed for %r', closeable)
+
+
 def retry_assertion(timeout_sec, retry_interval_sec=0.1):
     """
     Creates a decorator that retries the decorated function or method only upon `AssertionError`

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -22,8 +22,13 @@ class TestGetNativeIOLoop(unittest.TestCase,
 
 """
 
+import contextlib
+import logging
+
 from pika.adapters.utils import nbio_interface
 from tests.wrappers.threaded_test_wrapper import run_in_thread_with_timeout
+
+LOGGER = logging.getLogger(__name__)
 
 
 class IOServicesTestStubs:
@@ -50,8 +55,39 @@ class IOServicesTestStubs:
         :param unittest.TestCase self:
         """
         nbio = self._nbio_factory()
-        self.addCleanup(nbio.close)
+        self.addCleanup(self._close_nbio, nbio)
         return nbio
+
+    @staticmethod
+    def _close_nbio(nbio: nbio_interface.AbstractIOServices) -> None:
+        """
+        Close the given I/O services instance, tolerating a still-running loop.
+
+        Cleanups run on the main thread, while `start()` runs in a thread that
+        `run_in_thread_with_timeout` abandons when the test times out. The loop is then still
+        running, and closing it fails: asyncio and tornado raise `RuntimeError: Cannot close a
+        running event loop`, and `select_connection` asserts `Cannot call close() before start()
+        unwinds.`. Reported from cleanup, either one buries the `AssertionError: The test timed
+        out.` that says why the test actually failed.
+
+        So request a stop first, which an abandoned loop honors from its own thread, and warn rather
+        than raise if the close still does not take. There is only one attempt to make: tornado
+        unregisters its I/O loop before closing the asyncio loop underneath it, so a close that
+        fails part way leaves every later attempt raising `KeyError`. An unclosed loop is what a
+        timed-out test already left behind before this method existed.
+
+        :param nbio: the instance to close.
+        """
+        with contextlib.suppress(Exception):
+            # Honored only by a loop that is still running, i.e. an abandoned one
+            nbio.add_callback_threadsafe(nbio.stop)
+
+        try:
+            nbio.close()
+        except Exception as error:
+            LOGGER.warning(
+                'Could not close %r: %r. Its test most likely timed out, '
+                'leaving the I/O loop running.', nbio, error)
 
     def _run_start(self, nbio_factory, native_loop, use_ssl=False):
         """

--- a/tests/stubs/io_services_test_stubs.py
+++ b/tests/stubs/io_services_test_stubs.py
@@ -30,6 +30,11 @@ from tests.wrappers.threaded_test_wrapper import run_in_thread_with_timeout
 
 LOGGER = logging.getLogger(__name__)
 
+# Raised by `close()` when the loop is still running, which is the state a test abandoned by
+# `run_in_thread_with_timeout` leaves behind: `RuntimeError` from asyncio and tornado,
+# `AssertionError` from `select_connection.IOLoop`.
+_LOOP_STILL_RUNNING_ERRORS = (RuntimeError, AssertionError)
+
 
 class IOServicesTestStubs:
     """Provides a stub test method for each combination of parameters we wish to test."""
@@ -76,6 +81,10 @@ class IOServicesTestStubs:
         fails part way leaves every later attempt raising `KeyError`. An unclosed loop is what a
         timed-out test already left behind before this method existed.
 
+        Only the two errors an abandoned loop produces are tolerated. Anything else is a genuine
+        `close()` failure, and swallowing those would retire a signal the suite has always had, so
+        they propagate and fail the test as before.
+
         :param nbio: the instance to close.
         """
         with contextlib.suppress(Exception):
@@ -84,7 +93,7 @@ class IOServicesTestStubs:
 
         try:
             nbio.close()
-        except Exception as error:
+        except _LOOP_STILL_RUNNING_ERRORS as error:
             LOGGER.warning(
                 'Could not close %r: %r. Its test most likely timed out, '
                 'leaving the I/O loop running.', nbio, error)


### PR DESCRIPTION
## Proposed Changes

The `getaddrinfo` acceptance tests resolved `www.google.com` and `www.google.comSSS` against the public internet. On a runner where outbound DNS is slow or unavailable they blow through the 15 second per-test timeout and fail with `AssertionError: The test timed out.` That is exactly how #1661 was reported: six failures on `macos-15-intel` py3.9, both TLS legs, while every Linux and Windows leg passed.

Nothing in those tests is about the public internet. What they cover is the async plumbing of the `getaddrinfo` adaptations: that a result is delivered on the loop thread, that a resolution failure arrives as a value rather than an exception, and that a pending lookup can be cancelled. The network dependency buys no coverage and costs determinism, so this removes it.

Three commits, each independently reviewable:

### 1. tests: stop the getaddrinfo tests from using live DNS

The issue lists three candidate fixes as alternatives, but the five call sites assert different things and only one of them actually needs a stub, so this picks per test:

- `TestGetaddrinfoWWWGoogleDotComPort80` becomes `TestGetaddrinfoLocalhostPort80` and resolves `localhost`. That comes from the hosts file, so no network is involved, while a real `socket.getaddrinfo()` call still covers argument forwarding and the shape of the result end to end. Every existing assertion is unchanged. An IP address literal would also avoid the network, but it would stop exercising name resolution, which is the point of the test.
- `TestGetaddrinfoNonExistentHost` stubs the resolver. This is the one case that cannot be made hermetic with a real hostname: a name that does not resolve is not obtainable without the network, not even under the `.invalid` TLD reserved by RFC 6761, because the stub resolver still puts the query on the wire and waits for `NXDOMAIN`. Patching `socket.getaddrinfo()` is a single seam that covers all three adaptations, since both `selector_ioloop_adapter._AddressResolver` and asyncio's `loop.getaddrinfo()` bottom out in it. The assertion under test is unchanged: the `gaierror` must arrive as the value passed to `on_done`.
- The two cancellation tests block the resolver. They never waited for a result, so they did not time out, but they did leave a public DNS lookup running past the end of the test, which is what their `Event loop is closed` notes described. A lookup that cannot complete also removes the race their other note warned about, so the cancellation window is now deterministic rather than probabilistic.

### 2. tests: keep cleanup from burying a test's timeout failure

`create_nbio()` registered `nbio.close` directly as a cleanup. Cleanups run on the main thread, after `run_in_thread_with_timeout` has abandoned the thread running `start()`, so on a timeout the loop is still running and closing it fails: asyncio and tornado raise `RuntimeError: Cannot close a running event loop`, and `select_connection` asserts `Cannot call close() before start() unwinds.` Every timed-out test therefore reported that unrelated teardown error next to the timeout, which is the follow-on error described in the issue.

Closing now goes through `_close_nbio()`, which requests a stop that only a still-running loop honors, then closes once and warns rather than raises if the close does not take. The DNS timeouts surfaced this, but any future timeout in this suite would have been reported the same way.

### 3. ci: stop a failing matrix leg from cancelling its siblings

All three jobs in the reusable test workflow declare a matrix with no `fail-fast` key, so it defaulted to `true`. When the macOS leg failed, its `tls=false` sibling was cancelled rather than run and `tests-passed` went red with half the picture. This sets `fail-fast: false`. It makes no test less flaky; it keeps one failing leg from erasing the results of the twenty-odd that would have passed, which is what makes a flaky failure hard to tell apart from a real one.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1661

## Further Comments

### Why not the third option in the issue

A DNS reachability probe that skips the tests was the one option not taken. It adds its own latency, silently deletes coverage on exactly the runners where it fires, and would not have helped the reported failure: the macOS runner resolves names, just slowly, so it passes a probe and then still exceeds the timeout.