### PR TITLE
README: drop unsupported `maxAge` parameter from downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align='center'>
   <a href='http://badge.fury.io/py/pika'><img src='https://img.shields.io/pypi/v/pika.svg?' alt='Version'></a>
   <a href='https://pypi.python.org/pypi/pika'><img src='https://img.shields.io/pypi/pyversions/pika.svg' alt='Python versions'></a>
-  <a href='https://pypi.python.org/pypi/pika'><img src='https://img.shields.io/pypi/dm/pika.svg?maxAge=25920' alt='Downloads'></a>
+  <a href='https://pypi.python.org/pypi/pika'><img src='https://img.shields.io/pypi/dm/pika' alt='Downloads'></a>
   <a href='https://github.com/pika/pika/actions/workflows/main.yaml'><img src='https://github.com/pika/pika/actions/workflows/main.yaml/badge.svg' alt='Actions Status'></a>
   <a href='https://codecov.io/github/pika/pika?branch=main'><img src='https://img.shields.io/codecov/c/github/pika/pika/main.svg' alt='Coverage'></a>
   <a href='https://github.com/pika/pika/blob/main/LICENSE'><img src='https://img.shields.io/pypi/l/pika.svg?' alt='License'></a>


### PR DESCRIPTION
## Summary

The PyPI downloads badge in the README passed `?maxAge=25920`, but the [shields.io PyPI downloads badge](https://shields.io/badges/py-pi-downloads) accepts no `maxAge` parameter. The query string was inert, so this drops it along with the redundant `.svg` suffix.

```diff
-<img src='https://img.shields.io/pypi/dm/pika.svg?maxAge=25920' alt='Downloads'>
+<img src='https://img.shields.io/pypi/dm/pika' alt='Downloads'>
```

## What this does not fix

The badge sometimes renders `downloads | rate limited by upstream service`. That message comes from shields.io's own backend being throttled by pypistats.org and is not influenced by the query string, so this change does not address it. It is transient and self-heals. If it becomes a recurring annoyance, the follow-up options are `cacheSeconds` (the actual documented cache-control parameter) or switching to a provider such as pepy.tech.
<img width="277" height="37" alt="Screenshot From 2026-07-30 15-32-23" src="https://github.com/user-attachments/assets/1693d6ad-d001-4e57-9a06-4c7dca75c18e" />

## Testing

Fetched both the old and the new badge URL and confirmed each returns the same rendered value (`downloads: 13M/month`), verifying the parameter removal is a no-op for output:

```
$ curl -s 'https://img.shields.io/pypi/dm/pika' | grep -o '<title>[^<]*</title>'
<title>downloads: 13M/month</title>
$ curl -s 'https://img.shields.io/pypi/dm/pika.svg?maxAge=25920' | grep -o '<title>[^<]*</title>'
<title>downloads: 13M/month</title>
```

README-only change, so no code paths are affected.
