### PR TITLE
Remove six `type: ignore` comments from three adapters

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -499,23 +499,55 @@ class _StreamingProtocolShim(nbio_interface.AbstractStreamProtocol):
     thus avoiding contamination of API with methods that look public, but aren't.
     """
 
-    # Override abstract methods at class level to enable instantiation;
-    # actual implementations are assigned on the instance in __init__.
-    connection_made = None  # type: ignore[assignment]
-    connection_lost = None  # type: ignore[assignment]
-    eof_received = None  # type: ignore[assignment]
-    data_received = None  # type: ignore[assignment]
-
     def __init__(self, conn: BaseConnection) -> None:
         """
         :param conn:
         """
         self.conn = conn
 
-        self.connection_made = conn._proto_connection_made
-        self.connection_lost = conn._proto_connection_lost
-        self.eof_received = conn._proto_eof_received
-        self.data_received = conn._proto_data_received
+    @override
+    def connection_made(
+            self, transport: nbio_interface.AbstractStreamTransport) -> None:
+        """
+        Introduces transport to protocol after transport is connected.
+
+        :param transport:
+        :raises Exception: Exception-based exception on error
+        """
+        self.conn._proto_connection_made(transport)
+
+    @override
+    def connection_lost(self, error: BaseException | None) -> None:
+        """
+        Called upon loss or closing of connection.
+
+        :param error: An exception (check for `BaseException`) indicates connection failure. None
+            indicates that connection was closed on this side.
+        :raises Exception: Exception-based exception on error
+        """
+        self.conn._proto_connection_lost(error)
+
+    @override
+    def eof_received(self) -> bool | None:
+        """
+        Called after the remote peer shuts its write end of the connection.
+
+        :returns: A falsy value (including None) will cause the transport to close itself, resulting
+            in an eventual `connection_lost()` call from the transport. If a truthy value is
+            returned, it will be the protocol's responsibility to close/abort the transport.
+        :raises Exception: Exception-based exception on error
+        """
+        return self.conn._proto_eof_received()
+
+    @override
+    def data_received(self, data: bytes) -> None:
+        """
+        Called to deliver incoming data to the protocol.
+
+        :param data: Non-empty data bytes.
+        :raises Exception: Exception-based exception on error
+        """
+        self.conn._proto_data_received(data)
 
     def __getattr__(self, attr: str) -> Any:
         """

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -399,9 +399,10 @@ class BlockingConnection:
         self._server_channel_closures: deque[Exception] = deque()
 
         # Declared without a value so that the type stays non-optional for the
-        # rest of the class, every method of which runs only after a successful
-        # workflow. `_cleanup()` tests for the attribute instead, since
-        # `_create_connection()` may raise before it is ever assigned.
+        # public API, all of which runs only after a successful workflow.
+        # `_create_connection()` may raise before this is ever assigned, so the
+        # two members that can run on a half-built instance, `_cleanup()` and
+        # `__repr__()`, read it with `getattr()`.
         self._impl: select_connection.SelectConnection
 
         self._impl = self._create_connection(parameters, _impl_class)
@@ -409,7 +410,11 @@ class BlockingConnection:
 
     @override
     def __repr__(self) -> str:
-        return f'<{self.__class__.__name__} impl={self._impl!r}>'
+        # `getattr` because `__repr__` runs on a half-built instance whenever
+        # `__init__` raises: a traceback or debugger rendering the frame's locals
+        # must not turn the real error into an `AttributeError`.
+        impl = getattr(self, '_impl', None)
+        return f'<{self.__class__.__name__} impl={impl!r}>'
 
     def __enter__(self) -> Self:
         # Prepare `with` context

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -398,9 +398,12 @@ class BlockingConnection:
         # Store exceptions for server-initiated channel closures
         self._server_channel_closures: deque[Exception] = deque()
 
-        # Perform connection workflow; pre-assign so that the attribute exists
-        # even if _create_connection raises (cleanup code accesses _impl).
-        self._impl: select_connection.SelectConnection = None  # type: ignore[assignment]
+        # Declared without a value so that the type stays non-optional for the
+        # rest of the class, every method of which runs only after a successful
+        # workflow. `_cleanup()` tests for the attribute instead, since
+        # `_create_connection()` may raise before it is ever assigned.
+        self._impl: select_connection.SelectConnection
+
         self._impl = self._create_connection(parameters, _impl_class)
         self._impl.add_on_close_callback(self._closed_result.set_value_once)
 
@@ -422,7 +425,9 @@ class BlockingConnection:
     def _cleanup(self) -> None:
         """Clean up members that might inhibit garbage collection."""
         with self._cleanup_mutex:
-            if self._impl is not None:
+            # `getattr` rather than a plain attribute test: `__init__` may have
+            # raised before `_impl` was assigned.
+            if getattr(self, '_impl', None) is not None:
                 self._impl.ioloop.close()
             self._ready_events.clear()
             self._closed_result.reset()

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -10,6 +10,7 @@ import errno
 import heapq
 import logging
 import select
+import sys
 import threading
 import time
 from typing import TYPE_CHECKING, Any, Callable, Sequence, Union
@@ -1091,12 +1092,22 @@ class SelectPoller(_PollerBase):
 
 
 class KQueuePoller(_PollerBase):
-    """KQueuePoller works on BSD based systems and is faster than select."""
+    """
+    KQueuePoller works on BSD based systems and is faster than select.
+
+    `select.kqueue`, `select.kevent`, and the `KQ_*` constants exist only on BSD
+    platforms, and typeshed declares them behind a `sys.platform` guard to match.
+    Every method that touches them therefore opens with the same guard, which
+    narrows the platform for the type checker and never fires at runtime:
+    `_get_poller()` only constructs this class when `select.kqueue` exists.
+    """
 
     def __init__(self, get_wait_seconds: Callable[[], float | None],
                  process_timeouts: Callable[[], None]) -> None:
         """Create an instance of the KQueuePoller."""
-        self._kqueue = None
+        # `Any` because the annotation cannot name `select.kqueue` on platforms
+        # where the type checker has no such attribute to refer to.
+        self._kqueue: Any | None = None
         super().__init__(get_wait_seconds, process_timeouts)
 
     @staticmethod
@@ -1107,13 +1118,13 @@ class KQueuePoller(_PollerBase):
         :param kevent: a kevent object as returned by kqueue.control()
         """
         mask = 0
-        # Looked up by name because these constants exist only on kqueue
-        # platforms; a direct `select.KQ_*` reference fails type checking
-        # everywhere else, and `warn_unused_ignores` rules out `type: ignore`.
-        kq_filter_read = getattr(select, 'KQ_FILTER_READ')  # noqa: B009
-        kq_filter_write = getattr(select, 'KQ_FILTER_WRITE')  # noqa: B009
-        kq_ev_eof = getattr(select, 'KQ_EV_EOF')  # noqa: B009
-        kq_ev_error = getattr(select, 'KQ_EV_ERROR')  # noqa: B009
+        if sys.platform == 'linux' or sys.platform == 'win32':
+            raise NotImplementedError('kqueue is available on BSD only.')
+
+        kq_filter_read = select.KQ_FILTER_READ
+        kq_filter_write = select.KQ_FILTER_WRITE
+        kq_ev_eof = select.KQ_EV_EOF
+        kq_ev_error = select.KQ_EV_ERROR
 
         if kevent.filter == kq_filter_read:
             mask = PollEvents.READ
@@ -1158,7 +1169,10 @@ class KQueuePoller(_PollerBase):
         """Notify the implementation to allocate the poller resource."""
         assert self._kqueue is None
 
-        self._kqueue = select.kqueue()  # type: ignore[attr-defined, assignment, unused-ignore]  # yapf: disable
+        if sys.platform == 'linux' or sys.platform == 'win32':
+            raise NotImplementedError('kqueue is available on BSD only.')
+
+        self._kqueue = select.kqueue()
 
     @override
     def _uninit_poller(self) -> None:
@@ -1197,40 +1211,31 @@ class KQueuePoller(_PollerBase):
         if self._kqueue is None:
             return
 
+        if sys.platform == 'linux' or sys.platform == 'win32':
+            raise NotImplementedError('kqueue is available on BSD only.')
+
         kevents = []
 
         if events_to_clear & PollEvents.READ:
             kevents.append(
-                select.kevent(  # pyright: ignore[reportAttributeAccessIssue]
-                    fileno,
-                    filter=select.
-                    KQ_FILTER_READ,  # pyright: ignore[reportAttributeAccessIssue]
-                    flags=select.KQ_EV_DELETE)
-            )  # pyright: ignore[reportAttributeAccessIssue]
-        if events_to_set & PollEvents.READ:  # pyright: ignore[reportAttributeAccessIssue]
+                select.kevent(fileno,
+                              filter=select.KQ_FILTER_READ,
+                              flags=select.KQ_EV_DELETE))
+        if events_to_set & PollEvents.READ:
             kevents.append(
-                select.kevent(  # pyright: ignore[reportAttributeAccessIssue]
-                    fileno,
-                    filter=select.
-                    KQ_FILTER_READ,  # pyright: ignore[reportAttributeAccessIssue]
-                    flags=select.KQ_EV_ADD)
-            )  # pyright: ignore[reportAttributeAccessIssue]
+                select.kevent(fileno,
+                              filter=select.KQ_FILTER_READ,
+                              flags=select.KQ_EV_ADD))
         if events_to_clear & PollEvents.WRITE:
             kevents.append(
-                select.kevent(  # pyright: ignore[reportAttributeAccessIssue]
-                    fileno,
-                    filter=select.
-                    KQ_FILTER_WRITE,  # pyright: ignore[reportAttributeAccessIssue]
-                    flags=select.KQ_EV_DELETE)
-            )  # pyright: ignore[reportAttributeAccessIssue]
+                select.kevent(fileno,
+                              filter=select.KQ_FILTER_WRITE,
+                              flags=select.KQ_EV_DELETE))
         if events_to_set & PollEvents.WRITE:
             kevents.append(
-                select.kevent(  # pyright: ignore[reportAttributeAccessIssue]
-                    fileno,
-                    filter=select.
-                    KQ_FILTER_WRITE,  # pyright: ignore[reportAttributeAccessIssue]
-                    flags=select.KQ_EV_ADD)
-            )  # pyright: ignore[reportAttributeAccessIssue]
+                select.kevent(fileno,
+                              filter=select.KQ_FILTER_WRITE,
+                              flags=select.KQ_EV_ADD))
 
         self._kqueue.control(kevents, 0)
 

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -1117,10 +1117,10 @@ class KQueuePoller(_PollerBase):
 
         :param kevent: a kevent object as returned by kqueue.control()
         """
-        mask = 0
         if sys.platform == 'linux' or sys.platform == 'win32':
             raise NotImplementedError('kqueue is available on BSD only.')
 
+        mask = 0
         kq_filter_read = select.KQ_FILTER_READ
         kq_filter_write = select.KQ_FILTER_WRITE
         kq_ev_eof = select.KQ_EV_EOF

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -1105,9 +1105,9 @@ class KQueuePoller(_PollerBase):
     def __init__(self, get_wait_seconds: Callable[[], float | None],
                  process_timeouts: Callable[[], None]) -> None:
         """Create an instance of the KQueuePoller."""
-        # `Any` because the annotation cannot name `select.kqueue` on platforms
-        # where the type checker has no such attribute to refer to.
-        self._kqueue: Any | None = None
+        # `Any` because the value is either `None` or a `select.kqueue` object,
+        # a type the checker cannot name on platforms without that attribute.
+        self._kqueue: Any = None
         super().__init__(get_wait_seconds, process_timeouts)
 
     @staticmethod

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -53,16 +53,26 @@ class BlockingConnectionTests(unittest.TestCase):
         # `__repr__` runs on that half-built instance from any traceback or
         # debugger, and must report the object instead of masking the original
         # error with an `AttributeError`.
+        half_built = []
+
+        def capture_and_raise(connection, _parameters, _impl_class):
+            half_built.append(connection)
+            raise RuntimeError('workflow failed')
+
         with mock.patch.object(
                 blocking_connection.BlockingConnection,
                 '_create_connection',
-                side_effect=RuntimeError('workflow failed')), self.assertRaises(
-                    RuntimeError):
+                autospec=True,
+                side_effect=capture_and_raise), self.assertRaises(RuntimeError):
             blocking_connection.BlockingConnection(pika.ConnectionParameters())
 
-        connection = blocking_connection.BlockingConnection.__new__(
-            blocking_connection.BlockingConnection)
-        self.assertEqual(repr(connection), '<BlockingConnection impl=None>')
+        self.assertEqual(len(half_built), 1)
+        self.assertEqual(repr(half_built[0]), '<BlockingConnection impl=None>')
+
+        # `_create_connection()` calls `_cleanup()` on the same half-built
+        # instance before re-raising, so that reader must tolerate the missing
+        # attribute too.
+        half_built[0]._cleanup()
 
     @patch.object(blocking_connection.select_connection,
                   'SelectConnection',

--- a/tests/unit/blocking_connection_tests.py
+++ b/tests/unit/blocking_connection_tests.py
@@ -47,6 +47,26 @@ class BlockingConnectionTests(unittest.TestCase):
     @patch.object(blocking_connection.select_connection,
                   'SelectConnection',
                   spec_set=SelectConnectionTemplate)
+    def test_repr_when_create_connection_raises(self,
+                                                _select_connection_class_mock):
+        # `__init__` leaves `_impl` unassigned when `_create_connection` raises.
+        # `__repr__` runs on that half-built instance from any traceback or
+        # debugger, and must report the object instead of masking the original
+        # error with an `AttributeError`.
+        with mock.patch.object(
+                blocking_connection.BlockingConnection,
+                '_create_connection',
+                side_effect=RuntimeError('workflow failed')), self.assertRaises(
+                    RuntimeError):
+            blocking_connection.BlockingConnection(pika.ConnectionParameters())
+
+        connection = blocking_connection.BlockingConnection.__new__(
+            blocking_connection.BlockingConnection)
+        self.assertEqual(repr(connection), '<BlockingConnection impl=None>')
+
+    @patch.object(blocking_connection.select_connection,
+                  'SelectConnection',
+                  spec_set=SelectConnectionTemplate)
     def test_process_io_for_connection_setup(self,
                                              select_connection_class_mock):
         with mock.patch.object(blocking_connection.BlockingConnection,


### PR DESCRIPTION
## Summary

First of three PRs for #1618, covering 6 of the 14 suppressions fixable in 1.5.0.

| File | Removed | Change |
|------|---------|--------|
| `adapters/base_connection.py` | 4 `[assignment]` | `_StreamingProtocolShim`'s four `None` class attributes become real `@override` methods delegating to `conn._proto_*` |
| `adapters/blocking_connection.py` | 1 `[assignment]` | `_impl` declared without a value; the two readers that can run on a half-built instance use `getattr` |
| `adapters/select_connection.py` | 1 `[attr-defined, assignment, unused-ignore]` | `sys.platform` guards in `KQueuePoller` in place of the suppression |

Repo-wide `type: ignore` count drops from 21 to 15. The remaining 15 are PRs 2 and 3 of #1618 plus the 7 deferred to #1669.

## The kqueue suppression was hiding unchecked code

This is the substantive part of the PR. The suppression listed `assignment`, which left `self._kqueue` inferred as `None`. Every statement after the `if self._kqueue is None: return` guard was therefore unreachable, so mypy has never type-checked the body of `KQueuePoller`.

Measured with `warn_unreachable = True` under `--platform darwin`:

- On main: 4 unreachable statements inside `KQueuePoller`, 27 repo-wide.
- After this change: 0 inside `KQueuePoller`, 23 repo-wide, with no new unreachable code anywhere.

To confirm the restored checking is real and not cosmetic, I injected two errors into a scratch copy of the poller: `select.KQ_EV_NOPE` in place of a valid constant, and a `str` where `kevent()` requires an `int`. Both are caught under `--platform darwin` and both are invisible on Linux.

CI already enforces this. `mypy --platform` defaults to `sys.platform` and `mypy.ini` sets no `platform` key, so the existing `macos-latest` leg of the mypy workflow checks the poller body as soon as the suppression is gone. No workflow change is needed. There are also 17 kqueue tests in `tests/unit/select_connection_ioloop_tests.py` gated on `hasattr(select, 'kqueue')`; they skip on Linux and run on the macOS legs.

### Why the guard is repeated in three methods

Each of `_map_event`, `_init_poller`, and `_modify_fd_events` opens with the same `sys.platform` test. I tried two ways to avoid the repetition, and both fail:

- Aliasing the test to a module-level constant. mypy does not narrow through the alias, so `select.kqueue` still errors on Linux.
- Defining the class under a single `if sys.platform != 'linux' and sys.platform != 'win32':`. This breaks the `KQueuePoller` reference in `_get_poller()` at `select_connection.py:466` with `[name-defined]` on Linux.

Inline `sys.platform` checks are the only form mypy narrows on, which is also how typeshed declares these attributes.

## Behavior changes

Constructing `KQueuePoller` directly on Linux now raises `NotImplementedError` instead of `AttributeError` from `select.kqueue`. `_get_poller()` only constructs it when `select.kqueue` exists, so neither path is reachable in normal use, and both are errors either way.

`BlockingConnection._impl` no longer exists as an attribute until `_create_connection()` succeeds, where it was previously `None`. Two members can run against a half-built instance and both read the attribute with `getattr`:

- `_cleanup()`, which `_create_connection()` itself calls from its `except` block before re-raising.
- `__repr__()`, which runs from any traceback or debugger rendering the frame's locals.

I enumerated these rather than assuming: 14 members read `_impl`, and the other 12 are public API reachable only after a successful workflow. Verified end to end against an unreachable port, where `_cleanup()` runs with `_impl` absent from `__dict__`, `repr()` renders `impl=None`, and the real `AMQPConnectionError` surfaces intact.

Nothing else changes at runtime. The shim's four methods do exactly what the previously assigned bound methods did.

## Review fixes

alonfaraj caught that the first push had `__repr__` still reading `_impl` directly, which turned a broker-unreachable `AMQPConnectionError` into an `AttributeError` from the repr. Fixed with a regression test that captures the genuine half-built instance via `autospec=True` and exercises both readers. Worth recording that type checking cannot catch this shape: `self._impl: SelectConnection` with no value tells mypy the attribute exists, and mypy does not verify that every path assigns it, even with `possibly-undefined` and `warn_unreachable` enabled.

## Testing

- `hatch run lint-check`, `fmt-check`, `docfmt-check`, `typecheck` all exit 0.
- mypy clean under the default platform plus `--platform darwin`, `--platform win32`, and `--platform linux`.
- `hatch run test`: 1462 passed, 61 skipped, against a live RabbitMQ broker.

## Side note for #1564

This drops `select_connection.py` from 17 `pyright: ignore` comments to 4. Untested, since pyright has not been run against the tree.

See #1618
