### PR TITLE
Make `AbstractSelectorIOLoop` a structural `Protocol`

### DIFF
--- a/pika/_utils.py
+++ b/pika/_utils.py
@@ -25,7 +25,25 @@ else:
         return func
 
 
-__all__ = ['override']
+# `Protocol` and `runtime_checkable` (PEP 544) landed in the stdlib in 3.8,
+# while pika still supports 3.7. Same dependency-free approach as `override`
+# above: type checkers run at 3.10 or later and see the real objects, while a
+# 3.7 runtime falls back to a plain base class and a no-op decorator. Protocols
+# in pika are only ever subclassed explicitly, never instantiated or passed to
+# `isinstance`, so the nominal fallback behaves identically at runtime.
+# Re-exported across pika (declared in __all__ below).
+if sys.version_info >= (3, 8):
+    from typing import Protocol, runtime_checkable
+elif TYPE_CHECKING:
+    from typing_extensions import Protocol, runtime_checkable
+else:
+    Protocol = object
+
+    def runtime_checkable(cls):
+        return cls
+
+
+__all__ = ['Protocol', 'override', 'runtime_checkable']
 
 RE_NUM = re.compile(r'(\d+).+')
 

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -212,9 +212,9 @@ class _GeventSelectorIOLoop(AbstractSelectorIOLoop):
     # Gevent's READ and WRITE masks are defined as 1 and 2 respectively. No
     # ERROR mask is defined.
     # See https://www.gevent.org/api/gevent.hub.html#gevent._interfaces.ILoop.io
-    READ = 1  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
-    WRITE = 2  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
-    ERROR = 0  # pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]
+    READ = 1
+    WRITE = 2
+    ERROR = 0
 
     def __init__(self, gevent_hub: gevent.hub.Hub | None = None) -> None:
         """

--- a/pika/adapters/select_connection.py
+++ b/pika/adapters/select_connection.py
@@ -403,9 +403,9 @@ class IOLoop(AbstractSelectorIOLoop):
     """
 
     # READ/WRITE/ERROR per `AbstractSelectorIOLoop` requirements
-    READ = PollEvents.READ  # pyright: ignore[reportIncompatibleMethodOverride, reportAssignmentType]
-    WRITE = PollEvents.WRITE  # pyright: ignore[reportIncompatibleMethodOverride, reportAssignmentType]
-    ERROR = PollEvents.ERROR  # pyright: ignore[reportIncompatibleMethodOverride, reportAssignmentType]
+    READ = PollEvents.READ
+    WRITE = PollEvents.WRITE
+    ERROR = PollEvents.ERROR
 
     def __init__(self) -> None:
         self._timer = _Timer()

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -69,8 +69,7 @@ class TornadoConnection(base_connection.BaseConnection):
             nbio = custom_ioloop
         else:
             nbio = (selector_ioloop_adapter.SelectorIOServicesAdapter(
-                custom_ioloop or
-                ioloop.IOLoop.instance()))  # type: ignore[arg-type]
+                custom_ioloop or ioloop.IOLoop.instance()))
         super().__init__(
             parameters,
             on_open_callback,
@@ -98,7 +97,7 @@ class TornadoConnection(base_connection.BaseConnection):
         :param workflow: Optional connection workflow instance to use
         """
         nbio = selector_ioloop_adapter.SelectorIOServicesAdapter(
-            custom_ioloop or ioloop.IOLoop.instance())  # type: ignore[arg-type]
+            custom_ioloop or ioloop.IOLoop.instance())
 
         def connection_factory(
                 params: connection.Parameters | None) -> TornadoConnection:

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import logging
 import socket
 import threading
-from typing import Any, Callable, Protocol, runtime_checkable
+from typing import Any, Callable
 
-from pika._utils import override
+from pika._utils import Protocol, override, runtime_checkable
 from pika.adapters.utils import io_services_utils, nbio_interface
 from pika.adapters.utils.io_services_utils import check_callback_arg, check_fd_arg
 
@@ -28,7 +28,8 @@ class AbstractSelectorIOLoop(Protocol):
 
     A `Protocol` rather than a base class so that loops implementing this
     interface without deriving from it, such as `tornado.ioloop.IOLoop`, satisfy
-    it structurally.
+    it structurally. `Protocol` reached the stdlib in 3.8, so on 3.7 this falls
+    back to a plain base class; see `pika._utils`.
     """
 
     # The values of the I/O loop's READ/WRITE/ERROR flags, which may be used

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -4,11 +4,10 @@ as tornado's and our home-grown select_connection's I/O loops.
 
 from __future__ import annotations
 
-import abc
 import logging
 import socket
 import threading
-from typing import Any, Callable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 from pika._utils import override
 from pika.adapters.utils import io_services_utils, nbio_interface
@@ -17,7 +16,8 @@ from pika.adapters.utils.io_services_utils import check_callback_arg, check_fd_a
 LOGGER = logging.getLogger(__name__)
 
 
-class AbstractSelectorIOLoop:
+@runtime_checkable
+class AbstractSelectorIOLoop(Protocol):
     """
     Selector-based I/O loop interface expected by
     `selector_ioloop_adapter.SelectorIOServicesAdapter`
@@ -25,34 +25,19 @@ class AbstractSelectorIOLoop:
     NOTE: this interface follows the corresponding methods and attributes
      of `tornado.ioloop.IOLoop` in order to avoid additional adapter layering
      when wrapping tornado's IOLoop.
+
+    A `Protocol` rather than a base class so that loops implementing this
+    interface without deriving from it, such as `tornado.ioloop.IOLoop`, satisfy
+    it structurally.
     """
 
-    @property
-    @abc.abstractmethod
-    def READ(self) -> int:
-        """
-        The value of the I/O loop's READ flag; READ/WRITE/ERROR may be used with bitwise operators
-        as expected.
+    # The values of the I/O loop's READ/WRITE/ERROR flags, which may be used
+    # with bitwise operators as expected. Declared as attributes rather than
+    # properties so that implementations may use either.
+    READ: int
+    WRITE: int
+    ERROR: int
 
-        Implementation note: the implementations can simply replace these
-        READ/WRITE/ERROR properties with class-level attributes
-        """
-
-    @property
-    @abc.abstractmethod
-    def WRITE(self) -> int:
-        """The value of the I/O loop's WRITE flag; READ/WRITE/ERROR may be used with bitwise
-        operators as expected.
-        """
-
-    @property
-    @abc.abstractmethod
-    def ERROR(self) -> int:
-        """The value of the I/O loop's ERROR flag; READ/WRITE/ERROR may be used with bitwise
-        operators as expected.
-        """
-
-    @abc.abstractmethod
     def close(self) -> None:
         """
         Release IOLoop's resources.
@@ -62,7 +47,6 @@ class AbstractSelectorIOLoop:
         `IOLoop` should be performed.
         """
 
-    @abc.abstractmethod
     def start(self) -> None:
         """
         Run the I/O loop.
@@ -70,7 +54,6 @@ class AbstractSelectorIOLoop:
         It will loop until requested to exit. See `stop()`.
         """
 
-    @abc.abstractmethod
     def stop(self) -> None:
         """
         Request exit from the ioloop.
@@ -83,7 +66,6 @@ class AbstractSelectorIOLoop:
         `ioloop.add_callback(ioloop.stop)`
         """
 
-    @abc.abstractmethod
     def call_later(self, delay: float, callback: Callable[..., Any]) -> object:
         """
         Add the callback to the IOLoop timer to be called after delay seconds from the time of call
@@ -94,7 +76,6 @@ class AbstractSelectorIOLoop:
         :returns: handle to the created timeout that may be passed to `remove_timeout()`
         """
 
-    @abc.abstractmethod
     def remove_timeout(self, timeout_handle: Any) -> None:
         """
         Remove a timeout.
@@ -102,7 +83,6 @@ class AbstractSelectorIOLoop:
         :param timeout_handle: Handle of timeout to remove
         """
 
-    @abc.abstractmethod
     def add_callback(self, callback: Callable[..., Any]) -> None:
         """
         Requests a call to the given function as soon as possible in the context of this IOLoop's
@@ -118,7 +98,6 @@ class AbstractSelectorIOLoop:
         :param callback: The callback method
         """
 
-    @abc.abstractmethod
     def add_handler(self, fd: int, handler: Callable[[int, int], None],
                     events: int) -> None:
         """
@@ -129,7 +108,6 @@ class AbstractSelectorIOLoop:
         :param events: The event mask using READ, WRITE, ERROR.
         """
 
-    @abc.abstractmethod
     def update_handler(self, fd: int, events: int) -> None:
         """
         Changes the events we watch for.
@@ -138,7 +116,6 @@ class AbstractSelectorIOLoop:
         :param events: The event mask using READ, WRITE, ERROR
         """
 
-    @abc.abstractmethod
     def remove_handler(self, fd: int) -> None:
         """
         Stop watching the given file descriptor for events.

--- a/pika/adapters/utils/selector_ioloop_adapter.py
+++ b/pika/adapters/utils/selector_ioloop_adapter.py
@@ -30,11 +30,22 @@ class AbstractSelectorIOLoop(Protocol):
     interface without deriving from it, such as `tornado.ioloop.IOLoop`, satisfy
     it structurally. `Protocol` reached the stdlib in 3.8, so on 3.7 this falls
     back to a plain base class; see `pika._utils`.
+
+    The methods carry no `@abc.abstractmethod` decorators. `typing._ProtocolMeta`
+    derives from `abc.ABCMeta`, so adding them back would populate
+    `__abstractmethods__` and make an incomplete subclass fail at construction on
+    3.8 and later, but do nothing at all on 3.7, where the base is `object`.
+    mypy reports a missing method either way, so the decorators would buy
+    version-dependent runtime behavior and nothing else.
     """
 
     # The values of the I/O loop's READ/WRITE/ERROR flags, which may be used
-    # with bitwise operators as expected. Declared as attributes rather than
-    # properties so that implementations may use either.
+    # with bitwise operators as expected. Protocol variable members are not
+    # satisfied by read-only properties, so implementations must expose plain
+    # `int` attributes. Declaring these as properties here instead would accept
+    # both shapes under mypy, but pyright then rejects the `int` class
+    # attributes both in-tree loops use, which is what the six
+    # `pyright: ignore` comments this change retires were suppressing.
     READ: int
     WRITE: int
     ERROR: int

--- a/tests/typing/README.md
+++ b/tests/typing/README.md
@@ -3,10 +3,13 @@
 Type-checker fixtures that pin annotations pika's own `mypy` run cannot see.
 
 `hatch run typecheck` checks `packages = pika`, so it never covers code that
-consumes pika from the outside. Some guarantees only fail there: a downstream
-caller annotating `UnroutableError.messages` against the concrete
-`ReturnedMessage` broke when the attribute was annotated with the message
-protocol, and neither pika's `mypy` run nor the runtime unit tests observed it.
+consumes pika from the outside. Some guarantees only fail there, and two
+already have. A downstream caller annotating `UnroutableError.messages` against
+the concrete `ReturnedMessage` broke when the attribute was annotated with the
+message protocol. A caller wiring a custom I/O loop into
+`SelectorIOServicesAdapter` needs the loop interface to be structural rather
+than nominal. Neither pika's `mypy` run nor the runtime unit tests observed
+either one.
 
 Each file here is a small downstream consumer that must type-check clean.
 `hatch run typecheck` covers this directory alongside `pika/`, so an annotation

--- a/tests/typing/custom_ioloop.py
+++ b/tests/typing/custom_ioloop.py
@@ -1,0 +1,69 @@
+"""
+A downstream custom I/O loop.
+
+Pins the annotation that pika's own `mypy` run cannot cover: `SelectorIOServicesAdapter` accepts an
+implementation of `AbstractSelectorIOLoop`, and the point of the conversion to `typing.Protocol` is
+that a loop implementing the interface without deriving from it, as `tornado.ioloop.IOLoop` does,
+satisfies it. That guarantee lives at the boundary, so nothing inside `pika` observes it. See
+`tests/typing/README.md`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    from pika.adapters.utils.selector_ioloop_adapter import SelectorIOServicesAdapter
+
+
+class _StructuralLoop:
+    """
+    Implements the whole interface without deriving from it.
+
+    Mirrors the class of the same name in
+    `tests/unit/selector_ioloop_adapter_tests.py`, which exercises the runtime
+    behavior. This one exists to be type-checked, not run.
+    """
+
+    READ = 1
+    WRITE = 2
+    ERROR = 4
+
+    def close(self) -> None:
+        ...
+
+    def start(self) -> None:
+        ...
+
+    def stop(self) -> None:
+        ...
+
+    def call_later(self, delay: float, callback: Callable[..., Any]) -> object:
+        ...
+
+    def remove_timeout(self, timeout_handle: Any) -> None:
+        ...
+
+    def add_callback(self, callback: Callable[..., Any]) -> None:
+        ...
+
+    def add_handler(self, fd: int, handler: Callable[[int, int], None],
+                    events: int) -> None:
+        ...
+
+    def update_handler(self, fd: int, events: int) -> None:
+        ...
+
+    def remove_handler(self, fd: int) -> None:
+        ...
+
+
+def accepts_a_structurally_conforming_loop() -> SelectorIOServicesAdapter:
+    """
+    The reason for the `Protocol` conversion.
+
+    A loop implementing the interface without deriving from it satisfies the argument type. On
+    `main` before the conversion this fails with `[arg-type]`, since the class was a nominal base.
+    """
+    from pika.adapters.utils.selector_ioloop_adapter import SelectorIOServicesAdapter
+    return SelectorIOServicesAdapter(_StructuralLoop())

--- a/tests/unit/selector_ioloop_adapter_tests.py
+++ b/tests/unit/selector_ioloop_adapter_tests.py
@@ -1,0 +1,160 @@
+"""Tests for pika.adapters.utils.selector_ioloop_adapter.AbstractSelectorIOLoop."""
+
+import inspect
+import sys
+import unittest
+
+import pika._utils
+from pika.adapters import select_connection
+from pika.adapters.utils.selector_ioloop_adapter import AbstractSelectorIOLoop
+
+try:
+    import tornado.ioloop
+    HAS_TORNADO = True
+except ImportError:
+    HAS_TORNADO = False
+
+try:
+    from pika.adapters.gevent_connection import _GeventSelectorIOLoop
+    HAS_GEVENT = True
+except ImportError:
+    _GeventSelectorIOLoop = None
+    HAS_GEVENT = False
+
+FLAG_NAMES = ('READ', 'WRITE', 'ERROR')
+
+# Derived from the protocol itself rather than hard-coded, so a method added to
+# the interface is immediately required of every loop checked below.
+PROTOCOL_METHOD_NAMES = tuple(
+    sorted(name for name, value in vars(AbstractSelectorIOLoop).items()
+           if not name.startswith('_') and callable(value)))
+
+
+class _StructuralLoop:
+    """Implements the whole interface without deriving from it, as tornado's `IOLoop` does."""
+
+    READ = 1
+    WRITE = 2
+    ERROR = 4
+
+    def close(self):
+        pass
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def call_later(self, delay, callback):
+        pass
+
+    def remove_timeout(self, timeout_handle):
+        pass
+
+    def add_callback(self, callback):
+        pass
+
+    def add_handler(self, fd, handler, events):
+        pass
+
+    def update_handler(self, fd, events):
+        pass
+
+    def remove_handler(self, fd):
+        pass
+
+
+class _IncompleteLoop:
+    """Carries the flags but none of the methods."""
+
+    READ = 1
+    WRITE = 2
+    ERROR = 4
+
+
+class _ConformanceChecks:
+    """
+    Checks that a loop class satisfies `AbstractSelectorIOLoop`.
+
+    Mixed into a `unittest.TestCase` per loop class. Everything is checked against the class rather
+    than an instance so that no loop, hub, or file descriptor is created.
+    """
+
+    loop_class = None
+
+    def test_flags_are_int_attributes(self):
+        # The protocol declares READ/WRITE/ERROR as variable members, which a
+        # read-only property does not satisfy. `getattr_static` is what
+        # distinguishes the two: for a property it returns the property object
+        # rather than the value.
+        for name in FLAG_NAMES:
+            value = inspect.getattr_static(self.loop_class, name)
+            self.assertIsInstance(value, int, f'{name} is not a plain int')
+
+    def test_implements_every_protocol_method(self):
+        self.assertTrue(PROTOCOL_METHOD_NAMES)
+        for name in PROTOCOL_METHOD_NAMES:
+            self.assertTrue(callable(getattr(self.loop_class, name, None)),
+                            f'{name} is missing or not callable')
+
+
+class SelectConnectionIOLoopConformanceTests(_ConformanceChecks,
+                                             unittest.TestCase):
+    loop_class = select_connection.IOLoop
+
+
+@unittest.skipUnless(HAS_GEVENT, 'gevent not installed')
+@unittest.skipIf(pika._utils.ON_WINDOWS, 'Windows not supported')
+class GeventSelectorIOLoopConformanceTests(_ConformanceChecks,
+                                           unittest.TestCase):
+    loop_class = _GeventSelectorIOLoop
+
+
+@unittest.skipUnless(HAS_TORNADO, 'tornado not installed')
+class TornadoIOLoopConformanceTests(_ConformanceChecks, unittest.TestCase):
+    """
+    Tornado's `IOLoop` is the reason the interface is structural.
+
+    It implements every member without deriving from the protocol, which is what allowed the two
+    `[arg-type]` suppressions in `tornado_connection.py` to be removed.
+    """
+
+    loop_class = tornado.ioloop.IOLoop if HAS_TORNADO else None
+
+    def test_does_not_derive_from_the_protocol(self):
+        self.assertNotIn(AbstractSelectorIOLoop, self.loop_class.__mro__)
+
+
+class AbstractSelectorIOLoopTests(unittest.TestCase):
+
+    def test_flags_are_declared_as_variable_members(self):
+        # Declaring the flags as properties instead would let a loop expose them
+        # as read-only properties, but pyright then rejects the plain `int` class
+        # attributes both in-tree loops use. A property declaration puts a
+        # property object in the class dict; an annotation does not.
+        self.assertEqual(set(AbstractSelectorIOLoop.__annotations__),
+                         set(FLAG_NAMES))
+        for name in FLAG_NAMES:
+            self.assertNotIn(name, vars(AbstractSelectorIOLoop))
+
+    def test_carries_no_abstract_methods(self):
+        # `typing._ProtocolMeta` derives from `abc.ABCMeta`, so an
+        # `@abc.abstractmethod` here would block construction of an incomplete
+        # subclass on 3.8 and later while doing nothing at all on 3.7, where the
+        # protocol falls back to `object`.
+        self.assertEqual(
+            getattr(AbstractSelectorIOLoop, '__abstractmethods__', frozenset()),
+            frozenset())
+
+    @unittest.skipIf(sys.version_info < (3, 8),
+                     '`Protocol` falls back to a nominal base class on 3.7')
+    def test_isinstance_accepts_a_loop_that_does_not_derive_from_it(self):
+        loop = _StructuralLoop()
+        self.assertNotIn(AbstractSelectorIOLoop, type(loop).__mro__)
+        self.assertIsInstance(loop, AbstractSelectorIOLoop)
+
+    @unittest.skipIf(sys.version_info < (3, 8),
+                     '`Protocol` falls back to a nominal base class on 3.7')
+    def test_isinstance_rejects_an_incomplete_loop(self):
+        self.assertNotIsInstance(_IncompleteLoop(), AbstractSelectorIOLoop)

--- a/tests/unit/selector_ioloop_adapter_tests.py
+++ b/tests/unit/selector_ioloop_adapter_tests.py
@@ -93,10 +93,19 @@ class _ConformanceChecks:
             self.assertIsInstance(value, int, f'{name} is not a plain int')
 
     def test_implements_every_protocol_method(self):
+        # `getattr` resolves through the MRO, so for the two in-tree loops, which
+        # derive from the protocol, a missing method would find the protocol's own
+        # do-nothing body rather than being absent. Asking which class defined the
+        # member closes that: an inherited stub fails the same as an absent method.
         self.assertTrue(PROTOCOL_METHOD_NAMES)
         for name in PROTOCOL_METHOD_NAMES:
-            self.assertTrue(callable(getattr(self.loop_class, name, None)),
-                            f'{name} is missing or not callable')
+            owner = next((klass for klass in self.loop_class.__mro__
+                          if name in vars(klass)), None)
+            self.assertIsNotNone(owner, f'{name} is missing')
+            self.assertIsNot(owner, AbstractSelectorIOLoop,
+                             f'{name} is only the inherited protocol stub')
+            self.assertTrue(callable(getattr(self.loop_class, name)),
+                            f'{name} is not callable')
 
 
 class SelectConnectionIOLoopConformanceTests(_ConformanceChecks,


### PR DESCRIPTION
## Summary

Second of three PRs for #1618, covering item 2: the 2 tornado `[arg-type]` suppressions. It also removes 6 obsolete `pyright: ignore` comments that fall out of the same change.

Based directly on the #1670 merge commit, so it contains that work and applies cleanly.

| File | Change |
|------|--------|
| `adapters/utils/selector_ioloop_adapter.py` | `AbstractSelectorIOLoop` becomes a `@runtime_checkable` `Protocol`; `READ`/`WRITE`/`ERROR` become `int` attribute declarations; 12 `@abc.abstractmethod` decorators and the `abc` import removed |
| `adapters/tornado_connection.py` | 2 `type: ignore[arg-type]` removed |
| `adapters/select_connection.py` | 3 obsolete `pyright: ignore` removed |
| `adapters/gevent_connection.py` | 3 obsolete `pyright: ignore` removed |
| `_utils.py` | `Protocol`/`runtime_checkable` re-exported with a 3.7 fallback |
| `tests/unit/selector_ioloop_adapter_tests.py` | new: 11 conformance tests |

## Why a Protocol

The class already documents itself as an interface that a loop may satisfy "but not necessarily derived from it", and `SelectorIOServicesAdapter.__init__` repeats that in its own docstring. A nominal base class cannot express it. `tornado.ioloop.IOLoop` implements every member but does not inherit from `AbstractSelectorIOLoop`, so both call sites handing one to `SelectorIOServicesAdapter` needed `type: ignore[arg-type]`. Structural typing is what the interface was describing all along.

## The six pyright suppressions

`READ`/`WRITE`/`ERROR` were abstract properties, but every implementation assigns a plain `int`. That mismatch is why all three flags in both `IOLoop` and `_GeventSelectorIOLoop` carried `pyright: ignore[reportAssignmentType, reportIncompatibleMethodOverride]`. Declaring them as `int` attributes on the Protocol makes the assignments correct.

Measured at the branch tip: pyright reports **6** diagnostics across the four affected files both before and after, and none concern `READ`, `WRITE`, or `ERROR`. `[tool.pyright]` in `pyproject.toml` is empty, so this is pyright at its defaults.

## Flags are variable members, not properties

Protocol variable members are not satisfied by read-only properties, so an implementation must expose plain `int` attributes. This is narrower than the abstract-property declaration it replaces, where an implementation could use either shape, and the trade-off is deliberate.

Declaring the flags as read-only property members is the more permissive alternative under mypy, and it was tested rather than assumed. pyright then reports **18** diagnostics on the same four files instead of 6, and the 12 additions are exactly `reportAssignmentType` x6 and `reportIncompatibleMethodOverride` x6: every diagnostic the six retired suppressions were covering, back again. Both in-tree loops use plain ints, and so does tornado's `IOLoop` (`READ` 1, `WRITE` 4, `ERROR` 24), so the narrower declaration costs nothing in the tree and keeps pyright at parity, which matters for #1564.

## The `@abc.abstractmethod` decorators

12 decorators are removed, 3 on the flags and 9 on the methods.

They are **not** inert under `Protocol`. `typing._ProtocolMeta` derives from `abc.ABCMeta`, so keeping them would populate `__abstractmethods__` and make an incomplete subclass fail at construction. Verified on 3.14: re-adding them populates all 12, and a subclass missing `remove_handler` raises `TypeError`.

They stay removed anyway, for a reason specific to this project's support window. pika supports 3.7, where `typing.Protocol` does not exist and the base falls back to `object`; there `__abstractmethods__` is absent entirely and an incomplete subclass instantiates fine. Keeping the decorators would buy runtime enforcement on 3.8 through 3.14 and nothing on 3.7, so the behavior would differ across legs of the same test matrix. mypy reports a missing method on every version either way.

## Runtime behavior

Measured by running the code on both 3.14.5 and 3.7.17:

- **`AbstractSelectorIOLoop()` raises `TypeError: Protocols cannot be instantiated`** on 3.8+, and succeeds on 3.7 under the fallback. Nothing in the tree constructs it.
- **`isinstance` still works** because of `@runtime_checkable`, and now also returns `True` for a loop that satisfies the interface without deriving from it. On 3.7 the fallback makes it nominal, so a non-deriving loop returns `False` there. Nothing in the repo does `isinstance` against this class.
- **`issubclass` raises `TypeError`** on 3.8+. A `Protocol` with non-method members cannot support it, and this one has three. Nothing in the tree calls it.
- **Both in-tree implementations still work.** `IOLoop` and `_GeventSelectorIOLoop` subclass the Protocol explicitly, instantiate fine, and implement all 9 protocol methods.

`AbstractSelectorIOLoop` lives in `pika/adapters/utils/`, which `CLAUDE.md` describes as "adapter internals". It is not in any `__all__` and not referenced in the docs.

## Tests

`tests/unit/selector_ioloop_adapter_tests.py` is new. Nothing in `tests/` referenced `AbstractSelectorIOLoop` before, even though structural conformance is the whole premise of this change.

11 tests, all asserted against classes rather than instances so no loop, hub, or file descriptor is created. Method names are derived from the protocol at import time, so a member added to the interface is immediately required of all three loops checked (`select_connection.IOLoop`, `_GeventSelectorIOLoop`, `tornado.ioloop.IOLoop`).

Confirmed the tests bite, by mutating the source four ways and checking each mutation fails:

| Mutation | Caught by |
|---|---|
| Protocol flags declared as properties | `test_flags_are_declared_as_variable_members` |
| `select_connection.IOLoop` flags as properties | `test_flags_are_int_attributes` |
| New protocol method no loop implements | `test_implements_every_protocol_method` and the `isinstance` test |
| `@abc.abstractmethod` re-added | `test_carries_no_abstract_methods` |

## Testing

- `hatch run lint-check`, `fmt-check`, `docfmt-check`, `typecheck` all exit 0.
- mypy clean under the default platform plus `--platform darwin` and `--platform win32`.
- `hatch run test`: 1473 passed, 61 skipped against a live RabbitMQ broker.
- Python 3.7.17 unit suite: 912 passed, 24 skipped. The 2 `isinstance` tests skip there by design, since the fallback base is nominal.
- pyright: 6 diagnostics before and after, with 6 fewer suppressions.

## Corrections to the original description

Three claims in the first version of this description were wrong, and are fixed above:

- It said pyright reported "the same 10 diagnostics" before and after. The count is 6. The parity holds; the number did not.
- It said the `@abc.abstractmethod` decorators "were already inert". That was true of the `object`-based class before the conversion and false after it, since `_ProtocolMeta` derives from `ABCMeta`. Thanks to @alonfaraj for catching both this and the flags narrowing.
- It said 8 decorators were removed. It is 12.

See #1618
