### PR TITLE
Fail the build when a Codecov upload is rejected

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -36,6 +36,9 @@ jobs:
     name: upload coverage to Codecov
     runs-on: ubuntu-latest
     needs: [test-modern, test-legacy]
+    # Upload whatever the matrix produced. A single flaky leg must not throw
+    # away the coverage the other forty-odd legs already measured.
+    if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download coverage artifacts
@@ -44,16 +47,36 @@ jobs:
           pattern: coverage-*
           path: coverage
       - name: Verify coverage reports were collected
+        id: reports
+        env:
+          TESTS_PASSED: ${{ needs.test-modern.result == 'success' && needs.test-legacy.result == 'success' }}
         run: |
-          count=$(find coverage -name coverage.xml | wc -l)
+          count=$(find coverage -name coverage.xml 2>/dev/null | wc -l)
           echo "collected $count coverage reports"
-          test "$count" -gt 0
+          if [ "$count" -gt 0 ]; then
+            echo 'upload=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo 'upload=false' >> "$GITHUB_OUTPUT"
+          # No reports at all. Expected when every test job died before it
+          # could publish an artifact, so stay quiet and let those jobs report
+          # the failure. If the tests passed, the download pattern is what is
+          # broken and that must not pass silently.
+          if [ "$TESTS_PASSED" = 'true' ]; then
+            echo '::error::tests passed but no coverage.xml was downloaded'
+            exit 1
+          fi
       - name: Upload coverage to Codecov
+        if: ${{ steps.reports.outputs.upload == 'true' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage
-          fail_ci_if_error: false
+          # Fork pull requests have no access to the upload token and rely on
+          # Codecov's tokenless path, so a rejected upload there is not
+          # actionable. Everywhere else a rejection means coverage silently
+          # stopped being recorded, which is worth a red build.
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
 
   tests-passed:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Proposed Changes

`CODECOV_TOKEN` is empty, so `codecov-action` uploads tokenless. Codecov accepts that only for fork pull requests; pushes to `main` and same-repo pull requests are rejected. From #1670's coverage job ([run 30754080482](https://github.com/pika/pika/actions/runs/30754080482/job/91514224219)):

```
collected 48 coverage reports
 -> Token length: 0
Upload queued for processing failed: {"message":"Token required because branch is protected"}
```

That job's conclusion is `success`, because `fail_ci_if_error: false` swallowed the rejection. 848adc29 and the three commits #1670 contributed are unknown to Codecov.

Codecov does show a report on `main` dated 2026-07-30, which is what hides this. It belongs to d98d61b5, the head commit of #1667 from `alonfaraj:gh-1661`: the tokenless path accepted it, and Codecov re-labeled the branch to `main` once the pull request merged. Every report `main` holds arrived that way, so the baseline now degrades one merge at a time as branches move from forks into this repository.

Two changes. Neither fixes the upload, which needs the token; they make its absence visible and stop unrelated flakiness from discarding reports.

- `fail_ci_if_error` is derived from the event: `true` for pushes and same-repo pull requests, `false` for fork pull requests, which cannot reach the secret and must keep using the tokenless path. A rejected upload goes red instead of silently green.
- The `coverage` job had no `if:`, so one failed matrix leg skipped the upload and that commit recorded nothing. It now runs unless the workflow was cancelled and uploads whatever artifacts arrived. With no artifacts at all it stays quiet if the test jobs failed, and goes red if they passed, because then the `coverage-*` download pattern is what is broken.

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

CI only. No library code is touched.

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

There is no harness for workflow files. Verified instead by parsing `main.yaml`, confirming both expressions resolve as intended, and running the guard step's shell logic against all four combinations of zero or more reports crossed with tests passing or failing.

## Fixes

- Fixes #

## Further Comments

Decisions for maintainers:

**Alternative to a long-lived secret.** `use_oidc: true` plus `permissions: {id-token: write}` avoids the token entirely, at the cost of enabling OIDC on the Codecov side.
