### PR TITLE
Type-annotate the generated `spec.py` and drop its mypy exemption

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -15,6 +15,46 @@ ch.basic_publish(exchange='', routing_key='q', body=b'hello')
 
 The other connection adapters (`BlockingConnection`, `SelectConnection`, `AsyncioConnection`, etc.) are **not** thread-safe. Each connection instance is confined to the thread that created it. The only safe cross-thread operation on these adapters is calling `add_callback_threadsafe` to schedule a callback in the connection's IOLoop thread. See [connection adapters](modules/adapters/index.md) for details.
 
+### Why does mypy report new errors on my consumer callback after upgrading?
+
+Pika ships a `py.typed` marker, so a type checker reads pika's own annotations. `pika.spec` is generated code, and it was previously excluded from pika's `mypy` configuration, which left every field of a decoded frame typed as `Any`. `Any` silences all checking, so code like this passed:
+
+```python
+def on_message(ch, method, properties, body):
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+```
+
+`pika.spec` is now annotated and checked, so the same line reports:
+
+```
+error: Argument "delivery_tag" to "basic_ack" of "BlockingChannel"
+has incompatible type "int | None"; expected "int"
+```
+
+The errors are accurate rather than newly introduced behavior. Two properties of the generated code cause them:
+
+- **Fields are optional.** Every generated constructor defaults its arguments to `None`, so `delivery_tag` is `int | None`. A frame decoded off the wire always carries the field, but the type cannot express that.
+- **String fields may be bytes.** AMQP `shortstr` is a length-prefixed byte string with no declared encoding. Pika decodes it as UTF-8 and falls back to the raw `bytes` when that fails, so `routing_key`, `exchange`, and `consumer_tag` are `str | bytes | None`.
+
+An `assert` narrows the optional away, and `isinstance` narrows the `bytes`:
+
+```python
+def on_message(ch: BlockingChannel, method: Basic.Deliver,
+               properties: BasicProperties, body: bytes) -> None:
+    assert method.delivery_tag is not None
+    ch.basic_ack(delivery_tag=method.delivery_tag)
+
+    routing_key = method.routing_key
+    assert isinstance(routing_key, str)
+    ch.basic_publish(exchange='', routing_key=routing_key, body=body)
+```
+
+Narrowing only the optional is not always enough for a string field, since `str | bytes` remains. Whether that matters depends on the operation: `routing_key.upper()` checks either way, because `bytes` also has `upper()`, while passing the value back into `basic_publish`, using it as a `dict[str, ...]` key, or concatenating it with a `str` all require the `isinstance` narrowing above.
+
+Use `typing.cast` instead of `assert` where the check should carry no runtime cost. Note that `assert` statements are stripped under `python -O`.
+
+`pyright` reported most of these already, so its users see little change.
+
 ### How do I report a bug with Pika?
 
 The [main Pika repository](https://github.com/pika/pika) is hosted on [GitHub](https://github.com), and we use the issue tracker at [github.com/pika/pika/issues](https://github.com/pika/pika/issues).

--- a/mypy.ini
+++ b/mypy.ini
@@ -12,5 +12,3 @@ strict_equality = True
 extra_checks = True
 enable_error_code = explicit-override
 
-[mypy-pika.spec]
-ignore_errors = True

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -1889,9 +1889,12 @@ class BlockingChannel:
                         # NOTE: we can't use basic_nack with the multiple option
                         # to avoid nacking messages already held by our client.
                         for message in pending_messages:
-                            self._impl.basic_reject(
-                                message.method.delivery_tag, requeue=True
-                            )  # pyright: ignore[reportArgumentType]
+                            delivery_tag = message.method.delivery_tag
+                            # The generated spec types delivery_tag as
+                            # optional, but the broker always sets it on a
+                            # delivery.
+                            assert delivery_tag is not None
+                            self._impl.basic_reject(delivery_tag, requeue=True)
 
                 # Cancel the consumer; impl takes care of rejecting any
                 # additional deliveries that arrive for a auto_ack=False

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1883,13 +1883,16 @@ class Connection(abc.ABC):
         """
         LOGGER.debug('_on_connection_close_from_broker: frame=%s', method_frame)
 
+        # The generated spec types reply_code as optional, but a frame
+        # decoded off the wire always carries it.
+        reply_code = method_frame.method.reply_code
+        assert reply_code is not None
+
         self._terminate_stream(
-            exceptions.ConnectionClosedByBroker(
-                method_frame.method.
-                reply_code,  # pyright: ignore[reportArgumentType]
-                method_frame.method.reply_text,
-                host=self.params.host,
-                port=self.params.port))
+            exceptions.ConnectionClosedByBroker(reply_code,
+                                                method_frame.method.reply_text,
+                                                host=self.params.host,
+                                                port=self.params.port))
 
     def _on_connection_close_ok(
             self, method_frame: frame.Method[spec.Connection.CloseOk]) -> None:
@@ -2344,11 +2347,15 @@ class Connection(abc.ABC):
 
     def _send_connection_tune_ok(self) -> None:
         """Send a Connection.TuneOk frame."""
+        # Tuning resolves any heartbeat callable and negotiates an integral
+        # timeout before this is sent.
+        heartbeat = self.params.heartbeat
+        assert heartbeat is not None and not callable(heartbeat)
+
         self._send_method(
             0,
             spec.Connection.TuneOk(self.params.channel_max,
-                                   self.params.frame_max,
-                                   self.params.heartbeat))
+                                   self.params.frame_max, heartbeat))
 
     def _send_frame(
         self, frame_value: (frame.Frame | frame.ProtocolHeader)) -> None:

--- a/pika/data.py
+++ b/pika/data.py
@@ -35,13 +35,14 @@ _FIELD_TABLE = ord('F')
 _FIELD_VOID = ord('V')
 
 
-def encode_short_string(pieces: list[bytes], value: str) -> int:
+def encode_short_string(pieces: list[bytes], value: str | bytes) -> int:
     """
     Encode a string value as short string and append it to pieces list returning the size of the
     encoded value.
 
     :param pieces: Already encoded values
-    :param value: String value to encode
+    :param value: String value to encode; bytes are encoded as-is, which is what
+        `decode_short_string` yields for a payload that is not valid UTF-8
     """
     encoded_value = as_bytes(value)
     length = len(encoded_value)
@@ -84,12 +85,13 @@ def decode_short_string(encoded: bytes, offset: int) -> tuple[str | bytes, int]:
     return value, offset
 
 
-def encode_table(pieces: list[bytes], table: dict[str, Any] | None) -> int:
+def encode_table(pieces: list[bytes], table: dict[Any, Any] | None) -> int:
     """
     Encode a dict as an AMQP table appending the encoded table to the pieces list passed in.
 
     :param pieces: Already encoded frame pieces
-    :param table: The dict to encode
+    :param table: The dict to encode. Keys are encoded as short strings, so a table round-tripped
+        through `decode_table` may key on bytes
     """
     table = table or {}
     length_index = len(pieces)

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -147,7 +147,7 @@ class ConnectionClosed(AMQPConnectionError):
 
     def __init__(self,
                  reply_code: int,
-                 reply_text: str,
+                 reply_text: str | bytes,
                  host: str | None = None,
                  port: int | None = None) -> None:
         """
@@ -156,10 +156,17 @@ class ConnectionClosed(AMQPConnectionError):
             `Connection.Close` method. NEW in v1.0.0
         :param reply_text: reply-text that was used in user's or broker's
             `Connection.Close` method. Human-readable string corresponding to
-            `reply_code`. NEW in v1.0.0
+            `reply_code`. A broker may send text that is not valid UTF-8, in
+            which case it arrives as bytes and undecodable characters are
+            replaced. NEW in v1.0.0
         :param host: hostname or IP of the broker
         :param port: port of the broker
         """
+        if isinstance(reply_text, bytes):
+            # `str(bytes)` would yield the repr, b-prefix and escapes
+            # included, mangling the very text needed to diagnose the close.
+            reply_text = reply_text.decode('utf-8', errors='replace')
+
         super().__init__(int(reply_code), str(reply_text), host=host, port=port)
 
     @override

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from pika import amqp_object
 from pika import data
+from pika._utils import override
 
 PROTOCOL_VERSION = (0, 9, 1)
 PORT = 5672
@@ -73,6 +74,7 @@ class Basic(amqp_object.Class):
             self.prefetch_count = prefetch_count
             self.global_qos = global_qos
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Qos:
             self.prefetch_size = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -83,6 +85,7 @@ class Basic(amqp_object.Class):
             self.global_qos = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>I', self.prefetch_size))
@@ -102,9 +105,11 @@ class Basic(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.QosOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -133,6 +138,7 @@ class Basic(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Consume:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -148,6 +154,7 @@ class Basic(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -179,11 +186,13 @@ class Basic(amqp_object.Class):
         def __init__(self, consumer_tag: str | bytes | None = None):
             self.consumer_tag = consumer_tag
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.ConsumeOk:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
@@ -203,6 +212,7 @@ class Basic(amqp_object.Class):
             self.consumer_tag = consumer_tag
             self.nowait = nowait
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Cancel:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
@@ -211,6 +221,7 @@ class Basic(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
@@ -231,11 +242,13 @@ class Basic(amqp_object.Class):
         def __init__(self, consumer_tag: str | bytes | None = None):
             self.consumer_tag = consumer_tag
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.CancelOk:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
@@ -261,6 +274,7 @@ class Basic(amqp_object.Class):
             self.mandatory = mandatory
             self.immediate = immediate
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Publish:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -272,6 +286,7 @@ class Basic(amqp_object.Class):
             self.immediate = (bit_buffer & (1 << 1)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -305,6 +320,7 @@ class Basic(amqp_object.Class):
             self.exchange = exchange
             self.routing_key = routing_key
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Return:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -313,6 +329,7 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.reply_code))
@@ -345,6 +362,7 @@ class Basic(amqp_object.Class):
             self.exchange = exchange
             self.routing_key = routing_key
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Deliver:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
@@ -357,6 +375,7 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
@@ -389,6 +408,7 @@ class Basic(amqp_object.Class):
             self.queue = queue
             self.no_ack = no_ack
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Get:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -398,6 +418,7 @@ class Basic(amqp_object.Class):
             self.no_ack = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -428,6 +449,7 @@ class Basic(amqp_object.Class):
             self.routing_key = routing_key
             self.message_count = message_count
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.GetOk:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
@@ -440,6 +462,7 @@ class Basic(amqp_object.Class):
             offset += 4
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
@@ -465,10 +488,12 @@ class Basic(amqp_object.Class):
         def __init__(self, cluster_id: str | bytes = ''):
             self.cluster_id = cluster_id
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.GetEmpty:
             self.cluster_id, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.cluster_id, (str, bytes)),\
@@ -486,6 +511,7 @@ class Basic(amqp_object.Class):
             self.delivery_tag = delivery_tag
             self.multiple = multiple
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Ack:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
@@ -494,6 +520,7 @@ class Basic(amqp_object.Class):
             self.multiple = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
@@ -515,6 +542,7 @@ class Basic(amqp_object.Class):
             self.delivery_tag = delivery_tag
             self.requeue = requeue
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Reject:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
@@ -523,6 +551,7 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
@@ -541,12 +570,14 @@ class Basic(amqp_object.Class):
         def __init__(self, requeue: bool = False):
             self.requeue = requeue
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.RecoverAsync:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             bit_buffer = 0
@@ -564,12 +595,14 @@ class Basic(amqp_object.Class):
         def __init__(self, requeue: bool = False):
             self.requeue = requeue
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Recover:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             bit_buffer = 0
@@ -587,9 +620,11 @@ class Basic(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.RecoverOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -608,6 +643,7 @@ class Basic(amqp_object.Class):
             self.multiple = multiple
             self.requeue = requeue
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Nack:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
@@ -617,6 +653,7 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 1)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
@@ -652,6 +689,7 @@ class Connection(amqp_object.Class):
             self.mechanisms = mechanisms
             self.locales = locales
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Start:
             self.version_major = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
@@ -669,6 +707,7 @@ class Connection(amqp_object.Class):
             offset += length
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('B', self.version_major))
@@ -704,6 +743,7 @@ class Connection(amqp_object.Class):
             self.response = response
             self.locale = locale
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.StartOk:
             (self.client_properties,
              offset) = data.decode_table(encoded, offset)
@@ -715,6 +755,7 @@ class Connection(amqp_object.Class):
             self.locale, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             data.encode_table(pieces, self.client_properties)
@@ -741,6 +782,7 @@ class Connection(amqp_object.Class):
         def __init__(self, challenge: str | bytes | None = None):
             self.challenge = challenge
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Secure:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -748,6 +790,7 @@ class Connection(amqp_object.Class):
             offset += length
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.challenge, (str, bytes)),\
@@ -767,6 +810,7 @@ class Connection(amqp_object.Class):
         def __init__(self, response: str | bytes | None = None):
             self.response = response
 
+        @override
         def decode(self,
                    encoded: bytes,
                    offset: int = 0) -> Connection.SecureOk:
@@ -776,6 +820,7 @@ class Connection(amqp_object.Class):
             offset += length
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.response, (str, bytes)),\
@@ -800,6 +845,7 @@ class Connection(amqp_object.Class):
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Tune:
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -809,6 +855,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.channel_max))
@@ -830,6 +877,7 @@ class Connection(amqp_object.Class):
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.TuneOk:
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -839,6 +887,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.channel_max))
@@ -860,6 +909,7 @@ class Connection(amqp_object.Class):
             self.capabilities = capabilities
             self.insist = insist
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Open:
             self.virtual_host, offset = data.decode_short_string(
                 encoded, offset)
@@ -870,6 +920,7 @@ class Connection(amqp_object.Class):
             self.insist = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.virtual_host, (str, bytes)),\
@@ -893,10 +944,12 @@ class Connection(amqp_object.Class):
         def __init__(self, known_hosts: str | bytes = ''):
             self.known_hosts = known_hosts
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.OpenOk:
             self.known_hosts, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.known_hosts, (str, bytes)),\
@@ -920,6 +973,7 @@ class Connection(amqp_object.Class):
             self.class_id = class_id
             self.method_id = method_id
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Close:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -930,6 +984,7 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.reply_code))
@@ -949,9 +1004,11 @@ class Connection(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.CloseOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -965,10 +1022,12 @@ class Connection(amqp_object.Class):
         def __init__(self, reason: str | bytes = ''):
             self.reason = reason
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Blocked:
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.reason, (str, bytes)),\
@@ -985,11 +1044,13 @@ class Connection(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self,
                    encoded: bytes,
                    offset: int = 0) -> Connection.Unblocked:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1006,6 +1067,7 @@ class Connection(amqp_object.Class):
             self.new_secret = new_secret
             self.reason = reason
 
+        @override
         def decode(self,
                    encoded: bytes,
                    offset: int = 0) -> Connection.UpdateSecret:
@@ -1016,6 +1078,7 @@ class Connection(amqp_object.Class):
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.new_secret, (str, bytes)),\
@@ -1038,11 +1101,13 @@ class Connection(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self,
                    encoded: bytes,
                    offset: int = 0) -> Connection.UpdateSecretOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1062,10 +1127,12 @@ class Channel(amqp_object.Class):
         def __init__(self, out_of_band: str | bytes = ''):
             self.out_of_band = out_of_band
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.Open:
             self.out_of_band, offset = data.decode_short_string(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.out_of_band, (str, bytes)),\
@@ -1082,6 +1149,7 @@ class Channel(amqp_object.Class):
         def __init__(self, channel_id: str | bytes = ''):
             self.channel_id = channel_id
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.OpenOk:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -1089,6 +1157,7 @@ class Channel(amqp_object.Class):
             offset += length
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.channel_id, (str, bytes)),\
@@ -1108,12 +1177,14 @@ class Channel(amqp_object.Class):
         def __init__(self, active: bool | None = None):
             self.active = active
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.Flow:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             bit_buffer = 0
@@ -1131,12 +1202,14 @@ class Channel(amqp_object.Class):
         def __init__(self, active: bool | None = None):
             self.active = active
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.FlowOk:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             bit_buffer = 0
@@ -1161,6 +1234,7 @@ class Channel(amqp_object.Class):
             self.class_id = class_id
             self.method_id = method_id
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.Close:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1171,6 +1245,7 @@ class Channel(amqp_object.Class):
             offset += 2
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.reply_code))
@@ -1190,9 +1265,11 @@ class Channel(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.CloseOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1223,6 +1300,7 @@ class Access(amqp_object.Class):
             self.write = write
             self.read = read
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Access.Request:
             self.realm, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -1234,6 +1312,7 @@ class Access(amqp_object.Class):
             self.read = (bit_buffer & (1 << 4)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.realm, (str, bytes)),\
@@ -1262,11 +1341,13 @@ class Access(amqp_object.Class):
         def __init__(self, ticket: int = 1):
             self.ticket = ticket
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Access.RequestOk:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1304,6 +1385,7 @@ class Exchange(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Declare:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1319,6 +1401,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1352,9 +1435,11 @@ class Exchange(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.DeclareOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1375,6 +1460,7 @@ class Exchange(amqp_object.Class):
             self.if_unused = if_unused
             self.nowait = nowait
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Delete:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1385,6 +1471,7 @@ class Exchange(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 1)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1408,9 +1495,11 @@ class Exchange(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.DeleteOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1435,6 +1524,7 @@ class Exchange(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Bind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1447,6 +1537,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1475,9 +1566,11 @@ class Exchange(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.BindOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1502,6 +1595,7 @@ class Exchange(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Unbind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1514,6 +1608,7 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1542,9 +1637,11 @@ class Exchange(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.UnbindOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1579,6 +1676,7 @@ class Queue(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Declare:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1593,6 +1691,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1628,6 +1727,7 @@ class Queue(amqp_object.Class):
             self.message_count = message_count
             self.consumer_count = consumer_count
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.DeclareOk:
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
@@ -1636,6 +1736,7 @@ class Queue(amqp_object.Class):
             offset += 4
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             assert isinstance(self.queue, (str, bytes)),\
@@ -1665,6 +1766,7 @@ class Queue(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Bind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1677,6 +1779,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1705,9 +1808,11 @@ class Queue(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.BindOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1726,6 +1831,7 @@ class Queue(amqp_object.Class):
             self.queue = queue
             self.nowait = nowait
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Purge:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1735,6 +1841,7 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1756,11 +1863,13 @@ class Queue(amqp_object.Class):
         def __init__(self, message_count: int | None = None):
             self.message_count = message_count
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.PurgeOk:
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>I', self.message_count))
@@ -1784,6 +1893,7 @@ class Queue(amqp_object.Class):
             self.if_empty = if_empty
             self.nowait = nowait
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Delete:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1795,6 +1905,7 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 2)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1820,11 +1931,13 @@ class Queue(amqp_object.Class):
         def __init__(self, message_count: int | None = None):
             self.message_count = message_count
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.DeleteOk:
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>I', self.message_count))
@@ -1848,6 +1961,7 @@ class Queue(amqp_object.Class):
             self.routing_key = routing_key
             self.arguments = arguments
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Unbind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
@@ -1857,6 +1971,7 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
@@ -1881,9 +1996,11 @@ class Queue(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.UnbindOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1903,9 +2020,11 @@ class Tx(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Tx.Select:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1919,9 +2038,11 @@ class Tx(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Tx.SelectOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1935,9 +2056,11 @@ class Tx(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Tx.Commit:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1951,9 +2074,11 @@ class Tx(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Tx.CommitOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1967,9 +2092,11 @@ class Tx(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Tx.Rollback:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -1983,9 +2110,11 @@ class Tx(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Tx.RollbackOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces
@@ -2005,12 +2134,14 @@ class Confirm(amqp_object.Class):
         def __init__(self, nowait: bool = False):
             self.nowait = nowait
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Confirm.Select:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             bit_buffer = 0
@@ -2028,9 +2159,11 @@ class Confirm(amqp_object.Class):
         def __init__(self):
             pass
 
+        @override
         def decode(self, encoded: bytes, offset: int = 0) -> Confirm.SelectOk:
             return self
 
+        @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
             return pieces

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -11,7 +11,11 @@ rejected.
 
 """
 
+from __future__ import annotations
+
 import struct
+from typing import Any
+
 from pika import amqp_object
 from pika import data
 
@@ -59,17 +63,17 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C000A  # 60, 10; 3932170
         NAME = 'Basic.Qos'
+        synchronous: bool = True
 
-        def __init__(self, prefetch_size=0, prefetch_count=0, global_qos=False):
+        def __init__(self,
+                     prefetch_size: int = 0,
+                     prefetch_count: int = 0,
+                     global_qos: bool = False):
             self.prefetch_size = prefetch_size
             self.prefetch_count = prefetch_count
             self.global_qos = global_qos
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Qos:
             self.prefetch_size = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.prefetch_count = struct.unpack_from('>H', encoded, offset)[0]
@@ -79,8 +83,8 @@ class Basic(amqp_object.Class):
             self.global_qos = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>I', self.prefetch_size))
             pieces.append(struct.pack('>H', self.prefetch_count))
             bit_buffer = 0
@@ -93,35 +97,33 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C000B  # 60, 11; 3932171
         NAME = 'Basic.QosOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.QosOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Consume(amqp_object.Method):
 
         INDEX = 0x003C0014  # 60, 20; 3932180
         NAME = 'Basic.Consume'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     consumer_tag='',
-                     no_local=False,
-                     no_ack=False,
-                     exclusive=False,
-                     nowait=False,
-                     arguments=None):
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     consumer_tag: str | bytes = '',
+                     no_local: bool = False,
+                     no_ack: bool = False,
+                     exclusive: bool = False,
+                     nowait: bool = False,
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.queue = queue
             self.consumer_tag = consumer_tag
@@ -131,11 +133,7 @@ class Basic(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Consume:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -150,8 +148,8 @@ class Basic(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -176,21 +174,18 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0015  # 60, 21; 3932181
         NAME = 'Basic.ConsumeOk'
+        synchronous: bool = False
 
-        def __init__(self, consumer_tag=None):
+        def __init__(self, consumer_tag: str | bytes | None = None):
             self.consumer_tag = consumer_tag
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.ConsumeOk:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
             data.encode_short_string(pieces, self.consumer_tag)
@@ -200,16 +195,15 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C001E  # 60, 30; 3932190
         NAME = 'Basic.Cancel'
+        synchronous: bool = True
 
-        def __init__(self, consumer_tag=None, nowait=False):
+        def __init__(self,
+                     consumer_tag: str | bytes | None = None,
+                     nowait: bool = False):
             self.consumer_tag = consumer_tag
             self.nowait = nowait
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Cancel:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -217,8 +211,8 @@ class Basic(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
             data.encode_short_string(pieces, self.consumer_tag)
@@ -232,21 +226,18 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C001F  # 60, 31; 3932191
         NAME = 'Basic.CancelOk'
+        synchronous: bool = False
 
-        def __init__(self, consumer_tag=None):
+        def __init__(self, consumer_tag: str | bytes | None = None):
             self.consumer_tag = consumer_tag
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.CancelOk:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
             data.encode_short_string(pieces, self.consumer_tag)
@@ -256,24 +247,21 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0028  # 60, 40; 3932200
         NAME = 'Basic.Publish'
+        synchronous: bool = False
 
         def __init__(self,
-                     ticket=0,
-                     exchange='',
-                     routing_key='',
-                     mandatory=False,
-                     immediate=False):
+                     ticket: int = 0,
+                     exchange: str | bytes = '',
+                     routing_key: str | bytes = '',
+                     mandatory: bool = False,
+                     immediate: bool = False):
             self.ticket = ticket
             self.exchange = exchange
             self.routing_key = routing_key
             self.mandatory = mandatory
             self.immediate = immediate
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Publish:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -284,8 +272,8 @@ class Basic(amqp_object.Class):
             self.immediate = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
@@ -305,22 +293,19 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0032  # 60, 50; 3932210
         NAME = 'Basic.Return'
+        synchronous: bool = False
 
         def __init__(self,
-                     reply_code=None,
-                     reply_text='',
-                     exchange=None,
-                     routing_key=None):
+                     reply_code: int | None = None,
+                     reply_text: str | bytes = '',
+                     exchange: str | bytes | None = None,
+                     routing_key: str | bytes | None = None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.exchange = exchange
             self.routing_key = routing_key
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Return:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -328,8 +313,8 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
                    'A non-string value was supplied for self.reply_text'
@@ -346,24 +331,21 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C003C  # 60, 60; 3932220
         NAME = 'Basic.Deliver'
+        synchronous: bool = False
 
         def __init__(self,
-                     consumer_tag=None,
-                     delivery_tag=None,
-                     redelivered=False,
-                     exchange=None,
-                     routing_key=None):
+                     consumer_tag: str | bytes | None = None,
+                     delivery_tag: int | None = None,
+                     redelivered: bool = False,
+                     exchange: str | bytes | None = None,
+                     routing_key: str | bytes | None = None):
             self.consumer_tag = consumer_tag
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
             self.exchange = exchange
             self.routing_key = routing_key
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Deliver:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
@@ -375,8 +357,8 @@ class Basic(amqp_object.Class):
             self.routing_key, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
             data.encode_short_string(pieces, self.consumer_tag)
@@ -397,17 +379,17 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0046  # 60, 70; 3932230
         NAME = 'Basic.Get'
+        synchronous: bool = True
 
-        def __init__(self, ticket=0, queue='', no_ack=False):
+        def __init__(self,
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     no_ack: bool = False):
             self.ticket = ticket
             self.queue = queue
             self.no_ack = no_ack
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Get:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -416,8 +398,8 @@ class Basic(amqp_object.Class):
             self.no_ack = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -432,24 +414,21 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0047  # 60, 71; 3932231
         NAME = 'Basic.GetOk'
+        synchronous: bool = False
 
         def __init__(self,
-                     delivery_tag=None,
-                     redelivered=False,
-                     exchange=None,
-                     routing_key=None,
-                     message_count=None):
+                     delivery_tag: int | None = None,
+                     redelivered: bool = False,
+                     exchange: str | bytes | None = None,
+                     routing_key: str | bytes | None = None,
+                     message_count: int | None = None):
             self.delivery_tag = delivery_tag
             self.redelivered = redelivered
             self.exchange = exchange
             self.routing_key = routing_key
             self.message_count = message_count
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.GetOk:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -461,8 +440,8 @@ class Basic(amqp_object.Class):
             offset += 4
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
             if self.redelivered:
@@ -481,20 +460,17 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0048  # 60, 72; 3932232
         NAME = 'Basic.GetEmpty'
+        synchronous: bool = False
 
-        def __init__(self, cluster_id=''):
+        def __init__(self, cluster_id: str | bytes = ''):
             self.cluster_id = cluster_id
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.GetEmpty:
             self.cluster_id, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.cluster_id, (str, bytes)),\
                    'A non-string value was supplied for self.cluster_id'
             data.encode_short_string(pieces, self.cluster_id)
@@ -504,16 +480,13 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0050  # 60, 80; 3932240
         NAME = 'Basic.Ack'
+        synchronous: bool = False
 
-        def __init__(self, delivery_tag=0, multiple=False):
+        def __init__(self, delivery_tag: int = 0, multiple: bool = False):
             self.delivery_tag = delivery_tag
             self.multiple = multiple
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Ack:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -521,8 +494,8 @@ class Basic(amqp_object.Class):
             self.multiple = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
             if self.multiple:
@@ -534,16 +507,15 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C005A  # 60, 90; 3932250
         NAME = 'Basic.Reject'
+        synchronous: bool = False
 
-        def __init__(self, delivery_tag=None, requeue=True):
+        def __init__(self,
+                     delivery_tag: int | None = None,
+                     requeue: bool = True):
             self.delivery_tag = delivery_tag
             self.requeue = requeue
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Reject:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -551,8 +523,8 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
             if self.requeue:
@@ -564,22 +536,19 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C0064  # 60, 100; 3932260
         NAME = 'Basic.RecoverAsync'
+        synchronous: bool = False
 
-        def __init__(self, requeue=False):
+        def __init__(self, requeue: bool = False):
             self.requeue = requeue
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.RecoverAsync:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             bit_buffer = 0
             if self.requeue:
                 bit_buffer |= 1 << 0
@@ -590,22 +559,19 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C006E  # 60, 110; 3932270
         NAME = 'Basic.Recover'
+        synchronous: bool = True
 
-        def __init__(self, requeue=False):
+        def __init__(self, requeue: bool = False):
             self.requeue = requeue
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Recover:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             bit_buffer = 0
             if self.requeue:
                 bit_buffer |= 1 << 0
@@ -616,36 +582,33 @@ class Basic(amqp_object.Class):
 
         INDEX = 0x003C006F  # 60, 111; 3932271
         NAME = 'Basic.RecoverOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.RecoverOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Nack(amqp_object.Method):
 
         INDEX = 0x003C0078  # 60, 120; 3932280
         NAME = 'Basic.Nack'
+        synchronous: bool = False
 
-        def __init__(self, delivery_tag=0, multiple=False, requeue=True):
+        def __init__(self,
+                     delivery_tag: int = 0,
+                     multiple: bool = False,
+                     requeue: bool = True):
             self.delivery_tag = delivery_tag
             self.multiple = multiple
             self.requeue = requeue
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Basic.Nack:
             self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
             offset += 8
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
@@ -654,8 +617,8 @@ class Basic(amqp_object.Class):
             self.requeue = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>Q', self.delivery_tag))
             bit_buffer = 0
             if self.multiple:
@@ -675,24 +638,21 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A000A  # 10, 10; 655370
         NAME = 'Connection.Start'
+        synchronous: bool = True
 
         def __init__(self,
-                     version_major=0,
-                     version_minor=9,
-                     server_properties=None,
-                     mechanisms='PLAIN',
-                     locales='en_US'):
+                     version_major: int = 0,
+                     version_minor: int = 9,
+                     server_properties: dict[Any, Any] | None = None,
+                     mechanisms: str | bytes = 'PLAIN',
+                     locales: str | bytes = 'en_US'):
             self.version_major = version_major
             self.version_minor = version_minor
             self.server_properties = server_properties
             self.mechanisms = mechanisms
             self.locales = locales
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.Start:
             self.version_major = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.version_minor = struct.unpack_from('B', encoded, offset)[0]
@@ -709,8 +669,8 @@ class Connection(amqp_object.Class):
             offset += length
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('B', self.version_major))
             pieces.append(struct.pack('B', self.version_minor))
             data.encode_table(pieces, self.server_properties)
@@ -732,22 +692,19 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A000B  # 10, 11; 655371
         NAME = 'Connection.StartOk'
+        synchronous: bool = False
 
         def __init__(self,
-                     client_properties=None,
-                     mechanism='PLAIN',
-                     response=None,
-                     locale='en_US'):
+                     client_properties: dict[Any, Any] | None = None,
+                     mechanism: str | bytes = 'PLAIN',
+                     response: str | bytes | None = None,
+                     locale: str | bytes = 'en_US'):
             self.client_properties = client_properties
             self.mechanism = mechanism
             self.response = response
             self.locale = locale
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.StartOk:
             (self.client_properties,
              offset) = data.decode_table(encoded, offset)
             self.mechanism, offset = data.decode_short_string(encoded, offset)
@@ -758,8 +715,8 @@ class Connection(amqp_object.Class):
             self.locale, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             data.encode_table(pieces, self.client_properties)
             assert isinstance(self.mechanism, (str, bytes)),\
                    'A non-string value was supplied for self.mechanism'
@@ -779,23 +736,20 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0014  # 10, 20; 655380
         NAME = 'Connection.Secure'
+        synchronous: bool = True
 
-        def __init__(self, challenge=None):
+        def __init__(self, challenge: str | bytes | None = None):
             self.challenge = challenge
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.Secure:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.challenge = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.challenge, (str, bytes)),\
                    'A non-string value was supplied for self.challenge'
             value = self.challenge.encode('utf-8') if isinstance(
@@ -808,23 +762,22 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0015  # 10, 21; 655381
         NAME = 'Connection.SecureOk'
+        synchronous: bool = False
 
-        def __init__(self, response=None):
+        def __init__(self, response: str | bytes | None = None):
             self.response = response
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self,
+                   encoded: bytes,
+                   offset: int = 0) -> Connection.SecureOk:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.response = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.response, (str, bytes)),\
                    'A non-string value was supplied for self.response'
             value = self.response.encode('utf-8') if isinstance(
@@ -837,17 +790,17 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A001E  # 10, 30; 655390
         NAME = 'Connection.Tune'
+        synchronous: bool = True
 
-        def __init__(self, channel_max=0, frame_max=0, heartbeat=0):
+        def __init__(self,
+                     channel_max: int = 0,
+                     frame_max: int = 0,
+                     heartbeat: int = 0):
             self.channel_max = channel_max
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.Tune:
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
@@ -856,8 +809,8 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.channel_max))
             pieces.append(struct.pack('>I', self.frame_max))
             pieces.append(struct.pack('>H', self.heartbeat))
@@ -867,17 +820,17 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A001F  # 10, 31; 655391
         NAME = 'Connection.TuneOk'
+        synchronous: bool = False
 
-        def __init__(self, channel_max=0, frame_max=0, heartbeat=0):
+        def __init__(self,
+                     channel_max: int = 0,
+                     frame_max: int = 0,
+                     heartbeat: int = 0):
             self.channel_max = channel_max
             self.frame_max = frame_max
             self.heartbeat = heartbeat
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.TuneOk:
             self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
@@ -886,8 +839,8 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.channel_max))
             pieces.append(struct.pack('>I', self.frame_max))
             pieces.append(struct.pack('>H', self.heartbeat))
@@ -897,17 +850,17 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0028  # 10, 40; 655400
         NAME = 'Connection.Open'
+        synchronous: bool = True
 
-        def __init__(self, virtual_host='/', capabilities='', insist=False):
+        def __init__(self,
+                     virtual_host: str | bytes = '/',
+                     capabilities: str | bytes = '',
+                     insist: bool = False):
             self.virtual_host = virtual_host
             self.capabilities = capabilities
             self.insist = insist
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.Open:
             self.virtual_host, offset = data.decode_short_string(
                 encoded, offset)
             self.capabilities, offset = data.decode_short_string(
@@ -917,8 +870,8 @@ class Connection(amqp_object.Class):
             self.insist = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.virtual_host, (str, bytes)),\
                    'A non-string value was supplied for self.virtual_host'
             data.encode_short_string(pieces, self.virtual_host)
@@ -935,20 +888,17 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0029  # 10, 41; 655401
         NAME = 'Connection.OpenOk'
+        synchronous: bool = False
 
-        def __init__(self, known_hosts=''):
+        def __init__(self, known_hosts: str | bytes = ''):
             self.known_hosts = known_hosts
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.OpenOk:
             self.known_hosts, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.known_hosts, (str, bytes)),\
                    'A non-string value was supplied for self.known_hosts'
             data.encode_short_string(pieces, self.known_hosts)
@@ -958,22 +908,19 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0032  # 10, 50; 655410
         NAME = 'Connection.Close'
+        synchronous: bool = True
 
         def __init__(self,
-                     reply_code=None,
-                     reply_text='',
-                     class_id=None,
-                     method_id=None):
+                     reply_code: int | None = None,
+                     reply_text: str | bytes = '',
+                     class_id: int | None = None,
+                     method_id: int | None = None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
             self.method_id = method_id
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.Close:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -983,8 +930,8 @@ class Connection(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
                    'A non-string value was supplied for self.reply_text'
@@ -997,39 +944,33 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0033  # 10, 51; 655411
         NAME = 'Connection.CloseOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.CloseOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Blocked(amqp_object.Method):
 
         INDEX = 0x000A003C  # 10, 60; 655420
         NAME = 'Connection.Blocked'
+        synchronous: bool = False
 
-        def __init__(self, reason=''):
+        def __init__(self, reason: str | bytes = ''):
             self.reason = reason
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Connection.Blocked:
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.reason, (str, bytes)),\
                    'A non-string value was supplied for self.reason'
             data.encode_short_string(pieces, self.reason)
@@ -1039,35 +980,35 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A003D  # 10, 61; 655421
         NAME = 'Connection.Unblocked'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self,
+                   encoded: bytes,
+                   offset: int = 0) -> Connection.Unblocked:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class UpdateSecret(amqp_object.Method):
 
         INDEX = 0x000A0046  # 10, 70; 655430
         NAME = 'Connection.UpdateSecret'
+        synchronous: bool = True
 
-        def __init__(self, new_secret=None, reason=None):
+        def __init__(self,
+                     new_secret: str | bytes | None = None,
+                     reason: str | bytes | None = None):
             self.new_secret = new_secret
             self.reason = reason
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self,
+                   encoded: bytes,
+                   offset: int = 0) -> Connection.UpdateSecret:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.new_secret = encoded[offset:offset + length]
@@ -1075,8 +1016,8 @@ class Connection(amqp_object.Class):
             self.reason, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.new_secret, (str, bytes)),\
                    'A non-string value was supplied for self.new_secret'
             value = self.new_secret.encode('utf-8') if isinstance(
@@ -1092,19 +1033,18 @@ class Connection(amqp_object.Class):
 
         INDEX = 0x000A0047  # 10, 71; 655431
         NAME = 'Connection.UpdateSecretOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self,
+                   encoded: bytes,
+                   offset: int = 0) -> Connection.UpdateSecretOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
 
@@ -1117,20 +1057,17 @@ class Channel(amqp_object.Class):
 
         INDEX = 0x0014000A  # 20, 10; 1310730
         NAME = 'Channel.Open'
+        synchronous: bool = True
 
-        def __init__(self, out_of_band=''):
+        def __init__(self, out_of_band: str | bytes = ''):
             self.out_of_band = out_of_band
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Channel.Open:
             self.out_of_band, offset = data.decode_short_string(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.out_of_band, (str, bytes)),\
                    'A non-string value was supplied for self.out_of_band'
             data.encode_short_string(pieces, self.out_of_band)
@@ -1140,23 +1077,20 @@ class Channel(amqp_object.Class):
 
         INDEX = 0x0014000B  # 20, 11; 1310731
         NAME = 'Channel.OpenOk'
+        synchronous: bool = False
 
-        def __init__(self, channel_id=''):
+        def __init__(self, channel_id: str | bytes = ''):
             self.channel_id = channel_id
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Channel.OpenOk:
             length = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             self.channel_id = encoded[offset:offset + length]
             offset += length
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.channel_id, (str, bytes)),\
                    'A non-string value was supplied for self.channel_id'
             value = self.channel_id.encode('utf-8') if isinstance(
@@ -1169,22 +1103,19 @@ class Channel(amqp_object.Class):
 
         INDEX = 0x00140014  # 20, 20; 1310740
         NAME = 'Channel.Flow'
+        synchronous: bool = True
 
-        def __init__(self, active=None):
+        def __init__(self, active: bool | None = None):
             self.active = active
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Channel.Flow:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             bit_buffer = 0
             if self.active:
                 bit_buffer |= 1 << 0
@@ -1195,22 +1126,19 @@ class Channel(amqp_object.Class):
 
         INDEX = 0x00140015  # 20, 21; 1310741
         NAME = 'Channel.FlowOk'
+        synchronous: bool = False
 
-        def __init__(self, active=None):
+        def __init__(self, active: bool | None = None):
             self.active = active
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Channel.FlowOk:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             bit_buffer = 0
             if self.active:
                 bit_buffer |= 1 << 0
@@ -1221,22 +1149,19 @@ class Channel(amqp_object.Class):
 
         INDEX = 0x00140028  # 20, 40; 1310760
         NAME = 'Channel.Close'
+        synchronous: bool = True
 
         def __init__(self,
-                     reply_code=None,
-                     reply_text='',
-                     class_id=None,
-                     method_id=None):
+                     reply_code: int | None = None,
+                     reply_text: str | bytes = '',
+                     class_id: int | None = None,
+                     method_id: int | None = None):
             self.reply_code = reply_code
             self.reply_text = reply_text
             self.class_id = class_id
             self.method_id = method_id
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Channel.Close:
             self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
@@ -1246,8 +1171,8 @@ class Channel(amqp_object.Class):
             offset += 2
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
                    'A non-string value was supplied for self.reply_text'
@@ -1260,19 +1185,16 @@ class Channel(amqp_object.Class):
 
         INDEX = 0x00140029  # 20, 41; 1310761
         NAME = 'Channel.CloseOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Channel.CloseOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
 
@@ -1285,14 +1207,15 @@ class Access(amqp_object.Class):
 
         INDEX = 0x001E000A  # 30, 10; 1966090
         NAME = 'Access.Request'
+        synchronous: bool = True
 
         def __init__(self,
-                     realm='/data',
-                     exclusive=False,
-                     passive=True,
-                     active=True,
-                     write=True,
-                     read=True):
+                     realm: str | bytes = '/data',
+                     exclusive: bool = False,
+                     passive: bool = True,
+                     active: bool = True,
+                     write: bool = True,
+                     read: bool = True):
             self.realm = realm
             self.exclusive = exclusive
             self.passive = passive
@@ -1300,11 +1223,7 @@ class Access(amqp_object.Class):
             self.write = write
             self.read = read
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Access.Request:
             self.realm, offset = data.decode_short_string(encoded, offset)
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
@@ -1315,8 +1234,8 @@ class Access(amqp_object.Class):
             self.read = (bit_buffer & (1 << 4)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.realm, (str, bytes)),\
                    'A non-string value was supplied for self.realm'
             data.encode_short_string(pieces, self.realm)
@@ -1338,21 +1257,18 @@ class Access(amqp_object.Class):
 
         INDEX = 0x001E000B  # 30, 11; 1966091
         NAME = 'Access.RequestOk'
+        synchronous: bool = False
 
-        def __init__(self, ticket=1):
+        def __init__(self, ticket: int = 1):
             self.ticket = ticket
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Access.RequestOk:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             return pieces
 
@@ -1366,17 +1282,18 @@ class Exchange(amqp_object.Class):
 
         INDEX = 0x0028000A  # 40, 10; 2621450
         NAME = 'Exchange.Declare'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     exchange=None,
-                     type='direct',
-                     passive=False,
-                     durable=False,
-                     auto_delete=False,
-                     internal=False,
-                     nowait=False,
-                     arguments=None):
+                     ticket: int = 0,
+                     exchange: str | bytes | None = None,
+                     type: str | bytes = 'direct',
+                     passive: bool = False,
+                     durable: bool = False,
+                     auto_delete: bool = False,
+                     internal: bool = False,
+                     nowait: bool = False,
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.exchange = exchange
             self.type = type
@@ -1387,11 +1304,7 @@ class Exchange(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Declare:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1406,8 +1319,8 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
@@ -1434,41 +1347,35 @@ class Exchange(amqp_object.Class):
 
         INDEX = 0x0028000B  # 40, 11; 2621451
         NAME = 'Exchange.DeclareOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.DeclareOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Delete(amqp_object.Method):
 
         INDEX = 0x00280014  # 40, 20; 2621460
         NAME = 'Exchange.Delete'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     exchange=None,
-                     if_unused=False,
-                     nowait=False):
+                     ticket: int = 0,
+                     exchange: str | bytes | None = None,
+                     if_unused: bool = False,
+                     nowait: bool = False):
             self.ticket = ticket
             self.exchange = exchange
             self.if_unused = if_unused
             self.nowait = nowait
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Delete:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1478,8 +1385,8 @@ class Exchange(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 1)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
@@ -1496,33 +1403,31 @@ class Exchange(amqp_object.Class):
 
         INDEX = 0x00280015  # 40, 21; 2621461
         NAME = 'Exchange.DeleteOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.DeleteOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Bind(amqp_object.Method):
 
         INDEX = 0x0028001E  # 40, 30; 2621470
         NAME = 'Exchange.Bind'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     destination=None,
-                     source=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+                     ticket: int = 0,
+                     destination: str | bytes | None = None,
+                     source: str | bytes | None = None,
+                     routing_key: str | bytes = '',
+                     nowait: bool = False,
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1530,11 +1435,7 @@ class Exchange(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Bind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
@@ -1546,8 +1447,8 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
                    'A non-string value was supplied for self.destination'
@@ -1569,33 +1470,31 @@ class Exchange(amqp_object.Class):
 
         INDEX = 0x0028001F  # 40, 31; 2621471
         NAME = 'Exchange.BindOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.BindOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Unbind(amqp_object.Method):
 
         INDEX = 0x00280028  # 40, 40; 2621480
         NAME = 'Exchange.Unbind'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     destination=None,
-                     source=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+                     ticket: int = 0,
+                     destination: str | bytes | None = None,
+                     source: str | bytes | None = None,
+                     routing_key: str | bytes = '',
+                     nowait: bool = False,
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.destination = destination
             self.source = source
@@ -1603,11 +1502,7 @@ class Exchange(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Unbind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
@@ -1619,8 +1514,8 @@ class Exchange(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
                    'A non-string value was supplied for self.destination'
@@ -1642,19 +1537,16 @@ class Exchange(amqp_object.Class):
 
         INDEX = 0x00280033  # 40, 51; 2621491
         NAME = 'Exchange.UnbindOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Exchange.UnbindOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
 
@@ -1667,16 +1559,17 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x0032000A  # 50, 10; 3276810
         NAME = 'Queue.Declare'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     passive=False,
-                     durable=False,
-                     exclusive=False,
-                     auto_delete=False,
-                     nowait=False,
-                     arguments=None):
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     passive: bool = False,
+                     durable: bool = False,
+                     exclusive: bool = False,
+                     auto_delete: bool = False,
+                     nowait: bool = False,
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.queue = queue
             self.passive = passive
@@ -1686,11 +1579,7 @@ class Queue(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.Declare:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1704,8 +1593,8 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -1729,17 +1618,17 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x0032000B  # 50, 11; 3276811
         NAME = 'Queue.DeclareOk'
+        synchronous: bool = False
 
-        def __init__(self, queue=None, message_count=None, consumer_count=None):
+        def __init__(self,
+                     queue: str | bytes | None = None,
+                     message_count: int | None = None,
+                     consumer_count: int | None = None):
             self.queue = queue
             self.message_count = message_count
             self.consumer_count = consumer_count
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.DeclareOk:
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
@@ -1747,8 +1636,8 @@ class Queue(amqp_object.Class):
             offset += 4
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
@@ -1760,14 +1649,15 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x00320014  # 50, 20; 3276820
         NAME = 'Queue.Bind'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     exchange=None,
-                     routing_key='',
-                     nowait=False,
-                     arguments=None):
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     exchange: str | bytes | None = None,
+                     routing_key: str | bytes = '',
+                     nowait: bool = False,
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
@@ -1775,11 +1665,7 @@ class Queue(amqp_object.Class):
             self.nowait = nowait
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.Bind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1791,8 +1677,8 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -1814,36 +1700,33 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x00320015  # 50, 21; 3276821
         NAME = 'Queue.BindOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.BindOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Purge(amqp_object.Method):
 
         INDEX = 0x0032001E  # 50, 30; 3276830
         NAME = 'Queue.Purge'
+        synchronous: bool = True
 
-        def __init__(self, ticket=0, queue='', nowait=False):
+        def __init__(self,
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     nowait: bool = False):
             self.ticket = ticket
             self.queue = queue
             self.nowait = nowait
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.Purge:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1852,8 +1735,8 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -1868,21 +1751,18 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x0032001F  # 50, 31; 3276831
         NAME = 'Queue.PurgeOk'
+        synchronous: bool = False
 
-        def __init__(self, message_count=None):
+        def __init__(self, message_count: int | None = None):
             self.message_count = message_count
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.PurgeOk:
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
 
@@ -1890,24 +1770,21 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x00320028  # 50, 40; 3276840
         NAME = 'Queue.Delete'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     if_unused=False,
-                     if_empty=False,
-                     nowait=False):
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     if_unused: bool = False,
+                     if_empty: bool = False,
+                     nowait: bool = False):
             self.ticket = ticket
             self.queue = queue
             self.if_unused = if_unused
             self.if_empty = if_empty
             self.nowait = nowait
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.Delete:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1918,8 +1795,8 @@ class Queue(amqp_object.Class):
             self.nowait = (bit_buffer & (1 << 2)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -1938,21 +1815,18 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x00320029  # 50, 41; 3276841
         NAME = 'Queue.DeleteOk'
+        synchronous: bool = False
 
-        def __init__(self, message_count=None):
+        def __init__(self, message_count: int | None = None):
             self.message_count = message_count
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.DeleteOk:
             self.message_count = struct.unpack_from('>I', encoded, offset)[0]
             offset += 4
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>I', self.message_count))
             return pieces
 
@@ -1960,24 +1834,21 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x00320032  # 50, 50; 3276850
         NAME = 'Queue.Unbind'
+        synchronous: bool = True
 
         def __init__(self,
-                     ticket=0,
-                     queue='',
-                     exchange=None,
-                     routing_key='',
-                     arguments=None):
+                     ticket: int = 0,
+                     queue: str | bytes = '',
+                     exchange: str | bytes | None = None,
+                     routing_key: str | bytes = '',
+                     arguments: dict[Any, Any] | None = None):
             self.ticket = ticket
             self.queue = queue
             self.exchange = exchange
             self.routing_key = routing_key
             self.arguments = arguments
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.Unbind:
             self.ticket = struct.unpack_from('>H', encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
@@ -1986,8 +1857,8 @@ class Queue(amqp_object.Class):
             (self.arguments, offset) = data.decode_table(encoded, offset)
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             pieces.append(struct.pack('>H', self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
@@ -2005,19 +1876,16 @@ class Queue(amqp_object.Class):
 
         INDEX = 0x00320033  # 50, 51; 3276851
         NAME = 'Queue.UnbindOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Queue.UnbindOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
 
@@ -2030,114 +1898,96 @@ class Tx(amqp_object.Class):
 
         INDEX = 0x005A000A  # 90, 10; 5898250
         NAME = 'Tx.Select'
+        synchronous: bool = True
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Tx.Select:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class SelectOk(amqp_object.Method):
 
         INDEX = 0x005A000B  # 90, 11; 5898251
         NAME = 'Tx.SelectOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Tx.SelectOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Commit(amqp_object.Method):
 
         INDEX = 0x005A0014  # 90, 20; 5898260
         NAME = 'Tx.Commit'
+        synchronous: bool = True
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Tx.Commit:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class CommitOk(amqp_object.Method):
 
         INDEX = 0x005A0015  # 90, 21; 5898261
         NAME = 'Tx.CommitOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Tx.CommitOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class Rollback(amqp_object.Method):
 
         INDEX = 0x005A001E  # 90, 30; 5898270
         NAME = 'Tx.Rollback'
+        synchronous: bool = True
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Tx.Rollback:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
     class RollbackOk(amqp_object.Method):
 
         INDEX = 0x005A001F  # 90, 31; 5898271
         NAME = 'Tx.RollbackOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Tx.RollbackOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
 
@@ -2150,22 +2000,19 @@ class Confirm(amqp_object.Class):
 
         INDEX = 0x0055000A  # 85, 10; 5570570
         NAME = 'Confirm.Select'
+        synchronous: bool = True
 
-        def __init__(self, nowait=False):
+        def __init__(self, nowait: bool = False):
             self.nowait = nowait
 
-        @property
-        def synchronous(self):
-            return True
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Confirm.Select:
             bit_buffer = struct.unpack_from('B', encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
@@ -2176,19 +2023,16 @@ class Confirm(amqp_object.Class):
 
         INDEX = 0x0055000B  # 85, 11; 5570571
         NAME = 'Confirm.SelectOk'
+        synchronous: bool = False
 
         def __init__(self):
             pass
 
-        @property
-        def synchronous(self):
-            return False
-
-        def decode(self, encoded, offset=0):
+        def decode(self, encoded: bytes, offset: int = 0) -> Confirm.SelectOk:
             return self
 
-        def encode(self):
-            pieces = list()
+        def encode(self) -> list[bytes]:
+            pieces: list[bytes] = []
             return pieces
 
 
@@ -2214,20 +2058,20 @@ class BasicProperties(amqp_object.Properties):
     FLAG_CLUSTER_ID = (1 << 2)
 
     def __init__(self,
-                 content_type=None,
-                 content_encoding=None,
-                 headers=None,
-                 delivery_mode=None,
-                 priority=None,
-                 correlation_id=None,
-                 reply_to=None,
-                 expiration=None,
-                 message_id=None,
-                 timestamp=None,
-                 type=None,
-                 user_id=None,
-                 app_id=None,
-                 cluster_id=None):
+                 content_type: str | bytes | None = None,
+                 content_encoding: str | bytes | None = None,
+                 headers: dict[Any, Any] | None = None,
+                 delivery_mode: int | None = None,
+                 priority: int | None = None,
+                 correlation_id: str | bytes | None = None,
+                 reply_to: str | bytes | None = None,
+                 expiration: str | bytes | None = None,
+                 message_id: str | bytes | None = None,
+                 timestamp: int | None = None,
+                 type: str | bytes | None = None,
+                 user_id: str | bytes | None = None,
+                 app_id: str | bytes | None = None,
+                 cluster_id: str | bytes | None = None):
         self.content_type = content_type
         self.content_encoding = content_encoding
         self.headers = headers
@@ -2243,7 +2087,7 @@ class BasicProperties(amqp_object.Properties):
         self.app_id = app_id
         self.cluster_id = cluster_id
 
-    def decode(self, encoded, offset=0):
+    def decode(self, encoded: bytes, offset: int = 0) -> BasicProperties:
         flags = 0
         flagword_index = 0
         while True:
@@ -2317,8 +2161,8 @@ class BasicProperties(amqp_object.Properties):
             self.cluster_id = None
         return self
 
-    def encode(self):
-        pieces = list()
+    def encode(self) -> list[bytes]:
+        pieces: list[bytes] = []
         flags = 0
         if self.content_type is not None:
             flags = flags | BasicProperties.FLAG_CONTENT_TYPE
@@ -2382,7 +2226,7 @@ class BasicProperties(amqp_object.Properties):
             assert isinstance(self.cluster_id, (str, bytes)),\
                    'A non-string value was supplied for self.cluster_id'
             data.encode_short_string(pieces, self.cluster_id)
-        flag_pieces = list()
+        flag_pieces: list[bytes] = []
         while True:
             remainder = flags >> 16
             partial_flags = flags & 0xFFFE
@@ -2395,7 +2239,7 @@ class BasicProperties(amqp_object.Properties):
         return flag_pieces + pieces
 
 
-methods = {
+methods: dict[int, type[amqp_object.Method]] = {
     0x003C000A: Basic.Qos,
     0x003C000B: Basic.QosOk,
     0x003C0014: Basic.Consume,
@@ -2464,10 +2308,10 @@ methods = {
     0x0055000B: Confirm.SelectOk
 }
 
-props = {0x003C: BasicProperties}
+props: dict[int, type[BasicProperties]] = {0x003C: BasicProperties}
 
 
-def has_content(methodNumber):
+def has_content(methodNumber: int) -> bool:
     return methodNumber in (
         Basic.Publish.INDEX,
         Basic.Return.INDEX,

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -171,6 +171,17 @@ class ExceptionTests(unittest.TestCase):
         self.assertEqual(exc.reply_code, 200)
         self.assertEqual(exc.reply_text, 'Normal shutdown')
 
+    def test_connection_closed_decodes_bytes_reply_text(self):
+        exc = exceptions.ConnectionClosed(320, b'CONNECTION_FORCED')
+        self.assertEqual(exc.reply_text, 'CONNECTION_FORCED')
+
+    def test_connection_closed_replaces_undecodable_reply_text(self):
+        # A broker may send reply-text that is not valid UTF-8. It must not
+        # reach the user as a bytes repr.
+        exc = exceptions.ConnectionClosed(320, b'forced \xff')
+        self.assertEqual(exc.reply_text, 'forced �')
+        self.assertNotIn('\\xff', repr(exc))
+
     def test_connection_closed_by_broker_host_port(self):
         exc = exceptions.ConnectionClosedByBroker(320,
                                                   'forced',

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -41,6 +41,46 @@ DRIVER_METHODS = {
     "Tx.Rollback": ["Tx.RollbackOk"]
 }
 
+# Annotation emitted for each resolved AMQP domain. `shortstr` and `longstr`
+# admit bytes because `data.decode_short_string` returns the raw bytes when the
+# payload is not valid UTF-8, and the encoders accept either. Table keys are
+# likewise str or bytes, so `Any` keeps a caller's `dict[str, Any]` assignable
+# despite dict key invariance.
+SPEC_HEADER = '''"""
+AMQP Specification
+==================
+This module implements the constants and classes that comprise AMQP protocol
+level constructs. It should rarely be directly referenced outside of Pika's
+own internal use.
+
+.. note:: Auto-generated code by codegen.py, do not edit directly. Pull
+requests to this file without accompanying ``utils/codegen.py`` changes will be
+rejected.
+
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+
+from pika import amqp_object
+from pika import data
+
+'''
+
+DOMAIN_TYPES = {
+    'shortstr': 'str | bytes',
+    'longstr': 'str | bytes',
+    'octet': 'int',
+    'short': 'int',
+    'long': 'int',
+    'longlong': 'int',
+    'timestamp': 'int',
+    'bit': 'bool',
+    'table': 'dict[Any, Any]',
+}
+
 
 def fieldvalue(v):
     if isinstance(v, str):
@@ -169,7 +209,8 @@ def generate(specPath):
             raise Exception("Illegal domain in genSingleEncode", type)
 
     def genDecodeMethodFields(m):
-        print("        def decode(self, encoded, offset=0):")
+        print("        def decode(self, encoded: bytes, offset: int = 0) -> "
+              f"{m.structName()}:")
         bitindex = None
         for f in m.arguments:
             if spec.resolveDomain(f.domain) == 'bit':
@@ -193,7 +234,8 @@ def generate(specPath):
         print('')
 
     def genDecodeProperties(c):
-        print("    def decode(self, encoded, offset=0):")
+        print("    def decode(self, encoded: bytes, offset: int = 0) -> "
+              f"{c.structName()}:")
         print("        flags = 0")
         print("        flagword_index = 0")
         print("        while True:")
@@ -221,8 +263,8 @@ def generate(specPath):
         print('')
 
     def genEncodeMethodFields(m):
-        print("        def encode(self):")
-        print("            pieces = list()")
+        print("        def encode(self) -> list[bytes]:")
+        print("            pieces: list[bytes] = []")
         bitindex = None
 
         def finishBits():
@@ -251,8 +293,8 @@ def generate(specPath):
         print('')
 
     def genEncodeProperties(c):
-        print("    def encode(self):")
-        print("        pieces = list()")
+        print("    def encode(self) -> list[bytes]:")
+        print("        pieces: list[bytes] = []")
         print("        flags = 0")
         for f in c.fields:
             if spec.resolveDomain(f.domain) == 'bit':
@@ -263,7 +305,7 @@ def generate(specPath):
                 print(f"            flags = flags | {flagName(c, f)}")
                 genSingleEncode("            ", f"self.{pyize(f.name)}",
                                 f.domain)
-        print("        flag_pieces = list()")
+        print("        flag_pieces: list[bytes] = []")
         print("        while True:")
         print("            remainder = flags >> 16")
         print("            partial_flags = flags & 0xFFFE")
@@ -277,9 +319,23 @@ def generate(specPath):
         print("        return flag_pieces + pieces")
         print('')
 
+    def fieldtype(f):
+        """
+        Return the annotation for a method argument or properties field.
+
+        A field whose default is None is decoded as None when absent, so it is annotated as
+        optional.
+        """
+        annotation = DOMAIN_TYPES[spec.resolveDomain(f.domain)]
+        if fieldvalue(f.defaultvalue) == 'None':
+            return f'{annotation} | None'
+        return annotation
+
     def fieldDeclList(fields):
-        return ''.join(
-            [f", {pyize(f.name)}={fieldvalue(f.defaultvalue)}" for f in fields])
+        return ''.join([
+            f", {pyize(f.name)}: {fieldtype(f)} = {fieldvalue(f.defaultvalue)}"
+            for f in fields
+        ])
 
     def fieldInitList(prefix, fields):
         if fields:
@@ -289,26 +345,8 @@ def generate(specPath):
             ])
         else:
             return f'{prefix}pass\n'
-    print(\
-          """\"\"\"
-AMQP Specification
-==================
-This module implements the constants and classes that comprise AMQP protocol
-level constructs. It should rarely be directly referenced outside of Pika's
-own internal use.
 
-.. note:: Auto-generated code by codegen.py, do not edit directly. Pull
-requests to this file without accompanying ``utils/codegen.py`` changes will be
-rejected.
-
-\"\"\"
-
-import struct
-from pika import amqp_object
-from pika import data
-
-"""
-    )
+    print(SPEC_HEADER)
 
     print("PROTOCOL_VERSION = (%d, %d, %d)" %
           (spec.major, spec.minor, spec.revision))
@@ -345,14 +383,13 @@ from pika import data
             print("        INDEX = 0x%.08X  # %d, %d; %d" %
                   (methodid, m.klass.index, m.index, methodid))
             print("        NAME = %s" % (fieldvalue(m.structName(),)))
+            # A plain class attribute rather than a property, so that it
+            # overrides `amqp_object.Method.synchronous` in kind.
+            print("        synchronous: bool = %s" % m.isSynchronous)
             print('')
             print("        def __init__(self%s):" %
                   (fieldDeclList(m.arguments),))
             print(fieldInitList('            ', m.arguments))
-            print("        @property")
-            print("        def synchronous(self):")
-            print("            return %s" % m.isSynchronous)
-            print('')
             genDecodeMethodFields(m)
             genEncodeMethodFields(m)
 
@@ -383,7 +420,7 @@ from pika import data
             genDecodeProperties(c)
             genEncodeProperties(c)
 
-    print("methods = {")
+    print("methods: dict[int, type[amqp_object.Method]] = {")
     print(',\n'.join([
         f"    0x{m.klass.index << 16 | m.index:08X}: {m.structName()}"
         for m in spec.allMethods()
@@ -391,7 +428,10 @@ from pika import data
     print("}")
     print('')
 
-    print("props = {")
+    # Name the concrete properties classes rather than the base, so that
+    # `frame.Header` keeps the specific type it is annotated to accept.
+    prop_classes = [c.structName() for c in spec.allClasses() if c.fields]
+    print("props: dict[int, type[%s]] = {" % ' | '.join(prop_classes))
     print(',\n'.join([
         f"    0x{c.index:04X}: {c.structName()}" for c in spec.allClasses()
         if c.fields
@@ -400,7 +440,7 @@ from pika import data
     print('')
     print('')
 
-    print("def has_content(methodNumber):")
+    print("def has_content(methodNumber: int) -> bool:")
     print('    return methodNumber in (')
     for m in spec.allMethods():
         if m.hasContent:

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -66,6 +66,7 @@ from typing import Any
 
 from pika import amqp_object
 from pika import data
+from pika._utils import override
 
 '''
 
@@ -209,6 +210,9 @@ def generate(specPath):
             raise Exception("Illegal domain in genSingleEncode", type)
 
     def genDecodeMethodFields(m):
+        # Only the method classes get @override; `amqp_object.Properties`
+        # declares no decode/encode to override.
+        print("        @override")
         print("        def decode(self, encoded: bytes, offset: int = 0) -> "
               f"{m.structName()}:")
         bitindex = None
@@ -263,6 +267,7 @@ def generate(specPath):
         print('')
 
     def genEncodeMethodFields(m):
+        print("        @override")
         print("        def encode(self) -> list[bytes]:")
         print("            pieces: list[bytes] = []")
         bitindex = None

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -6,6 +6,12 @@ The required spec json file can be found at https://github.com/rabbitmq/rabbitmq
 After cloning it run the following to generate a spec.py
 file:
 python ./utils/codegen.py ../rabbitmq-server
+
+The generator emits unformatted output, so reformat it afterwards. The
+repo's `fmt` script excludes pika/spec.py, so run yapf against it
+directly; without this step the result differs from the committed file
+by line wrapping alone:
+yapf --in-place --style google pika/spec.py
 """
 
 import os


### PR DESCRIPTION
## Proposed Changes

`pika/spec.py` is generated without type annotations, so every field read off a decoded frame resolves to `Unknown | Any | None`. Two consequences follow from that.

First, `mypy.ini` carried `[mypy-pika.spec] ignore_errors = True`, making the generated module the only part of the package mypy never looked at. Because the generated `__init__` methods were untyped, mypy saw every spec field as `Any` and reported the package clean while four genuine type errors sat in it:

```
pika/connection.py:1888  reply_code    int | None                              -> int
pika/connection.py:1890  reply_text    str | bytes                             -> str
pika/connection.py:2351  heartbeat     int | Callable[[Connection, float], int] | None -> int
pika/adapters/blocking_connection.py:1883  delivery_tag  int | None            -> int
```

Three of those four are already reported by pyright on `main` today. The fourth, `reply_code`, is suppressed there with a `pyright: ignore` comment, which mypy does not honour.

Second, one of them is a live bug rather than a typing nit. `Connection.Close.decode()` fills `reply_text` from `data.decode_short_string`, which returns raw bytes when the payload is not valid UTF-8. `ConnectionClosed` then coerced it with `str()`, which yields the bytes repr. A broker close carrying non-UTF-8 text reached the user as `b'forced \xff'` through both `reply_text` and `__repr__`, mangling the text needed to diagnose why the connection dropped.

This annotates the generated output, fixes the four sites it exposes, and drops the mypy exemption.

## Numbers

pyright, before and after:

| target | before | after |
| --- | --- | --- |
| `pika/spec.py` | 133 errors | **0** |
| `pika/` (whole package) | 159 errors | **23** |

The 136 difference is 133 from `spec.py` plus the 3 pre-existing errors at the call sites above.

mypy reports success both before and after, but afterwards it checks all 31 source files including `pika/spec.py`, which it previously skipped entirely.

## What the generator now emits

- Each resolved AMQP domain maps to an annotation. `shortstr` and `longstr` admit bytes, matching what `data.decode_short_string` yields for a payload that is not valid UTF-8. A field defaulting to None is annotated optional, which also covers properties fields, since an absent flag decodes as None.
- `synchronous` becomes a class attribute rather than a property, so it overrides `amqp_object.Method.synchronous` in kind. Its only reader, `channel.py:1451`, accesses it on an instance, where the two are equivalent.
- `decode`, `encode`, the module-level lookup dicts and `has_content` are annotated. `props` names the concrete properties classes rather than the base, so `frame.Header` keeps the specific type it accepts and the per-message header path needs no cast or isinstance check.
- 132 generated `decode` and `encode` methods carry `@override`, which `enable_error_code = explicit-override` requires once the module is checked. Only the method classes get it; `amqp_object.Properties` declares no decode or encode to override.
- `from __future__ import annotations`, required for the `X | None` syntax on the 3.7 to 3.9 legacy matrix. No annotation is evaluated at runtime, and the `override` shim in `pika/_utils.py` is dependency-free with a no-op fallback below 3.12.

`pika/data.py` is also touched: `encode_short_string` passes its value through `as_bytes`, which takes `str | bytes`, and `encode_table` encodes its keys the same way. Both were annotated to accept only `str`, narrower than they behave. Widening them is an annotation fix with no behavior change.

## Impact on downstream type checking

pika ships `py.typed`, so this changes a public contract. Measured against typed user code doing the usual things (`basic_ack(delivery_tag=method.delivery_tag)`, `method.routing_key.upper()`, passing `method.exchange` back into `basic_publish`):

| checker | on `main` | with this change |
| --- | --- | --- |
| pyright | 6 errors | 6 errors, same sites, clearer messages |
| mypy | 0 errors | **6 errors** |

pyright users are unaffected, because those Optionals are already visible to it. mypy users go from clean to 6 errors on idiomatic code, because mypy had been treating the untyped module as `Any`.

Every one of those errors is true: `Basic.Deliver.delivery_tag` really is `int | None` under the generated constructor, and `routing_key` really can be `bytes`. But it will break downstream type-checking CI on upgrade.

## Types of Changes

- [x] Bugfix <!-- non-UTF-8 reply-text no longer reaches the user as a bytes repr -->
- [ ] New feature
- [x] Breaking change <!-- see the downstream type-checking section; runtime impact is limited to the two items under Further Comments -->
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

Full suite against a local RabbitMQ: 1464 passed, 61 skipped. `hatch run typecheck`, `fmt-check`, `docfmt-check`, `lint-check` and `docs:build` all pass. Every one of the seven commits passes all five gates individually, so the branch bisects cleanly.

Two tests cover the reply-text fix, in `tests/unit/exceptions_test.py`. Both fail without it, with the mangling described above:

```
E   - b'forced \xff'
E   + forced <replacement char>
```

Documentation added to `utils/codegen.py`: the regeneration recipe omitted the formatting step, without which the result differs from the committed file by line wrapping alone.

## Fixes

No linked issue.

## Further Comments

**Alternatives considered.**

`decode_short_string` could return `str` unconditionally, decoding with `errors='replace'`. That would remove the `str | bytes` union from every queue name, routing key and consumer tag, and make the `reply_text` handling here redundant. I prototyped it: roughly 14 hand-written lines across three files, fully green. I left it out because it reverses a deliberate and tested behavior (`test_decode_short_string_invalid_utf8` asserts bytes), it leaves an unresolved asymmetry with long strings, which keep their bytes fallback in `decode_value`, and measurably it does not reduce the downstream error count above, since that is driven by Optionality rather than by the bytes union.

Annotating method fields as non-Optional would reduce the downstream count, since a method class's `decode()` sets every field unconditionally. It is left out because it forces the constructor defaults to change from None to type-appropriate zeros, and today `spec.Connection.Close()` followed by `.encode()` raises `struct.error` on the None, which is arguably the correct fail-fast behavior. Defaulting to `0` would instead put a silently wrong `reply_code` on the wire. That trade is an API decision worth its own discussion.