### PR TITLE
Perf: codec hot paths

### DIFF
--- a/pika/channel.py
+++ b/pika/channel.py
@@ -8,7 +8,7 @@ import logging
 import uuid
 from collections import deque
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Union
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Union, cast
 
 from pika import exceptions, frame, spec, validators
 from pika._utils import as_bytes, override
@@ -1143,11 +1143,12 @@ class Channel:
             return
 
         if response:
-            if isinstance(response[0].method, spec.Basic.Deliver):
+            method_index = response[0].method.INDEX
+            if method_index == spec.Basic.Deliver.INDEX:
                 self._on_deliver(*response)
-            elif isinstance(response[0].method, spec.Basic.GetOk):
+            elif method_index == spec.Basic.GetOk.INDEX:
                 self._on_getok(*response)
-            elif isinstance(response[0].method, spec.Basic.Return):
+            elif method_index == spec.Basic.Return.INDEX:
                 self._on_return(*response)
 
     def _on_cancel(self, method_frame: frame.Method) -> None:
@@ -1591,17 +1592,20 @@ class ContentFrameAssembler:
 
         :param frame_value: The frame to process
         """
-        if (isinstance(frame_value, frame.Method) and
-                spec.has_content(frame_value.method.INDEX)):
-            self._method_frame = frame_value
-            return None
-        if isinstance(frame_value, frame.Header):
-            self._header_frame = frame_value
-            if frame_value.body_size == 0:
+        frame_type = frame_value.frame_type
+        if frame_type == spec.FRAME_METHOD:
+            method_frame = cast(frame.Method, frame_value)
+            if spec.has_content(method_frame.method.INDEX):
+                self._method_frame = method_frame
+                return None
+        elif frame_type == spec.FRAME_HEADER:
+            header_frame = cast(frame.Header, frame_value)
+            self._header_frame = header_frame
+            if header_frame.body_size == 0:
                 return self._finish()
             return None
-        if isinstance(frame_value, frame.Body):
-            return self._handle_body_frame(frame_value)
+        elif frame_type == spec.FRAME_BODY:
+            return self._handle_body_frame(cast(frame.Body, frame_value))
         raise exceptions.UnexpectedFrameError(frame_value)
 
     def _finish(self) -> tuple[frame.Method, frame.Header, bytes]:

--- a/pika/channel.py
+++ b/pika/channel.py
@@ -8,7 +8,7 @@ import logging
 import uuid
 from collections import deque
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, ClassVar, Union
 
 from pika import exceptions, frame, spec, validators
 from pika._utils import as_bytes, override
@@ -1594,18 +1594,19 @@ class ContentFrameAssembler:
         """
         frame_type = frame_value.frame_type
         if frame_type == spec.FRAME_METHOD:
-            method_frame = cast(frame.Method, frame_value)
-            if spec.has_content(method_frame.method.INDEX):
-                self._method_frame = method_frame
+            assert isinstance(frame_value, frame.Method)
+            if spec.has_content(frame_value.method.INDEX):
+                self._method_frame = frame_value
                 return None
         elif frame_type == spec.FRAME_HEADER:
-            header_frame = cast(frame.Header, frame_value)
-            self._header_frame = header_frame
-            if header_frame.body_size == 0:
+            assert isinstance(frame_value, frame.Header)
+            self._header_frame = frame_value
+            if frame_value.body_size == 0:
                 return self._finish()
             return None
         elif frame_type == spec.FRAME_BODY:
-            return self._handle_body_frame(cast(frame.Body, frame_value))
+            assert isinstance(frame_value, frame.Body)
+            return self._handle_body_frame(frame_value)
         raise exceptions.UnexpectedFrameError(frame_value)
 
     def _finish(self) -> tuple[frame.Method, frame.Header, bytes]:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1739,7 +1739,7 @@ class Connection(abc.ABC):
 
         :param value: The frame to evaluate
         """
-        return isinstance(value, frame.Method)
+        return value.frame_type == spec.FRAME_METHOD
 
     def _is_protocol_header_frame(self, value: frame.Frame) -> bool:
         """
@@ -2244,12 +2244,13 @@ class Connection(abc.ABC):
         :param frame_value: The frame to process
         """
         # Will receive a frame type of -1 if protocol version mismatch
-        if frame_value.frame_type < 0:
+        frame_type = frame_value.frame_type
+        if frame_type < 0:
             return
 
         # ProtocolHeader (frame_type == -1) is handled above; narrow
         # the type for mypy.
-        assert not isinstance(frame_value, frame.ProtocolHeader)
+        frame_value = cast(frame.Frame, frame_value)
 
         # Keep track of how many frames have been read
         self.frames_received += 1
@@ -2259,7 +2260,7 @@ class Connection(abc.ABC):
             return
 
         # If a heartbeat is received, update the checker
-        if isinstance(frame_value, frame.Heartbeat):
+        if frame_type == spec.FRAME_HEARTBEAT:
             if self._heartbeat_checker:
                 self._heartbeat_checker.received()
             else:

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -2250,7 +2250,7 @@ class Connection(abc.ABC):
 
         # ProtocolHeader (frame_type == -1) is handled above; narrow
         # the type for mypy.
-        frame_value = cast(frame.Frame, frame_value)
+        assert not isinstance(frame_value, frame.ProtocolHeader)
 
         # Keep track of how many frames have been read
         self.frames_received += 1

--- a/pika/data.py
+++ b/pika/data.py
@@ -9,7 +9,6 @@ from datetime import datetime, timezone
 from typing import Any
 
 from pika import exceptions
-from pika._utils import as_bytes
 
 # AMQP field-table value type tags, as integer byte values. decode_value
 # dispatches on the raw byte rather than a 1-byte slice to avoid a bytes
@@ -34,6 +33,28 @@ _FIELD_TIMESTAMP = ord('T')
 _FIELD_TABLE = ord('F')
 _FIELD_VOID = ord('V')
 
+# Pre-compiled struct formats for field-table values. The bare formats are
+# used on decode, where the type tag has already been consumed; the `_TAG_`
+# ones pack the type tag together with the value on encode.
+_PACK_UINT = struct.Struct('>I')
+_PACK_INT = struct.Struct('>i')
+_PACK_LONG_LONG = struct.Struct('>q')
+_PACK_UNSIGNED_LONG_LONG = struct.Struct('>Q')
+_PACK_SHORT = struct.Struct('>h')
+_PACK_USHORT = struct.Struct('>H')
+_PACK_SIGNED_BYTE = struct.Struct('>b')
+_PACK_FLOAT = struct.Struct('>f')
+_PACK_DOUBLE = struct.Struct('>d')
+_PACK_TAG_UINT = struct.Struct('>cI')
+_PACK_TAG_BYTE = struct.Struct('>cB')
+_PACK_TAG_INT = struct.Struct('>ci')
+_PACK_TAG_LONG_LONG = struct.Struct('>cq')
+_PACK_TAG_UNSIGNED_LONG_LONG = struct.Struct('>cQ')
+_PACK_TAG_BYTE_INT = struct.Struct('>cBi')
+
+# Single-byte `bytes` objects indexed by value, for short-string lengths.
+_LENGTH_BYTES = tuple(bytes((i,)) for i in range(256))
+
 
 def encode_short_string(pieces: list[bytes], value: str | bytes) -> int:
     """
@@ -44,7 +65,7 @@ def encode_short_string(pieces: list[bytes], value: str | bytes) -> int:
     :param value: String value to encode; bytes are encoded as-is, which is what
         `decode_short_string` yields for a payload that is not valid UTF-8
     """
-    encoded_value = as_bytes(value)
+    encoded_value = value if isinstance(value, bytes) else value.encode('UTF-8')
     length = len(encoded_value)
 
     # 4.2.5.3
@@ -61,7 +82,7 @@ def encode_short_string(pieces: list[bytes], value: str | bytes) -> int:
     if length > 255:
         raise exceptions.ShortStringTooLong(encoded_value)
 
-    pieces.append(bytes((length,)))
+    pieces.append(_LENGTH_BYTES[length])
     pieces.append(encoded_value)
     return 1 + length
 
@@ -102,7 +123,7 @@ def encode_table(pieces: list[bytes], table: dict[Any, Any] | None) -> int:
         tablesize += encode_short_string(pieces, key)
         tablesize += encode_value(pieces, value)
 
-    pieces[length_index] = struct.pack('>I', tablesize)
+    pieces[length_index] = _PACK_UINT.pack(tablesize)
     return tablesize + 4
 
 
@@ -115,52 +136,53 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
     :param value: The value to encode
     """
     if isinstance(value, str):
-        value = as_bytes(value)
-        pieces.append(struct.pack('>cI', b'S', len(value)))
+        value = value.encode('UTF-8')
+        pieces.append(_PACK_TAG_UINT.pack(b'S', len(value)))
         pieces.append(value)
         return 5 + len(value)
     if isinstance(value, bytes):
-        pieces.append(struct.pack('>cI', b'x', len(value)))
+        pieces.append(_PACK_TAG_UINT.pack(b'x', len(value)))
         pieces.append(value)
         return 5 + len(value)
     if isinstance(value, bool):
-        pieces.append(struct.pack('>cB', b't', int(value)))
+        pieces.append(_PACK_TAG_BYTE.pack(b't', int(value)))
         return 2
     if isinstance(value, int):
         try:
-            packed = struct.pack('>ci', b'I', value)
+            packed = _PACK_TAG_INT.pack(b'I', value)
             pieces.append(packed)
             return 5
         except struct.error:
-            pieces.append(struct.pack('>cq', b'l', value))
+            pieces.append(_PACK_TAG_LONG_LONG.pack(b'l', value))
             return 9
     elif isinstance(value, decimal.Decimal):
         value = value.normalize()
         if value.as_tuple().exponent < 0:
             decimals = -value.as_tuple().exponent
             raw = int(value * (decimal.Decimal(10)**decimals))
-            pieces.append(struct.pack('>cBi', b'D', decimals, raw))
+            pieces.append(_PACK_TAG_BYTE_INT.pack(b'D', decimals, raw))
         else:
             # per spec, the "decimals" octet is unsigned (!)
-            pieces.append(struct.pack('>cBi', b'D', 0, int(value)))
+            pieces.append(_PACK_TAG_BYTE_INT.pack(b'D', 0, int(value)))
         return 6
     elif isinstance(value, datetime):
         pieces.append(
-            struct.pack('>cQ', b'T', calendar.timegm(value.utctimetuple())))
+            _PACK_TAG_UNSIGNED_LONG_LONG.pack(
+                b'T', calendar.timegm(value.utctimetuple())))
         return 9
     elif isinstance(value, dict):
-        pieces.append(struct.pack('>c', b'F'))
+        pieces.append(b'F')
         return 1 + encode_table(pieces, value)
     elif isinstance(value, list):
         list_pieces: list[Any] = []
         for val in value:
             encode_value(list_pieces, val)
         piece = b''.join(list_pieces)
-        pieces.append(struct.pack('>cI', b'A', len(piece)))
+        pieces.append(_PACK_TAG_UINT.pack(b'A', len(piece)))
         pieces.append(piece)
         return 5 + len(piece)
     elif value is None:
-        pieces.append(struct.pack('>c', b'V'))
+        pieces.append(b'V')
         return 1
     else:
         raise exceptions.UnsupportedAMQPFieldException(pieces, value)
@@ -176,7 +198,7 @@ def decode_table(encoded: bytes,
     :param offset: The starting byte offset
     """
     result = {}
-    tablesize = struct.unpack_from('>I', encoded, offset)[0]
+    tablesize = _PACK_UINT.unpack_from(encoded, offset)[0]
     offset += 4
     limit = offset + tablesize
     while offset < limit:
@@ -203,7 +225,7 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     # Long String
     if kind == _FIELD_LONG_STRING:
-        length = struct.unpack_from('>I', encoded, offset)[0]
+        length = _PACK_UINT.unpack_from(encoded, offset)[0]
         offset += 4
         value = encoded[offset:offset + length]
         try:
@@ -219,19 +241,20 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     # Long Int
     elif kind == _FIELD_LONG_INT:
-        value = struct.unpack_from('>i', encoded, offset)[0]
+        value = _PACK_INT.unpack_from(encoded, offset)[0]
         offset += 4
 
     # Long-Long Int (both 'l' and 'L' are signed per RabbitMQ and the
     # AMQP 0-9-1 errata; see rabbitmq/rabbitmq-server#1093)
     elif kind == _FIELD_LONG_LONG_INT_ALT:
-        value = struct.unpack_from('>q', encoded, offset)[0]
+        value = _PACK_LONG_LONG.unpack_from(encoded, offset)[0]
         offset += 8
 
     # Timestamp
     elif kind == _FIELD_TIMESTAMP:
         value = datetime.fromtimestamp(
-            struct.unpack_from('>Q', encoded, offset)[0], timezone.utc)
+            _PACK_UNSIGNED_LONG_LONG.unpack_from(encoded, offset)[0],
+            timezone.utc)
         offset += 8
 
     # Field Table
@@ -240,7 +263,7 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     # Field Array
     elif kind == _FIELD_ARRAY:
-        length = struct.unpack_from('>I', encoded, offset)[0]
+        length = _PACK_UINT.unpack_from(encoded, offset)[0]
         offset += 4
         offset_end = offset + length
         value = []
@@ -249,14 +272,14 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
             value.append(val)
 
     elif kind == _FIELD_BYTE_ARRAY:
-        length = struct.unpack_from('>I', encoded, offset)[0]
+        length = _PACK_UINT.unpack_from(encoded, offset)[0]
         offset += 4
         value = encoded[offset:offset + length]
         offset += length
 
     # Short-Short Int
     elif kind == _FIELD_SHORT_SHORT_INT:
-        value = struct.unpack_from('>b', encoded, offset)[0]
+        value = _PACK_SIGNED_BYTE.unpack_from(encoded, offset)[0]
         offset += 1
 
     # Short-Short Unsigned Int
@@ -266,46 +289,46 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     # Short Int
     elif kind == _FIELD_SHORT_INT:
-        value = struct.unpack_from('>h', encoded, offset)[0]
+        value = _PACK_SHORT.unpack_from(encoded, offset)[0]
         offset += 2
 
     # Short Unsigned Int
     elif kind == _FIELD_SHORT_UINT:
-        value = struct.unpack_from('>H', encoded, offset)[0]
+        value = _PACK_USHORT.unpack_from(encoded, offset)[0]
         offset += 2
 
     # Long Unsigned Int
     elif kind == _FIELD_LONG_UINT:
-        value = struct.unpack_from('>I', encoded, offset)[0]
+        value = _PACK_UINT.unpack_from(encoded, offset)[0]
         offset += 4
 
     # Long-Long Int
     elif kind == _FIELD_LONG_LONG_INT:
-        value = struct.unpack_from('>q', encoded, offset)[0]
+        value = _PACK_LONG_LONG.unpack_from(encoded, offset)[0]
         offset += 8
 
     # Float
     elif kind == _FIELD_FLOAT:
-        value = struct.unpack_from('>f', encoded, offset)[0]
+        value = _PACK_FLOAT.unpack_from(encoded, offset)[0]
         offset += 4
 
     # Double
     elif kind == _FIELD_DOUBLE:
-        value = struct.unpack_from('>d', encoded, offset)[0]
+        value = _PACK_DOUBLE.unpack_from(encoded, offset)[0]
         offset += 8
 
     # Decimal
     elif kind == _FIELD_DECIMAL:
         decimals = encoded[offset]
         offset += 1
-        raw = struct.unpack_from('>i', encoded, offset)[0]
+        raw = _PACK_INT.unpack_from(encoded, offset)[0]
         offset += 4
         value = decimal.Decimal(raw) * (decimal.Decimal(10)**-decimals)
 
     # https://github.com/pika/pika/issues/1205
     # Short Signed Int
     elif kind == _FIELD_SHORT_INT_ALT:
-        value = struct.unpack_from('>h', encoded, offset)[0]
+        value = _PACK_SHORT.unpack_from(encoded, offset)[0]
         offset += 2
 
     # Null / Void

--- a/pika/data.py
+++ b/pika/data.py
@@ -40,7 +40,7 @@ _PACK_UINT = struct.Struct('>I')
 _PACK_INT = struct.Struct('>i')
 _PACK_LONG_LONG = struct.Struct('>q')
 _PACK_UNSIGNED_LONG_LONG = struct.Struct('>Q')
-_PACK_SHORT = struct.Struct('>h')
+_PACK_SHORT_SIGNED = struct.Struct('>h')
 _PACK_USHORT = struct.Struct('>H')
 _PACK_SIGNED_BYTE = struct.Struct('>b')
 _PACK_FLOAT = struct.Struct('>f')
@@ -52,8 +52,9 @@ _PACK_TAG_LONG_LONG = struct.Struct('>cq')
 _PACK_TAG_UNSIGNED_LONG_LONG = struct.Struct('>cQ')
 _PACK_TAG_BYTE_INT = struct.Struct('>cBi')
 
-# Single-byte `bytes` objects indexed by value, for short-string lengths.
-_LENGTH_BYTES = tuple(bytes((i,)) for i in range(256))
+# Single-byte `bytes` objects indexed by value. Shared with `pika.spec`,
+# which imports this table for its bit-field buffers.
+_OCTET_BYTES = tuple(bytes((i,)) for i in range(256))
 
 
 def encode_short_string(pieces: list[bytes], value: str | bytes) -> int:
@@ -82,7 +83,7 @@ def encode_short_string(pieces: list[bytes], value: str | bytes) -> int:
     if length > 255:
         raise exceptions.ShortStringTooLong(encoded_value)
 
-    pieces.append(_LENGTH_BYTES[length])
+    pieces.append(_OCTET_BYTES[length])
     pieces.append(encoded_value)
     return 1 + length
 
@@ -289,7 +290,7 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     # Short Int
     elif kind == _FIELD_SHORT_INT:
-        value = _PACK_SHORT.unpack_from(encoded, offset)[0]
+        value = _PACK_SHORT_SIGNED.unpack_from(encoded, offset)[0]
         offset += 2
 
     # Short Unsigned Int
@@ -328,7 +329,7 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
     # https://github.com/pika/pika/issues/1205
     # Short Signed Int
     elif kind == _FIELD_SHORT_INT_ALT:
-        value = _PACK_SHORT.unpack_from(encoded, offset)[0]
+        value = _PACK_SHORT_SIGNED.unpack_from(encoded, offset)[0]
         offset += 2
 
     # Null / Void

--- a/pika/frame.py
+++ b/pika/frame.py
@@ -15,6 +15,17 @@ _MethodT = TypeVar('_MethodT', bound=amqp_object.Method)
 
 _FRAME_END_BYTE = bytes((spec.FRAME_END,))
 
+# First byte of the AMQP protocol header. No frame type shares this value, so
+# it distinguishes the protocol header from a real frame.
+_PROTOCOL_HEADER_FIRST_BYTE = ord('A')
+
+# Pre-compiled struct formats for the fixed-size parts of each frame.
+_FRAME_HEADER = struct.Struct('>BHI')  # frame type, channel, payload size
+_PROTOCOL_VERSION = struct.Struct('BBB')  # major, minor, revision
+_METHOD_ID = struct.Struct('>I')  # method frame class/method index
+_CONTENT_HEADER = struct.Struct('>HHQ')  # class id, weight, body size
+_PROPERTIES_HEADER = struct.Struct('>HxxQ')  # class id, pad, body size
+
 # Payload size (bytes) above which decode_frame copies the frame body via a
 # memoryview rather than a plain slice. For a bytearray input a plain slice
 # makes an intermediate bytearray before the bytes() copy; a memoryview skips
@@ -51,8 +62,9 @@ class Frame(amqp_object.AMQPObject):
         :param pieces: Encoded AMQP frame fragments to assemble
         """
         payload = b''.join(pieces)
-        return struct.pack('>BHI', self.frame_type, self.channel_number,
-                           len(payload)) + payload + _FRAME_END_BYTE
+        return b''.join(
+            (_FRAME_HEADER.pack(self.frame_type, self.channel_number,
+                                len(payload)), payload, _FRAME_END_BYTE))
 
     def marshal(self) -> bytes:
         """
@@ -87,7 +99,7 @@ class Method(Frame, Generic[_MethodT]):
     def marshal(self) -> bytes:
         """Return the AMQP binary encoded value of the frame."""
         pieces = self.method.encode()
-        pieces.insert(0, struct.pack('>I', self.method.INDEX))
+        pieces.insert(0, _METHOD_ID.pack(self.method.INDEX))
         return self._marshal(pieces)
 
 
@@ -119,7 +131,7 @@ class Header(Frame):
         """Return the AMQP binary encoded value of the frame."""
         pieces = self.properties.encode()
         pieces.insert(
-            0, struct.pack('>HxxQ', self.properties.INDEX, self.body_size))
+            0, _PROPERTIES_HEADER.pack(self.properties.INDEX, self.body_size))
         return self._marshal(pieces)
 
 
@@ -211,9 +223,10 @@ def decode_frame(data_in: bytes | bytearray,
     """
     # Look to see if it's a protocol header frame
     try:
-        if data_in[offset:offset + 4] == b'AMQP':
-            major, minor, revision = struct.unpack_from('BBB', data_in,
-                                                        offset + 5)
+        if (data_in[offset] == _PROTOCOL_HEADER_FIRST_BYTE and
+                data_in[offset:offset + 4] == b'AMQP'):
+            major, minor, revision = _PROTOCOL_VERSION.unpack_from(
+                data_in, offset + 5)
             return 8, ProtocolHeader(major, minor, revision)
     except (IndexError, struct.error):
         return 0, None
@@ -221,7 +234,7 @@ def decode_frame(data_in: bytes | bytearray,
     # Get the Frame Type, Channel Number and Frame Size
     try:
         (frame_type, channel_number,
-         frame_size) = struct.unpack_from('>BHL', data_in, offset)
+         frame_size) = _FRAME_HEADER.unpack_from(data_in, offset)
     except struct.error:
         return 0, None
 
@@ -249,7 +262,7 @@ def decode_frame(data_in: bytes | bytearray,
     if frame_type == spec.FRAME_METHOD:
 
         # Get the Method ID from the frame data
-        method_id = struct.unpack_from('>I', frame_data)[0]
+        method_id = _METHOD_ID.unpack_from(frame_data)[0]
 
         # Get a Method object for this method_id
         method = spec.methods[method_id]()
@@ -263,7 +276,7 @@ def decode_frame(data_in: bytes | bytearray,
     if frame_type == spec.FRAME_HEADER:
 
         # Return the header class and body size
-        class_id, _weight, body_size = struct.unpack_from('>HHQ', frame_data)
+        class_id, _weight, body_size = _CONTENT_HEADER.unpack_from(frame_data)
 
         # Get the Properties type
         properties = spec.props[class_id]()

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -20,6 +20,16 @@ from pika import amqp_object
 from pika import data
 from pika._utils import override
 
+# Pre-compiled struct formats, one per fixed-size AMQP domain.
+_PACK_OCTET = struct.Struct('B')
+_PACK_SHORT = struct.Struct('>H')
+_PACK_LONG = struct.Struct('>I')
+_PACK_LONGLONG = struct.Struct('>Q')
+
+# Single-byte `bytes` objects indexed by value, for the bit-field buffers
+# below, which only ever hold `1 << 0` through `1 << 7`.
+_OCTET_BYTES = tuple(bytes((i,)) for i in range(256))
+
 PROTOCOL_VERSION = (0, 9, 1)
 PORT = 5672
 
@@ -76,11 +86,11 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Qos:
-            self.prefetch_size = struct.unpack_from('>I', encoded, offset)[0]
+            self.prefetch_size = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
-            self.prefetch_count = struct.unpack_from('>H', encoded, offset)[0]
+            self.prefetch_count = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.global_qos = (bit_buffer & (1 << 0)) != 0
             return self
@@ -88,12 +98,12 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>I', self.prefetch_size))
-            pieces.append(struct.pack('>H', self.prefetch_count))
+            pieces.append(_PACK_LONG.pack(self.prefetch_size))
+            pieces.append(_PACK_SHORT.pack(self.prefetch_count))
             bit_buffer = 0
             if self.global_qos:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class QosOk(amqp_object.Method):
@@ -140,12 +150,12 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Consume:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.no_local = (bit_buffer & (1 << 0)) != 0
             self.no_ack = (bit_buffer & (1 << 1)) != 0
@@ -157,7 +167,7 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
@@ -173,7 +183,7 @@ class Basic(amqp_object.Class):
                 bit_buffer |= 1 << 2
             if self.nowait:
                 bit_buffer |= 1 << 3
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -216,7 +226,7 @@ class Basic(amqp_object.Class):
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Cancel:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
@@ -230,7 +240,7 @@ class Basic(amqp_object.Class):
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class CancelOk(amqp_object.Method):
@@ -276,11 +286,11 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Publish:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
             self.routing_key, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.mandatory = (bit_buffer & (1 << 0)) != 0
             self.immediate = (bit_buffer & (1 << 1)) != 0
@@ -289,7 +299,7 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
             data.encode_short_string(pieces, self.exchange)
@@ -301,7 +311,7 @@ class Basic(amqp_object.Class):
                 bit_buffer |= 1 << 0
             if self.immediate:
                 bit_buffer |= 1 << 1
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class Return(amqp_object.Method):
@@ -322,7 +332,7 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Return:
-            self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
+            self.reply_code = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -332,7 +342,7 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.reply_code))
+            pieces.append(_PACK_SHORT.pack(self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
                    'A non-string value was supplied for self.reply_text'
             data.encode_short_string(pieces, self.reply_text)
@@ -366,9 +376,9 @@ class Basic(amqp_object.Class):
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Deliver:
             self.consumer_tag, offset = data.decode_short_string(
                 encoded, offset)
-            self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
+            self.delivery_tag = _PACK_LONGLONG.unpack_from(encoded, offset)[0]
             offset += 8
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.redelivered = (bit_buffer & (1 << 0)) != 0
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -381,11 +391,11 @@ class Basic(amqp_object.Class):
             assert isinstance(self.consumer_tag, (str, bytes)),\
                    'A non-string value was supplied for self.consumer_tag'
             data.encode_short_string(pieces, self.consumer_tag)
-            pieces.append(struct.pack('>Q', self.delivery_tag))
+            pieces.append(_PACK_LONGLONG.pack(self.delivery_tag))
             bit_buffer = 0
             if self.redelivered:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
             data.encode_short_string(pieces, self.exchange)
@@ -410,10 +420,10 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Get:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.no_ack = (bit_buffer & (1 << 0)) != 0
             return self
@@ -421,14 +431,14 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
             bit_buffer = 0
             if self.no_ack:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class GetOk(amqp_object.Method):
@@ -451,32 +461,32 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.GetOk:
-            self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
+            self.delivery_tag = _PACK_LONGLONG.unpack_from(encoded, offset)[0]
             offset += 8
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.redelivered = (bit_buffer & (1 << 0)) != 0
             self.exchange, offset = data.decode_short_string(encoded, offset)
             self.routing_key, offset = data.decode_short_string(encoded, offset)
-            self.message_count = struct.unpack_from('>I', encoded, offset)[0]
+            self.message_count = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>Q', self.delivery_tag))
+            pieces.append(_PACK_LONGLONG.pack(self.delivery_tag))
             bit_buffer = 0
             if self.redelivered:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
             data.encode_short_string(pieces, self.exchange)
             assert isinstance(self.routing_key, (str, bytes)),\
                    'A non-string value was supplied for self.routing_key'
             data.encode_short_string(pieces, self.routing_key)
-            pieces.append(struct.pack('>I', self.message_count))
+            pieces.append(_PACK_LONG.pack(self.message_count))
             return pieces
 
     class GetEmpty(amqp_object.Method):
@@ -513,9 +523,9 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Ack:
-            self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
+            self.delivery_tag = _PACK_LONGLONG.unpack_from(encoded, offset)[0]
             offset += 8
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.multiple = (bit_buffer & (1 << 0)) != 0
             return self
@@ -523,11 +533,11 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>Q', self.delivery_tag))
+            pieces.append(_PACK_LONGLONG.pack(self.delivery_tag))
             bit_buffer = 0
             if self.multiple:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class Reject(amqp_object.Method):
@@ -544,9 +554,9 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Reject:
-            self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
+            self.delivery_tag = _PACK_LONGLONG.unpack_from(encoded, offset)[0]
             offset += 8
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
@@ -554,11 +564,11 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>Q', self.delivery_tag))
+            pieces.append(_PACK_LONGLONG.pack(self.delivery_tag))
             bit_buffer = 0
             if self.requeue:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class RecoverAsync(amqp_object.Method):
@@ -572,7 +582,7 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.RecoverAsync:
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
@@ -583,7 +593,7 @@ class Basic(amqp_object.Class):
             bit_buffer = 0
             if self.requeue:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class Recover(amqp_object.Method):
@@ -597,7 +607,7 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Recover:
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.requeue = (bit_buffer & (1 << 0)) != 0
             return self
@@ -608,7 +618,7 @@ class Basic(amqp_object.Class):
             bit_buffer = 0
             if self.requeue:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class RecoverOk(amqp_object.Method):
@@ -645,9 +655,9 @@ class Basic(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Basic.Nack:
-            self.delivery_tag = struct.unpack_from('>Q', encoded, offset)[0]
+            self.delivery_tag = _PACK_LONGLONG.unpack_from(encoded, offset)[0]
             offset += 8
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.multiple = (bit_buffer & (1 << 0)) != 0
             self.requeue = (bit_buffer & (1 << 1)) != 0
@@ -656,13 +666,13 @@ class Basic(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>Q', self.delivery_tag))
+            pieces.append(_PACK_LONGLONG.pack(self.delivery_tag))
             bit_buffer = 0
             if self.multiple:
                 bit_buffer |= 1 << 0
             if self.requeue:
                 bit_buffer |= 1 << 1
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
 
@@ -691,17 +701,17 @@ class Connection(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Start:
-            self.version_major = struct.unpack_from('B', encoded, offset)[0]
+            self.version_major = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
-            self.version_minor = struct.unpack_from('B', encoded, offset)[0]
+            self.version_minor = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             (self.server_properties,
              offset) = data.decode_table(encoded, offset)
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.mechanisms = encoded[offset:offset + length]
             offset += length
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.locales = encoded[offset:offset + length]
             offset += length
@@ -710,20 +720,20 @@ class Connection(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('B', self.version_major))
-            pieces.append(struct.pack('B', self.version_minor))
+            pieces.append(_PACK_OCTET.pack(self.version_major))
+            pieces.append(_PACK_OCTET.pack(self.version_minor))
             data.encode_table(pieces, self.server_properties)
             assert isinstance(self.mechanisms, (str, bytes)),\
                    'A non-string value was supplied for self.mechanisms'
             value = self.mechanisms.encode('utf-8') if isinstance(
                 self.mechanisms, str) else self.mechanisms
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             assert isinstance(self.locales, (str, bytes)),\
                    'A non-string value was supplied for self.locales'
             value = self.locales.encode('utf-8') if isinstance(
                 self.locales, str) else self.locales
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             return pieces
 
@@ -748,7 +758,7 @@ class Connection(amqp_object.Class):
             (self.client_properties,
              offset) = data.decode_table(encoded, offset)
             self.mechanism, offset = data.decode_short_string(encoded, offset)
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.response = encoded[offset:offset + length]
             offset += length
@@ -766,7 +776,7 @@ class Connection(amqp_object.Class):
                    'A non-string value was supplied for self.response'
             value = self.response.encode('utf-8') if isinstance(
                 self.response, str) else self.response
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             assert isinstance(self.locale, (str, bytes)),\
                    'A non-string value was supplied for self.locale'
@@ -784,7 +794,7 @@ class Connection(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Secure:
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.challenge = encoded[offset:offset + length]
             offset += length
@@ -797,7 +807,7 @@ class Connection(amqp_object.Class):
                    'A non-string value was supplied for self.challenge'
             value = self.challenge.encode('utf-8') if isinstance(
                 self.challenge, str) else self.challenge
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             return pieces
 
@@ -814,7 +824,7 @@ class Connection(amqp_object.Class):
         def decode(self,
                    encoded: bytes,
                    offset: int = 0) -> Connection.SecureOk:
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.response = encoded[offset:offset + length]
             offset += length
@@ -827,7 +837,7 @@ class Connection(amqp_object.Class):
                    'A non-string value was supplied for self.response'
             value = self.response.encode('utf-8') if isinstance(
                 self.response, str) else self.response
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             return pieces
 
@@ -847,20 +857,20 @@ class Connection(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Tune:
-            self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
+            self.channel_max = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
-            self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
+            self.frame_max = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
-            self.heartbeat = struct.unpack_from('>H', encoded, offset)[0]
+            self.heartbeat = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.channel_max))
-            pieces.append(struct.pack('>I', self.frame_max))
-            pieces.append(struct.pack('>H', self.heartbeat))
+            pieces.append(_PACK_SHORT.pack(self.channel_max))
+            pieces.append(_PACK_LONG.pack(self.frame_max))
+            pieces.append(_PACK_SHORT.pack(self.heartbeat))
             return pieces
 
     class TuneOk(amqp_object.Method):
@@ -879,20 +889,20 @@ class Connection(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.TuneOk:
-            self.channel_max = struct.unpack_from('>H', encoded, offset)[0]
+            self.channel_max = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
-            self.frame_max = struct.unpack_from('>I', encoded, offset)[0]
+            self.frame_max = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
-            self.heartbeat = struct.unpack_from('>H', encoded, offset)[0]
+            self.heartbeat = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.channel_max))
-            pieces.append(struct.pack('>I', self.frame_max))
-            pieces.append(struct.pack('>H', self.heartbeat))
+            pieces.append(_PACK_SHORT.pack(self.channel_max))
+            pieces.append(_PACK_LONG.pack(self.frame_max))
+            pieces.append(_PACK_SHORT.pack(self.heartbeat))
             return pieces
 
     class Open(amqp_object.Method):
@@ -915,7 +925,7 @@ class Connection(amqp_object.Class):
                 encoded, offset)
             self.capabilities, offset = data.decode_short_string(
                 encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.insist = (bit_buffer & (1 << 0)) != 0
             return self
@@ -932,7 +942,7 @@ class Connection(amqp_object.Class):
             bit_buffer = 0
             if self.insist:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class OpenOk(amqp_object.Method):
@@ -975,24 +985,24 @@ class Connection(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Connection.Close:
-            self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
+            self.reply_code = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
-            self.class_id = struct.unpack_from('>H', encoded, offset)[0]
+            self.class_id = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
-            self.method_id = struct.unpack_from('>H', encoded, offset)[0]
+            self.method_id = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.reply_code))
+            pieces.append(_PACK_SHORT.pack(self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
                    'A non-string value was supplied for self.reply_text'
             data.encode_short_string(pieces, self.reply_text)
-            pieces.append(struct.pack('>H', self.class_id))
-            pieces.append(struct.pack('>H', self.method_id))
+            pieces.append(_PACK_SHORT.pack(self.class_id))
+            pieces.append(_PACK_SHORT.pack(self.method_id))
             return pieces
 
     class CloseOk(amqp_object.Method):
@@ -1071,7 +1081,7 @@ class Connection(amqp_object.Class):
         def decode(self,
                    encoded: bytes,
                    offset: int = 0) -> Connection.UpdateSecret:
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.new_secret = encoded[offset:offset + length]
             offset += length
@@ -1085,7 +1095,7 @@ class Connection(amqp_object.Class):
                    'A non-string value was supplied for self.new_secret'
             value = self.new_secret.encode('utf-8') if isinstance(
                 self.new_secret, str) else self.new_secret
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             assert isinstance(self.reason, (str, bytes)),\
                    'A non-string value was supplied for self.reason'
@@ -1151,7 +1161,7 @@ class Channel(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.OpenOk:
-            length = struct.unpack_from('>I', encoded, offset)[0]
+            length = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             self.channel_id = encoded[offset:offset + length]
             offset += length
@@ -1164,7 +1174,7 @@ class Channel(amqp_object.Class):
                    'A non-string value was supplied for self.channel_id'
             value = self.channel_id.encode('utf-8') if isinstance(
                 self.channel_id, str) else self.channel_id
-            pieces.append(struct.pack('>I', len(value)))
+            pieces.append(_PACK_LONG.pack(len(value)))
             pieces.append(value)
             return pieces
 
@@ -1179,7 +1189,7 @@ class Channel(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.Flow:
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
@@ -1190,7 +1200,7 @@ class Channel(amqp_object.Class):
             bit_buffer = 0
             if self.active:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class FlowOk(amqp_object.Method):
@@ -1204,7 +1214,7 @@ class Channel(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.FlowOk:
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.active = (bit_buffer & (1 << 0)) != 0
             return self
@@ -1215,7 +1225,7 @@ class Channel(amqp_object.Class):
             bit_buffer = 0
             if self.active:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class Close(amqp_object.Method):
@@ -1236,24 +1246,24 @@ class Channel(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Channel.Close:
-            self.reply_code = struct.unpack_from('>H', encoded, offset)[0]
+            self.reply_code = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.reply_text, offset = data.decode_short_string(encoded, offset)
-            self.class_id = struct.unpack_from('>H', encoded, offset)[0]
+            self.class_id = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
-            self.method_id = struct.unpack_from('>H', encoded, offset)[0]
+            self.method_id = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.reply_code))
+            pieces.append(_PACK_SHORT.pack(self.reply_code))
             assert isinstance(self.reply_text, (str, bytes)),\
                    'A non-string value was supplied for self.reply_text'
             data.encode_short_string(pieces, self.reply_text)
-            pieces.append(struct.pack('>H', self.class_id))
-            pieces.append(struct.pack('>H', self.method_id))
+            pieces.append(_PACK_SHORT.pack(self.class_id))
+            pieces.append(_PACK_SHORT.pack(self.method_id))
             return pieces
 
     class CloseOk(amqp_object.Method):
@@ -1303,7 +1313,7 @@ class Access(amqp_object.Class):
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Access.Request:
             self.realm, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.exclusive = (bit_buffer & (1 << 0)) != 0
             self.passive = (bit_buffer & (1 << 1)) != 0
@@ -1329,7 +1339,7 @@ class Access(amqp_object.Class):
                 bit_buffer |= 1 << 3
             if self.read:
                 bit_buffer |= 1 << 4
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class RequestOk(amqp_object.Method):
@@ -1343,14 +1353,14 @@ class Access(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Access.RequestOk:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             return pieces
 
 
@@ -1387,11 +1397,11 @@ class Exchange(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Declare:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
             self.type, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.passive = (bit_buffer & (1 << 0)) != 0
             self.durable = (bit_buffer & (1 << 1)) != 0
@@ -1404,7 +1414,7 @@ class Exchange(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
             data.encode_short_string(pieces, self.exchange)
@@ -1422,7 +1432,7 @@ class Exchange(amqp_object.Class):
                 bit_buffer |= 1 << 3
             if self.nowait:
                 bit_buffer |= 1 << 4
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -1462,10 +1472,10 @@ class Exchange(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Delete:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.exchange, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.if_unused = (bit_buffer & (1 << 0)) != 0
             self.nowait = (bit_buffer & (1 << 1)) != 0
@@ -1474,7 +1484,7 @@ class Exchange(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.exchange, (str, bytes)),\
                    'A non-string value was supplied for self.exchange'
             data.encode_short_string(pieces, self.exchange)
@@ -1483,7 +1493,7 @@ class Exchange(amqp_object.Class):
                 bit_buffer |= 1 << 0
             if self.nowait:
                 bit_buffer |= 1 << 1
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class DeleteOk(amqp_object.Method):
@@ -1526,12 +1536,12 @@ class Exchange(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Bind:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
             self.source, offset = data.decode_short_string(encoded, offset)
             self.routing_key, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             (self.arguments, offset) = data.decode_table(encoded, offset)
@@ -1540,7 +1550,7 @@ class Exchange(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
                    'A non-string value was supplied for self.destination'
             data.encode_short_string(pieces, self.destination)
@@ -1553,7 +1563,7 @@ class Exchange(amqp_object.Class):
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -1597,12 +1607,12 @@ class Exchange(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Exchange.Unbind:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.destination, offset = data.decode_short_string(encoded, offset)
             self.source, offset = data.decode_short_string(encoded, offset)
             self.routing_key, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             (self.arguments, offset) = data.decode_table(encoded, offset)
@@ -1611,7 +1621,7 @@ class Exchange(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.destination, (str, bytes)),\
                    'A non-string value was supplied for self.destination'
             data.encode_short_string(pieces, self.destination)
@@ -1624,7 +1634,7 @@ class Exchange(amqp_object.Class):
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -1678,10 +1688,10 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Declare:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.passive = (bit_buffer & (1 << 0)) != 0
             self.durable = (bit_buffer & (1 << 1)) != 0
@@ -1694,7 +1704,7 @@ class Queue(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
@@ -1709,7 +1719,7 @@ class Queue(amqp_object.Class):
                 bit_buffer |= 1 << 3
             if self.nowait:
                 bit_buffer |= 1 << 4
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -1730,9 +1740,9 @@ class Queue(amqp_object.Class):
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.DeclareOk:
             self.queue, offset = data.decode_short_string(encoded, offset)
-            self.message_count = struct.unpack_from('>I', encoded, offset)[0]
+            self.message_count = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
-            self.consumer_count = struct.unpack_from('>I', encoded, offset)[0]
+            self.consumer_count = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             return self
 
@@ -1742,8 +1752,8 @@ class Queue(amqp_object.Class):
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
-            pieces.append(struct.pack('>I', self.message_count))
-            pieces.append(struct.pack('>I', self.consumer_count))
+            pieces.append(_PACK_LONG.pack(self.message_count))
+            pieces.append(_PACK_LONG.pack(self.consumer_count))
             return pieces
 
     class Bind(amqp_object.Method):
@@ -1768,12 +1778,12 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Bind:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.exchange, offset = data.decode_short_string(encoded, offset)
             self.routing_key, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             (self.arguments, offset) = data.decode_table(encoded, offset)
@@ -1782,7 +1792,7 @@ class Queue(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
@@ -1795,7 +1805,7 @@ class Queue(amqp_object.Class):
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             data.encode_table(pieces, self.arguments)
             return pieces
 
@@ -1833,10 +1843,10 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Purge:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
@@ -1844,14 +1854,14 @@ class Queue(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class PurgeOk(amqp_object.Method):
@@ -1865,14 +1875,14 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.PurgeOk:
-            self.message_count = struct.unpack_from('>I', encoded, offset)[0]
+            self.message_count = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>I', self.message_count))
+            pieces.append(_PACK_LONG.pack(self.message_count))
             return pieces
 
     class Delete(amqp_object.Method):
@@ -1895,10 +1905,10 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Delete:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.if_unused = (bit_buffer & (1 << 0)) != 0
             self.if_empty = (bit_buffer & (1 << 1)) != 0
@@ -1908,7 +1918,7 @@ class Queue(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
@@ -1919,7 +1929,7 @@ class Queue(amqp_object.Class):
                 bit_buffer |= 1 << 1
             if self.nowait:
                 bit_buffer |= 1 << 2
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class DeleteOk(amqp_object.Method):
@@ -1933,14 +1943,14 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.DeleteOk:
-            self.message_count = struct.unpack_from('>I', encoded, offset)[0]
+            self.message_count = _PACK_LONG.unpack_from(encoded, offset)[0]
             offset += 4
             return self
 
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>I', self.message_count))
+            pieces.append(_PACK_LONG.pack(self.message_count))
             return pieces
 
     class Unbind(amqp_object.Method):
@@ -1963,7 +1973,7 @@ class Queue(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Queue.Unbind:
-            self.ticket = struct.unpack_from('>H', encoded, offset)[0]
+            self.ticket = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             self.queue, offset = data.decode_short_string(encoded, offset)
             self.exchange, offset = data.decode_short_string(encoded, offset)
@@ -1974,7 +1984,7 @@ class Queue(amqp_object.Class):
         @override
         def encode(self) -> list[bytes]:
             pieces: list[bytes] = []
-            pieces.append(struct.pack('>H', self.ticket))
+            pieces.append(_PACK_SHORT.pack(self.ticket))
             assert isinstance(self.queue, (str, bytes)),\
                    'A non-string value was supplied for self.queue'
             data.encode_short_string(pieces, self.queue)
@@ -2136,7 +2146,7 @@ class Confirm(amqp_object.Class):
 
         @override
         def decode(self, encoded: bytes, offset: int = 0) -> Confirm.Select:
-            bit_buffer = struct.unpack_from('B', encoded, offset)[0]
+            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
             self.nowait = (bit_buffer & (1 << 0)) != 0
             return self
@@ -2147,7 +2157,7 @@ class Confirm(amqp_object.Class):
             bit_buffer = 0
             if self.nowait:
                 bit_buffer |= 1 << 0
-            pieces.append(struct.pack('B', bit_buffer))
+            pieces.append(_OCTET_BYTES[bit_buffer])
             return pieces
 
     class SelectOk(amqp_object.Method):
@@ -2224,7 +2234,7 @@ class BasicProperties(amqp_object.Properties):
         flags = 0
         flagword_index = 0
         while True:
-            partial_flags = struct.unpack_from('>H', encoded, offset)[0]
+            partial_flags = _PACK_SHORT.unpack_from(encoded, offset)[0]
             offset += 2
             flags = flags | (partial_flags << (flagword_index * 16))
             if not (partial_flags & 1):
@@ -2245,12 +2255,12 @@ class BasicProperties(amqp_object.Properties):
         else:
             self.headers = None
         if flags & BasicProperties.FLAG_DELIVERY_MODE:
-            self.delivery_mode = struct.unpack_from('B', encoded, offset)[0]
+            self.delivery_mode = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
         else:
             self.delivery_mode = None
         if flags & BasicProperties.FLAG_PRIORITY:
-            self.priority = struct.unpack_from('B', encoded, offset)[0]
+            self.priority = _PACK_OCTET.unpack_from(encoded, offset)[0]
             offset += 1
         else:
             self.priority = None
@@ -2272,7 +2282,7 @@ class BasicProperties(amqp_object.Properties):
         else:
             self.message_id = None
         if flags & BasicProperties.FLAG_TIMESTAMP:
-            self.timestamp = struct.unpack_from('>Q', encoded, offset)[0]
+            self.timestamp = _PACK_LONGLONG.unpack_from(encoded, offset)[0]
             offset += 8
         else:
             self.timestamp = None
@@ -2312,10 +2322,10 @@ class BasicProperties(amqp_object.Properties):
             data.encode_table(pieces, self.headers)
         if self.delivery_mode is not None:
             flags = flags | BasicProperties.FLAG_DELIVERY_MODE
-            pieces.append(struct.pack('B', self.delivery_mode))
+            pieces.append(_PACK_OCTET.pack(self.delivery_mode))
         if self.priority is not None:
             flags = flags | BasicProperties.FLAG_PRIORITY
-            pieces.append(struct.pack('B', self.priority))
+            pieces.append(_PACK_OCTET.pack(self.priority))
         if self.correlation_id is not None:
             flags = flags | BasicProperties.FLAG_CORRELATION_ID
             assert isinstance(self.correlation_id, (str, bytes)),\
@@ -2338,7 +2348,7 @@ class BasicProperties(amqp_object.Properties):
             data.encode_short_string(pieces, self.message_id)
         if self.timestamp is not None:
             flags = flags | BasicProperties.FLAG_TIMESTAMP
-            pieces.append(struct.pack('>Q', self.timestamp))
+            pieces.append(_PACK_LONGLONG.pack(self.timestamp))
         if self.type is not None:
             flags = flags | BasicProperties.FLAG_TYPE
             assert isinstance(self.type, (str, bytes)),\
@@ -2365,7 +2375,7 @@ class BasicProperties(amqp_object.Properties):
             partial_flags = flags & 0xFFFE
             if remainder != 0:
                 partial_flags |= 1
-            flag_pieces.append(struct.pack('>H', partial_flags))
+            flag_pieces.append(_PACK_SHORT.pack(partial_flags))
             flags = remainder
             if not flags:
                 break

--- a/pika/spec.py
+++ b/pika/spec.py
@@ -26,9 +26,11 @@ _PACK_SHORT = struct.Struct('>H')
 _PACK_LONG = struct.Struct('>I')
 _PACK_LONGLONG = struct.Struct('>Q')
 
-# Single-byte `bytes` objects indexed by value, for the bit-field buffers
-# below, which only ever hold `1 << 0` through `1 << 7`.
-_OCTET_BYTES = tuple(bytes((i,)) for i in range(256))
+# Single-byte `bytes` objects indexed by value 0 through 255, for the
+# bit-field buffers below, which OR several bit flags into one octet.
+# Reuse the table built in `pika.data` rather than constructing an
+# identical one here.
+_OCTET_BYTES = data._OCTET_BYTES
 
 PROTOCOL_VERSION = (0, 9, 1)
 PORT = 5672

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -686,9 +686,15 @@ class ConnectionTests(unittest.TestCase):
         """Test on data available and process frame."""
         data_in = b'd'
         self.connection._frame_buffer = bytearray(b'o')
-        for frame_type in (frame.Method, spec.Basic.Deliver, frame.Heartbeat):
+        # `frame_type` must match the class being mocked, as it does on a real
+        # frame: `_process_frame` dispatches on it.
+        for frame_type, frame_type_id in ((frame.Method, spec.FRAME_METHOD),
+                                          (spec.Basic.Deliver,
+                                           spec.FRAME_METHOD),
+                                          (frame.Heartbeat,
+                                           spec.FRAME_HEARTBEAT)):
             frame_value = mock.Mock(spec=frame_type)
-            frame_value.frame_type = 2
+            frame_value.frame_type = frame_type_id
             frame_value.method = 2
             frame_value.channel_number = 1
             self.connection.bytes_received = 0

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -74,6 +74,16 @@ from pika import amqp_object
 from pika import data
 from pika._utils import override
 
+# Pre-compiled struct formats, one per fixed-size AMQP domain.
+_PACK_OCTET = struct.Struct('B')
+_PACK_SHORT = struct.Struct('>H')
+_PACK_LONG = struct.Struct('>I')
+_PACK_LONGLONG = struct.Struct('>Q')
+
+# Single-byte `bytes` objects indexed by value, for the bit-field buffers
+# below, which only ever hold `1 << 0` through `1 << 7`.
+_OCTET_BYTES = tuple(bytes((i,)) for i in range(256))
+
 '''
 
 DOMAIN_TYPES = {
@@ -146,29 +156,31 @@ def generate(specPath):
                   cLvalue)
         elif type == 'longstr':
             print(prefix +
-                  "length = struct.unpack_from('>I', encoded, offset)[0]")
+                  "length = _PACK_LONG.unpack_from(encoded, offset)[0]")
             print(prefix + "offset += 4")
             print(prefix + "%s = encoded[offset:offset + length]" % cLvalue)
             print(prefix + "offset += length")
         elif type == 'octet':
             print(prefix +
-                  "%s = struct.unpack_from('B', encoded, offset)[0]" % cLvalue)
+                  "%s = _PACK_OCTET.unpack_from(encoded, offset)[0]" % cLvalue)
             print(prefix + "offset += 1")
         elif type == 'short':
             print(prefix +
-                  "%s = struct.unpack_from('>H', encoded, offset)[0]" % cLvalue)
+                  "%s = _PACK_SHORT.unpack_from(encoded, offset)[0]" % cLvalue)
             print(prefix + "offset += 2")
         elif type == 'long':
             print(prefix +
-                  "%s = struct.unpack_from('>I', encoded, offset)[0]" % cLvalue)
+                  "%s = _PACK_LONG.unpack_from(encoded, offset)[0]" % cLvalue)
             print(prefix + "offset += 4")
         elif type == 'longlong':
             print(prefix +
-                  "%s = struct.unpack_from('>Q', encoded, offset)[0]" % cLvalue)
+                  "%s = _PACK_LONGLONG.unpack_from(encoded, offset)[0]" %
+                  cLvalue)
             print(prefix + "offset += 8")
         elif type == 'timestamp':
             print(prefix +
-                  "%s = struct.unpack_from('>Q', encoded, offset)[0]" % cLvalue)
+                  "%s = _PACK_LONGLONG.unpack_from(encoded, offset)[0]" %
+                  cLvalue)
             print(prefix + "offset += 8")
         elif type == 'bit':
             raise Exception("Can't decode bit in genSingleDecode")
@@ -196,18 +208,18 @@ def generate(specPath):
             print(prefix +
                   "value = %s.encode('utf-8') if isinstance(%s, str) else %s" %
                   (cValue, cValue, cValue))
-            print(prefix + "pieces.append(struct.pack('>I', len(value)))")
+            print(prefix + "pieces.append(_PACK_LONG.pack(len(value)))")
             print(prefix + "pieces.append(value)")
         elif type == 'octet':
-            print(prefix + "pieces.append(struct.pack('B', %s))" % cValue)
+            print(prefix + "pieces.append(_PACK_OCTET.pack(%s))" % cValue)
         elif type == 'short':
-            print(prefix + "pieces.append(struct.pack('>H', %s))" % cValue)
+            print(prefix + "pieces.append(_PACK_SHORT.pack(%s))" % cValue)
         elif type == 'long':
-            print(prefix + "pieces.append(struct.pack('>I', %s))" % cValue)
+            print(prefix + "pieces.append(_PACK_LONG.pack(%s))" % cValue)
         elif type == 'longlong':
-            print(prefix + "pieces.append(struct.pack('>Q', %s))" % cValue)
+            print(prefix + "pieces.append(_PACK_LONGLONG.pack(%s))" % cValue)
         elif type == 'timestamp':
-            print(prefix + "pieces.append(struct.pack('>Q', %s))" % cValue)
+            print(prefix + "pieces.append(_PACK_LONGLONG.pack(%s))" % cValue)
         elif type == 'bit':
             raise Exception("Can't encode bit in genSingleEncode")
         elif type == 'table':
@@ -230,7 +242,7 @@ def generate(specPath):
                     bitindex = 0
                 if not bitindex:
                     print(
-                        "            bit_buffer = struct.unpack_from('B', encoded, offset)[0]"
+                        "            bit_buffer = _PACK_OCTET.unpack_from(encoded, offset)[0]"
                     )
                     print("            offset += 1")
                 print("            self.%s = (bit_buffer & (1 << %d)) != 0" %
@@ -250,7 +262,7 @@ def generate(specPath):
         print("        flagword_index = 0")
         print("        while True:")
         print(
-            "            partial_flags = struct.unpack_from('>H', encoded, offset)[0]"
+            "            partial_flags = _PACK_SHORT.unpack_from(encoded, offset)[0]"
         )
         print("            offset += 2")
         print(
@@ -280,7 +292,7 @@ def generate(specPath):
 
         def finishBits():
             if bitindex is not None:
-                print("            pieces.append(struct.pack('B', bit_buffer))")
+                print("            pieces.append(_OCTET_BYTES[bit_buffer])")
 
         for f in m.arguments:
             if spec.resolveDomain(f.domain) == 'bit':
@@ -322,8 +334,7 @@ def generate(specPath):
         print("            partial_flags = flags & 0xFFFE")
         print("            if remainder != 0:")
         print("                partial_flags |= 1")
-        print(
-            "            flag_pieces.append(struct.pack('>H', partial_flags))")
+        print("            flag_pieces.append(_PACK_SHORT.pack(partial_flags))")
         print("            flags = remainder")
         print("            if not flags:")
         print("                break")

--- a/utils/codegen.py
+++ b/utils/codegen.py
@@ -80,9 +80,11 @@ _PACK_SHORT = struct.Struct('>H')
 _PACK_LONG = struct.Struct('>I')
 _PACK_LONGLONG = struct.Struct('>Q')
 
-# Single-byte `bytes` objects indexed by value, for the bit-field buffers
-# below, which only ever hold `1 << 0` through `1 << 7`.
-_OCTET_BYTES = tuple(bytes((i,)) for i in range(256))
+# Single-byte `bytes` objects indexed by value 0 through 255, for the
+# bit-field buffers below, which OR several bit flags into one octet.
+# Reuse the table built in `pika.data` rather than constructing an
+# identical one here.
+_OCTET_BYTES = data._OCTET_BYTES
 
 '''
 


### PR DESCRIPTION
## Proposed Changes

Speeds up the paths profiling flagged in a publish/consume workload. No API changes, bytes on the wire unchanged. Four fixes, each measured independently:

1. **`Frame._marshal` copied the payload three times.** It built `struct.pack(...) + payload + FRAME_END`; each `+` allocates and copies both operands. A single `b''.join` allocates once, so large bodies gain most.
2. **`struct.pack`/`unpack_from` took format strings**, re-resolving the format every call. Pre-compiled `struct.Struct` is ~40% faster per call, and these run once *per field* on every frame across `data.py`, `frame.py`, and the generated `spec.py`. Biggest contributor.
3. **`decode_frame` sliced every frame** to compare against `b'AMQP'`, allocating 4 bytes per frame to find a header that appears once per connection. No frame type shares the value of `b'A'`, so a one-byte check rules it out first.
4. **Dispatch ran 22 `isinstance` checks per delivered message** across `ContentFrameAssembler.process`, `_handle_content_frame`, `_process_frame`, and `_is_method_frame`, re-deriving what `frame_type` and `Method.INDEX` already store as ints.

Also: `encode_short_string` built a fresh `bytes((length,))` per string though the length is already validated to fit a byte, and `struct.pack('>c', b'F')` produced a one-byte constant.

## Types of Changes

- [ ] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics
- [x] Performance (no category fits exactly; no intended behavior change)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

No new tests: a perf change has nothing to assert that would not be flaky on CI. What it needs is proof behavior did not change, below. The suite passes at **every commit**, so the branch bisects cleanly; all four `hatch` gates are clean.

## Fixes

## Further Comments

### Worth reviewing closely

Commit 4 narrows a contract: with `frame_type` comparisons replacing `isinstance`, an object subclassing a frame class without the matching `frame_type` is no longer recognized. Real frames always set it in `__init__` from the matching `spec.FRAME_*` constant, so nothing changes on the wire.

It surfaced in `test_on_data_available`, which mocked `frame.Heartbeat` but hardcoded `frame_type` to 2 where a real one carries 8. It passed before only because a mock satisfies `isinstance` regardless of attributes. The fix pairs each mocked class with the frame type a real instance carries: a fixture correction, but please confirm you agree.

That commit also drops `assert not isinstance(frame_value, frame.ProtocolHeader)` for a `cast`. It was pure mypy narrowing and unreachable, since `ProtocolHeader` sets `frame_type` to -1 and the check above returns on negatives.

### Verifying nothing changed

A differential wire-format harness against `main`, **282 checks**: every field-table type, every frame type, `bytes` and `bytearray` inputs, non-zero offsets, and input truncated at *every* byte position. Encoded bytes and decoded values identical.

`spec.py` is regenerated from `utils/codegen.py` in the same commit, and the generator reproduces the committed file byte for byte beforehand, so its diff is only the intended substitutions.

### Benchmarks

Interleaved A/B against a `main` worktree, alternating order each round, min-of-rounds plus head-to-head wins. CPython 3.14.4, Linux, idle machine, 15 rounds. Milliseconds, lower is better.

| workload | main | branch | delta | wins |
|---|---:|---:|---:|---:|
| publish/64k | 0.921 | 0.690 | -25.1% | 15/15 |
| publish/headers | 9.646 | 8.032 | -16.7% | 15/15 |
| table/roundtrip | 76.318 | 63.995 | -16.1% | 15/15 |
| publish/small | 4.976 | 4.276 | -14.1% | 14/15 |
| decode/small | 4.415 | 3.886 | -12.0% | 15/15 |
| decode/headers | 7.707 | 6.886 | -10.7% | 12/15 |
| consume/headers | 11.758 | 10.543 | -10.3% | 11/15 |
| consume/small | 8.120 | 7.439 | -8.4% | 10/15 |
| ack | 5.683 | 5.302 | -6.7% | 10/15 |
| decode/64k | 0.384 | 0.358 | -6.6% | 12/15 |

The publish and table rows are unambiguous at 15/15. `consume/small` and `ack` at 10/15 are the weakest: their deltas are consistent in sign across runs, but the win counts do not establish them on their own.

End to end, 20k messages with headers against local RabbitMQ 4.3.4, 21 rounds:

| phase | main | branch | delta | wins |
|---|---:|---:|---:|---:|
| publish | 49,532 msg/s | 50,738 msg/s | -2.4% | 16/21 |
| consume | 142,078 msg/s | 140,032 msg/s | +1.5% | 9/21 |

Publishing gains a consistent 2-4%, since marshaling is the publish-path work. **Consuming shows nothing** (9/21 is a coin flip) despite decode being 7-9% faster in isolation: socket reads and broker round-trips dominate. An I/O-bound client should not expect much here. This matters when pika itself is the bottleneck: large bodies, heavy header tables, or consumers doing little work per message.

### Reproducing

Scripts are uncommitted since there is no benchmark directory today; Drop both in the repo root (they need `pika` importable from the script's own directory) and run:

```bash
python3 ab.py --base main --rounds 15
```

Use enough rounds on an idle machine.

<details>
<summary><code>bench.py</code></summary>

```python
"""CPU-bound benchmarks for pika's codec and frame-dispatch paths.

No broker required: workloads drive the marshal/decode paths directly and
through a Connection subclass whose adapter writes to a list.

    python3 bench.py                       # run all workloads
    python3 bench.py --save out.json       # record timings
    python3 bench.py --profile consume/small
"""
import argparse
import gc
import json
import statistics
import time
from unittest import mock

from pika import channel, connection, data, frame, spec

N_MSGS = 2000
SMALL_BODY = 256
BIG_BODY = 64 * 1024
HEADERS = {
    'x-request-id': 'ab3f9c1e-1122-4c8f-9a7e-77aa0011bb22',
    'x-retry-count': 3,
    'x-source': 'bench-producer',
    'x-flag': True,
    'x-nested': {
        'a': 1,
        'b': 'two'
    },
}


class FakeConnection(connection.Connection):
    """Connection that never touches a socket."""

    sink: list

    def _adapter_connect_stream(self):
        pass

    def _adapter_disconnect_stream(self):
        pass

    def _adapter_call_later(self, delay, callback):
        return None

    def _adapter_remove_timeout(self, timeout_id):
        pass

    def _adapter_add_callback_threadsafe(self, callback):
        pass

    def _adapter_emit_data(self, data):
        self.sink.append(data)


def make_connection():
    with mock.patch.object(connection.Connection, '_adapter_connect_stream'):
        conn = FakeConnection()
    conn.sink = []
    conn._set_connection_state(conn.CONNECTION_OPEN)
    return conn


def make_open_channel(conn, number=1):
    chan = channel.Channel(conn, number, lambda *a: None)
    chan._state = chan.OPEN
    conn._channels[number] = chan
    return chan


def build_delivery_stream(count, body_size, headers=None):
    """Raw wire bytes for `count` Deliver + Header + Body triplets."""
    out = bytearray()
    body = b'x' * body_size
    props = spec.BasicProperties(content_type='application/json',
                                 delivery_mode=2,
                                 app_id='bench',
                                 headers=headers)
    for i in range(count):
        method = spec.Basic.Deliver('ctag1.bench', i + 1, False,
                                    'bench-exchange', 'bench.routing.key')
        out += frame.Method(1, method).marshal()
        out += frame.Header(1, len(body), props).marshal()
        out += frame.Body(1, body).marshal()
    return bytes(out)


STREAM_SMALL = build_delivery_stream(N_MSGS, SMALL_BODY)
STREAM_HDRS = build_delivery_stream(N_MSGS, SMALL_BODY, HEADERS)
STREAM_BIG = build_delivery_stream(100, BIG_BODY)


def _decode_all(buf):
    offset, size, decode = 0, len(buf), frame.decode_frame
    while offset < size:
        consumed, _f = decode(buf, offset)
        offset += consumed


def _consume(stream):
    conn = make_connection()
    chan = make_open_channel(conn)
    chan._consumers['ctag1.bench'] = lambda *a: None
    conn._on_data_available(stream)


def _publish(count, body, props):
    conn = make_connection()
    chan = make_open_channel(conn)
    for _ in range(count):
        chan.basic_publish('bench-exchange', 'bench.routing.key', body, props)
        conn.sink.clear()


def w_decode_small():
    _decode_all(STREAM_SMALL)


def w_decode_headers():
    _decode_all(STREAM_HDRS)


def w_decode_big():
    _decode_all(STREAM_BIG)


def w_consume_small():
    _consume(STREAM_SMALL)


def w_consume_headers():
    _consume(STREAM_HDRS)


def w_publish_small():
    _publish(
        N_MSGS, b'x' * SMALL_BODY,
        spec.BasicProperties(content_type='application/json',
                             delivery_mode=2,
                             app_id='bench'))


def w_publish_headers():
    _publish(
        N_MSGS, b'x' * SMALL_BODY,
        spec.BasicProperties(content_type='application/json',
                             delivery_mode=2,
                             app_id='bench',
                             headers=HEADERS))


def w_publish_big():
    _publish(200, b'x' * BIG_BODY, spec.BasicProperties(delivery_mode=2))


def w_table_roundtrip():
    for _ in range(20000):
        pieces = []
        data.encode_table(pieces, HEADERS)
        data.decode_table(b''.join(pieces), 0)


def w_ack():
    conn = make_connection()
    chan = make_open_channel(conn)
    for i in range(N_MSGS * 5):
        chan.basic_ack(i + 1)
        conn.sink.clear()


WORKLOADS = {
    'decode/small': w_decode_small,
    'decode/headers': w_decode_headers,
    'decode/64k': w_decode_big,
    'consume/small': w_consume_small,
    'consume/headers': w_consume_headers,
    'publish/small': w_publish_small,
    'publish/headers': w_publish_headers,
    'publish/64k': w_publish_big,
    'table/roundtrip': w_table_roundtrip,
    'ack': w_ack,
}


def timeit(fn, repeats=7):
    times = []
    for _ in range(repeats):
        gc.collect()
        gc.disable()
        start = time.perf_counter()
        fn()
        times.append(time.perf_counter() - start)
        gc.enable()
    return min(times), statistics.median(times)


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--save')
    parser.add_argument('--profile')
    parser.add_argument('--only')
    args = parser.parse_args()

    if args.profile:
        import cProfile
        import pstats
        profiler = cProfile.Profile()
        profiler.enable()
        WORKLOADS[args.profile]()
        profiler.disable()
        pstats.Stats(profiler).sort_stats('tottime').print_stats(20)
        return

    selected = args.only.split(',') if args.only else list(WORKLOADS)
    results = {}
    for name in selected:
        fn = WORKLOADS[name]
        fn()  # warm up
        best, median = timeit(fn)
        results[name] = best
        print(f'{name:20s} min={best * 1000:9.3f} ms  '
              f'median={median * 1000:9.3f} ms')

    if args.save:
        with open(args.save, 'w') as handle:
            json.dump(results, handle, indent=2)


if __name__ == '__main__':
    main()
```

</details>

<details>
<summary><code>ab.py</code></summary>

```python
"""Interleaved A/B runner for bench.py.

Checks out a baseline revision into a temporary git worktree and runs
bench.py against both trees, alternating which goes first each round so
CPU frequency drift hits both variants equally. Reports min-of-rounds and
a head-to-head win count, so a small delta can be told apart from noise.

    python3 ab.py --base main --rounds 11

Single before/after runs on a laptop drift by more than 10%, which is
larger than several of the effects being measured; that is what this is
for.
"""
import argparse
import json
import os
import shutil
import statistics
import subprocess
import sys
import tempfile

HERE = os.path.dirname(os.path.abspath(__file__))
BENCH = os.path.join(HERE, 'bench.py')


def run(root, out):
    subprocess.run([sys.executable, BENCH, '--save', out],
                   env=dict(os.environ, PYTHONPATH=root),
                   check=True,
                   stdout=subprocess.DEVNULL)
    with open(out) as handle:
        return json.load(handle)


def main():
    parser = argparse.ArgumentParser()
    parser.add_argument('--base', default='main', help='baseline revision')
    parser.add_argument('--repo', default=os.getcwd())
    parser.add_argument('--rounds', type=int, default=11)
    args = parser.parse_args()

    tmp = tempfile.mkdtemp(prefix='pika-ab-')
    baseline = os.path.join(tmp, 'base')
    subprocess.run(
        ['git', '-C', args.repo, 'worktree', 'add', '--detach', baseline,
         args.base],
        check=True,
        stdout=subprocess.DEVNULL,
        stderr=subprocess.DEVNULL)
    try:
        variants = {'base': baseline, 'new': args.repo}
        samples = {name: [] for name in variants}
        for round_index in range(args.rounds):
            order = list(variants)
            if round_index % 2:
                order.reverse()
            for name in order:
                out = os.path.join(tmp, f'{name}.json')
                samples[name].append(run(variants[name], out))
            print(f'round {round_index + 1}/{args.rounds}', file=sys.stderr)
    finally:
        subprocess.run(
            ['git', '-C', args.repo, 'worktree', 'remove', '--force',
             baseline],
            check=False)
        shutil.rmtree(tmp, ignore_errors=True)

    print(f'\n{"workload":20s} {"base":>9s} {"new":>9s} {"delta":>8s} '
          f'{"speedup":>8s}  wins')
    for workload in samples['base'][0]:
        base = [s[workload] for s in samples['base']]
        new = [s[workload] for s in samples['new']]
        best_base, best_new = min(base), min(new)
        wins = sum(1 for b, n in zip(base, new) if n < b)
        print(f'{workload:20s} {best_base * 1000:9.3f} {best_new * 1000:9.3f} '
              f'{(best_new - best_base) / best_base * 100:+7.1f}% '
              f'{best_base / best_new:7.2f}x  {wins}/{len(base)}')

    print('\nmedian-of-rounds:')
    for workload in samples['base'][0]:
        base = statistics.median([s[workload] for s in samples['base']])
        new = statistics.median([s[workload] for s in samples['new']])
        print(f'{workload:20s} {base * 1000:9.3f} {new * 1000:9.3f} '
              f'{(new - base) / base * 100:+7.1f}%')


if __name__ == '__main__':
    main()
```

</details>
