### PR TITLE
Revert "Fix `callLater` typing by passing keyword arguments"

### DIFF
--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1079,7 +1079,15 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
                          on_close_callback=on_close_callback,
                          internal_connection_workflow=False)
 
-        self._reactor = custom_reactor or reactor
+        # Annotated as `Any` rather than as a reactor interface on purpose.
+        # Reactor implementations rename the parameters the interfaces
+        # declare: `IReactorTime.callLater(delay, callable, *args, **kw)` but
+        # `AsyncioSelectorReactor.callLater(seconds, f, *args, **kwargs)`.
+        # Only positional arguments work across every reactor, and a typed
+        # attribute makes the type checker reject the positional call because
+        # `IReactorTime.callLater` is unbound, so `delay` is consumed as
+        # `self`. See https://github.com/pika/pika/pull/1678.
+        self._reactor: Any = custom_reactor or reactor
         self._transport: twisted.internet.interfaces.ITransport | None = None  # to be provided by `connection_made()`
 
     @override
@@ -1090,8 +1098,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         :param callback: The callback to call after the delay
         """
         check_callback_arg(callback, 'callback')
-        return _TimerHandle(self._reactor.callLater(
-            delay, callback))  # pyright: ignore[reportAttributeAccessIssue]
+        return _TimerHandle(self._reactor.callLater(delay, callback))
 
     @override
     def _adapter_remove_timeout(self, timeout_id: Any) -> None:
@@ -1107,8 +1114,7 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         :param callback: The callback to call from the thread
         """
         check_callback_arg(callback, 'callback')
-        self._reactor.callFromThread(
-            callback)  # pyright: ignore[reportAttributeAccessIssue]
+        self._reactor.callFromThread(callback)
 
     @override
     def _adapter_connect_stream(self) -> None:

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1090,9 +1090,8 @@ class _TwistedConnectionAdapter(pika.connection.Connection):
         :param callback: The callback to call after the delay
         """
         check_callback_arg(callback, 'callback')
-        return _TimerHandle(
-            self._reactor.callLater(delay=delay, callable=callback)
-        )  # pyright: ignore[reportAttributeAccessIssue]
+        return _TimerHandle(self._reactor.callLater(
+            delay, callback))  # pyright: ignore[reportAttributeAccessIssue]
 
     @override
     def _adapter_remove_timeout(self, timeout_id: Any) -> None:

--- a/tests/acceptance/twisted_adapter_tests.py
+++ b/tests/acceptance/twisted_adapter_tests.py
@@ -851,15 +851,36 @@ class TwistedProtocolConnectionTestCase(TestCase):
         self.conn_impl_mock.close.assert_not_called()
 
 
+class _AsyncioReactorSignatureStub:
+    """
+    A reactor stub using `AsyncioSelectorReactor`'s parameter names.
+
+    `AsyncioSelectorReactor.callLater(seconds, f, *args, **kwargs)` renames the parameters that
+    `IReactorTime.callLater(delay, callable, *args, **kw)` declares, so only positional arguments
+    work across every reactor.
+    """
+
+    def __init__(self):
+        self.call_later_args = []
+
+    def callLater(self, seconds, f, *args, **kwargs):
+        self.call_later_args.append((seconds, f, args, kwargs))
+        return mock.Mock()
+
+
 class TwistedConnectionAdapterTestCase(TestCase):
 
     def setUp(self):
         self.conn = _TwistedConnectionAdapter(None, None, None, None, None)
 
     def tearDown(self):
-        if self.conn._transport is None:
-            self.conn._transport = mock.Mock()
-        self.conn.close()
+        self._close_adapter(self.conn)
+
+    @staticmethod
+    def _close_adapter(conn):
+        if conn._transport is None:
+            conn._transport = mock.Mock()
+        conn.close()
 
     def test_adapter_disconnect_stream(self):
         # Verify that the underlying transport is aborted.
@@ -883,6 +904,18 @@ class TwistedConnectionAdapterTestCase(TestCase):
         self.conn._adapter_remove_timeout(timer_id)
         self.assertNotIn(timer_id._handle, reactor.getDelayedCalls())
         callback.assert_not_called()
+
+    def test_timeout_passes_positional_args(self):
+        # Verify that `callLater` is called positionally. The default reactor
+        # names its parameters `delay` and `callable`, so a keyword call passes
+        # here while crashing on `AsyncioSelectorReactor`, which names them
+        # `seconds` and `f`.
+        callback = mock.Mock()
+        stub = _AsyncioReactorSignatureStub()
+        conn = _TwistedConnectionAdapter(None, None, None, None, stub)
+        self.addCleanup(self._close_adapter, conn)
+        conn._adapter_call_later(5, callback)
+        self.assertEqual(stub.call_later_args, [(5, callback, (), {})])
 
     @pytest.mark.timeout(5)
     def test_call_threadsafe(self):


### PR DESCRIPTION
Twisted doesn't accept keyword arguments for this function[0] as far as I can tell. Updating to Pika 1.4.2 has caused Fedora's pika applications, which use Twisted, to start crashing with:

```
  File "pika/adapters/twisted_connection.py", line 1152, in _adapter_call_later
    self._reactor.callLater(delay=delay, callable=callback)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: AsyncioSelectorReactor.callLater() missing 2 required positional arguments: 'seconds' and 'f'
```

[0] https://github.com/twisted/twisted/blob/3dc92b79333c231338390c2b8cec5c142a31863d/src/twisted/internet/base.py#L947

This reverts commit 79efa4903a40bab07cbda32e830dfa0f52b5a17f.

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
