### PR TITLE
Fix: gh-1679 (Reject work scheduled on a closed ThreadSafeConnection)

### DIFF
--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import itertools
 import logging
 import queue
-import sys
 import threading
 import time
 from threading import Event
@@ -471,7 +470,7 @@ class ThreadSafeChannel:
                 error[0] = exc
                 ready.set()
 
-        self._wrapper.add_callback_threadsafe(_invoke)
+        self._wrapper._schedule_unchecked(_invoke)
 
         try:
             if not ready.wait(timeout=timeout):
@@ -531,7 +530,7 @@ class ThreadSafeChannel:
                 if on_publish is not None:
                     on_publish(self._next_publish_seq_no)
 
-        self._wrapper.add_callback_threadsafe(_publish)
+        self._wrapper._schedule_unchecked(_publish)
 
     def basic_ack(self, delivery_tag: int = 0, multiple: bool = False) -> None:
         """
@@ -553,7 +552,7 @@ class ThreadSafeChannel:
                 LOGGER.warning('basic_ack failed (channel may have closed)',
                                exc_info=True)
 
-        self._wrapper.add_callback_threadsafe(_ack)
+        self._wrapper._schedule_unchecked(_ack)
 
     def basic_nack(self,
                    delivery_tag: int = 0,
@@ -580,7 +579,7 @@ class ThreadSafeChannel:
                 LOGGER.warning('basic_nack failed (channel may have closed)',
                                exc_info=True)
 
-        self._wrapper.add_callback_threadsafe(_nack)
+        self._wrapper._schedule_unchecked(_nack)
 
     def basic_reject(self, delivery_tag: int = 0, requeue: bool = True) -> None:
         """
@@ -602,7 +601,7 @@ class ThreadSafeChannel:
                 LOGGER.warning('basic_reject failed (channel may have closed)',
                                exc_info=True)
 
-        self._wrapper.add_callback_threadsafe(_reject)
+        self._wrapper._schedule_unchecked(_reject)
 
     def basic_qos(self,
                   prefetch_size: int = 0,
@@ -689,7 +688,7 @@ class ThreadSafeChannel:
                 error[0] = exc
                 ready.set()
 
-        self._wrapper.add_callback_threadsafe(_get)
+        self._wrapper._schedule_unchecked(_get)
 
         try:
             if not ready.wait(timeout=timeout):
@@ -735,7 +734,7 @@ class ThreadSafeChannel:
             except Exception:
                 LOGGER.warning('add_on_cancel_callback failed', exc_info=True)
 
-        self._wrapper.add_callback_threadsafe(_register)
+        self._wrapper._schedule_unchecked(_register)
 
     def add_on_return_callback(self, callback) -> None:
         """
@@ -772,7 +771,7 @@ class ThreadSafeChannel:
             except Exception:
                 LOGGER.warning('add_on_return_callback failed', exc_info=True)
 
-        self._wrapper.add_callback_threadsafe(_register)
+        self._wrapper._schedule_unchecked(_register)
 
     def confirm_delivery(self,
                          ack_nack_callback,
@@ -1221,7 +1220,7 @@ class ThreadSafeChannel:
                 error[0] = exc
                 ready.set()
 
-        self._wrapper.add_callback_threadsafe(_close)
+        self._wrapper._schedule_unchecked(_close)
 
         try:
             if not ready.wait(timeout=timeout):
@@ -1745,6 +1744,19 @@ class ThreadSafeConnection:
             reason was recorded.
         """
         self._check_not_closed()
+        self._schedule_unchecked(callback)
+
+    def _schedule_unchecked(self, callback) -> None:
+        """
+        Hand *callback* to the IOLoop without the closed-connection check.
+
+        For internal callers that must not be rejected mid-teardown.  Several channel methods
+        register a waiter before scheduling and unregister it in a ``finally``; raising here would
+        skip that cleanup and leak the waiter, so they check whatever state they care about
+        themselves and then schedule through this method.
+
+        :param callback: Zero-argument callable.
+        """
         self._connection.ioloop.add_callback_threadsafe(callback)
 
     def _check_not_closed(self) -> None:
@@ -1765,14 +1777,9 @@ class ThreadSafeConnection:
             if self._closed_reason is not None:
                 raise self._closed_reason
         if self._connection.is_closed:
-            # Name the calling method by frame introspection rather than having
-            # each caller hand in its own name, which can drift from the method
-            # it labels.  Only the error path pays for it, so callers on the
-            # publish hot path are unaffected.
-            caller = sys._getframe(1).f_code.co_name
             raise ConnectionWrongStateError(
-                f'ThreadSafeConnection.{caller}() called on closed or '
-                f'closing connection.')
+                'ThreadSafeConnection.add_callback_threadsafe() called on '
+                'closed connection.')
 
     def add_on_connection_blocked_callback(self, callback) -> None:
         """

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -23,6 +23,8 @@ from threading import Event
 from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
+    from types import TracebackType
+
     from typing_extensions import Literal, Self
 
 from pika import spec
@@ -72,6 +74,52 @@ def _validate_put_timeout(put_timeout: float) -> float:
             f'work_queue_put_timeout must be a positive number of seconds, '
             f'got {put_timeout!r}')
     return put_timeout
+
+
+def _with_close_traceback(error: BaseException,
+                          close_tb: TracebackType | None) -> BaseException:
+    """
+    Return *error* carrying the traceback it had when the close reason was recorded.
+
+    A ``raise`` appends the raising frames to the exception and leaves them there, which is harmless
+    for an exception that dies with the ``except`` clause that caught it.  The close reason does not:
+    it stays reachable from ``_closed_reason`` for the life of the connection, so every caller that
+    is rejected against a closed connection grows the same instance's traceback, and every appended
+    frame pins that call's arguments - a published message body included.
+
+    Restoring the traceback captured at close time bounds the depth.  Clearing it instead would too,
+    but would discard frames worth keeping, such as the crash site of an exception that killed the
+    IOLoop.  The instance is returned unchanged otherwise, because callers compare what they catch
+    against the reason the connection recorded.
+
+    :param error: The recorded close reason, about to be raised again.
+    :param close_tb: The traceback snapshotted when the reason was recorded.
+    :returns: *error*, with *close_tb* as its traceback.
+    """
+    return error.with_traceback(close_tb)
+
+
+def _reraisable(error: BaseException, close_reason: BaseException | None,
+                close_tb: TracebackType | None) -> BaseException:
+    """
+    Return an exception recorded for a blocking waiter, ready to be raised.
+
+    A waiter woken by the connection closing is handed the shared close reason itself, so raising it
+    grows that instance's traceback the way :func:`_with_close_traceback` avoids.  Any other value
+    was raised for this call alone and is returned untouched - grafting the close-time traceback onto
+    it would misreport where it came from.
+
+    Returns the exception rather than raising it so the ``raise`` stays at the caller's own site,
+    which is the frame worth reporting.
+
+    :param error: The exception recorded for this waiter.
+    :param close_reason: The connection's recorded close reason, if any.
+    :param close_tb: The traceback snapshotted when that reason was recorded.
+    :returns: *error*, with its close-time traceback restored if it is the shared close reason.
+    """
+    if error is not close_reason:
+        return error
+    return _with_close_traceback(error, close_tb)
 
 
 def _submit_or_terminate(pool: _BoundedWorkPool, connection: SelectConnection,
@@ -341,8 +389,10 @@ class ThreadSafeChannel:
         already gone.
         """
         with self._wrapper._channel_waiters_lock:
-            if self._wrapper._closed_reason is not None:
-                raise self._wrapper._closed_reason
+            reason = self._wrapper._closed_reason
+            if reason is not None:
+                raise _with_close_traceback(reason,
+                                            self._wrapper._closed_reason_tb)
 
     @staticmethod
     def _safe_dispatch(label, callback, *args) -> None:
@@ -405,8 +455,10 @@ class ThreadSafeChannel:
         ready = threading.Event()
         error: list[BaseException | None] = [None]
         with self._wrapper._channel_waiters_lock:
-            if self._wrapper._closed_reason is not None:
-                raise self._wrapper._closed_reason
+            reason = self._wrapper._closed_reason
+            if reason is not None:
+                raise _with_close_traceback(reason,
+                                            self._wrapper._closed_reason_tb)
             self._wrapper._blocking_waiters.append((ready, error))
         return ready, error
 
@@ -480,7 +532,8 @@ class ThreadSafeChannel:
             self._unregister_waiter(ready, error)
 
         if error[0] is not None:
-            raise error[0]
+            raise _reraisable(error[0], self._wrapper._closed_reason,
+                              self._wrapper._closed_reason_tb)
         return result[0]
 
     def basic_publish(self,
@@ -698,7 +751,8 @@ class ThreadSafeChannel:
             self._unregister_waiter(ready, error)
 
         if error[0] is not None:
-            raise error[0]
+            raise _reraisable(error[0], self._wrapper._closed_reason,
+                              self._wrapper._closed_reason_tb)
         return tuple(result)
 
     def add_on_cancel_callback(self, callback) -> None:
@@ -1237,7 +1291,8 @@ class ThreadSafeChannel:
             self._unregister_waiter(ready, error)
 
         if error[0] is not None:
-            raise error[0]
+            raise _reraisable(error[0], self._wrapper._closed_reason,
+                              self._wrapper._closed_reason_tb)
 
     def abort(self,
               reply_code: int = 0,
@@ -1387,7 +1442,11 @@ class ThreadSafeConnection:
         self._instance_id = next(self._instance_counter)
 
         self._channel_waiters_lock = threading.Lock()
-        self._closed_reason = None
+        self._closed_reason: BaseException | None = None
+        # The traceback _closed_reason carried when it was recorded.  Raising
+        # the shared instance appends frames to it permanently, so every raise
+        # site restores this snapshot; see _with_close_traceback.
+        self._closed_reason_tb: TracebackType | None = None
         self._blocking_waiters: list[tuple[threading.Event,
                                            list[BaseException | None]]] = []
         self._channels: list[ThreadSafeChannel] = []
@@ -1426,7 +1485,7 @@ class ThreadSafeConnection:
                 LOGGER.exception('IOLoop thread crashed')
                 with self._channel_waiters_lock:
                     if self._closed_reason is None:
-                        self._closed_reason = exc
+                        self._record_closed_reason(exc)
                     for evt, err in self._blocking_waiters:
                         if err[0] is None:
                             err[0] = self._closed_reason
@@ -1487,7 +1546,7 @@ class ThreadSafeConnection:
         # if a pool worker is mid-callback).
         self._connection.ioloop.stop()
         with self._channel_waiters_lock:
-            self._closed_reason = reason
+            self._record_closed_reason(reason)
             for evt, err in self._blocking_waiters:
                 err[0] = reason
                 evt.set()
@@ -1570,8 +1629,9 @@ class ThreadSafeConnection:
         error: list[BaseException | None] = [None]
 
         with self._channel_waiters_lock:
-            if self._closed_reason is not None:
-                raise self._closed_reason
+            reason = self._closed_reason
+            if reason is not None:
+                raise _with_close_traceback(reason, self._closed_reason_tb)
             self._blocking_waiters.append((ready, error))
 
         def _open() -> None:
@@ -1600,15 +1660,17 @@ class ThreadSafeConnection:
                     pass
 
         if error[0] is not None:
-            raise error[0]
+            raise _reraisable(error[0], self._closed_reason,
+                              self._closed_reason_tb)
 
         # Race guard: the connection may have closed on the IOLoop thread
         # after _on_open fired but before we woke up.  Without this check,
         # _shutdown_all_consumer_pools() would have already run and the
         # newly-constructed channel's consumer pool would never be reached.
         with self._channel_waiters_lock:
-            if self._closed_reason is not None:
-                raise self._closed_reason
+            reason = self._closed_reason
+            if reason is not None:
+                raise _with_close_traceback(reason, self._closed_reason_tb)
             ch = ThreadSafeChannel(
                 result[0],
                 self,
@@ -1689,7 +1751,7 @@ class ThreadSafeConnection:
                 'connection force-closed: broker did not respond to close')
             with self._channel_waiters_lock:
                 if self._closed_reason is None:
-                    self._closed_reason = forced
+                    self._record_closed_reason(forced)
                     for evt, err in self._blocking_waiters:
                         if err[0] is None:
                             err[0] = self._closed_reason
@@ -1733,10 +1795,10 @@ class ThreadSafeConnection:
         through the wrapper methods.
 
         Raises rather than accepting work that can never run: once the connection is closed the
-        IOLoop thread has exited, so a queued callback would be silently dropped.
-        :meth:`pika.BlockingConnection.add_callback_threadsafe` likewise refuses a closed
-        connection, though it always reports
-        :class:`~pika.exceptions.ConnectionWrongStateError` where this raises the close reason.
+        IOLoop thread has exited, so a queued callback would be silently dropped.  The caller gets
+        the recorded close reason, the same exception every other method on the connection raises
+        once closed, or a :class:`~pika.exceptions.ConnectionWrongStateError` when no reason was
+        recorded yet.
 
         Calls from the IOLoop thread itself are exempt and never raise, mirroring :meth:`close`.
         A close callback runs on that thread while the connection is already closed, so raising
@@ -1744,10 +1806,10 @@ class ThreadSafeConnection:
         accepted and logged at debug level, but a stopping IOLoop will most likely never run it.
 
         :param callback: Zero-argument callable.
-        :raises Exception: the close reason, if the connection is already closed and this is not
-            the IOLoop thread.
-        :raises pika.exceptions.ConnectionWrongStateError: if the connection is closed but no close
-            reason was recorded, and this is not the IOLoop thread.
+        :raises BaseException: the recorded close reason, if the connection is closed and this is
+            not the IOLoop thread.
+        :raises pika.exceptions.ConnectionWrongStateError: if the connection is closed but no reason
+            was recorded yet, and this is not the IOLoop thread.
         """
         try:
             self._check_not_closed()
@@ -1780,6 +1842,21 @@ class ThreadSafeConnection:
         """
         self._connection.ioloop.add_callback_threadsafe(callback)
 
+    def _record_closed_reason(self, reason: BaseException) -> None:
+        """
+        Record the connection's close reason and the traceback it arrived with.
+
+        Callers must already hold ``_channel_waiters_lock``: the reason and its traceback are read
+        together and must not be seen half-updated.
+
+        :param reason: The exception every blocked caller will be given. A value that is not an
+            exception carries no traceback to snapshot; pika always passes an exception, but
+            ``_on_connection_closed`` is driven by the underlying connection and does not enforce
+            that.
+        """
+        self._closed_reason = reason
+        self._closed_reason_tb = getattr(reason, '__traceback__', None)
+
     def _check_not_closed(self) -> None:
         """
         Raise if the connection is known to be closed.
@@ -1788,15 +1865,21 @@ class ThreadSafeConnection:
         IOLoop, which no amount of locking can prevent.  It catches the case that matters in
         practice - work submitted to a connection the caller already closed.
 
-        :raises Exception: ``_closed_reason`` if one was recorded (the same exception every other
-            :class:`ThreadSafeConnection` method raises once closed).
+        Raises the recorded ``_closed_reason`` itself, the same exception every other method on the
+        class raises once closed, with its close-time traceback restored so re-raising the shared
+        instance does not grow it (see :func:`_with_close_traceback`).  Only when the connection is
+        closed but no reason was recorded yet does it raise a fresh
+        :class:`~pika.exceptions.ConnectionWrongStateError`.
+
+        :raises BaseException: ``_closed_reason`` if one was recorded.
         :raises pika.exceptions.ConnectionWrongStateError: if the underlying connection is closed
             but no reason was recorded yet, which is the brief window between the connection
             reaching the closed state and ``_on_connection_closed`` running.
         """
         with self._channel_waiters_lock:
-            if self._closed_reason is not None:
-                raise self._closed_reason
+            reason = self._closed_reason
+            if reason is not None:
+                raise _with_close_traceback(reason, self._closed_reason_tb)
         if self._connection.is_closed:
             raise ConnectionWrongStateError(
                 'ThreadSafeConnection.add_callback_threadsafe() called on '
@@ -1864,8 +1947,9 @@ class ThreadSafeConnection:
         :param callback: User callback to dispatch on the connection work pool."
         """
         with self._channel_waiters_lock:
-            if self._closed_reason is not None:
-                raise self._closed_reason
+            reason = self._closed_reason
+            if reason is not None:
+                raise _with_close_traceback(reason, self._closed_reason_tb)
 
         def _wrapped(_raw_conn, method_frame) -> None:
             _submit_or_terminate(

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -1738,12 +1738,33 @@ class ThreadSafeConnection:
         connection, though it always reports
         :class:`~pika.exceptions.ConnectionWrongStateError` where this raises the close reason.
 
+        Calls from the IOLoop thread itself are exempt and never raise, mirroring :meth:`close`.
+        A close callback runs on that thread while the connection is already closed, so raising
+        would abort the rest of teardown rather than reach the application.  The callback is
+        accepted and logged at debug level, but a stopping IOLoop will most likely never run it.
+
         :param callback: Zero-argument callable.
-        :raises Exception: the close reason, if the connection is already closed.
+        :raises Exception: the close reason, if the connection is already closed and this is not
+            the IOLoop thread.
         :raises pika.exceptions.ConnectionWrongStateError: if the connection is closed but no close
-            reason was recorded.
+            reason was recorded, and this is not the IOLoop thread.
         """
-        self._check_not_closed()
+        try:
+            self._check_not_closed()
+        except Exception:
+            # Teardown runs on the IOLoop thread: _on_connection_closed records
+            # the close reason and then invokes the user's on_close_callback,
+            # whose natural idiom is to schedule follow-up work.  Raising there
+            # would propagate out through CallbackManager.process and abort the
+            # rest of teardown, so accept the callback from that thread instead.
+            # The IOLoop is already stopping, so the callback most likely will
+            # not run; that beats leaving the connection half torn down.
+            if threading.current_thread() is not self._ioloop_thread:
+                raise
+            LOGGER.debug(
+                'add_callback_threadsafe() called from the IOLoop thread on a '
+                'closed connection; the callback may not run',
+                exc_info=True)
         self._schedule_unchecked(callback)
 
     def _schedule_unchecked(self, callback) -> None:

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import itertools
 import logging
 import queue
+import sys
 import threading
 import time
 from threading import Event
@@ -27,7 +28,7 @@ if TYPE_CHECKING:
 
 from pika import spec
 from pika.adapters.select_connection import SelectConnection
-from pika.exceptions import WorkQueueFullError
+from pika.exceptions import ConnectionWrongStateError, WorkQueueFullError
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1732,9 +1733,46 @@ class ThreadSafeConnection:
         Safe to call from any thread.  Exposed so callers can schedule arbitrary work without going
         through the wrapper methods.
 
+        Raises rather than accepting work that can never run: once the connection is closed the
+        IOLoop thread has exited, so a queued callback would be silently dropped.
+        :meth:`pika.BlockingConnection.add_callback_threadsafe` likewise refuses a closed
+        connection, though it always reports
+        :class:`~pika.exceptions.ConnectionWrongStateError` where this raises the close reason.
+
         :param callback: Zero-argument callable.
+        :raises Exception: the close reason, if the connection is already closed.
+        :raises pika.exceptions.ConnectionWrongStateError: if the connection is closed but no close
+            reason was recorded.
         """
+        self._check_not_closed()
         self._connection.ioloop.add_callback_threadsafe(callback)
+
+    def _check_not_closed(self) -> None:
+        """
+        Raise if the connection is known to be closed.
+
+        Best-effort: the connection may still close between this check and the caller's use of the
+        IOLoop, which no amount of locking can prevent.  It catches the case that matters in
+        practice - work submitted to a connection the caller already closed.
+
+        :raises Exception: ``_closed_reason`` if one was recorded (the same exception every other
+            :class:`ThreadSafeConnection` method raises once closed).
+        :raises pika.exceptions.ConnectionWrongStateError: if the underlying connection is closed
+            but no reason was recorded yet, which is the brief window between the connection
+            reaching the closed state and ``_on_connection_closed`` running.
+        """
+        with self._channel_waiters_lock:
+            if self._closed_reason is not None:
+                raise self._closed_reason
+        if self._connection.is_closed:
+            # Name the calling method by frame introspection rather than having
+            # each caller hand in its own name, which can drift from the method
+            # it labels.  Only the error path pays for it, so callers on the
+            # publish hot path are unaffected.
+            caller = sys._getframe(1).f_code.co_name
+            raise ConnectionWrongStateError(
+                f'ThreadSafeConnection.{caller}() called on closed or '
+                f'closing connection.')
 
     def add_on_connection_blocked_callback(self, callback) -> None:
         """

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -363,8 +363,9 @@ class TestAddCallbackThreadsafeAfterClose(ThreadSafeTestCaseBase):
     add_callback_threadsafe() after a real close() raises and runs nothing.
 
     close() returns only after the IOLoop thread has exited, so a callback accepted afterwards could
-    never run.  The caller gets the close reason (an AMQPConnectionError) rather than silent
-    acceptance, matching what every other method on the connection does once closed.
+    never run.  The caller gets the recorded close reason (an :class:`AMQPConnectionError`), the
+    same exception every other method on the connection raises once closed, rather than silent
+    acceptance.
     """
 
     def test(self):

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -15,6 +15,7 @@ import uuid
 
 import pika
 from pika.adapters.thread_safe_connection import ThreadSafeChannel, ThreadSafeConnection
+from pika.exceptions import AMQPConnectionError
 from tests.misc.forward_server import ForwardServer
 from tests.misc.test_utils import retry_assertion, safe_close
 
@@ -355,6 +356,28 @@ class TestConcurrentClose(ThreadSafeTestCaseBase):
 
         self.assertEqual([], errors)
         self.assertTrue(conn.is_closed)
+
+
+class TestAddCallbackThreadsafeAfterClose(ThreadSafeTestCaseBase):
+    """
+    add_callback_threadsafe() after a real close() raises and runs nothing.
+
+    close() returns only after the IOLoop thread has exited, so a callback accepted afterwards could
+    never run.  The caller gets the close reason (an AMQPConnectionError) rather than silent
+    acceptance, matching what every other method on the connection does once closed.
+    """
+
+    def test(self):
+        conn = self._connect()
+        conn.close()
+        self.assertTrue(conn.is_closed)
+
+        called = threading.Event()
+
+        with self.assertRaises(AMQPConnectionError):
+            conn.add_callback_threadsafe(called.set)
+
+        self.assertFalse(called.is_set())
 
 
 class TestContextManager(ThreadSafeTestCaseBase):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -12,7 +12,12 @@ from pika.adapters.thread_safe_connection import (
     _BoundedWorkPool,
     _submit_or_terminate,
 )
-from pika.exceptions import AMQPConnectionError, WorkQueueFullError
+from pika.exceptions import (
+    AMQPConnectionError,
+    ConnectionClosedByClient,
+    ConnectionWrongStateError,
+    WorkQueueFullError,
+)
 
 
 class SubmitOrTerminateTests(unittest.TestCase):
@@ -2437,6 +2442,44 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         cb = MagicMock()
         conn.add_callback_threadsafe(cb)
         mock_ioloop.add_callback_threadsafe.assert_called_once_with(cb)
+
+    def test_add_callback_threadsafe_raises_after_connection_closed(self):
+        """
+        Scheduling on a closed connection raises the close reason.
+
+        The IOLoop thread is gone once the connection closes, so a callback accepted here would
+        never run.  The caller must be told instead of being left to assume it was scheduled.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+        reason = ConnectionClosedByClient(200, 'Normal shutdown')
+        conn._on_connection_closed(mock_conn, reason)
+        mock_ioloop.add_callback_threadsafe.reset_mock()
+        cb = MagicMock()
+
+        with self.assertRaises(ConnectionClosedByClient) as ctx:
+            conn.add_callback_threadsafe(cb)
+
+        self.assertIs(ctx.exception, reason)
+        mock_ioloop.add_callback_threadsafe.assert_not_called()
+        cb.assert_not_called()
+
+    def test_add_callback_threadsafe_raises_wrong_state_without_close_reason(
+            self):
+        """
+        Closed connection with no recorded reason must still raise.
+
+        Covers the window between the underlying connection reaching the closed state and
+        ``_on_connection_closed`` setting ``_closed_reason``.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+        mock_conn.is_closed = True
+        self.assertIsNone(conn._closed_reason)
+
+        with self.assertRaises(ConnectionWrongStateError) as ctx:
+            conn.add_callback_threadsafe(MagicMock())
+
+        self.assertIn('add_callback_threadsafe', str(ctx.exception))
+        mock_ioloop.add_callback_threadsafe.assert_not_called()
 
     def test_channel_schedules_open_via_add_callback_threadsafe(self):
         conn, mock_conn, mock_ioloop = self._make_connection()

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import threading
+import traceback
 import unittest
 from unittest.mock import ANY, MagicMock, patch
 
@@ -10,7 +11,9 @@ from pika.adapters.thread_safe_connection import (
     ThreadSafeChannel,
     ThreadSafeConnection,
     _BoundedWorkPool,
+    _reraisable,
     _submit_or_terminate,
+    _with_close_traceback,
 )
 from pika.exceptions import (
     AMQPConnectionError,
@@ -66,6 +69,118 @@ class SubmitOrTerminateTests(unittest.TestCase):
         pool.submit.assert_not_called()
         connection._terminate_stream.assert_not_called()
         logger.debug.assert_called_once_with('dropped msg')
+
+
+def _tb_depth(exc):
+    """
+    Count the frames in *exc*'s traceback.
+
+    :param exc: The exception to measure.
+    :returns: Number of traceback frames.
+    """
+    depth, tb = 0, exc.__traceback__
+    while tb is not None:
+        depth += 1
+        tb = tb.tb_next
+    return depth
+
+
+def _raised(exc):
+    """
+    Give *exc* a traceback by raising and catching it.
+
+    :param exc: The exception to raise.
+    :returns: *exc*, now carrying a traceback.
+    """
+    try:
+        raise exc
+    except BaseException as caught:
+        return caught
+
+
+@contextlib.contextmanager
+def _expect_raised(test, exc_type):
+    """
+    Assert the block raises *exc_type*, leaving the exception's traceback intact.
+
+    :meth:`unittest.TestCase.assertRaises` calls ``with_traceback(None)`` on what it catches, which
+    erases exactly what the traceback-growth tests measure and makes them pass vacuously.
+
+    :param test: The test case, used to fail when nothing is raised.
+    :param exc_type: The exception type expected.
+    :yields: A list that receives the caught exception.
+    """
+    caught = []
+    try:
+        yield caught
+    except exc_type as exc:
+        caught.append(exc)
+    if not caught:
+        test.fail(f'{exc_type.__name__} not raised')
+
+
+class CloseTracebackHelperTests(unittest.TestCase):
+    """Tests for the helpers that keep the shared close reason's traceback bounded."""
+
+    def test_with_close_traceback_bounds_repeated_raises(self):
+        """
+        Re-raising through the helper must land at the same depth every time.
+
+        A raise still appends its own frames, so the depth after one raise exceeds the snapshot;
+        what matters is that the next raise starts from the snapshot again instead of from the grown
+        traceback, which is what makes the depth stable rather than unbounded.
+        """
+        reason = _raised(Exception('closed'))
+        close_tb = reason.__traceback__
+
+        with _expect_raised(self, Exception):
+            raise _with_close_traceback(reason, close_tb)
+        after_first = _tb_depth(reason)
+
+        for _ in range(50):
+            with _expect_raised(self, Exception):
+                raise _with_close_traceback(reason, close_tb)
+
+        self.assertEqual(_tb_depth(reason), after_first)
+
+    def test_with_close_traceback_preserves_the_recorded_frames(self):
+        """The snapshot must keep the frames that show where the connection died."""
+
+        def ioloop_crash_site():
+            raise RuntimeError('ioloop died')
+
+        try:
+            ioloop_crash_site()
+        except RuntimeError as exc:
+            reason = exc
+        close_tb = reason.__traceback__
+
+        with _expect_raised(self, RuntimeError):
+            raise _with_close_traceback(reason, close_tb)
+
+        frames = [f.name for f in traceback.extract_tb(reason.__traceback__)]
+        self.assertIn('ioloop_crash_site', frames)
+
+    def test_reraisable_resets_only_the_shared_close_reason(self):
+        """The close reason gets its snapshot back; a per-call exception is returned untouched."""
+        reason = _raised(Exception('closed'))
+        close_tb = reason.__traceback__
+
+        self.assertIs(_reraisable(reason, reason, close_tb), reason)
+        self.assertIs(reason.__traceback__, close_tb)
+
+        own = _raised(ValueError('this call only'))
+        own_tb = own.__traceback__
+        self.assertIs(_reraisable(own, reason, close_tb), own)
+        self.assertIs(own.__traceback__, own_tb)
+
+    def test_reraisable_leaves_a_traceback_free_error_alone(self):
+        """A per-call exception that never propagated must not gain the close-time frames."""
+        reason = _raised(Exception('closed'))
+        own = ValueError('never raised')
+
+        self.assertIsNone(
+            _reraisable(own, reason, reason.__traceback__).__traceback__)
 
 
 class BoundedWorkPoolTests(unittest.TestCase):
@@ -346,6 +461,9 @@ class ThreadSafeChannelTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -499,6 +617,70 @@ class ThreadSafeChannelTests(unittest.TestCase):
 
         self.assertIs(ctx.exception, reason)
         wrapper._schedule_unchecked.assert_not_called()
+
+    def test_basic_publish_does_not_grow_close_reason_traceback(self):
+        """
+        Publishing into a closed connection must not accumulate frames on the shared close reason.
+
+        The reason stays reachable from ``_closed_reason`` for the life of the connection, so each
+        appended frame is permanent and pins that call's ``body``.
+        """
+        ch, _raw_ch, wrapper = self._make_channel()
+        reason = _raised(Exception('closed'))
+        wrapper._closed_reason = reason
+        wrapper._closed_reason_tb = reason.__traceback__
+
+        with _expect_raised(self, Exception):
+            ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
+        after_first = _tb_depth(reason)
+
+        for _ in range(50):
+            with _expect_raised(self, Exception):
+                ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
+
+        self.assertEqual(_tb_depth(reason), after_first)
+
+    def test_blocking_method_does_not_grow_close_reason_traceback(self):
+        """
+        A waiter woken by the close reason must not append frames to it either.
+
+        ``queue_declare`` gets the shared instance through ``error[0]``, so raising it directly
+        would grow it once per blocked caller.  Only the first call takes that path; once the reason
+        is recorded, later calls are rejected by the pre-registration guard instead, so the depth is
+        sampled after both paths have run once.
+        """
+        ch, _raw_ch, wrapper = self._make_channel()
+        reason = _raised(Exception('connection lost'))
+
+        def close_while_waiting(_cb):
+            with wrapper._channel_waiters_lock:
+                if wrapper._closed_reason is None:
+                    # _record_closed_reason snapshots the traceback once, at
+                    # close time; re-snapshotting here would capture a grown
+                    # one and mask the growth this test looks for.
+                    wrapper._closed_reason = reason
+                    wrapper._closed_reason_tb = reason.__traceback__
+                for evt, err in wrapper._blocking_waiters:
+                    err[0] = reason
+                    evt.set()
+                wrapper._blocking_waiters.clear()
+
+        wrapper._schedule_unchecked.side_effect = close_while_waiting
+
+        # First call: woken by the close reason through error[0].
+        with _expect_raised(self, Exception) as caught:
+            ch.queue_declare(queue='q')
+        self.assertIs(caught[0], reason)
+        # Second call: rejected up front, now that the reason is recorded.
+        with _expect_raised(self, Exception):
+            ch.queue_declare(queue='q')
+        settled = _tb_depth(reason)
+
+        for _ in range(50):
+            with _expect_raised(self, Exception):
+                ch.queue_declare(queue='q')
+
+        self.assertEqual(_tb_depth(reason), settled)
 
     def test_basic_ack_raises_when_connection_already_closed(self):
         ch, _raw_ch, wrapper = self._make_channel()
@@ -926,6 +1108,9 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -1433,6 +1618,9 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -1602,6 +1790,9 @@ class BlockingRPCPassthroughTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -1702,6 +1893,9 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -1755,6 +1949,9 @@ class BasicGetTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -1838,6 +2035,9 @@ class ChannelCloseErrorPathTests(unittest.TestCase):
         raw_ch.is_closing = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -1886,6 +2086,9 @@ class CallbackRegistrationFailureTests(unittest.TestCase):
         raw_ch.is_closed = False
         wrapper = MagicMock()
         wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
         wrapper._channel_waiters_lock = threading.Lock()
         wrapper._blocking_waiters = []
         # A healthy connection has no pending error; _submit_or_terminate
@@ -2446,7 +2649,9 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         Scheduling on a closed connection raises the close reason.
 
         The IOLoop thread is gone once the connection closes, so a callback accepted here would
-        never run.  The caller must be told instead of being left to assume it was scheduled.
+        never run.  The caller must be told instead of being left to assume it was scheduled.  The
+        reported exception is ``_closed_reason`` itself, the same exception every other method on
+        the connection raises once closed.
         """
         conn, mock_conn, mock_ioloop = self._make_connection()
         reason = ConnectionClosedByClient(200, 'Normal shutdown')
@@ -2460,6 +2665,52 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         self.assertIs(ctx.exception, reason)
         mock_ioloop.add_callback_threadsafe.assert_not_called()
         cb.assert_not_called()
+
+    def test_add_callback_threadsafe_does_not_grow_close_reason_traceback(self):
+        """
+        Repeated rejections must not accumulate tracebacks on the close reason.
+
+        ``add_callback_threadsafe`` re-raises the shared ``_closed_reason`` like every other method
+        here, so bounding its depth depends on restoring the close-time traceback rather than on
+        raising something fresh.  Without that, each rejection would append a frame to the shared
+        instance and keep that call's arguments alive.
+        """
+        conn, mock_conn, _mock_ioloop = self._make_connection()
+        reason = ConnectionClosedByClient(200, 'Normal shutdown')
+        conn._on_connection_closed(mock_conn, reason)
+
+        with _expect_raised(self, ConnectionClosedByClient) as caught:
+            conn.add_callback_threadsafe(MagicMock())
+        self.assertIs(caught[0], reason)
+        after_first = _tb_depth(reason)
+
+        for _ in range(50):
+            with _expect_raised(self, ConnectionClosedByClient):
+                conn.add_callback_threadsafe(MagicMock())
+
+        self.assertEqual(_tb_depth(reason), after_first)
+
+    def test_channel_does_not_grow_close_reason_traceback(self):
+        """
+        ``channel()`` on a closed connection re-raises the close reason, so it must not grow it.
+
+        Like every method here, this path raises ``_closed_reason`` itself.  Bounding it depends on
+        restoring the traceback captured at close time rather than on raising something fresh.
+        """
+        conn, mock_conn, _mock_ioloop = self._make_connection()
+        reason = ConnectionClosedByClient(200, 'Normal shutdown')
+        conn._on_connection_closed(mock_conn, reason)
+
+        with _expect_raised(self, ConnectionClosedByClient) as caught:
+            conn.channel()
+        self.assertIs(caught[0], reason)
+        after_first = _tb_depth(reason)
+
+        for _ in range(50):
+            with _expect_raised(self, ConnectionClosedByClient):
+                conn.channel()
+
+        self.assertEqual(_tb_depth(reason), after_first)
 
     def test_add_callback_threadsafe_raises_wrong_state_without_close_reason(
             self):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -353,10 +353,10 @@ class ThreadSafeChannelTests(unittest.TestCase):
         wrapper._connection._error = None
         return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
 
-    def test_basic_publish_routes_through_add_callback_threadsafe(self):
+    def test_basic_publish_routes_through_schedule_unchecked(self):
         ch, _raw_ch, wrapper = self._make_channel()
         ch.basic_publish(exchange='ex', routing_key='rk', body=b'hello')
-        wrapper.add_callback_threadsafe.assert_called_once()
+        wrapper._schedule_unchecked.assert_called_once()
 
     def test_basic_publish_does_not_call_raw_channel_directly(self):
         ch, raw_ch, _wrapper = self._make_channel()
@@ -371,7 +371,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
                          properties='props',
                          mandatory=True)
         # Extract and invoke the scheduled callback manually
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()
         raw_ch.basic_publish.assert_called_once_with(
             exchange='ex',
@@ -390,7 +390,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         raw_ch.basic_publish.side_effect = ChannelWrongStateError(
             'channel closed')
         ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()  # must not raise
         raw_ch.basic_publish.assert_called_once()
 
@@ -404,7 +404,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
                          routing_key='rk',
                          body=b'x',
                          on_publish=on_publish)
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()
         raw_ch.basic_publish.assert_called_once()
         on_publish.assert_not_called()
@@ -420,17 +420,17 @@ class ThreadSafeChannelTests(unittest.TestCase):
                          routing_key='rk',
                          body=b'a',
                          on_publish=lambda tag: tags.append(tag))
-        wrapper.add_callback_threadsafe.call_args[0][0]()
+        wrapper._schedule_unchecked.call_args[0][0]()
         ch.basic_publish(exchange='ex',
                          routing_key='rk',
                          body=b'b',
                          on_publish=lambda tag: tags.append(tag))
-        wrapper.add_callback_threadsafe.call_args[0][0]()
+        wrapper._schedule_unchecked.call_args[0][0]()
         ch.basic_publish(exchange='ex',
                          routing_key='rk',
                          body=b'c',
                          on_publish=lambda tag: tags.append(tag))
-        wrapper.add_callback_threadsafe.call_args[0][0]()
+        wrapper._schedule_unchecked.call_args[0][0]()
         self.assertEqual(tags, [1, 2, 3])
 
     def test_on_publish_not_called_when_publish_raises(self):
@@ -446,7 +446,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
                          routing_key='rk',
                          body=b'x',
                          on_publish=on_publish)
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()  # must not raise
         on_publish.assert_not_called()
         self.assertEqual(ch._next_publish_seq_no, 0)
@@ -461,7 +461,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         ch, _raw_ch, wrapper = self._make_channel()
         ch._next_publish_seq_no = 0
         ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
-        wrapper.add_callback_threadsafe.call_args[0][0]()
+        wrapper._schedule_unchecked.call_args[0][0]()
         self.assertEqual(ch._next_publish_seq_no, 1)
 
     def test_basic_ack_callback_swallows_channel_wrong_state_error(self):
@@ -469,7 +469,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.basic_ack.side_effect = ChannelWrongStateError('channel closed')
         ch.basic_ack(delivery_tag=1)
-        wrapper.add_callback_threadsafe.call_args[0][0]()  # must not raise
+        wrapper._schedule_unchecked.call_args[0][0]()  # must not raise
         raw_ch.basic_ack.assert_called_once()
 
     def test_basic_nack_callback_swallows_channel_wrong_state_error(self):
@@ -477,7 +477,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.basic_nack.side_effect = ChannelWrongStateError('channel closed')
         ch.basic_nack(delivery_tag=1)
-        wrapper.add_callback_threadsafe.call_args[0][0]()  # must not raise
+        wrapper._schedule_unchecked.call_args[0][0]()  # must not raise
         raw_ch.basic_nack.assert_called_once()
 
     def test_basic_reject_callback_swallows_channel_wrong_state_error(self):
@@ -486,7 +486,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         raw_ch.basic_reject.side_effect = ChannelWrongStateError(
             'channel closed')
         ch.basic_reject(delivery_tag=1)
-        wrapper.add_callback_threadsafe.call_args[0][0]()  # must not raise
+        wrapper._schedule_unchecked.call_args[0][0]()  # must not raise
         raw_ch.basic_reject.assert_called_once()
 
     def test_basic_publish_raises_when_connection_already_closed(self):
@@ -498,7 +498,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
     def test_basic_ack_raises_when_connection_already_closed(self):
         ch, _raw_ch, wrapper = self._make_channel()
@@ -509,7 +509,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             ch.basic_ack(delivery_tag=1)
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
     def test_basic_nack_raises_when_connection_already_closed(self):
         ch, _raw_ch, wrapper = self._make_channel()
@@ -520,7 +520,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             ch.basic_nack(delivery_tag=1)
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
     def test_basic_reject_raises_when_connection_already_closed(self):
         ch, _raw_ch, wrapper = self._make_channel()
@@ -531,46 +531,46 @@ class ThreadSafeChannelTests(unittest.TestCase):
             ch.basic_reject(delivery_tag=1)
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
-    def test_basic_ack_routes_through_add_callback_threadsafe(self):
+    def test_basic_ack_routes_through_schedule_unchecked(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.basic_ack(delivery_tag=42, multiple=True)
-        wrapper.add_callback_threadsafe.assert_called_once()
+        wrapper._schedule_unchecked.assert_called_once()
         raw_ch.basic_ack.assert_not_called()
 
     def test_basic_ack_callback_calls_raw_channel(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.basic_ack(delivery_tag=42, multiple=True)
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()
         raw_ch.basic_ack.assert_called_once_with(delivery_tag=42, multiple=True)
 
-    def test_basic_nack_routes_through_add_callback_threadsafe(self):
+    def test_basic_nack_routes_through_schedule_unchecked(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.basic_nack(delivery_tag=7, multiple=False, requeue=False)
-        wrapper.add_callback_threadsafe.assert_called_once()
+        wrapper._schedule_unchecked.assert_called_once()
         raw_ch.basic_nack.assert_not_called()
 
     def test_basic_nack_callback_calls_raw_channel(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.basic_nack(delivery_tag=7, multiple=False, requeue=False)
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()
         raw_ch.basic_nack.assert_called_once_with(delivery_tag=7,
                                                   multiple=False,
                                                   requeue=False)
 
-    def test_basic_reject_routes_through_add_callback_threadsafe(self):
+    def test_basic_reject_routes_through_schedule_unchecked(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.basic_reject(delivery_tag=3, requeue=False)
-        wrapper.add_callback_threadsafe.assert_called_once()
+        wrapper._schedule_unchecked.assert_called_once()
         raw_ch.basic_reject.assert_not_called()
 
     def test_basic_reject_callback_calls_raw_channel(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.basic_reject(delivery_tag=3, requeue=False)
-        scheduled_cb = wrapper.add_callback_threadsafe.call_args[0][0]
+        scheduled_cb = wrapper._schedule_unchecked.call_args[0][0]
         scheduled_cb()
         raw_ch.basic_reject.assert_called_once_with(delivery_tag=3,
                                                     requeue=False)
@@ -588,7 +588,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             raw_ch.queue_declare.side_effect = fake_queue_declare
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         result = ch.queue_declare(queue='my_queue', durable=True)
 
@@ -612,7 +612,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             ch.queue_declare(queue='my_queue')
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
     def test_queue_declare_raises_when_connection_closes_while_waiting(self):
         ch, _raw_ch, wrapper = self._make_channel()
@@ -627,7 +627,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
                     evt.set()
                 wrapper._blocking_waiters.clear()
 
-        wrapper.add_callback_threadsafe.side_effect = close_while_waiting
+        wrapper._schedule_unchecked.side_effect = close_while_waiting
 
         with self.assertRaises(Exception) as ctx:
             ch.queue_declare(queue='my_queue')
@@ -646,7 +646,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             raw_ch.basic_qos.side_effect = fake_qos
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         result = ch.basic_qos(prefetch_count=10)
 
@@ -682,7 +682,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         tag = ch.basic_consume(queue='q', on_message_callback=MagicMock())
 
@@ -708,7 +708,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.basic_consume(queue='q', on_message_callback=my_callback)
 
@@ -741,7 +741,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             raw_ch.basic_cancel.side_effect = fake_cancel
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         result = ch.basic_cancel('ctag1')
 
@@ -774,7 +774,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
                 0](raw_ch, ChannelClosedByClient(reply_code, reply_text))
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.close()  # must not raise
 
@@ -798,7 +798,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         def execute_immediately(cb):
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+        wrapper._schedule_unchecked.side_effect = execute_immediately
 
         ch.close()  # must not raise; channel is already closed
 
@@ -819,7 +819,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         def execute_immediately(cb):
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+        wrapper._schedule_unchecked.side_effect = execute_immediately
 
         ch.abort(reply_code=320, reply_text='shutting down', timeout=5)
         # Verify the close path ran (work pool was shut down via close())
@@ -833,7 +833,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         def execute_immediately(cb):
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+        wrapper._schedule_unchecked.side_effect = execute_immediately
 
         # Wedge the consumer worker in a never-releasing callback so the pool
         # cannot drain and exit.
@@ -872,7 +872,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         def execute_immediately(cb):
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+        wrapper._schedule_unchecked.side_effect = execute_immediately
 
         ch.close(timeout=None)
         self.assertTrue(ch._pool_shutdown)
@@ -899,7 +899,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
             with scheduled_lock:
                 scheduled.append(cb)
 
-        wrapper.add_callback_threadsafe.side_effect = record
+        wrapper._schedule_unchecked.side_effect = record
 
         barrier = threading.Barrier(n)
 
@@ -955,7 +955,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.basic_consume(queue='q', on_message_callback=my_callback)
         ch._consumer_work_pool.shutdown(wait=True)
@@ -985,7 +985,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.basic_consume(queue='q', on_message_callback=my_callback)
         ch._consumer_work_pool.shutdown(wait=True)
@@ -1017,7 +1017,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.basic_consume(queue='q', on_message_callback=my_callback)
         ch._consumer_work_pool.shutdown(wait=True)
@@ -1062,7 +1062,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
                     -1](raw_ch, ChannelClosedByClient(reply_code, reply_text))
                 cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.basic_consume(queue='q', on_message_callback=slow_callback)
         ch.close()
@@ -1098,7 +1098,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         with patch(
                 'pika.adapters.thread_safe_connection.LOGGER') as mock_logger:
@@ -1125,7 +1125,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.basic_consume.side_effect = fake_consume
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.basic_consume(queue='q', on_message_callback=MagicMock())
 
@@ -1140,11 +1140,10 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         ch._shutdown_pool()
         ch._shutdown_pool()  # second call must be a no-op
 
-    def test_add_on_return_callback_routes_through_add_callback_threadsafe(
-            self):
+    def test_add_on_return_callback_routes_through_schedule_unchecked(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.add_on_return_callback(MagicMock())
-        wrapper.add_callback_threadsafe.assert_called_once()
+        wrapper._schedule_unchecked.assert_called_once()
         raw_ch.add_on_return_callback.assert_not_called()
 
     def test_add_on_return_callback_registers_on_raw_channel(self):
@@ -1153,7 +1152,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         def execute_immediately(cb):
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+        wrapper._schedule_unchecked.side_effect = execute_immediately
 
         ch.add_on_return_callback(MagicMock())
         raw_ch.add_on_return_callback.assert_called_once()
@@ -1175,7 +1174,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             # Simulate the broker returning a message
             wrapped(raw_ch, 'method', 'props', b'returned-body')
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.add_on_return_callback(user_cb)
         ch._consumer_work_pool.shutdown(wait=True)
@@ -1196,7 +1195,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             cb()
             wrapped_holder.append(raw_ch.add_on_return_callback.call_args[0][0])
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.add_on_return_callback(MagicMock())
         ch._shutdown_pool()
@@ -1212,13 +1211,12 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             ch.add_on_return_callback(MagicMock())
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
-    def test_add_on_cancel_callback_routes_through_add_callback_threadsafe(
-            self):
+    def test_add_on_cancel_callback_routes_through_schedule_unchecked(self):
         ch, raw_ch, wrapper = self._make_channel()
         ch.add_on_cancel_callback(MagicMock())
-        wrapper.add_callback_threadsafe.assert_called_once()
+        wrapper._schedule_unchecked.assert_called_once()
         raw_ch.add_on_cancel_callback.assert_not_called()
 
     def test_add_on_cancel_callback_registers_on_raw_channel(self):
@@ -1227,7 +1225,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         def execute_immediately(cb):
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_immediately
+        wrapper._schedule_unchecked.side_effect = execute_immediately
 
         ch.add_on_cancel_callback(MagicMock())
         raw_ch.add_on_cancel_callback.assert_called_once()
@@ -1247,7 +1245,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             wrapped = raw_ch.add_on_cancel_callback.call_args[0][0]
             wrapped('cancel-frame')
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.add_on_cancel_callback(user_cb)
         ch._consumer_work_pool.shutdown(wait=True)
@@ -1264,7 +1262,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             cb()
             wrapped_holder.append(raw_ch.add_on_cancel_callback.call_args[0][0])
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         ch.add_on_cancel_callback(MagicMock())
         ch._shutdown_pool()
@@ -1279,7 +1277,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             ch.add_on_cancel_callback(MagicMock())
 
         self.assertIs(ctx.exception, reason)
-        wrapper.add_callback_threadsafe.assert_not_called()
+        wrapper._schedule_unchecked.assert_not_called()
 
     def test_return_listener_exception_is_logged_not_lost(self):
         """An exception raised inside a return listener must be logged (not silently dropped on an
@@ -1295,7 +1293,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             wrapped = raw_ch.add_on_return_callback.call_args[0][0]
             wrapped(raw_ch, 'method', 'props', b'body')
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         with self.assertLogs('pika.adapters.thread_safe_connection',
                              level='ERROR') as cm:
@@ -1317,7 +1315,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             wrapped = raw_ch.add_on_cancel_callback.call_args[0][0]
             wrapped('cancel-frame')
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         with self.assertLogs('pika.adapters.thread_safe_connection',
                              level='ERROR') as cm:
@@ -1344,7 +1342,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.confirm_delivery.side_effect = fake_confirm
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         with self.assertLogs('pika.adapters.thread_safe_connection',
                              level='ERROR') as cm:
@@ -1372,7 +1370,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.confirm_delivery.side_effect = fake_confirm
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
         ch.confirm_delivery(MagicMock())
         self.assertEqual(ch._next_publish_seq_no, 0)
 
@@ -1391,7 +1389,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
             raw_ch.confirm_delivery.side_effect = fake_confirm
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         result1 = ch.confirm_delivery(MagicMock())
         self.assertIs(result1, ok_frame)
@@ -1403,7 +1401,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         self.assertIs(result2, ok_frame)
         self.assertEqual(ch._next_publish_seq_no, 5)
         # Only one RPC should have been sent
-        self.assertEqual(wrapper.add_callback_threadsafe.call_count, 1)
+        self.assertEqual(wrapper._schedule_unchecked.call_count, 1)
 
     def test_next_publish_seq_no_property_none_before_confirms(self):
         """next_publish_seq_no returns None when confirms are not enabled."""
@@ -1421,7 +1419,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         ch, _raw_ch, wrapper = self._make_channel()
         ch._next_publish_seq_no = 0
         ch.basic_publish(exchange='ex', routing_key='rk', body=b'x')
-        wrapper.add_callback_threadsafe.call_args[0][0]()
+        wrapper._schedule_unchecked.call_args[0][0]()
         self.assertEqual(ch.next_publish_seq_no, 2)
 
 
@@ -1451,7 +1449,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.queue_declare = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         with self.assertRaises(TimeoutError) as ctx:
             ch.queue_declare(queue='q', timeout=0.05)
@@ -1466,7 +1464,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.basic_qos = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         with self.assertRaises(TimeoutError) as ctx:
             ch.basic_qos(prefetch_count=1, timeout=0.05)
@@ -1481,7 +1479,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.basic_consume = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         with self.assertRaises(TimeoutError) as ctx:
             ch.basic_consume(queue='q',
@@ -1498,7 +1496,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.basic_cancel = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         with self.assertRaises(TimeoutError) as ctx:
             ch.basic_cancel('ctag1', timeout=0.05)
@@ -1516,7 +1514,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.close = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         # Must not raise - close() treats timeout as "channel is dead"
         ch.close(timeout=0.05)
@@ -1534,7 +1532,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.basic_qos.side_effect = fake_qos
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = execute_and_fire
+        wrapper._schedule_unchecked.side_effect = execute_and_fire
 
         result = ch.basic_qos(prefetch_count=1)
         self.assertIs(result, mock_frame)
@@ -1548,7 +1546,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.queue_declare = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         with self.assertRaises(TimeoutError):
             ch.queue_declare(queue='q', timeout=0.05)
@@ -1565,7 +1563,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.basic_get = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         with self.assertRaises(TimeoutError):
             ch.basic_get(queue='q', timeout=0.05)
@@ -1583,7 +1581,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
             raw_ch.close = MagicMock()
             cb()
 
-        wrapper.add_callback_threadsafe.side_effect = never_respond
+        wrapper._schedule_unchecked.side_effect = never_respond
 
         ch.close(timeout=0.05)
         self.assertEqual(wrapper._blocking_waiters, [])
@@ -1623,7 +1621,7 @@ class BlockingRPCPassthroughTests(unittest.TestCase):
             kwargs['callback'](mock_frame)
 
         getattr(raw_ch, raw_method).side_effect = fake_method
-        wrapper.add_callback_threadsafe.side_effect = execute
+        wrapper._schedule_unchecked.side_effect = execute
         return ch, raw_ch, wrapper, mock_frame
 
     def test_exchange_declare_returns_method_frame(self):
@@ -1715,7 +1713,7 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
         ch, raw_ch, wrapper = self._make_channel()
         boom = RuntimeError('connection torn down')
         raw_ch.queue_declare.side_effect = boom
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         with self.assertRaises(RuntimeError) as ctx:
             ch.queue_declare(queue='q', timeout=0.5)
@@ -1740,7 +1738,7 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
             captured_close_cb['cb'](raw_ch, reason)
 
         raw_ch.queue_declare.side_effect = fire_close
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         with self.assertRaises(Exception) as ctx:
             ch.queue_declare(queue='q', timeout=0.5)
@@ -1771,7 +1769,7 @@ class BasicGetTests(unittest.TestCase):
             kwargs['callback'](raw_ch, 'method', 'props', b'body')
 
         raw_ch.basic_get.side_effect = fire_get_ok
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         method, properties, body = ch.basic_get(queue='q', timeout=0.5)
         self.assertEqual(method, 'method')
@@ -1793,7 +1791,7 @@ class BasicGetTests(unittest.TestCase):
             captured_empty_cb['cb']('empty-frame')
 
         raw_ch.basic_get.side_effect = fire_empty
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         result = ch.basic_get(queue='q', timeout=0.5)
         self.assertEqual(result, (None, None, None))
@@ -1802,7 +1800,7 @@ class BasicGetTests(unittest.TestCase):
         ch, raw_ch, wrapper = self._make_channel()
         boom = RuntimeError('basic_get raised')
         raw_ch.basic_get.side_effect = boom
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         with self.assertRaises(RuntimeError) as ctx:
             ch.basic_get(queue='q', timeout=0.5)
@@ -1822,7 +1820,7 @@ class BasicGetTests(unittest.TestCase):
             captured_close_cb['cb'](raw_ch, reason)
 
         raw_ch.basic_get.side_effect = fire_close
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         with self.assertRaises(Exception) as ctx:
             ch.basic_get(queue='q', timeout=0.5)
@@ -1861,7 +1859,7 @@ class ChannelCloseErrorPathTests(unittest.TestCase):
             captured_close_cb['cb'](raw_ch, reason)
 
         raw_ch.close.side_effect = fire_close
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         with self.assertRaises(Exception) as ctx:
             ch.close(timeout=0.5)
@@ -1871,7 +1869,7 @@ class ChannelCloseErrorPathTests(unittest.TestCase):
         ch, raw_ch, wrapper = self._make_channel()
         boom = RuntimeError('close raised')
         raw_ch.close.side_effect = boom
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
 
         with self.assertRaises(RuntimeError) as ctx:
             ch.close(timeout=0.5)
@@ -1898,7 +1896,7 @@ class CallbackRegistrationFailureTests(unittest.TestCase):
     def test_add_on_cancel_callback_logs_when_raw_register_raises(self):
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.add_on_cancel_callback.side_effect = RuntimeError('boom')
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
         with patch(
                 'pika.adapters.thread_safe_connection.LOGGER') as mock_logger:
             ch.add_on_cancel_callback(MagicMock())
@@ -1909,7 +1907,7 @@ class CallbackRegistrationFailureTests(unittest.TestCase):
     def test_add_on_return_callback_logs_when_raw_register_raises(self):
         ch, raw_ch, wrapper = self._make_channel()
         raw_ch.add_on_return_callback.side_effect = RuntimeError('boom')
-        wrapper.add_callback_threadsafe.side_effect = lambda cb: cb()
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
         with patch(
                 'pika.adapters.thread_safe_connection.LOGGER') as mock_logger:
             ch.add_on_return_callback(MagicMock())

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2644,6 +2644,25 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         conn.add_callback_threadsafe(cb)
         mock_ioloop.add_callback_threadsafe.assert_called_once_with(cb)
 
+    def test_schedule_unchecked_bypasses_closed_connection_guard(self):
+        """
+        ``_schedule_unchecked`` must hand the callback straight to the IOLoop even when closed.
+
+        Channel methods register a waiter and then schedule through this method, unregistering in a
+        ``finally``.  If it applied the closed-connection guard, the raise would jump over that
+        cleanup and leak the waiter, so the guard belongs only on the public
+        ``add_callback_threadsafe``.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+        conn._on_connection_closed(mock_conn,
+                                   ConnectionClosedByClient(200, 'shutdown'))
+        mock_ioloop.add_callback_threadsafe.reset_mock()
+        cb = MagicMock()
+
+        conn._schedule_unchecked(cb)
+
+        mock_ioloop.add_callback_threadsafe.assert_called_once_with(cb)
+
     def test_add_callback_threadsafe_raises_after_connection_closed(self):
         """
         Scheduling on a closed connection raises the close reason.
@@ -2729,6 +2748,30 @@ class ThreadSafeConnectionTests(unittest.TestCase):
 
         self.assertIn('add_callback_threadsafe', str(ctx.exception))
         mock_ioloop.add_callback_threadsafe.assert_not_called()
+
+    def test_add_callback_threadsafe_from_ioloop_thread_is_exempt(self):
+        """
+        A callback scheduled from the IOLoop thread on a closed connection must be accepted.
+
+        ``_on_connection_closed`` records the reason and then runs the user close callback on the
+        IOLoop thread; scheduling follow-up work from there is the natural idiom.  Raising would
+        propagate out through ``CallbackManager.process`` and abort the rest of teardown, so the
+        IOLoop thread is exempt even though the callback most likely will not run.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+        reason = ConnectionClosedByClient(200, 'Normal shutdown')
+        conn._on_connection_closed(mock_conn, reason)
+        mock_ioloop.add_callback_threadsafe.reset_mock()
+        # Make current_thread() is self._ioloop_thread true.
+        conn._ioloop_thread = threading.current_thread()
+        cb = MagicMock()
+
+        with patch(
+                'pika.adapters.thread_safe_connection.LOGGER') as mock_logger:
+            conn.add_callback_threadsafe(cb)
+
+        mock_ioloop.add_callback_threadsafe.assert_called_once_with(cb)
+        mock_logger.debug.assert_called_once()
 
     def test_channel_schedules_open_via_add_callback_threadsafe(self):
         conn, mock_conn, mock_ioloop = self._make_connection()


### PR DESCRIPTION
## Proposed Changes

`ThreadSafeConnection.add_callback_threadsafe` accepted work on a closed connection and then silently discarded it. The method delegated straight to the IOLoop:

```python
self._connection.ioloop.add_callback_threadsafe(callback)
```

Once the connection is closed the IOLoop thread has already exited, so the callback lands in a deque nobody drains. The caller got no error and the callback never ran, as reported in #1679:

```python
conn = pika.ThreadSafeConnection(pika.ConnectionParameters())
conn.close()
conn.add_callback_threadsafe(hello)  # accepted, never called, no error
```

Every other public method on the class already guards against this (`basic_publish`, `basic_ack` and friends via `ThreadSafeChannel._check_not_closed`, plus `channel()` and the blocked/unblocked registrars inline). `add_callback_threadsafe` was the one entry point that did not, which made it the only way to lose work without being told.

This adds a `ThreadSafeConnection._check_not_closed` helper and calls it at the top of `add_callback_threadsafe`. It raises in two cases:

- `_closed_reason` is set, so it re-raises that. This is deliberately the same exception the rest of the class raises once closed (for example `ConnectionClosedByClient`), rather than introducing a different error type for this one method.
- `_closed_reason` is still `None` but the underlying connection has reached the closed state, so it raises `ConnectionWrongStateError` with a message mirroring `BlockingConnection`'s. That covers the brief window on the IOLoop thread between the connection closing and `_on_connection_closed` recording the reason, and the force-close path where `_closed_reason` is set while the transport is still closing.

The helper names the calling method by frame introspection (`sys._getframe(1).f_code.co_name`) instead of taking a hand-passed string, so the message cannot drift from the method it labels. That lookup sits inside the error branch, so nothing on the publish hot path pays for it.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1679

## Further Comments

### Tests

Unit tests in `tests/unit/thread_safe_connection_tests.py`, one per branch of the guard:

- after `_on_connection_closed` fires, the recorded close reason is re-raised, and the callback is neither scheduled on the IOLoop nor invoked
- a closed connection with no recorded reason raises `ConnectionWrongStateError`, asserting the message names `add_callback_threadsafe` so the frame introspection is covered rather than just "something raised"

The pre-existing `test_add_callback_threadsafe_delegates` already covers the negative case, that the guard does not reject a healthy connection, so I did not duplicate it.

Acceptance test `TestAddCallbackThreadsafeAfterClose` in `tests/acceptance/thread_safe_connection_test.py` drives the reported scenario against a real broker: connect, `close()`, then `add_callback_threadsafe` must raise and must not run the callback. I confirmed all three tests fail without the fix.
