### PR TITLE
Rename ThreadSafeConnection/Channel to Connection/Channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Pika is a pure-Python implementation of the AMQP 0-9-1 protocol including Rabbit
 - Since threads aren't appropriate to every situation, it doesn't require
   threads. Pika core takes care not to forbid them, either. The same goes for
   greenlets, callbacks, continuations, and generators. Most connection adapters
-  are single-threaded; use `ThreadSafeConnection` when you need to publish or
+  are single-threaded; use `Connection` when you need to publish or
   consume from multiple threads.
 - People may be using direct sockets, plain old `select()`, or any of the
   wide variety of ways of getting network events to and from a Python
@@ -93,7 +93,7 @@ Pika provides the following adapters:
   for use with [Tornado](https://tornadoweb.org)'s I/O loop.
 - `pika.adapters.twisted_connection.TwistedProtocolConnection` - asynchronous
   adapter for use with [Twisted](https://twistedmatrix.com)'s I/O loop.
-- `pika.adapters.thread_safe_connection.ThreadSafeConnection` - thread-safe
+- `pika.adapters.thread_safe_connection.Connection` - thread-safe
   adapter that runs SelectConnection's IOLoop in a background thread. All
   channel methods are safe to call from any thread simultaneously.
 
@@ -114,14 +114,14 @@ With non-blocking adapters, such as `pika.SelectConnection` and `pika.adapters.a
 
 ## Threading
 
-### Using ThreadSafeConnection (recommended)
+### Using Connection (recommended)
 
-`pika.adapters.thread_safe_connection.ThreadSafeConnection` is the simplest way to use Pika from multiple threads. It runs the IOLoop in a background thread and provides a blocking API that is safe to call from any number of threads simultaneously. Consumer callbacks run on a per-channel worker thread, so slow processing never stalls heartbeats:
+`pika.adapters.thread_safe_connection.Connection` is the simplest way to use Pika from multiple threads. It runs the IOLoop in a background thread and provides a blocking API that is safe to call from any number of threads simultaneously. Consumer callbacks run on a per-channel worker thread, so slow processing never stalls heartbeats:
 
 ```python
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 
-conn = ThreadSafeConnection(pika.ConnectionParameters('localhost'))
+conn = Connection(pika.ConnectionParameters('localhost'))
 ch = conn.channel()
 
 def on_message(channel, method, properties, body):

--- a/docs/examples/long_running_publisher_threaded.md
+++ b/docs/examples/long_running_publisher_threaded.md
@@ -1,10 +1,10 @@
 # Thread-Safe Long-Running Publisher
 
-This example demonstrates a long-running publisher with `ThreadSafeConnection`. It is the counterpart to the `BlockingConnection`-based `examples/long_running_publisher.py`.
+This example demonstrates a long-running publisher with `Connection`. It is the counterpart to the `BlockingConnection`-based `examples/long_running_publisher.py`.
 
 The blocking version has to run its own background thread calling `process_data_events()` so heartbeats keep flowing while the application is idle, and it bounces every publish onto that thread with `add_callback_threadsafe` — the classic "heartbeat vs. work" tension of a single-threaded design.
 
-`ThreadSafeConnection` removes that tension: its IOLoop runs on a dedicated background thread, so heartbeats are sent on time no matter how long the main thread sleeps between publishes. The main thread simply calls `basic_publish` whenever it has something to send.
+`Connection` removes that tension: its IOLoop runs on a dedicated background thread, so heartbeats are sent on time no matter how long the main thread sleeps between publishes. The main thread simply calls `basic_publish` whenever it has something to send.
 
 `examples/long_running_publisher_threaded.py`:
 

--- a/docs/examples/publisher_confirms_threaded.md
+++ b/docs/examples/publisher_confirms_threaded.md
@@ -1,8 +1,8 @@
 # Thread-Safe Publisher Confirms
 
-This example demonstrates publisher confirms with `ThreadSafeConnection`. It is the asynchronous counterpart to [Delivery Confirmations](blocking_delivery_confirmations.md), which uses `BlockingConnection`.
+This example demonstrates publisher confirms with `Connection`. It is the asynchronous counterpart to [Delivery Confirmations](blocking_delivery_confirmations.md), which uses `BlockingConnection`.
 
-Where the blocking version calls `confirm_delivery()` with no arguments and catches `UnroutableError` synchronously, `ThreadSafeChannel.confirm_delivery(ack_nack_callback)` registers a callback that the broker's `Basic.Ack` / `Basic.Nack` frames are delivered to. That callback runs on the channel's worker thread — not the IOLoop thread — so a slow confirm handler never stalls heartbeats, and it may safely call any `ThreadSafeChannel` method.
+Where the blocking version calls `confirm_delivery()` with no arguments and catches `UnroutableError` synchronously, `Channel.confirm_delivery(ack_nack_callback)` registers a callback that the broker's `Basic.Ack` / `Basic.Nack` frames are delivered to. That callback runs on the channel's worker thread — not the IOLoop thread — so a slow confirm handler never stalls heartbeats, and it may safely call any `Channel` method.
 
 Each publish is tagged with a monotonically increasing delivery tag, exposed through the `on_publish` callback and the `next_publish_seq_no` property.
 

--- a/docs/examples/threaded_consumer.md
+++ b/docs/examples/threaded_consumer.md
@@ -1,8 +1,8 @@
 # Thread-Safe Consumer
 
-This example demonstrates consuming messages with `ThreadSafeConnection`. Consumer callbacks run on a dedicated worker thread, so blocking operations inside the callback do not stall heartbeats.
+This example demonstrates consuming messages with `Connection`. Consumer callbacks run on a dedicated worker thread, so blocking operations inside the callback do not stall heartbeats.
 
-`ThreadSafeChannel` methods (`basic_ack`, `basic_publish`, `queue_declare`, etc.) are safe to call directly from within the callback without using `add_callback_threadsafe`.
+`Channel` methods (`basic_ack`, `basic_publish`, `queue_declare`, etc.) are safe to call directly from within the callback without using `add_callback_threadsafe`.
 
 Pairs with [Thread-Safe Publisher](threaded_publisher.md). Run this consumer first.
 

--- a/docs/examples/threaded_publisher.md
+++ b/docs/examples/threaded_publisher.md
@@ -1,6 +1,6 @@
 # Thread-Safe Publisher
 
-This example demonstrates publishing from multiple threads using `ThreadSafeConnection`. Every call to `basic_publish` is routed through the IOLoop thread internally, so there is no need for external synchronization.
+This example demonstrates publishing from multiple threads using `Connection`. Every call to `basic_publish` is routed through the IOLoop thread internally, so there is no need for external synchronization.
 
 Pairs with [Thread-Safe Consumer](threaded_consumer.md). Run the consumer first.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -2,12 +2,12 @@
 
 ### Is Pika thread safe?
 
-Pika provides [`ThreadSafeConnection`](modules/adapters/thread_safe.md) for multi-threaded applications. It wraps `SelectConnection` with a dedicated IOLoop thread and exposes a blocking API that is safe to call from any number of threads simultaneously. Consumer callbacks run on a per-channel worker thread, so blocking work inside a callback does not stall heartbeats or require manual callback scheduling.
+Pika provides [`Connection`](modules/adapters/thread_safe.md) for multi-threaded applications. It wraps `SelectConnection` with a dedicated IOLoop thread and exposes a blocking API that is safe to call from any number of threads simultaneously. Consumer callbacks run on a per-channel worker thread, so blocking work inside a callback does not stall heartbeats or require manual callback scheduling.
 
 ```python
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 
-conn = ThreadSafeConnection(pika.ConnectionParameters('localhost'))
+conn = Connection(pika.ConnectionParameters('localhost'))
 ch = conn.channel()
 # safe to call from any thread
 ch.basic_publish(exchange='', routing_key='q', body=b'hello')

--- a/docs/modules/adapters/blocking.md
+++ b/docs/modules/adapters/blocking.md
@@ -4,7 +4,7 @@
 > `BlockingConnection` is deprecated and will be removed in Pika 2.0. Because
 > the calling thread *is* the IOLoop, any blocking user code stalls heartbeats
 > unless `process_data_events()` is called periodically, and the adapter is not
-> thread-safe. Use [`ThreadSafeConnection`](thread_safe.md) instead, which runs
+> thread-safe. Use [`Connection`](thread_safe.md) instead, which runs
 > its own IOLoop on a background thread and provides a thread-safe blocking API.
 
 ::: pika.adapters.blocking_connection

--- a/docs/modules/adapters/gevent.md
+++ b/docs/modules/adapters/gevent.md
@@ -2,7 +2,7 @@
 
 > [!WARNING]
 > `GeventConnection` is deprecated and will be removed in Pika 2.0. Use
-> [`ThreadSafeConnection`](thread_safe.md) instead, which runs its own IOLoop
+> [`Connection`](thread_safe.md) instead, which runs its own IOLoop
 > on a background thread and works with any framework, including Gevent.
 
 ::: pika.adapters.gevent_connection

--- a/docs/modules/adapters/index.md
+++ b/docs/modules/adapters/index.md
@@ -3,7 +3,7 @@ Pika uses connection adapters to provide a flexible method for adapting pika's c
 
 ## Adapters
 
-- [ThreadSafeConnection](thread_safe.md)
+- [Connection](thread_safe.md)
 - [BlockingConnection](blocking.md) *(deprecated, removed in Pika 2.0)*
 - [SelectConnection](select.md)
 - [AsyncioConnection](asyncio.md)
@@ -17,21 +17,21 @@ Pika uses connection adapters to provide a flexible method for adapting pika's c
 > adapters exist to integrate Pika into a framework's event loop — a constraint
 > that no longer applies — and `BlockingConnection` runs the IOLoop on the
 > calling thread, which makes heartbeats fragile and the adapter non-thread-safe.
-> [`ThreadSafeConnection`](thread_safe.md) runs its own IOLoop on a background
+> [`Connection`](thread_safe.md) runs its own IOLoop on a background
 > thread and works with any framework (asyncio, Tornado, Twisted, Gevent,
 > Django, Flask, or plain synchronous code) without adapter-specific
 > integration.
 
 ## Threading
 
-### Using ThreadSafeConnection (recommended)
+### Using Connection (recommended)
 
-[ThreadSafeConnection](thread_safe.md) is the simplest way to use Pika from multiple threads. It runs the IOLoop in a background thread and provides a blocking, thread-safe API. Consumer callbacks run on a dedicated worker thread, so slow processing never stalls heartbeats, and you can call `basic_ack`, `basic_publish`, and other channel methods directly from the callback without any special coordination:
+[Connection](thread_safe.md) is the simplest way to use Pika from multiple threads. It runs the IOLoop in a background thread and provides a blocking, thread-safe API. Consumer callbacks run on a dedicated worker thread, so slow processing never stalls heartbeats, and you can call `basic_ack`, `basic_publish`, and other channel methods directly from the callback without any special coordination:
 
 ```python
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 
-conn = ThreadSafeConnection(pika.ConnectionParameters('localhost'))
+conn = Connection(pika.ConnectionParameters('localhost'))
 ch = conn.channel()
 
 def on_message(channel, method, properties, body):

--- a/docs/modules/adapters/thread_safe.md
+++ b/docs/modules/adapters/thread_safe.md
@@ -1,12 +1,12 @@
 # Thread-Safe Connection Adapter
 
-`ThreadSafeConnection` wraps `SelectConnection` and runs its IOLoop in a dedicated background thread. All channel operations are routed through `add_callback_threadsafe` so that socket I/O stays confined to a single thread. External threads can call any `ThreadSafeChannel` method concurrently without coordination.
+`Connection` wraps `SelectConnection` and runs its IOLoop in a dedicated background thread. All channel operations are routed through `add_callback_threadsafe` so that socket I/O stays confined to a single thread. External threads can call any `Channel` method concurrently without coordination.
 
 This eliminates the need to manually schedule callbacks via `add_callback_threadsafe` when publishing or acknowledging from multiple threads.
 
-## When to use ThreadSafeConnection
+## When to use Connection
 
-Use `ThreadSafeConnection` when your application needs to publish or consume messages from multiple threads. It provides a blocking, synchronous API similar to `BlockingConnection` but with full thread safety:
+Use `Connection` when your application needs to publish or consume messages from multiple threads. It provides a blocking, synchronous API similar to `BlockingConnection` but with full thread safety:
 
 - Multiple threads can call `basic_publish` simultaneously
 - Consumer callbacks run on a dedicated worker thread, not the IOLoop thread, so slow processing does not stall heartbeats
@@ -17,9 +17,9 @@ Use `ThreadSafeConnection` when your application needs to publish or consume mes
 ```python
 import threading
 import pika
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 
-conn = ThreadSafeConnection(pika.ConnectionParameters('localhost'))
+conn = Connection(pika.ConnectionParameters('localhost'))
 ch = conn.channel()
 
 ch.queue_declare('work')
@@ -41,7 +41,7 @@ The `on_message_callback` registered with `basic_consume` is dispatched on a per
 - Blocking operations (database writes, HTTP calls, even `queue_declare` or `basic_qos`) are safe inside delivery callbacks
 - The IOLoop thread is never starved by slow consumer processing, so heartbeats are always sent on time
 - Messages are delivered to the callback in order (single worker thread per channel)
-- All `ThreadSafeChannel` methods (`basic_ack`, `basic_nack`, `basic_reject`, `basic_publish`) are safe to call from within the callback
+- All `Channel` methods (`basic_ack`, `basic_nack`, `basic_reject`, `basic_publish`) are safe to call from within the callback
 
 ## Work queue bounds and back-pressure
 
@@ -49,10 +49,10 @@ Each worker thread consumes from a bounded queue holding at most `work_queue_max
 
 Heartbeats are not sent while the IOLoop is blocked, so the broker's heartbeat timeout bounds how long a wedged consumer can stall the connection before the broker closes it.
 
-Both knobs are constructor parameters on `ThreadSafeConnection`:
+Both knobs are constructor parameters on `Connection`:
 
 ```python
-conn = ThreadSafeConnection(
+conn = Connection(
     pika.ConnectionParameters('localhost'),
     work_queue_maxsize=1000,     # 0 means unbounded
     work_queue_put_timeout=30.0, # seconds; must be positive, default 30 s
@@ -63,7 +63,7 @@ conn = ThreadSafeConnection(
 
 ## Comparison with other adapters
 
-| | BlockingConnection | SelectConnection + add_callback_threadsafe | ThreadSafeConnection |
+| | BlockingConnection | SelectConnection + add_callback_threadsafe | Connection |
 |---|---|---|---|
 | Thread safety | Not thread-safe | Manual callback scheduling required | Fully thread-safe |
 | Consumer threading | Same thread as IOLoop | Same thread as IOLoop | Dedicated worker thread |
@@ -72,10 +72,10 @@ conn = ThreadSafeConnection(
 
 ## Class Reference
 
-::: pika.adapters.thread_safe_connection.ThreadSafeConnection
+::: pika.adapters.thread_safe_connection.Connection
     options:
       members: true
 
-::: pika.adapters.thread_safe_connection.ThreadSafeChannel
+::: pika.adapters.thread_safe_connection.Channel
     options:
       members: true

--- a/docs/modules/adapters/tornado.md
+++ b/docs/modules/adapters/tornado.md
@@ -2,7 +2,7 @@
 
 > [!WARNING]
 > `TornadoConnection` is deprecated and will be removed in Pika 2.0. Use
-> [`ThreadSafeConnection`](thread_safe.md) instead, which runs its own IOLoop
+> [`Connection`](thread_safe.md) instead, which runs its own IOLoop
 > on a background thread and works with any framework, including Tornado.
 
 ::: pika.adapters.tornado_connection

--- a/docs/modules/adapters/twisted.md
+++ b/docs/modules/adapters/twisted.md
@@ -2,7 +2,7 @@
 
 > [!WARNING]
 > `TwistedProtocolConnection` is deprecated and will be removed in Pika 2.0.
-> Use [`ThreadSafeConnection`](thread_safe.md) instead, which runs its own
+> Use [`Connection`](thread_safe.md) instead, which runs its own
 > IOLoop on a background thread and works with any framework, including
 > Twisted.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -63,11 +63,11 @@ The TLS mutual authentication examples use test certificates from `tests/certs/`
 
 | File | Description |
 |------|-------------|
-| `basic_consumer_threaded.py` | Consuming with `ThreadSafeConnection` worker threads |
-| `basic_publisher_threaded.py` | Publishing from multiple threads with `ThreadSafeConnection` |
-| `publisher_confirms_threaded.py` | Publisher confirms with `ThreadSafeConnection` (ack/nack on a worker thread) |
+| `basic_consumer_threaded.py` | Consuming with `Connection` worker threads |
+| `basic_publisher_threaded.py` | Publishing from multiple threads with `Connection` |
+| `publisher_confirms_threaded.py` | Publisher confirms with `Connection` (ack/nack on a worker thread) |
 | `long_running_publisher.py` | Background publisher thread with `BlockingConnection` |
-| `long_running_publisher_threaded.py` | Long-running publisher with `ThreadSafeConnection` (no `process_data_events` loop) |
+| `long_running_publisher_threaded.py` | Long-running publisher with `Connection` (no `process_data_events` loop) |
 | `consumer_queued.py` | Threaded consumer buffering messages for batch processing |
 | `consumer_simple.py` | Simple blocking consumer with multiple exchanges |
 | `producer.py` | Blocking publisher for multiple exchanges |

--- a/examples/basic_consumer_threaded.py
+++ b/examples/basic_consumer_threaded.py
@@ -1,14 +1,14 @@
 """
-Example: consuming with ThreadSafeConnection.
+Example: consuming with Connection.
 
-ThreadSafeChannel dispatches each delivery on a dedicated per-channel worker
+Channel dispatches each delivery on a dedicated per-channel worker
 thread, not the IOLoop thread.  Long-running work in the callback no longer
 stalls heartbeats: the IOLoop keeps running on its own thread while the
 worker is busy.  Deliveries on a single channel are processed serially on
 that worker thread, so prefetch controls how many unacked messages the
 broker will hand out, not the worker thread count.
 
-Calls to ThreadSafeChannel methods (basic_ack, basic_publish, etc.) are
+Calls to Channel methods (basic_ack, basic_publish, etc.) are
 safe from any thread, including the worker thread that delivers the
 message - so there is no need to bounce the ack through
 add_callback_threadsafe as the BlockingConnection-based example required.
@@ -22,7 +22,7 @@ import threading
 import time
 
 import pika
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 from pika.exceptions import ConnectionClosed
 from pika.exchange_type import ExchangeType
 
@@ -64,7 +64,7 @@ def main():
     )
 
     LOGGER.info('Connecting ...')
-    conn = ThreadSafeConnection(parameters)
+    conn = Connection(parameters)
     ch = conn.channel()
 
     ch.exchange_declare(exchange=EXCHANGE_NAME,

--- a/examples/basic_publisher_threaded.py
+++ b/examples/basic_publisher_threaded.py
@@ -1,7 +1,7 @@
 """
-Example: publishing from multiple threads using ThreadSafeConnection.
+Example: publishing from multiple threads using Connection.
 
-ThreadSafeConnection runs SelectConnection's IOLoop in a dedicated background thread.  Every call to
+Connection runs SelectConnection's IOLoop in a dedicated background thread.  Every call to
 channel.basic_publish() is routed through add_callback_threadsafe so that _tx_buffers is only ever
 touched from the IOLoop thread, eliminating the IndexError race seen in issues #1144 and #511.
 
@@ -12,7 +12,7 @@ import logging
 import threading
 
 import pika
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 from pika.exchange_type import ExchangeType
 
 LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
@@ -30,7 +30,7 @@ def main():
         credentials=pika.PlainCredentials('guest', 'guest'))
 
     LOGGER.info('Connecting ...')
-    conn = ThreadSafeConnection(parameters)
+    conn = Connection(parameters)
 
     # channel() blocks until the channel is open.
     ch = conn.channel()
@@ -45,7 +45,7 @@ def main():
     LOGGER.info('Topology declared: %s -> %s -> %s', EXCHANGE_NAME, ROUTING_KEY,
                 QUEUE_NAME)
 
-    # Publish from 5 threads simultaneously - safe with ThreadSafeConnection.
+    # Publish from 5 threads simultaneously - safe with Connection.
     n_threads = 5
     barrier = threading.Barrier(n_threads)
 

--- a/examples/long_running_publisher_threaded.py
+++ b/examples/long_running_publisher_threaded.py
@@ -1,7 +1,7 @@
 """
-Example: a long-running publisher using ThreadSafeConnection.
+Example: a long-running publisher using Connection.
 
-This is the ThreadSafeConnection counterpart to
+This is the Connection counterpart to
 examples/long_running_publisher.py.
 
 The BlockingConnection version has to run its own background thread calling
@@ -11,7 +11,7 @@ via add_callback_threadsafe.  That is the classic "heartbeat vs. work"
 tension of a single-threaded design: nothing happens on the connection
 unless the application keeps handing control back to pika.
 
-ThreadSafeConnection removes the tension entirely.  Its SelectConnection
+Connection removes the tension entirely.  Its SelectConnection
 IOLoop runs on its own dedicated background thread, so heartbeats are sent on
 time no matter how long the main thread sleeps between publishes.  The main
 thread just calls basic_publish whenever it has something to send - the call
@@ -22,7 +22,7 @@ import logging
 import time
 
 import pika
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 
 LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
               '-35s %(lineno) -5d: %(message)s')
@@ -42,7 +42,7 @@ def main():
     )
 
     LOGGER.info('Connecting ...')
-    conn = ThreadSafeConnection(parameters)
+    conn = Connection(parameters)
     ch = conn.channel()
     ch.queue_declare(queue=QUEUE_NAME, durable=True)
 

--- a/examples/publisher_confirms_threaded.py
+++ b/examples/publisher_confirms_threaded.py
@@ -1,17 +1,17 @@
 """
-Example: publisher confirms with ThreadSafeConnection.
+Example: publisher confirms with Connection.
 
-This is the ThreadSafeConnection counterpart to
+This is the Connection counterpart to
 examples/blocking_delivery_confirmations.py.  Where the BlockingConnection
 version calls confirm_delivery() with no arguments and relies on
-basic_publish raising UnroutableError synchronously, ThreadSafeChannel is
+basic_publish raising UnroutableError synchronously, Channel is
 fully asynchronous: confirm_delivery() takes an ack_nack_callback that the
 broker's Basic.Ack / Basic.Nack frames are delivered to.
 
 That callback is dispatched on the channel's per-channel worker thread - the
 same thread that delivery callbacks use - not the IOLoop thread.  A slow
 confirm handler therefore never stalls heartbeats, and the callback may
-safely call any ThreadSafeChannel method.
+safely call any Channel method.
 
 Each publish is tagged with a monotonically increasing delivery tag, exposed
 via the on_publish callback and the next_publish_seq_no property, matching
@@ -27,7 +27,7 @@ import threading
 
 import pika
 from pika import spec
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 from pika.exchange_type import ExchangeType
 
 LOG_FORMAT = ('%(levelname) -10s %(asctime)s %(name) -30s %(funcName) '
@@ -46,7 +46,7 @@ def main():
         credentials=pika.PlainCredentials('guest', 'guest'))
 
     LOGGER.info('Connecting ...')
-    conn = ThreadSafeConnection(parameters)
+    conn = Connection(parameters)
     ch = conn.channel()
 
     ch.exchange_declare(exchange=EXCHANGE_NAME,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -117,7 +117,7 @@ nav:
           - Tornado: modules/adapters/tornado.md
           - Twisted: modules/adapters/twisted.md
           - Gevent: modules/adapters/gevent.md
-          - ThreadSafe: modules/adapters/thread_safe.md
+          - Thread-Safe: modules/adapters/thread_safe.md
       - Channel: modules/channel.md
       - Connection: modules/connection.md
       - Credentials: modules/credentials.md

--- a/pika/__init__.py
+++ b/pika/__init__.py
@@ -8,7 +8,7 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 # ruff: noqa: E402
 
 from pika import adapters, frame, spec
-from pika.adapters import BaseConnection, BlockingConnection, SelectConnection, ThreadSafeConnection
+from pika.adapters import BaseConnection, BlockingConnection, Connection, SelectConnection
 from pika.adapters.utils.connection_workflow import AMQPConnectionWorkflow
 from pika.connection import ConnectionParameters, SSLOptions, URLParameters
 from pika.credentials import PlainCredentials
@@ -20,12 +20,12 @@ __all__ = [
     'BaseConnection',
     'BasicProperties',
     'BlockingConnection',
+    'Connection',
     'ConnectionParameters',
     'DeliveryMode',
     'PlainCredentials',
     'SSLOptions',
     'SelectConnection',
-    'ThreadSafeConnection',
     'URLParameters',
     'adapters',
     'frame',

--- a/pika/adapters/__init__.py
+++ b/pika/adapters/__init__.py
@@ -11,7 +11,7 @@ Pika provides multiple adapters to connect to RabbitMQ:
   Gevent.
 - adapters.select_connection.SelectConnection: A native event based connection
   adapter that implements select, kqueue, poll and epoll.
-- adapters.thread_safe_connection.ThreadSafeConnection: A native event based connection
+- adapters.thread_safe_connection.Connection: A native event based connection
   adapter that implements select, kqueue, poll and epoll, and is thread safe.
 - adapters.tornado_connection.TornadoConnection: Connection adapter for use
   with the Tornado web framework.
@@ -24,13 +24,13 @@ from pika.adapters.asyncio_connection import AsyncioConnection
 from pika.adapters.base_connection import BaseConnection
 from pika.adapters.blocking_connection import BlockingConnection
 from pika.adapters.select_connection import IOLoop, SelectConnection
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 
 __all__ = [
     'AsyncioConnection',
     'BaseConnection',
     'BlockingConnection',
+    'Connection',
     'IOLoop',
     'SelectConnection',
-    'ThreadSafeConnection',
 ]

--- a/pika/adapters/blocking_connection.py
+++ b/pika/adapters/blocking_connection.py
@@ -366,7 +366,7 @@ class BlockingConnection:
         """
         warnings.warn(
             'BlockingConnection is deprecated and will be removed in Pika 2.0. '
-            'Use ThreadSafeConnection instead, which runs its own IOLoop on a '
+            'Use Connection instead, which runs its own IOLoop on a '
             'background thread and provides a thread-safe blocking API that '
             'does not stall heartbeats on slow message processing. See '
             'https://pika.github.io/pika/modules/adapters/thread_safe/',

--- a/pika/adapters/gevent_connection.py
+++ b/pika/adapters/gevent_connection.py
@@ -78,7 +78,7 @@ class GeventConnection(BaseConnection):
         """
         warnings.warn(
             'GeventConnection is deprecated and will be removed in Pika 2.0. '
-            'Use ThreadSafeConnection instead, which works with any framework '
+            'Use Connection instead, which works with any framework '
             'including Gevent. See '
             'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -313,7 +313,7 @@ class _BoundedWorkPool:
         return not thread.is_alive()
 
 
-class ThreadSafeChannel:
+class Channel:
     """
     Thread-safe wrapper around :class:`pika.channel.Channel`.
 
@@ -335,7 +335,7 @@ class ThreadSafeChannel:
       sent on time.
     - Messages are delivered to the callback **in order** (a single
       worker thread per channel).
-    - All :class:`ThreadSafeChannel` methods (:meth:`basic_ack`,
+    - All :class:`Channel` methods (:meth:`basic_ack`,
       :meth:`basic_nack`, :meth:`basic_reject`, :meth:`basic_publish`,
       :meth:`queue_declare`, etc.) are safe to call from within the
       callback.
@@ -357,7 +357,7 @@ class ThreadSafeChannel:
     .. rubric:: IOLoop-thread callbacks
 
     Callables passed directly to
-    :meth:`~ThreadSafeConnection.add_callback_threadsafe` still run
+    :meth:`~Connection.add_callback_threadsafe` still run
     on the IOLoop thread.  These must return quickly and must not call
     blocking channel methods (which would deadlock).
     """
@@ -553,14 +553,11 @@ class ThreadSafeChannel:
         :param body: The message body to publish.
         :param properties: Properties for the message.
         :param mandatory: If True, return unroutable messages to the publisher
-        :param on_publish: Optional callback invoked on the
-            **IOLoop thread** immediately after the publish frame is
-            written successfully, with the delivery tag (int) as its
-            sole argument.  Only meaningful when publisher confirms are
-            enabled via :meth:`confirm_delivery`; ignored otherwise.
-            Must return quickly (same contract as any
-            :meth:`~ThreadSafeConnection.add_callback_threadsafe`
-            callback).
+        :param on_publish: Optional callback invoked on the **IOLoop thread** immediately after the
+            publish frame is written successfully, with the delivery tag (int) as its sole argument.
+            Only meaningful when publisher confirms are enabled via :meth:`confirm_delivery`;
+            ignored otherwise. Must return quickly (same contract as any
+            :meth:`~Connection.add_callback_threadsafe` callback).
         :raises Exception: if the connection is already closed.
         """
         self._check_not_closed()
@@ -764,9 +761,9 @@ class ThreadSafeChannel:
         consumer can silently stop receiving messages.
 
         Dispatched on the per-channel worker thread (same as delivery callbacks), so the callback
-        may safely call any :class:`ThreadSafeChannel` method.  The RabbitMQ Java and .NET clients
-        run this listener inline on the I/O thread; pika's wrapper deliberately diverges so a slow
-        listener cannot stall heartbeats.
+        may safely call any :class:`Channel` method.  The RabbitMQ Java and .NET clients run this
+        listener inline on the I/O thread; pika's wrapper deliberately diverges so a slow listener
+        cannot stall heartbeats.
 
         Safe to call from any thread.
 
@@ -799,15 +796,15 @@ class ThreadSafeChannel:
         returned message.
 
         Dispatched on the per-channel worker thread (same as delivery callbacks), so the callback
-        may safely call any :class:`ThreadSafeChannel` method.  The RabbitMQ Java and .NET clients
-        run this listener inline on the I/O thread; pika's wrapper deliberately diverges so a slow
-        listener cannot stall heartbeats.
+        may safely call any :class:`Channel` method.  The RabbitMQ Java and .NET clients run this
+        listener inline on the I/O thread; pika's wrapper deliberately diverges so a slow listener
+        cannot stall heartbeats.
 
         Safe to call from any thread.
 
         :param callback:``callback(channel, method, properties, body)`` where *channel* is this
-            :class:`ThreadSafeChannel`, *method* is a :class:`pika.spec.Basic.Return`, *properties*
-            is a :class:`pika.spec.BasicProperties`, and *body* is :class:`bytes`.
+            :class:`Channel`, *method* is a :class:`pika.spec.Basic.Return`, *properties* is a
+            :class:`pika.spec.BasicProperties`, and *body* is :class:`bytes`.
         :raises Exception: if the connection is already closed.
         """
         self._check_not_closed()
@@ -888,7 +885,7 @@ class ThreadSafeChannel:
         Register a consumer and block until Basic.ConsumeOk arrives.
 
         The *on_message_callback* is dispatched on the channel's worker thread, not the IOLoop
-        thread.  All :class:`ThreadSafeChannel` methods are safe to call from within the callback.
+        thread.  All :class:`Channel` methods are safe to call from within the callback.
 
         Because the channel uses a single worker thread, deliveries are processed serially.  A
         callback that blocks (e.g. on a database write or a call to :meth:`queue_declare`) delays
@@ -1348,7 +1345,7 @@ class ThreadSafeChannel:
         return self._channel.is_closed
 
 
-class ThreadSafeConnection:
+class Connection:
     """Pika connection that is safe to use from multiple threads.
 
     .. note:: Each instance starts a background thread named
@@ -1364,7 +1361,7 @@ class ThreadSafeConnection:
 
     Usage::
 
-        conn = ThreadSafeConnection(pika.ConnectionParameters('localhost'))
+        conn = Connection(pika.ConnectionParameters('localhost'))
         ch = conn.channel()
 
         # safe to call from any number of threads simultaneously
@@ -1376,7 +1373,7 @@ class ThreadSafeConnection:
 
     Can also be used as a context manager::
 
-        with ThreadSafeConnection(pika.ConnectionParameters('localhost')) as conn:
+        with Connection(pika.ConnectionParameters('localhost')) as conn:
             ch = conn.channel()
             ch.basic_publish(exchange='', routing_key='q', body='hello')
 
@@ -1449,7 +1446,7 @@ class ThreadSafeConnection:
         self._closed_reason_tb: TracebackType | None = None
         self._blocking_waiters: list[tuple[threading.Event,
                                            list[BaseException | None]]] = []
-        self._channels: list[ThreadSafeChannel] = []
+        self._channels: list[Channel] = []
 
         # Single-worker pool for connection-level event callbacks
         # (Connection.Blocked / Unblocked).  Keeps user code off the
@@ -1610,11 +1607,9 @@ class ThreadSafeConnection:
     # Public API
     # ------------------------------------------------------------------
 
-    def channel(
-            self,
-            timeout: float | None = DEFAULT_RPC_TIMEOUT) -> ThreadSafeChannel:
+    def channel(self, timeout: float | None = DEFAULT_RPC_TIMEOUT) -> Channel:
         """
-        Open a new channel and return a :class:`ThreadSafeChannel`.
+        Open a new channel and return a :class:`Channel`.
 
         Blocks the calling thread until the channel is open.  The returned channel's methods are
         safe to call from any thread.
@@ -1671,11 +1666,10 @@ class ThreadSafeConnection:
             reason = self._closed_reason
             if reason is not None:
                 raise _with_close_traceback(reason, self._closed_reason_tb)
-            ch = ThreadSafeChannel(
-                result[0],
-                self,
-                work_queue_maxsize=self._work_queue_maxsize,
-                work_queue_put_timeout=self._work_queue_put_timeout)
+            ch = Channel(result[0],
+                         self,
+                         work_queue_maxsize=self._work_queue_maxsize,
+                         work_queue_put_timeout=self._work_queue_put_timeout)
             self._channels.append(ch)
         return ch
 
@@ -1882,7 +1876,7 @@ class ThreadSafeConnection:
                 raise _with_close_traceback(reason, self._closed_reason_tb)
         if self._connection.is_closed:
             raise ConnectionWrongStateError(
-                'ThreadSafeConnection.add_callback_threadsafe() called on '
+                'Connection.add_callback_threadsafe() called on '
                 'closed connection.')
 
     def add_on_connection_blocked_callback(self, callback) -> None:
@@ -1896,7 +1890,7 @@ class ThreadSafeConnection:
 
         Dispatched on a connection-level worker thread (one per
         connection), so the callback may safely call any
-        :class:`ThreadSafeChannel` method without stalling heartbeats.
+        :class:`Channel` method without stalling heartbeats.
         The RabbitMQ Java and .NET clients run this listener inline on
         the I/O thread; pika's wrapper deliberately diverges so a slow
         listener cannot stall heartbeats.
@@ -1905,7 +1899,7 @@ class ThreadSafeConnection:
 
         :param callback:
             ``callback(connection, method_frame)`` where *connection* is
-            this :class:`ThreadSafeConnection` and *method_frame* contains
+            this :class:`Connection` and *method_frame* contains
             a :class:`pika.spec.Connection.Blocked`.
         :raises Exception: if the connection is already closed.
         """
@@ -1929,7 +1923,7 @@ class ThreadSafeConnection:
 
         :param callback:
             ``callback(connection, method_frame)`` where *connection* is
-            this :class:`ThreadSafeConnection` and *method_frame* contains
+            this :class:`Connection` and *method_frame* contains
             a :class:`pika.spec.Connection.Unblocked`.
         :raises Exception: if the connection is already closed.
         """
@@ -1955,8 +1949,8 @@ class ThreadSafeConnection:
             _submit_or_terminate(
                 self._connection_work_pool, self._connection,
                 'Connection event dropped: work pool shut down',
-                ThreadSafeChannel._safe_dispatch, raw_method_name, callback,
-                self, method_frame)
+                Channel._safe_dispatch, raw_method_name, callback, self,
+                method_frame)
 
         def _register() -> None:
             try:

--- a/pika/adapters/tornado_connection.py
+++ b/pika/adapters/tornado_connection.py
@@ -59,7 +59,7 @@ class TornadoConnection(base_connection.BaseConnection):
         """
         warnings.warn(
             'TornadoConnection is deprecated and will be removed in Pika 2.0. '
-            'Use ThreadSafeConnection instead, which works with any framework '
+            'Use Connection instead, which works with any framework '
             'including Tornado. See '
             'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,

--- a/pika/adapters/twisted_connection.py
+++ b/pika/adapters/twisted_connection.py
@@ -1202,7 +1202,7 @@ class TwistedProtocolConnection(protocol.Protocol):
                  custom_reactor: Any = None) -> None:
         warnings.warn(
             'TwistedProtocolConnection is deprecated and will be removed in '
-            'Pika 2.0. Use ThreadSafeConnection instead, which works with any '
+            'Pika 2.0. Use Connection instead, which works with any '
             'framework including Twisted. See '
             'https://pika.github.io/pika/modules/adapters/thread_safe/',
             DeprecationWarning,

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -408,9 +408,8 @@ class WorkQueueFullError(AMQPConnectionError):
     """
     The work queue stayed full for longer than the configured ``work_queue_put_timeout``.
 
-    Used by ThreadSafeConnection/ThreadSafeChannel.  Subclasses :class:`AMQPConnectionError` because
-    an overflow tears the connection down, so applications catching connection loss by base class
-    see it too.
+    Used by Connection/Channel.  Subclasses :class:`AMQPConnectionError` because an overflow tears
+    the connection down, so applications catching connection loss by base class see it too.
     """
 
 

--- a/tests/acceptance/thread_safe_bounded_queue_test.py
+++ b/tests/acceptance/thread_safe_bounded_queue_test.py
@@ -1,5 +1,5 @@
 """
-Integration tests for the ThreadSafeConnection bounded work queue.
+Integration tests for the Connection bounded work queue.
 
 These tests require a RabbitMQ broker listening on 127.0.0.1:5672 with the
 default guest/guest credentials.  They will fail, not skip, if the broker is
@@ -18,7 +18,7 @@ import unittest
 import uuid
 
 import pika
-from pika.adapters.thread_safe_connection import ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Connection
 from pika.exceptions import WorkQueueFullError
 from tests.misc.test_utils import retry_assertion, safe_close
 
@@ -35,7 +35,7 @@ BLOCKING_CALL_TIMEOUT = 10
 class ThreadSafeBoundedQueueTestCaseBase(unittest.TestCase):
 
     def _connect(self, **kwargs):
-        conn = ThreadSafeConnection(DEFAULT_PARAMS, **kwargs)
+        conn = Connection(DEFAULT_PARAMS, **kwargs)
         self.addCleanup(safe_close, conn, timeout=BLOCKING_CALL_TIMEOUT)
         return conn
 

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -1,5 +1,5 @@
 """
-Integration tests for ThreadSafeConnection and ThreadSafeChannel.
+Integration tests for Connection and Channel.
 
 These tests require a RabbitMQ broker listening on 127.0.0.1:5672 with the
 default guest/guest credentials.  They will fail, not skip, if the broker is
@@ -14,7 +14,7 @@ import unittest
 import uuid
 
 import pika
-from pika.adapters.thread_safe_connection import ThreadSafeChannel, ThreadSafeConnection
+from pika.adapters.thread_safe_connection import Channel, Connection
 from pika.exceptions import AMQPConnectionError
 from tests.misc.forward_server import ForwardServer
 from tests.misc.test_utils import retry_assertion, safe_close
@@ -32,7 +32,7 @@ BLOCKING_CALL_TIMEOUT = 10
 class ThreadSafeTestCaseBase(unittest.TestCase):
 
     def _connect(self, parameters=None):
-        conn = ThreadSafeConnection(parameters or DEFAULT_PARAMS)
+        conn = Connection(parameters or DEFAULT_PARAMS)
         self.addCleanup(safe_close, conn)
         return conn
 
@@ -49,7 +49,7 @@ class TestBasicLifecycle(ThreadSafeTestCaseBase):
         self.assertTrue(conn.is_open)
 
         ch = conn.channel()
-        self.assertIsInstance(ch, ThreadSafeChannel)
+        self.assertIsInstance(ch, Channel)
         self.assertTrue(ch.is_open)
 
         queue = self._unique_queue()
@@ -223,7 +223,7 @@ class TestBrokerDropBlockedInChannel(ThreadSafeTestCaseBase):
             port=fwd.server_address[1],
             credentials=pika.PlainCredentials('guest', 'guest'),
         )
-        conn = ThreadSafeConnection(params)
+        conn = Connection(params)
         self.addCleanup(safe_close, conn)
 
         # Intercept add_callback_threadsafe so channel() registers its waiter
@@ -282,7 +282,7 @@ class TestBrokerDropBlockedInQueueDeclare(ThreadSafeTestCaseBase):
             port=fwd.server_address[1],
             credentials=pika.PlainCredentials('guest', 'guest'),
         )
-        conn = ThreadSafeConnection(params)
+        conn = Connection(params)
         self.addCleanup(safe_close, conn)
 
         # Open the channel before intercepting so we get a real channel object.
@@ -390,7 +390,7 @@ class TestContextManager(ThreadSafeTestCaseBase):
             port=5672,
             credentials=pika.PlainCredentials('guest', 'guest'),
         )
-        with ThreadSafeConnection(params) as conn:
+        with Connection(params) as conn:
             self.assertTrue(conn.is_open)
             ch = conn.channel()
             queue = self._unique_queue()

--- a/tests/unit/deprecation_tests.py
+++ b/tests/unit/deprecation_tests.py
@@ -50,7 +50,7 @@ class DeprecationTestCase(unittest.TestCase):
         message = str(deprecations[0].message)
         self.assertIn(adapter_name, message)
         self.assertIn('Pika 2.0', message)
-        self.assertIn('ThreadSafeConnection', message)
+        self.assertIn('Connection', message)
 
 
 class BlockingConnectionDeprecationTests(DeprecationTestCase):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -8,8 +8,8 @@ from unittest.mock import ANY, MagicMock, patch
 
 from pika.adapters.thread_safe_connection import (
     DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
-    ThreadSafeChannel,
-    ThreadSafeConnection,
+    Channel,
+    Connection,
     _BoundedWorkPool,
     _reraisable,
     _submit_or_terminate,
@@ -401,58 +401,51 @@ class BoundedWorkPoolTests(unittest.TestCase):
         self.assertEqual(result, [True])
 
     def test_connection_params_propagate_to_channel_pool(self):
-        """Work-queue parameters passed to ThreadSafeChannel must reach its pool."""
+        """Work-queue parameters passed to Channel must reach its pool."""
         raw_ch = MagicMock()
         wrapper = MagicMock()
-        ch = ThreadSafeChannel(raw_ch,
-                               wrapper,
-                               work_queue_maxsize=7,
-                               work_queue_put_timeout=45.0)
+        ch = Channel(raw_ch,
+                     wrapper,
+                     work_queue_maxsize=7,
+                     work_queue_put_timeout=45.0)
         self.assertEqual(ch._consumer_work_pool._queue.maxsize, 7)
         self.assertEqual(ch._consumer_work_pool._put_timeout, 45.0)
 
     def test_channel_rejects_none_put_timeout(self):
-        """ThreadSafeChannel must reject a None put timeout (would block the IOLoop forever)."""
+        """Channel must reject a None put timeout (would block the IOLoop forever)."""
         with self.assertRaises(ValueError):
-            ThreadSafeChannel(MagicMock(),
-                              MagicMock(),
-                              work_queue_put_timeout=None)
+            Channel(MagicMock(), MagicMock(), work_queue_put_timeout=None)
 
     def test_channel_rejects_non_positive_put_timeout(self):
-        """ThreadSafeChannel must reject a zero, negative, or NaN put timeout."""
+        """Channel must reject a zero, negative, or NaN put timeout."""
         for bad in (0, -1.0, float('nan')):
             with self.assertRaises(ValueError):
-                ThreadSafeChannel(MagicMock(),
-                                  MagicMock(),
-                                  work_queue_put_timeout=bad)
+                Channel(MagicMock(), MagicMock(), work_queue_put_timeout=bad)
 
     def test_channel_accepts_small_positive_put_timeout(self):
         """A positive override below the default must be accepted (no floor)."""
-        ch = ThreadSafeChannel(MagicMock(),
-                               MagicMock(),
-                               work_queue_put_timeout=5.0)
+        ch = Channel(MagicMock(), MagicMock(), work_queue_put_timeout=5.0)
         self.assertEqual(ch._consumer_work_pool._put_timeout, 5.0)
 
     def test_channel_accepts_default_put_timeout(self):
         """The default put timeout must satisfy its own validation."""
-        ch = ThreadSafeChannel(MagicMock(), MagicMock())
+        ch = Channel(MagicMock(), MagicMock())
         self.assertEqual(ch._consumer_work_pool._put_timeout,
                          DEFAULT_WORK_QUEUE_PUT_TIMEOUT)
 
     def test_connection_rejects_invalid_put_timeout(self):
         """
-        ThreadSafeConnection must validate its put timeout before connecting.
+        Connection must validate its put timeout before connecting.
 
         Validation happens ahead of SelectConnection construction, so a bad value raises without any
         connection machinery or patching.
         """
         for bad in (None, 0, -1.0, float('nan')):
             with self.assertRaises(ValueError):
-                ThreadSafeConnection(parameters='params',
-                                     work_queue_put_timeout=bad)
+                Connection(parameters='params', work_queue_put_timeout=bad)
 
 
-class ThreadSafeChannelTests(unittest.TestCase):
+class ChannelTests(unittest.TestCase):
 
     def _make_channel(self):
         raw_ch = MagicMock()
@@ -469,7 +462,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_basic_publish_routes_through_schedule_unchecked(self):
         ch, _raw_ch, wrapper = self._make_channel()
@@ -871,7 +864,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         self.assertEqual(tag, 'ctag1')
 
     def test_basic_consume_wraps_callback_with_thread_safe_channel(self):
-        """on_message_callback must receive the ThreadSafeChannel, not the raw channel."""
+        """on_message_callback must receive the Channel, not the raw channel."""
         ch, raw_ch, wrapper = self._make_channel()
         mock_frame = MagicMock()
         mock_frame.method.consumer_tag = 'ctag1'
@@ -898,7 +891,7 @@ class ThreadSafeChannelTests(unittest.TestCase):
         ch._consumer_work_pool.shutdown(wait=True)
 
         self.assertEqual(len(received), 1)
-        self.assertIsInstance(received[0], ThreadSafeChannel)
+        self.assertIsInstance(received[0], Channel)
         self.assertIs(received[0], ch)
 
     def test_basic_consume_raises_when_connection_already_closed(self):
@@ -1116,7 +1109,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_callback_runs_on_worker_thread_not_ioloop(self):
         """on_message_callback must execute on the pool thread, not the thread that invoked the
@@ -1365,7 +1358,7 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         ch._consumer_work_pool.shutdown(wait=True)
 
         self.assertEqual(len(received), 1)
-        # First arg must be the ThreadSafeChannel, not the raw channel
+        # First arg must be the Channel, not the raw channel
         self.assertIs(received[0][0], ch)
         self.assertEqual(received[0][1:], ('method', 'props', b'returned-body'))
         self.assertIsNot(callback_thread[0], threading.current_thread())
@@ -1626,7 +1619,7 @@ class BlockingMethodTimeoutTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_queue_declare_raises_timeout_error(self):
         ch, raw_ch, wrapper = self._make_channel()
@@ -1798,7 +1791,7 @@ class BlockingRPCPassthroughTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def _run_immediate_rpc(self, raw_method, *call_args, **call_kwargs):
         """Wire up wrapper/raw_method so the callback fires immediately."""
@@ -1878,7 +1871,7 @@ class BlockingRPCPassthroughTests(unittest.TestCase):
 
 class BlockingRPCErrorPathTests(unittest.TestCase):
     """
-    Cover the two error paths inside ThreadSafeChannel._blocking_rpc:
+    Cover the two error paths inside Channel._blocking_rpc:
 
     * channel_method itself raises during _invoke (connection already
       torn down on the IOLoop thread).
@@ -1901,7 +1894,7 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_method_raise_propagates_to_caller(self):
         ch, raw_ch, wrapper = self._make_channel()
@@ -1940,7 +1933,7 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
 
 
 class BasicGetTests(unittest.TestCase):
-    """Cover ThreadSafeChannel.basic_get success, empty, error and channel-close paths."""
+    """Cover Channel.basic_get success, empty, error and channel-close paths."""
 
     def _make_channel(self):
         raw_ch = MagicMock()
@@ -1957,7 +1950,7 @@ class BasicGetTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_basic_get_returns_message_tuple(self):
         ch, raw_ch, wrapper = self._make_channel()
@@ -2025,7 +2018,7 @@ class BasicGetTests(unittest.TestCase):
 
 
 class ChannelCloseErrorPathTests(unittest.TestCase):
-    """Cover error branches inside ThreadSafeChannel.close()."""
+    """Cover error branches inside Channel.close()."""
 
     def _make_channel(self):
         raw_ch = MagicMock()
@@ -2043,7 +2036,7 @@ class ChannelCloseErrorPathTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_close_propagates_broker_initiated_close_reason(self):
         ch, raw_ch, wrapper = self._make_channel()
@@ -2094,7 +2087,7 @@ class CallbackRegistrationFailureTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_add_on_cancel_callback_logs_when_raw_register_raises(self):
         ch, raw_ch, wrapper = self._make_channel()
@@ -2170,7 +2163,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             MockSelectConn.side_effect = fake_init
             MockSelectConn.return_value = mock_conn
 
-            conn = ThreadSafeConnection(parameters='params')
+            conn = Connection(parameters='params')
             conn._ioloop_thread.join(timeout=1)
 
         return conn, mock_conn, mock_ioloop
@@ -2226,8 +2219,8 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         """
         conn, _mock_conn, _mock_ioloop = self._make_connection()
 
-        wedged = ThreadSafeChannel(MagicMock(), conn)
-        healthy = ThreadSafeChannel(MagicMock(), conn)
+        wedged = Channel(MagicMock(), conn)
+        healthy = Channel(MagicMock(), conn)
         with conn._channel_waiters_lock:
             conn._channels.extend([wedged, healthy])
 
@@ -2267,7 +2260,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
     def test_concurrent_channel_close_runs_shutdown_once(self):
         """Two concurrent close() calls must not both run the pool join."""
         conn, _mock_conn, _mock_ioloop = self._make_connection()
-        ch = ThreadSafeChannel(MagicMock(), conn)
+        ch = Channel(MagicMock(), conn)
 
         calls = []
         real_shutdown = ch._consumer_work_pool.shutdown
@@ -2323,10 +2316,10 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
                 raise crash
 
             mock_ioloop.start.side_effect = ioloop_start
-            conn = ThreadSafeConnection(parameters='params')
+            conn = Connection(parameters='params')
 
         # Manually add a channel to the tracking list
-        ch = ThreadSafeChannel(MagicMock(), conn)
+        ch = Channel(MagicMock(), conn)
         with conn._channel_waiters_lock:
             conn._channels.append(ch)
 
@@ -2342,7 +2335,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         conn._ioloop_thread = MagicMock()
         conn._ioloop_thread.is_alive.return_value = True
 
-        ch = ThreadSafeChannel(MagicMock(), conn)
+        ch = Channel(MagicMock(), conn)
         with conn._channel_waiters_lock:
             conn._channels.append(ch)
 
@@ -2358,7 +2351,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         conn._ioloop_thread = MagicMock()
         conn._ioloop_thread.is_alive.side_effect = [True, False]
 
-        ch = ThreadSafeChannel(MagicMock(), conn)
+        ch = Channel(MagicMock(), conn)
         with conn._channel_waiters_lock:
             conn._channels.append(ch)
 
@@ -2432,7 +2425,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             mock_ioloop.start = MagicMock()  # IOLoop does nothing
 
             with self.assertRaises(TimeoutError) as ctx:
-                ThreadSafeConnection(parameters='params', timeout=0.05)
+                Connection(parameters='params', timeout=0.05)
 
             self.assertIn('timed out', str(ctx.exception))
             mock_ioloop.add_callback_threadsafe.assert_called()
@@ -2460,7 +2453,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             with patch('pika.adapters.thread_safe_connection._BoundedWorkPool',
                        side_effect=capturing_pool), self.assertRaises(
                            RuntimeError) as ctx:
-                ThreadSafeConnection(parameters='params')
+                Connection(parameters='params')
             self.assertIs(ctx.exception, boom)
             self.assertEqual(len(captured), 1)
             # The captured pool must be shut down.  shutdown(wait=True)
@@ -2500,7 +2493,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
             MockSelectConn.return_value = mock_conn
 
             try:
-                ThreadSafeConnection(parameters='params', timeout=0.05)
+                Connection(parameters='params', timeout=0.05)
             except TimeoutError as exc:
                 # By the time the TimeoutError reaches us, the IOLoop
                 # thread must have been joined - i.e., it is no longer
@@ -2554,7 +2547,7 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         Channel() must raise (not return a leaked channel) if the connection closes between
         Channel.OpenOk and the caller waking.
 
-        Without the race guard, a ThreadSafeChannel would be appended to _channels after
+        Without the race guard, a Channel would be appended to _channels after
         _shutdown_all_consumer_pools() had already run, leaking the per-channel consumer pool.
         """
         conn, mock_conn, mock_ioloop = self._make_connection()
@@ -2582,13 +2575,13 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         self.assertEqual(conn._channels, [])
 
 
-class ThreadSafeConnectionTests(unittest.TestCase):
+class ConnectionTests(unittest.TestCase):
 
     def _make_connection(self,
                          on_open_error_callback=None,
                          on_close_callback=None):
         """
-        Construct a ThreadSafeConnection with a mocked SelectConnection.
+        Construct a Connection with a mocked SelectConnection.
 
         The mock immediately fires on_open_callback so __init__ unblocks.
         """
@@ -2614,7 +2607,7 @@ class ThreadSafeConnectionTests(unittest.TestCase):
             MockSelectConn.side_effect = fake_init
             MockSelectConn.return_value = mock_conn
 
-            conn = ThreadSafeConnection(
+            conn = Connection(
                 parameters='params',
                 on_open_error_callback=on_open_error_callback,
                 on_close_callback=on_close_callback,
@@ -2791,7 +2784,7 @@ class ThreadSafeConnectionTests(unittest.TestCase):
         mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled
 
         ch = conn.channel()
-        self.assertIsInstance(ch, ThreadSafeChannel)
+        self.assertIsInstance(ch, Channel)
 
     def test_channel_wraps_self_not_inner_connection(self):
         conn, mock_conn, mock_ioloop = self._make_connection()
@@ -2867,7 +2860,7 @@ class ThreadSafeConnectionTests(unittest.TestCase):
 
             mock_ioloop.start.side_effect = ioloop_start
 
-            conn = ThreadSafeConnection(parameters='params')
+            conn = Connection(parameters='params')
 
         exc_holder = [None]
 
@@ -2915,7 +2908,7 @@ class ThreadSafeConnectionTests(unittest.TestCase):
             mock_ioloop.start.side_effect = ioloop_start
 
             with self.assertRaises(Exception) as ctx:
-                ThreadSafeConnection(parameters='params')
+                Connection(parameters='params')
 
         self.assertIs(ctx.exception, error)
         mock_ioloop.stop.assert_called_once()
@@ -3201,7 +3194,7 @@ class ThreadSafeConnectionTests(unittest.TestCase):
 
 
 class ConnectionInitErrorPathTests(unittest.TestCase):
-    """Cover the IOLoop-thread error paths in ThreadSafeConnection.__init__."""
+    """Cover the IOLoop-thread error paths in Connection.__init__."""
 
     def test_ioloop_crash_before_open_propagates_to_init(self):
         """If ioloop.start() raises before on_open_callback fires, __init__ must surface the
@@ -3218,7 +3211,7 @@ class ConnectionInitErrorPathTests(unittest.TestCase):
             mock_ioloop.start.side_effect = crash
 
             with self.assertRaises(RuntimeError) as ctx:
-                ThreadSafeConnection(parameters='params')
+                Connection(parameters='params')
         self.assertIs(ctx.exception, crash)
 
     def test_on_connection_open_error_invokes_user_callback(self):
@@ -3249,14 +3242,13 @@ class ConnectionInitErrorPathTests(unittest.TestCase):
             mock_ioloop.start.side_effect = ioloop_start
 
             with self.assertRaises(AMQPConnectionError):
-                ThreadSafeConnection(parameters='params',
-                                     on_open_error_callback=user_cb)
+                Connection(parameters='params', on_open_error_callback=user_cb)
 
         user_cb.assert_called_once_with(mock_conn, error)
 
 
 class ConnectionCloseFromIOLoopTests(unittest.TestCase):
-    """Cover the close-from-IOLoop-thread path in ThreadSafeConnection.close()."""
+    """Cover the close-from-IOLoop-thread path in Connection.close()."""
 
     def _make_connection(self):
         with patch('pika.adapters.thread_safe_connection.SelectConnection'
@@ -3279,7 +3271,7 @@ class ConnectionCloseFromIOLoopTests(unittest.TestCase):
             MockSelectConn.side_effect = fake_init
             MockSelectConn.return_value = mock_conn
 
-            conn = ThreadSafeConnection(parameters='params')
+            conn = Connection(parameters='params')
             conn._ioloop_thread.join(timeout=1)
         return conn, mock_conn, mock_ioloop
 
@@ -3323,7 +3315,7 @@ class ConnectionEventRegistrationFailureTests(unittest.TestCase):
             MockSelectConn.side_effect = fake_init
             MockSelectConn.return_value = mock_conn
 
-            conn = ThreadSafeConnection(parameters='params')
+            conn = Connection(parameters='params')
             conn._ioloop_thread.join(timeout=1)
         return conn, mock_conn, mock_ioloop
 
@@ -3342,8 +3334,8 @@ class ConnectionEventRegistrationFailureTests(unittest.TestCase):
 
 
 class ChannelOpenExceptionPathTests(unittest.TestCase):
-    """Cover the exception path inside ThreadSafeConnection.channel() when the inner
-    connection.channel() call itself raises.
+    """Cover the exception path inside Connection.channel() when the inner connection.channel() call
+    itself raises.
     """
 
     def _make_connection(self):
@@ -3367,7 +3359,7 @@ class ChannelOpenExceptionPathTests(unittest.TestCase):
             MockSelectConn.side_effect = fake_init
             MockSelectConn.return_value = mock_conn
 
-            conn = ThreadSafeConnection(parameters='params')
+            conn = Connection(parameters='params')
             conn._ioloop_thread.join(timeout=1)
         return conn, mock_conn, mock_ioloop
 


### PR DESCRIPTION
## Summary

Rename `ThreadSafeConnection` to `Connection` and `ThreadSafeChannel` to `Channel`, and export `pika.Connection`. `ThreadSafeConnection` was added in 1.4.0 and is the primary user-facing connection going forward; the "ThreadSafe" qualifier only distinguished it from the other adapters, which are deprecated.

This is the minimal, non-breaking part of #1617. The larger `pika/_core/` restructure originally described in that issue is deferred to 2.0.0 and tracked in #1681, because it would move import paths (`pika.connection`, `pika.channel`, `pika.adapters.select_connection`) that carry a large amount of released downstream code.

## What changed

- Rename the classes **in place**. The module stays at `pika/adapters/thread_safe_connection.py`, so `from pika.adapters.thread_safe_connection import Connection` works and no existing module path moves.
- Export `pika.Connection` (top level and `pika.adapters`); re-sort `__all__` and imports.
- Update the deprecation-warning strings in the blocking and twisted adapters to name `Connection`.
- Update tests, docs, examples, the README, and the docs navigation label.

## Deliberate scope decisions

- **`Channel` is not exported from `pika`.** `ThreadSafeChannel` was never public; channels come from `Connection.channel()`. Renaming it is enough.
- **Protocol classes untouched.** `pika.connection.Connection` and `pika.channel.Channel` are left exactly as they are.

## Testing

- `hatch run test` (unit + acceptance against a RabbitMQ container): 1494 passed, 61 skipped
- `hatch run lint-check`, `fmt-check`, `docfmt-check`, `typecheck`: all pass
- `hatch run docs:build` (mkdocs `--strict`): passes

Fixes #1617. See #1681 for the deferred 2.0.0 restructure.

---

Implemented with AI assistance (Claude Code); reviewed by me.
