### PR TITLE
Fix: gh-1684 (Release each blocking RPC's channel callbacks)

### DIFF
--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -478,6 +478,31 @@ class Channel:
             except ValueError:
                 pass
 
+    def _release_close_callback(self, on_chan_close, *extra) -> None:
+        """
+        Unregister the per-RPC channel callbacks now that the call has finished.
+
+        :meth:`~pika.channel.Channel.add_on_close_callback` registers with ``one_shot=False`` and
+        each RPC passes a distinct closure, so nothing ever collapses them: left in place they
+        accumulate for the life of the channel, and ``CallbackManager.add`` rescans that growing
+        list on every later registration.  A completed RPC has no use for its close callback, so
+        drop it.
+
+        Removal is scheduled rather than done inline because the channel's callback stack belongs to
+        the IOLoop thread.  Ordering is safe: the ``_invoke`` that registers is queued before this,
+        and the IOLoop drains its callback queue in FIFO order, so the removal never runs first.
+
+        :param on_chan_close: The close callback registered for this RPC.
+        :param extra: Zero-argument callables removing any other per-RPC callbacks.
+        """
+
+        def _remove() -> None:
+            self._channel.remove_on_close_callback(on_chan_close)
+            for remove_one in extra:
+                remove_one()
+
+        self._wrapper._schedule_unchecked(_remove)
+
     def _blocking_rpc(self, method_name: str, channel_method,
                       timeout: float | None, *args, **kwargs) -> Any:
         """
@@ -503,18 +528,17 @@ class Channel:
         ready, error = self._register_waiter()
         result = [None]
 
-        def _invoke() -> None:
+        def _on_ok(method_frame) -> None:
+            result[0] = method_frame
+            ready.set()
 
-            def _on_ok(method_frame) -> None:
-                result[0] = method_frame
+        def _on_chan_close(ch, reason) -> None:
+            if not ready.is_set():
+                if error[0] is None:
+                    error[0] = reason
                 ready.set()
 
-            def _on_chan_close(ch, reason) -> None:
-                if not ready.is_set():
-                    if error[0] is None:
-                        error[0] = reason
-                    ready.set()
-
+        def _invoke() -> None:
             try:
                 self._channel.add_on_close_callback(_on_chan_close)
                 channel_method(*args, **kwargs, callback=_on_ok)
@@ -530,6 +554,7 @@ class Channel:
                     f'{method_name} timed out after {timeout} seconds')
         finally:
             self._unregister_waiter(ready, error)
+            self._release_close_callback(_on_chan_close)
 
         if error[0] is not None:
             raise _reraisable(error[0], self._wrapper._closed_reason,
@@ -705,23 +730,22 @@ class Channel:
         ready, error = self._register_waiter()
         result = [None, None, None]
 
+        def _on_get_ok(ch, method, properties, body) -> None:
+            result[0] = method
+            result[1] = properties
+            result[2] = body
+            ready.set()
+
+        def _on_get_empty(method_frame) -> None:
+            ready.set()
+
+        def _on_chan_close(ch, reason) -> None:
+            if not ready.is_set():
+                if error[0] is None:
+                    error[0] = reason
+                ready.set()
+
         def _get() -> None:
-
-            def _on_get_ok(ch, method, properties, body) -> None:
-                result[0] = method
-                result[1] = properties
-                result[2] = body
-                ready.set()
-
-            def _on_get_empty(method_frame) -> None:
-                ready.set()
-
-            def _on_chan_close(ch, reason) -> None:
-                if not ready.is_set():
-                    if error[0] is None:
-                        error[0] = reason
-                    ready.set()
-
             try:
                 self._channel.add_on_close_callback(_on_chan_close)
                 self._channel.add_callback(
@@ -746,6 +770,11 @@ class Channel:
                     f'basic_get timed out after {timeout} seconds')
         finally:
             self._unregister_waiter(ready, error)
+            # A one-shot is only consumed if it fires, so the Basic.GetEmpty
+            # callback outlives every get that actually returned a message.
+            self._release_close_callback(
+                _on_chan_close, lambda: self._channel.remove_callback(
+                    _on_get_empty, [spec.Basic.GetEmpty]))
 
         if error[0] is not None:
             raise _reraisable(error[0], self._wrapper._closed_reason,

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -400,5 +400,46 @@ class TestContextManager(ThreadSafeTestCaseBase):
         self.assertTrue(conn.is_closed)
 
 
+class TestPerRPCCallbacksDoNotAccumulate(ThreadSafeTestCaseBase):
+    """
+    A long-lived channel must not grow a callback per RPC it serves.
+
+    ``add_on_close_callback`` registers with ``one_shot=False`` and every RPC passes a distinct
+    closure, so anything left behind is held until the channel closes and is rescanned by every
+    later registration.  Unit tests assert the removal calls; this asserts the observable
+    consequence against a real broker.
+    """
+
+    @staticmethod
+    def _close_callback_count(ch):
+        raw = ch._channel
+        # CallbackManager normalizes the prefix to a string.
+        stack = raw.callbacks._stack.get(str(raw.channel_number), {})
+        return len(stack.get('_on_channel_close', []))
+
+    def test(self):
+        conn = self._connect()
+        ch = conn.channel()
+        queue = self._unique_queue()
+        ch.queue_declare(queue=queue, exclusive=True)
+
+        baseline = self._close_callback_count(ch)
+        for _ in range(50):
+            ch.queue_declare(queue=queue, exclusive=True)
+
+        # At most one cleanup may still be in flight on the IOLoop thread.
+        retry_assertion(BLOCKING_CALL_TIMEOUT)(lambda: self.assertLessEqual(
+            self._close_callback_count(ch), baseline + 1))()
+
+        # The Basic.GetEmpty one-shot is only consumed if it fires, so a get
+        # that returns a message has to remove its own.
+        ch.basic_publish(exchange='', routing_key=queue, body=b'x')
+        for _ in range(20):
+            ch.basic_get(queue=queue, auto_ack=True)
+
+        retry_assertion(BLOCKING_CALL_TIMEOUT)(lambda: self.assertLessEqual(
+            self._close_callback_count(ch), baseline + 1))()
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -411,34 +411,59 @@ class TestPerRPCCallbacksDoNotAccumulate(ThreadSafeTestCaseBase):
     """
 
     @staticmethod
-    def _close_callback_count(ch):
+    def _callback_count(ch, key):
         raw = ch._channel
         # CallbackManager normalizes the prefix to a string.
         stack = raw.callbacks._stack.get(str(raw.channel_number), {})
-        return len(stack.get('_on_channel_close', []))
+        return len(stack.get(key, []))
 
     def test(self):
+        n = 20
         conn = self._connect()
         ch = conn.channel()
         queue = self._unique_queue()
         ch.queue_declare(queue=queue, exclusive=True)
 
-        baseline = self._close_callback_count(ch)
+        close_baseline = self._callback_count(ch, '_on_channel_close')
+        empty_baseline = self._callback_count(ch, 'Basic.GetEmpty')
         for _ in range(50):
             ch.queue_declare(queue=queue, exclusive=True)
 
         # At most one cleanup may still be in flight on the IOLoop thread.
         retry_assertion(BLOCKING_CALL_TIMEOUT)(lambda: self.assertLessEqual(
-            self._close_callback_count(ch), baseline + 1))()
+            self._callback_count(ch, '_on_channel_close'), close_baseline + 1))(
+            )
 
-        # The Basic.GetEmpty one-shot is only consumed if it fires, so a get
-        # that returns a message has to remove its own.
-        ch.basic_publish(exchange='', routing_key=queue, body=b'x')
-        for _ in range(20):
-            ch.basic_get(queue=queue, auto_ack=True)
+        # The Basic.GetEmpty one-shot self-consumes only when it fires, so a
+        # get that returns a message leaves its own behind for
+        # _release_close_callback to drop.  Publish one message per get and
+        # wait for all to arrive so every get returns a message and exercises
+        # that removal.
+        for i in range(n):
+            ch.basic_publish(exchange='',
+                             routing_key=queue,
+                             body=f'msg-{i}'.encode())
 
+        @retry_assertion(timeout_sec=BLOCKING_CALL_TIMEOUT)
+        def assert_all_arrived():
+            frame = ch.queue_declare(queue=queue, passive=True)
+            assert frame is not None
+            self.assertEqual(frame.method.message_count, n)
+
+        assert_all_arrived()
+
+        for _ in range(n):
+            method, _properties, body = ch.basic_get(queue=queue, auto_ack=True)
+            self.assertIsNotNone(method, 'expected a message, got an empty get')
+            self.assertIsNotNone(body)
+
+        # The GetEmpty one-shots from message-returning gets must be dropped,
+        # and the close callbacks each get registered must not accumulate.
         retry_assertion(BLOCKING_CALL_TIMEOUT)(lambda: self.assertLessEqual(
-            self._close_callback_count(ch), baseline + 1))()
+            self._callback_count(ch, 'Basic.GetEmpty'), empty_baseline + 1))()
+        retry_assertion(BLOCKING_CALL_TIMEOUT)(lambda: self.assertLessEqual(
+            self._callback_count(ch, '_on_channel_close'), close_baseline + 1))(
+            )
 
 
 if __name__ == '__main__':

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -6,6 +6,7 @@ import traceback
 import unittest
 from unittest.mock import ANY, MagicMock, patch
 
+from pika import spec
 from pika.adapters.thread_safe_connection import (
     DEFAULT_WORK_QUEUE_PUT_TIMEOUT,
     Channel,
@@ -2017,6 +2018,110 @@ class BasicGetTests(unittest.TestCase):
         with self.assertRaises(Exception) as ctx:
             ch.basic_get(queue='q', timeout=0.5)
         self.assertIs(ctx.exception, reason)
+
+
+class PerRPCCallbackReleaseTests(unittest.TestCase):
+    """
+    Cover the release of the per-RPC channel callbacks.
+
+    ``add_on_close_callback`` registers with ``one_shot=False`` and every RPC passes a distinct
+    closure, so any callback left behind accumulates for the life of the channel and slows every
+    later registration down.  A finished RPC has to take its own callbacks back out.
+    """
+
+    def _make_channel(self):
+        raw_ch = MagicMock()
+        raw_ch.channel_number = 1
+        raw_ch.is_open = True
+        raw_ch.is_closed = False
+        wrapper = MagicMock()
+        wrapper._closed_reason = None
+        # A MagicMock would auto-create this as a Mock, which with_traceback()
+        # rejects; the real attribute is None until a close reason is recorded.
+        wrapper._closed_reason_tb = None
+        wrapper._channel_waiters_lock = threading.Lock()
+        wrapper._blocking_waiters = []
+        # A healthy connection has no pending error; _submit_or_terminate
+        # short-circuits when _error is set, so it must be None here.
+        wrapper._connection._error = None
+        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+
+    def test_blocking_rpc_removes_the_close_callback_it_registered(self):
+        """A completed RPC must remove the exact close callback it added."""
+        ch, raw_ch, wrapper = self._make_channel()
+
+        def fire_ok(*_args, **kwargs):
+            kwargs['callback']('Queue.DeclareOk')
+
+        raw_ch.queue_declare.side_effect = fire_ok
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        ch.queue_declare(queue='q', timeout=0.5)
+
+        registered = raw_ch.add_on_close_callback.call_args[0][0]
+        raw_ch.remove_on_close_callback.assert_called_once_with(registered)
+
+    def test_blocking_rpc_removes_the_close_callback_after_a_timeout(self):
+        """A timed-out RPC must clean up too, or a flaky broker leaks one per call."""
+        ch, raw_ch, wrapper = self._make_channel()
+        # Never fire the ok callback, so the wait times out.
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        with self.assertRaises(TimeoutError):
+            ch.queue_declare(queue='q', timeout=0.01)
+
+        registered = raw_ch.add_on_close_callback.call_args[0][0]
+        raw_ch.remove_on_close_callback.assert_called_once_with(registered)
+
+    def test_basic_get_removes_both_of_its_callbacks(self):
+        """
+        basic_get must drop its close callback and its Basic.GetEmpty one-shot.
+
+        A one-shot is only consumed if it fires, so a get that returns a message leaves its
+        Basic.GetEmpty callback registered unless it is removed explicitly.
+        """
+        ch, raw_ch, wrapper = self._make_channel()
+
+        def fire_get_ok(*_args, **kwargs):
+            kwargs['callback'](raw_ch, 'method', 'props', b'body')
+
+        raw_ch.basic_get.side_effect = fire_get_ok
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        ch.basic_get(queue='q', timeout=0.5)
+
+        registered_close = raw_ch.add_on_close_callback.call_args[0][0]
+        raw_ch.remove_on_close_callback.assert_called_once_with(
+            registered_close)
+        registered_empty = raw_ch.add_callback.call_args[0][0]
+        raw_ch.remove_callback.assert_called_once_with(registered_empty,
+                                                       [spec.Basic.GetEmpty])
+
+    def test_release_is_scheduled_rather_than_run_inline(self):
+        """Removal must go through the IOLoop, which owns the channel's callback stack."""
+        ch, raw_ch, wrapper = self._make_channel()
+        scheduled = []
+
+        def fire_ok(*_args, **kwargs):
+            kwargs['callback']('Queue.DeclareOk')
+
+        raw_ch.queue_declare.side_effect = fire_ok
+
+        def capture(cb):
+            scheduled.append(cb)
+            # Only run the RPC itself; leave the cleanup queued.
+            if len(scheduled) == 1:
+                cb()
+
+        wrapper._schedule_unchecked.side_effect = capture
+
+        ch.queue_declare(queue='q', timeout=0.5)
+
+        # The cleanup was handed to the IOLoop, not executed on this thread.
+        self.assertEqual(len(scheduled), 2)
+        raw_ch.remove_on_close_callback.assert_not_called()
+        scheduled[1]()
+        raw_ch.remove_on_close_callback.assert_called_once()
 
 
 class ChannelCloseErrorPathTests(unittest.TestCase):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2044,7 +2044,7 @@ class PerRPCCallbackReleaseTests(unittest.TestCase):
         # A healthy connection has no pending error; _submit_or_terminate
         # short-circuits when _error is set, so it must be None here.
         wrapper._connection._error = None
-        return ThreadSafeChannel(raw_ch, wrapper), raw_ch, wrapper
+        return Channel(raw_ch, wrapper), raw_ch, wrapper
 
     def test_blocking_rpc_removes_the_close_callback_it_registered(self):
         """A completed RPC must remove the exact close callback it added."""

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1578,8 +1578,10 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         result2 = ch.confirm_delivery(MagicMock())
         self.assertIs(result2, ok_frame)
         self.assertEqual(ch._next_publish_seq_no, 5)
-        # Only one RPC should have been sent
-        self.assertEqual(wrapper._schedule_unchecked.call_count, 1)
+        # Only one RPC should have been sent.  Count the frames handed to the
+        # raw channel rather than the callbacks scheduled on the IOLoop: a
+        # single RPC also schedules its own callback cleanup.
+        self.assertEqual(raw_ch.confirm_delivery.call_count, 1)
 
     def test_next_publish_seq_no_property_none_before_confirms(self):
         """next_publish_seq_no returns None when confirms are not enabled."""


### PR DESCRIPTION
## Proposed Changes

`ThreadSafeChannel._blocking_rpc` registered a fresh `_on_chan_close` closure on the raw channel for every call and never removed it:

```python
def _on_chan_close(ch, reason) -> None:
    if not ready.is_set():
        ...

try:
    self._channel.add_on_close_callback(_on_chan_close)   # never removed
    channel_method(*args, **kwargs, callback=_on_ok)
```

`Channel.add_on_close_callback` registers with `one_shot=False`, and each call passes a distinct closure, so `CallbackManager.add`'s duplicate check never collapses them. They accumulate for the life of the channel. `basic_get` does the same and additionally leaves its `Basic.GetEmpty` one-shot behind whenever the get returns a message, because a one-shot is only consumed if it fires.

This affects every blocking RPC: `queue_declare`, `queue_bind`, `queue_delete`, `queue_purge`, `exchange_declare`, `exchange_bind`, `exchange_delete`, `basic_qos`, `basic_get`, `basic_consume`, `basic_cancel`, `confirm_delivery`, and `close`.

Firing the strays is harmless, since each guards on `ready.is_set()` and a completed RPC has it set, so this costs memory and CPU rather than correctness. Two effects, both proportional to how many RPCs the channel has served:

- around 2 KiB per RPC, held until the channel closes
- `CallbackManager.add` linearly rescans the existing list on every registration, and since the closures never match, that scan is pure waste that grows without bound

It matters for the workload this adapter targets, a long-lived connection whose channels stay open for the process lifetime. A short-lived channel never notices.

The fix hoists the per-RPC closures out of the scheduled `_invoke` so they can be referenced afterwards, and adds `_release_close_callback`, called from the same `finally` that already unregisters the waiter. Removal goes through the public `Channel.remove_on_close_callback` and `Channel.remove_callback`, scheduled on the IOLoop thread because the channel's callback stack belongs to it. Ordering is safe: the `_invoke` that registers is queued first and the IOLoop drains its callback queue in FIFO order, so the removal can never run ahead of the registration.

## Types of Changes

- [x] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1684

## Further Comments

### Measured effect

The reproduction script from #1684, run unchanged against `main` and this branch back to back on the same machine and broker (RabbitMQ 4.3.4, Python 3.14.4). 500 warmup plus 8000 measured `queue_declare` calls on one channel.

Before, on `main`:

```
close callbacks before any RPC : 0
queue_declare calls issued     : 500 warmup + 8000 measured
close callbacks after warmup   : 500
close callbacks at the end     : 8500
retained heap growth           : 15873 KiB

mean RPC latency, first  500   :   0.164 ms
mean RPC latency, last   500   :   0.453 ms
slowdown                       : 2.8x
```

After, on this branch:

```
close callbacks before any RPC : 0
queue_declare calls issued     : 500 warmup + 8000 measured
close callbacks after warmup   : 0
close callbacks at the end     : 1
retained heap growth           : 269 KiB

mean RPC latency, first  500   :   0.149 ms
mean RPC latency, last   500   :   0.141 ms
slowdown                       : 0.9x
```

| | before | after |
| --- | --- | --- |
| close callbacks retained | 8500 | 1 |
| retained heap growth | 15873 KiB | 269 KiB |
| mean RPC latency, first 500 | 0.164 ms | 0.149 ms |
| mean RPC latency, last 500 | 0.453 ms | 0.141 ms |
| slowdown across 8000 calls | 2.8x | 0.9x |

The point is that latency stops climbing: flat within noise across 8000 calls, against nearly tripling before. The retained `1` is not a leftover; removal is scheduled on the IOLoop, so at most one cleanup is in flight when the count is sampled. It drains to 0 and does not grow with the number of RPCs, which I checked at 100, 1000 and 5000.

End-to-end timings include broker round trips and are noisy, so the ratio is not a precise figure. Across repeated runs it was 1.7x to 4.1x before and 0.5x to 1.1x after, always in the same direction. The deterministic measurement behind it is the cost of one more registration, which rises linearly with what is already registered:

```
  already registered   cost of next add
                   0             2.1 us
                1000            19.8 us
                4000            79.9 us
               16000           331.6 us
```

That curve is a property of `CallbackManager` and is unchanged by this PR, which is why the script prints the same table before and after. What changes is that a long-lived channel no longer travels down it, staying at the top row instead of reaching the bottom.

Separately, 300 `basic_get` calls that all returned a message left 301 close callbacks and 301 `Basic.GetEmpty` entries; those are now 0 and 1, the 1 being pika's own permanent handler.

### Tests

Unit tests in `tests/unit/thread_safe_connection_tests.py`, one per property:

- a completed RPC removes the exact close callback it registered
- a timed-out RPC cleans up too, so a flaky broker does not leak one per call
- `basic_get` removes both its close callback and its `Basic.GetEmpty` one-shot
- the removal is scheduled on the IOLoop rather than run on the calling thread

Acceptance test `TestPerRPCCallbacksDoNotAccumulate` drives 50 `queue_declare` calls and 20 gets over a real connection and asserts the observable consequence, that the close-callback list does not grow with the RPCs served. It allows one in-flight cleanup, since removal is scheduled rather than inline.

All five fail against the unfixed adapter; the acceptance test reports `51 not less than or equal to 2`.

One existing assertion changed. `test_confirm_delivery_is_idempotent` counted callbacks scheduled on the IOLoop as a proxy for "one RPC was sent", which no longer holds now that a single RPC also schedules its own cleanup. It now counts the frames handed to the raw channel, which is what it was actually trying to assert.
