### PR TITLE
Drop each closed channel from the connection's tracking list

### DIFF
--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -427,6 +427,14 @@ class Channel:
         """
         Shut down the consumer work pool, allowing in-flight work to finish.
 
+        Also drops this channel from the connection's tracking list.  That list exists only so
+        :meth:`~Connection._shutdown_all_consumer_pools` can reach every live pool, and a channel
+        whose pool is shut down has nothing left to drain; left in place the entries accumulate for
+        the life of the connection, retaining each closed channel's pool, raw channel and per-RPC
+        callbacks.  This is the one choke point for the transition and ``_pool_shutdown`` makes it
+        idempotent, so each channel is dropped exactly once whether it was closed by the user or
+        swept at connection shutdown.
+
         :param timeout: Seconds to wait for the worker to drain and exit. ``None`` waits
             indefinitely. A wedged worker that outlives a finite *timeout* is left running (it is a
             daemon thread) rather than stalling the caller; a warning is logged.
@@ -439,6 +447,13 @@ class Channel:
             if self._pool_shutdown:
                 return
             self._pool_shutdown = True
+            # Safe to mutate while a sweep is in flight:
+            # _shutdown_all_consumer_pools snapshots the list under this same
+            # lock before iterating it.
+            try:
+                self._wrapper._channels.remove(self)
+            except ValueError:
+                pass
         if not self._consumer_work_pool.shutdown(wait=True, timeout=timeout):
             LOGGER.warning(
                 'Channel %s consumer work pool did not drain within '

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -423,42 +423,87 @@ class Channel:
         """
         self._consumer_work_pool.shutdown(wait=False)
 
+    def _claim_pool_shutdown(self) -> bool:
+        """
+        Claim this channel's pool shutdown and drop it from connection tracking.
+
+        Returns ``True`` if this call is the first to claim the shutdown - so the caller owns any
+        follow-up work, such as joining the worker - and ``False`` if a prior close already claimed
+        it.  Being idempotent lets a user :meth:`close`, the broker-close hook
+        (:meth:`_on_broker_close`) and the connection-shutdown sweep race while each channel is
+        dropped from ``_channels`` exactly once.
+
+        The tracking list exists only so :meth:`~Connection._shutdown_all_consumer_pools` can reach
+        every live pool, and a channel whose pool is shutting down has nothing left to drain; left
+        in place the entries accumulate for the life of the connection, retaining each closed
+        channel's pool, raw channel and per-RPC callbacks.
+
+        :returns: ``True`` if this call claimed the shutdown, ``False`` if a prior close already did.
+        """
+        # Safe to mutate the list while a sweep is in flight:
+        # _shutdown_all_consumer_pools snapshots it under this same lock before
+        # iterating.
+        with self._wrapper._channel_waiters_lock:
+            if self._pool_shutdown:
+                return False
+            self._pool_shutdown = True
+            try:
+                self._wrapper._channels.remove(self)
+            except ValueError:
+                pass
+        return True
+
     def _shutdown_pool(self, timeout: float | None = None) -> None:
         """
-        Shut down the consumer work pool, allowing in-flight work to finish.
+        Shut down the consumer work pool, joining its worker.
 
-        Also drops this channel from the connection's tracking list.  That list exists only so
-        :meth:`~Connection._shutdown_all_consumer_pools` can reach every live pool, and a channel
-        whose pool is shut down has nothing left to drain; left in place the entries accumulate for
-        the life of the connection, retaining each closed channel's pool, raw channel and per-RPC
-        callbacks.  This is the one choke point for the transition and ``_pool_shutdown`` makes it
-        idempotent, so each channel is dropped exactly once whether it was closed by the user or
-        swept at connection shutdown.
+        Claims the shutdown and drops the channel from tracking via :meth:`_claim_pool_shutdown`,
+        then joins the worker.  Used by the paths that can afford to wait off the IOLoop thread: a
+        user :meth:`close` (on the caller's thread) and the connection-shutdown sweep (after the
+        IOLoop has stopped).
 
         :param timeout: Seconds to wait for the worker to drain and exit. ``None`` waits
             indefinitely. A wedged worker that outlives a finite *timeout* is left running (it is a
             daemon thread) rather than stalling the caller; a warning is logged.
         """
-        # Atomically claim the shutdown so concurrent close() calls do not both
-        # run the join.  The join itself stays outside the lock: it can block
-        # for the whole timeout, and holding the connection-wide lock that long
-        # would stall every other channel operation.
-        with self._wrapper._channel_waiters_lock:
-            if self._pool_shutdown:
-                return
-            self._pool_shutdown = True
-            # Safe to mutate while a sweep is in flight:
-            # _shutdown_all_consumer_pools snapshots the list under this same
-            # lock before iterating it.
-            try:
-                self._wrapper._channels.remove(self)
-            except ValueError:
-                pass
+        # The join stays outside the lock: it can block for the whole timeout,
+        # and holding the connection-wide lock that long would stall every other
+        # channel operation.
+        if not self._claim_pool_shutdown():
+            return
         if not self._consumer_work_pool.shutdown(wait=True, timeout=timeout):
             LOGGER.warning(
                 'Channel %s consumer work pool did not drain within '
                 '%s seconds; abandoning its worker thread',
                 self._channel.channel_number, timeout)
+
+    def _on_broker_close(self, _channel, reason) -> None:
+        """
+        Drop this channel from tracking when the broker closes it on its own.
+
+        Registered once per channel, on the IOLoop thread, right after the channel opens.  A client
+        close - a user :meth:`close`, or the per-channel closes a graceful :meth:`Connection.close`
+        issues - reports :class:`~pika.exceptions.ChannelClosedByClient` and is left to
+        :meth:`_shutdown_pool`, so this handles only broker- or error-initiated closes.  Without it
+        those channels stay in ``_channels`` (with their pool, worker thread, raw channel and
+        per-RPC callbacks) until the connection itself is torn down - the leak #1688 describes,
+        reached through a close path :meth:`_shutdown_pool` never sees.
+
+        Runs on the IOLoop thread, so it must not join the worker: joining a worker that is mid
+        delivery-callback and waiting on this same IOLoop would deadlock, which is why pool joins
+        are otherwise deferred off this thread (see :meth:`~Connection._on_connection_closed`).  It
+        only signals the pool to drain; the daemon worker exits on its own once the channel is
+        closed and no further deliveries arrive.  The connection-shutdown sweep, running after the
+        IOLoop stops, joins any channel this has not already dropped.
+
+        :param _channel: The raw channel reporting the close (unused).
+        :param reason: The exception describing why the channel closed.
+        """
+        from pika.exceptions import ChannelClosedByClient
+        if isinstance(reason, ChannelClosedByClient):
+            return
+        if self._claim_pool_shutdown():
+            self._consumer_work_pool.shutdown(wait=False)
 
     def _register_waiter(self) -> tuple[Event, list[BaseException | None]]:
         """
@@ -1715,6 +1760,13 @@ class Connection:
                          work_queue_maxsize=self._work_queue_maxsize,
                          work_queue_put_timeout=self._work_queue_put_timeout)
             self._channels.append(ch)
+        # Register the broker-close hook on the IOLoop thread, where the raw
+        # channel's callback stack is safe to mutate.  A broker close arriving
+        # in the brief gap before this runs simply falls back to the
+        # connection-shutdown sweep, which still drops the channel from
+        # tracking.
+        self._schedule_unchecked(
+            lambda: ch._channel.add_on_close_callback(ch._on_broker_close))
         return ch
 
     def close(self, timeout: float | None = 10) -> None:

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2333,6 +2333,70 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         self.assertTrue(all(ch._pool_shutdown for ch in channels))
         self.assertEqual(conn._channels, [])
 
+    def test_channel_open_registers_broker_close_hook(self):
+        """
+        Opening a channel registers the broker-close hook on the raw channel.
+
+        The hook is what drops a broker-closed channel from tracking, so a channel that opened
+        without it would leak until connection teardown.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+
+        def execute_scheduled(cb):
+            mock_raw_ch = MagicMock()
+            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(
+                mock_raw_ch)
+            cb()
+
+        mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled
+
+        ch = conn.channel()
+        ch._channel.add_on_close_callback.assert_called_once_with(
+            ch._on_broker_close)
+
+    def test_broker_close_drops_channel_without_joining(self):
+        """
+        A broker-initiated close drops the channel from tracking and signals the pool to drain
+        without joining.
+
+        The hook runs on the IOLoop thread, where joining a worker that is mid delivery-callback
+        would deadlock, so it must use shutdown(wait=False) rather than _shutdown_pool's join.
+        """
+        from pika.exceptions import ChannelClosedByBroker
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+        ch = Channel(MagicMock(), conn)
+        ch._consumer_work_pool = MagicMock()
+        with conn._channel_waiters_lock:
+            conn._channels.append(ch)
+
+        ch._on_broker_close(ch._channel,
+                            ChannelClosedByBroker(320, 'connection closed'))
+
+        self.assertNotIn(ch, conn._channels)
+        self.assertTrue(ch._pool_shutdown)
+        ch._consumer_work_pool.shutdown.assert_called_once_with(wait=False)
+
+    def test_client_close_reason_left_to_shutdown_pool(self):
+        """
+        A client-initiated close is ignored by the hook.
+
+        close() drives the removal and the worker join itself via _shutdown_pool, so the hook must
+        not pre-empt it: the channel stays tracked and the pool untouched until then.
+        """
+        from pika.exceptions import ChannelClosedByClient
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+        ch = Channel(MagicMock(), conn)
+        ch._consumer_work_pool = MagicMock()
+        with conn._channel_waiters_lock:
+            conn._channels.append(ch)
+
+        ch._on_broker_close(ch._channel,
+                            ChannelClosedByClient(200, 'Normal shutdown'))
+
+        self.assertIn(ch, conn._channels)
+        self.assertFalse(ch._pool_shutdown)
+        ch._consumer_work_pool.shutdown.assert_not_called()
+
     def test_connection_close_shuts_down_channel_pools(self):
         """Pool shutdown happens after ioloop.start() returns, not inside _on_connection_closed
         (which runs on the IOLoop thread).

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2289,6 +2289,50 @@ class ConsumerPoolConnectionIntegrationTests(unittest.TestCase):
         ch = conn.channel()
         self.assertIn(ch, conn._channels)
 
+    def test_channel_close_drops_it_from_connection_tracking(self):
+        """
+        A closed channel must not stay on _channels.
+
+        The list exists only so the shutdown sweep can reach every live pool, and a channel whose
+        pool is shut down has nothing left to drain.  Left append-only, a connection with channel
+        churn retains every Channel it ever opened, along with that channel's work pool, raw channel
+        and per-RPC callbacks.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+
+        def execute_scheduled(cb):
+            mock_raw_ch = MagicMock()
+            mock_conn.channel.side_effect = lambda on_open_callback: on_open_callback(
+                mock_raw_ch)
+            cb()
+
+        mock_ioloop.add_callback_threadsafe.side_effect = execute_scheduled
+
+        for _ in range(5):
+            ch = conn.channel()
+            self.assertIn(ch, conn._channels)
+            ch.close()
+            self.assertNotIn(ch, conn._channels)
+        self.assertEqual(conn._channels, [])
+
+    def test_shutdown_sweep_drops_every_channel_from_tracking(self):
+        """
+        The connection-wide sweep leaves the tracking list empty.
+
+        Mutating the list from _shutdown_pool is safe during the sweep because
+        _shutdown_all_consumer_pools snapshots it under the lock before iterating.
+        """
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+
+        channels = [Channel(MagicMock(), conn) for _ in range(3)]
+        with conn._channel_waiters_lock:
+            conn._channels.extend(channels)
+
+        conn._shutdown_all_consumer_pools()
+
+        self.assertTrue(all(ch._pool_shutdown for ch in channels))
+        self.assertEqual(conn._channels, [])
+
     def test_connection_close_shuts_down_channel_pools(self):
         """Pool shutdown happens after ioloop.start() returns, not inside _on_connection_closed
         (which runs on the IOLoop thread).


### PR DESCRIPTION
## Proposed Changes

`Connection._channels` exists only so `_shutdown_all_consumer_pools` can reach every live consumer pool, but nothing ever removed an entry. `Channel.close()` shut the pool down and left the wrapper on the list, so a connection with channel churn retained every `Channel` it had ever opened, along with that channel's `_BoundedWorkPool`, raw channel and per-RPC callbacks. Channel-per-unit-of-work is the pattern this adapter encourages, and long-lived connections are what it targets, so the leak grows without bound in exactly the deployments it is built for.

This removes the channel in `_shutdown_pool`, under the lock that already guards the transition.

200 open/close cycles against RabbitMQ 4.3.4, using the reproduction from #1688:

| | before | after |
| --- | --- | --- |
| wrapper channels tracked | 200 | 0 |
| `_BoundedWorkPool` objects retained | 200 | 0 |

<details>
<summary>Reproduction output, before and after</summary>

Both runs are from the same working tree, reverting and restoring only `pika/adapters/thread_safe_connection.py` between them, against RabbitMQ 4.3.4 on Python 3.14.4.

Before:

```
wrapper channels tracked at start        : 0
wrapper channels tracked after 200 open/close: 200
all of them report is_closed            : True
raw pika channels on the underlying conn : 0
live _BoundedWorkPool objects retained   : 200
```

After:

```
wrapper channels tracked at start        : 0
wrapper channels tracked after 200 open/close: 0
all of them report is_closed            : True
raw pika channels on the underlying conn : 0
live _BoundedWorkPool objects retained   : 0
```

All 200 wrappers were closed and unreachable from user code in both runs, and the underlying `pika.connection.Connection` correctly dropped all 200 of its own channels in both. Only the wrapper's list differs. The `is_closed` line reads `True` vacuously in the second run, over an empty list.

<details>
<summary>Script</summary>

```python
import gc

import pika
from pika.adapters.thread_safe_connection import Connection

CHURN = 200

conn = Connection(pika.ConnectionParameters('localhost'))
print(f'wrapper channels tracked at start        : {len(conn._channels)}')

for _ in range(CHURN):
    ch = conn.channel()
    ch.close()
del ch
gc.collect()

tracked = conn._channels
print(f'wrapper channels tracked after {CHURN} open/close: {len(tracked)}')
print(f'all of them report is_closed            : '
      f'{all(c.is_closed for c in tracked)}')
print(f'raw pika channels on the underlying conn : '
      f'{len(conn._connection._channels)}')
print(f'live _BoundedWorkPool objects retained   : '
      f'{sum(1 for c in tracked if c._consumer_work_pool is not None)}')
conn.close()
```

The queue-free version above declares nothing, so it runs as-is. Note that on RabbitMQ 4.x a `queue_declare(auto_delete=True)` in a variant of this script is rejected (`transient_nonexcl_queues` is deprecated); use `durable=True`.

</details>
</details>

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

`hatch run unit`: 940 passed, 21 skipped. `lint-check`, `fmt-check`, `docfmt-check` and `typecheck` clean. `tests/acceptance/thread_safe_connection_test.py` and `thread_safe_bounded_queue_test.py` against a live broker: 12 passed.

Two unit tests added: one churns channels and asserts each is tracked while live and dropped on close, one covers the connection-wide sweep and pins the snapshot-under-lock reasoning that makes the mutation safe. Documentation is the updated `_shutdown_pool` docstring; no user-facing docs change, since the tracking list is internal.

## Fixes

- Fixes #1688
