### PR TITLE
Make `CallbackManager.remove` honor its remove-all docstring

### DIFF
--- a/pika/callback.py
+++ b/pika/callback.py
@@ -284,7 +284,16 @@ class CallbackManager:
                 except KeyError:
                     pass
 
-        self._cleanup_callback_dict(prefix, key)
+            self._cleanup_callback_dict(prefix, key)
+        elif arguments is None:
+            # Only prefix and key given: remove every callback for them, as the
+            # docstring promises.
+            self.remove_all(prefix, key)
+        else:
+            # An arguments filter without a callback_value has no defined
+            # removal semantics here; leave the stack untouched rather than
+            # wipe the whole key.
+            self._cleanup_callback_dict(prefix, key)
         return True
 
     @sanitize_prefix

--- a/pika/callback.py
+++ b/pika/callback.py
@@ -261,11 +261,16 @@ class CallbackManager:
         Remove a callback from the stack by prefix, key and optionally the callback itself.
 
         If you only pass in prefix and key, all callbacks for that prefix and key will be removed.
+        Passing ``arguments`` without a ``callback_value`` removes nothing, since an arguments
+        filter on its own has no defined removal semantics here.
 
         :param prefix: The prefix for keeping track of callbacks with
         :param key: The callback key
         :param callback_value: The method defined to call on callback
-        :param arguments: Optional arguments to check
+        :param arguments: Optional arguments to match against; only honored together with
+            ``callback_value``
+        :returns: True if the prefix and key exist, whether or not a callback was actually removed;
+            see :meth:`remove_matching` when the caller needs to know that a removal occurred
         """
         if callback_value:
             offsets_to_remove = []

--- a/tests/unit/callback_tests.py
+++ b/tests/unit/callback_tests.py
@@ -299,6 +299,23 @@ class CallbackTests(unittest.TestCase):
             self.mock_caller,
             self.obj._stack[self.PREFIX][other_key][0][self.CALLBACK])
 
+    def test_remove_no_callback_value_removes_all_for_key(self):
+        # With no callback_value, remove() must drop every callback for the
+        # prefix/key, as its docstring promises (see issue #1052).
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.mock_caller)
+        self.assertTrue(self.obj.remove(self.PREFIX, self.KEY))
+        self.assertNotIn(self.KEY, self.obj._stack.get(self.PREFIX, {}))
+
+    def test_remove_arguments_without_callback_value_leaves_stack(self):
+        # An arguments filter with no callback_value has no defined removal
+        # semantics; remove() must not wipe the whole key in that case.
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
+        self.obj.add(self.PREFIX_CLASS, self.KEY, self.mock_caller)
+        self.assertTrue(
+            self.obj.remove(self.PREFIX, self.KEY, arguments={'x': 1}))
+        self.assertEqual(len(self.obj._stack[self.PREFIX][self.KEY]), 2)
+
     def test_remove_all(self):
         self.obj.add(self.PREFIX_CLASS, self.KEY, self.callback_mock)
         self.obj.remove_all(self.PREFIX, self.KEY)

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -242,6 +242,33 @@ class ConnectionTests(unittest.TestCase):
         self.assertEqual(conn.callbacks.pending(0, spec.Connection.Unblocked),
                          before_unblocked)
 
+    def test_on_stream_terminated_does_not_inflate_one_shot_callbacks(self):
+        """
+        A terminate re-init cycle must not inflate the one-shot call counter of the internal
+        Connection.Close/Connection.Start handlers (issue #1052).
+
+        Unlike the blocked/unblocked handlers, these are bound methods added with one_shot=True, so
+        a re-add compares equal and add() bumps the existing entry's counter instead of appending.
+        pending() therefore stays at 1 while the handler silently gains an extra life, surviving its
+        first invocation.
+        """
+        self.connection._adapter_disconnect_stream = mock.Mock()
+        callbacks = self.connection.callbacks
+
+        def call_counts(method_cls):
+            return [
+                entry[callbacks.CALLS]
+                for entry in callbacks._stack['0'][method_cls.NAME]
+            ]
+
+        self.assertEqual(call_counts(spec.Connection.Close), [1])
+        self.assertEqual(call_counts(spec.Connection.Start), [1])
+
+        self.connection._on_stream_terminated(Exception('boom'))
+
+        self.assertEqual(call_counts(spec.Connection.Close), [1])
+        self.assertEqual(call_counts(spec.Connection.Start), [1])
+
     def test_on_stream_terminated_invokes_connection_closed_callback(self):
         """_on_stream_terminated invokes `Connection.ON_CONNECTION_CLOSED` callbacks."""
         process_mock = mock.Mock(wraps=self.connection.callbacks.process)

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -214,6 +214,34 @@ class ConnectionTests(unittest.TestCase):
 
         self.assertTrue(self.connection.is_closed)
 
+    def test_on_stream_terminated_does_not_duplicate_blocked_callbacks(self):
+        """
+        A terminate re-init cycle must not accumulate the internal Connection.Blocked/Unblocked
+        callbacks (issue #1052).
+
+        _on_stream_terminated removes them and _init_connection_state re-adds them; a broken
+        _remove_callbacks leaves the originals in place so the re-add doubles the count.
+        """
+        params = connection.ConnectionParameters(blocked_connection_timeout=60)
+        with mock.patch.object(ConstructibleConnection,
+                               '_adapter_connect_stream'):
+            conn = ConstructibleConnection(params)
+        conn._set_connection_state(connection.Connection.CONNECTION_OPEN)
+        conn._opened = True
+        conn._adapter_disconnect_stream = mock.Mock()
+
+        before_blocked = conn.callbacks.pending(0, spec.Connection.Blocked)
+        before_unblocked = conn.callbacks.pending(0, spec.Connection.Unblocked)
+        self.assertEqual(before_blocked, 1)
+        self.assertEqual(before_unblocked, 1)
+
+        conn._on_stream_terminated(Exception('boom'))
+
+        self.assertEqual(conn.callbacks.pending(0, spec.Connection.Blocked),
+                         before_blocked)
+        self.assertEqual(conn.callbacks.pending(0, spec.Connection.Unblocked),
+                         before_unblocked)
+
     def test_on_stream_terminated_invokes_connection_closed_callback(self):
         """_on_stream_terminated invokes `Connection.ON_CONNECTION_CLOSED` callbacks."""
         process_mock = mock.Mock(wraps=self.connection.callbacks.process)


### PR DESCRIPTION
> [!NOTE]
> This PR description was written by Claude (Anthropic's Claude Code) under the direction of @lukebakken, who reviewed it before filing. Code references were verified against `main`.

## Summary

`CallbackManager.remove(prefix, key)` called with no `callback_value` did nothing but run `_cleanup_callback_dict` (a no-op unless the list was already empty), despite its docstring promising that "if you only pass in prefix and key, all callbacks for that prefix and key will be removed". This delegates that case to the existing `remove_all`.

The sole caller relying on remove-all is `Connection._remove_callbacks`, which `_on_stream_terminated` uses to drop the internal `Connection.Close`/`Start`/`Blocked`/`Unblocked` handlers before `_init_connection_state` re-registers them. With the removal a no-op, re-registration doubled those callbacks. In pika 0.11.2 (bound methods) that surfaced as the `Duplicate callback found` warning reported in #1052; today they are `functools.partial` wrappers, so the duplicate is silent instead.

An `arguments` filter passed without a `callback_value` has no defined removal semantics here, so that form is left as a no-op rather than wiping the whole key, avoiding a surprising full removal on a public method.

## Tested

- New unit tests: `remove` with no `callback_value` clears the key; the `arguments`-only form leaves it intact; and a terminate cycle no longer doubles a connection's blocked/unblocked callbacks. Each verified to fail without the fix.
- Full unit suite green (`hatch run unit`); `lint-check`, `fmt-check`, `docfmt-check`, and `typecheck` all clean.

Fixes #1052
