### PR TITLE
Fix: Stop `ThreadSafeChannel` confirm tags drifting from the broker

### DIFF
--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -380,6 +380,12 @@ class Channel:
         self._pool_shutdown = False
         self._next_publish_seq_no: int | None = None
         self._confirm_select_ok = None
+        # Serializes confirm_delivery so two threads cannot both pass the
+        # _confirm_select_ok guard while the first is still waiting for
+        # Confirm.SelectOk.  Per-channel rather than the connection-wide
+        # _channel_waiters_lock: the call blocks for a broker round trip, which
+        # must not stall operations on other channels.
+        self._confirm_lock = threading.Lock()
 
     def _check_not_closed(self) -> None:
         """
@@ -943,10 +949,17 @@ class Channel:
         """
         Enable publisher confirms and block until Confirm.SelectOk arrives.
 
-        Idempotent: calling this method more than once on the same channel
-        returns the original Confirm.SelectOk without sending a frame to
-        the broker or resetting the delivery-tag counter, matching the
+        Idempotent: calling this method more than once on the same
+        channel - concurrently from several threads included - returns
+        the original Confirm.SelectOk without sending a frame to the
+        broker or resetting the delivery-tag counter, matching the
         behavior of the RabbitMQ Java and .NET clients.
+
+        Concurrent callers are serialized on a per-channel lock, so a
+        second thread waits for the first call's round trip to finish
+        before it is handed the cached frame.  Its own *timeout* bounds
+        only the wait for the broker's response, not that queueing, so
+        it can block for the first caller's timeout on top of its own.
 
         The *ack_nack_callback* is dispatched on the channel's worker
         thread (same as delivery callbacks), not the IOLoop thread.
@@ -966,39 +979,40 @@ class Channel:
         :raises Exception: if the connection is closed before the response arrives.
         :raises TimeoutError: if *timeout* expires before the response arrives.
         """
-        if self._confirm_select_ok is not None:
-            return self._confirm_select_ok
+        with self._confirm_lock:
+            if self._confirm_select_ok is not None:
+                return self._confirm_select_ok
 
-        def _wrapped_ack_nack(method_frame) -> None:
-            _submit_or_terminate(
-                self._consumer_work_pool, self._wrapper._connection,
-                'Publisher confirm dropped: work pool shut down',
-                self._safe_dispatch, 'publisher confirm callback',
-                ack_nack_callback, method_frame)
+            def _wrapped_ack_nack(method_frame) -> None:
+                _submit_or_terminate(
+                    self._consumer_work_pool, self._wrapper._connection,
+                    'Publisher confirm dropped: work pool shut down',
+                    self._safe_dispatch, 'publisher confirm callback',
+                    ack_nack_callback, method_frame)
 
-        def _arm_seq_no() -> None:
-            # Runs on the IOLoop thread the moment Confirm.Select is written,
-            # so it is ordered ahead of every publish the IOLoop has queued
-            # behind it.  Arming from the calling thread once the RPC returns
-            # instead would miss each publish issued during the round trip: the
-            # broker numbers those from 1, leaving the counter permanently
-            # behind the broker's delivery tags.
-            #
-            # Arm only once.  A confirm_delivery that timed out may still have
-            # reached the broker, and the retry's second Confirm.Select does not
-            # reset the broker's counter, so neither may this.
-            if self._next_publish_seq_no is None:
-                self._next_publish_seq_no = 0
+            def _arm_seq_no() -> None:
+                # Runs on the IOLoop thread the moment Confirm.Select is
+                # written, so it is ordered ahead of every publish the IOLoop
+                # has queued behind it.  Arming from the calling thread once the
+                # RPC returns instead would miss each publish issued during the
+                # round trip: the broker numbers those from 1, leaving the
+                # counter permanently behind the broker's delivery tags.
+                #
+                # Arm only once.  A confirm_delivery that timed out may still
+                # have reached the broker, and the retry's second Confirm.Select
+                # does not reset the broker's counter, so neither may this.
+                if self._next_publish_seq_no is None:
+                    self._next_publish_seq_no = 0
 
-        result = self._blocking_rpc(
-            'confirm_delivery',
-            self._channel.confirm_delivery,
-            timeout,
-            on_sent=_arm_seq_no,
-            ack_nack_callback=_wrapped_ack_nack,
-        )
-        self._confirm_select_ok = result
-        return result
+            result = self._blocking_rpc(
+                'confirm_delivery',
+                self._channel.confirm_delivery,
+                timeout,
+                on_sent=_arm_seq_no,
+                ack_nack_callback=_wrapped_ack_nack,
+            )
+            self._confirm_select_ok = result
+            return result
 
     def basic_consume(self,
                       queue,

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -563,8 +563,13 @@ class Channel:
 
         self._wrapper._schedule_unchecked(_remove)
 
-    def _blocking_rpc(self, method_name: str, channel_method,
-                      timeout: float | None, *args, **kwargs) -> Any:
+    def _blocking_rpc(self,
+                      method_name: str,
+                      channel_method,
+                      timeout: float | None,
+                      *args,
+                      on_sent: Callable[[], None] | None = None,
+                      **kwargs) -> Any:
         """
         Execute a channel RPC and block until the broker responds.
 
@@ -581,6 +586,11 @@ class Channel:
         :param method_name: Human-readable name for timeout messages.
         :param channel_method: Bound method on the raw channel.
         :param timeout: Seconds to wait.
+        :param on_sent: Optional zero-argument callable run on the IOLoop thread
+            immediately after *channel_method* writes its frame, ahead of any
+            callback already queued behind it.  For state that must be ordered
+            against the frame going out rather than against the broker's
+            response coming back.
         :returns: The broker response frame.
         :raises TimeoutError: if *timeout* expires.
         :raises Exception: if the connection or channel closes first.
@@ -602,6 +612,8 @@ class Channel:
             try:
                 self._channel.add_on_close_callback(_on_chan_close)
                 channel_method(*args, **kwargs, callback=_on_ok)
+                if on_sent is not None:
+                    on_sent()
             except Exception as exc:
                 error[0] = exc
                 ready.set()
@@ -964,13 +976,27 @@ class Channel:
                 self._safe_dispatch, 'publisher confirm callback',
                 ack_nack_callback, method_frame)
 
+        def _arm_seq_no() -> None:
+            # Runs on the IOLoop thread the moment Confirm.Select is written,
+            # so it is ordered ahead of every publish the IOLoop has queued
+            # behind it.  Arming from the calling thread once the RPC returns
+            # instead would miss each publish issued during the round trip: the
+            # broker numbers those from 1, leaving the counter permanently
+            # behind the broker's delivery tags.
+            #
+            # Arm only once.  A confirm_delivery that timed out may still have
+            # reached the broker, and the retry's second Confirm.Select does not
+            # reset the broker's counter, so neither may this.
+            if self._next_publish_seq_no is None:
+                self._next_publish_seq_no = 0
+
         result = self._blocking_rpc(
             'confirm_delivery',
             self._channel.confirm_delivery,
             timeout,
+            on_sent=_arm_seq_no,
             ack_nack_callback=_wrapped_ack_nack,
         )
-        self._next_publish_seq_no = 0
         self._confirm_select_ok = result
         return result
 

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -618,11 +618,26 @@ class Channel:
             try:
                 self._channel.add_on_close_callback(_on_chan_close)
                 channel_method(*args, **kwargs, callback=_on_ok)
-                if on_sent is not None:
-                    on_sent()
             except Exception as exc:
                 error[0] = exc
                 ready.set()
+                return
+            # The frame is on the wire.  Run the post-send hook separately: if
+            # channel_method delivered its response synchronously (result and
+            # ready already set) a raising hook must not clobber that result,
+            # since _blocking_rpc checks error ahead of result.  Surface the
+            # hook's failure only while the response is still outstanding.
+            if on_sent is not None:
+                try:
+                    on_sent()
+                except Exception as exc:
+                    if not ready.is_set():
+                        error[0] = exc
+                        ready.set()
+                    else:
+                        LOGGER.exception(
+                            'on_sent hook raised after %s completed',
+                            method_name)
 
         self._wrapper._schedule_unchecked(_invoke)
 
@@ -968,6 +983,15 @@ class Channel:
         listener cannot stall heartbeats.
 
         Safe to call from any thread.
+
+        A :class:`TimeoutError` does not mean confirms are off.  The
+        Confirm.Select frame is written before the wait begins and may
+        well have reached the broker, which then numbers publishes from
+        1, so the delivery-tag counter is armed regardless of whether
+        Confirm.SelectOk arrived in time.  A subsequent publish therefore
+        still fires its ``on_publish`` and advances
+        :attr:`next_publish_seq_no`.  Retry ``confirm_delivery`` rather
+        than assuming confirms were left disabled.
 
         :param ack_nack_callback:
             ``callback(method_frame)`` called for each Basic.Ack or

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -538,3 +538,75 @@ class TestPerRPCCallbacksDoNotAccumulate(ThreadSafeTestCaseBase):
 
 if __name__ == '__main__':
     unittest.main()
+
+
+class TestPublishDuringConfirmSelectRoundTrip(ThreadSafeTestCaseBase):
+    """
+    A publish issued while Confirm.SelectOk is in flight must carry the broker's tag.
+
+    The broker numbers from the first publish it processes after Confirm.Select, so a publish made
+    during the round trip is tag 1.  Arming the wrapper's counter on the calling thread once
+    confirm_delivery returned skipped it, leaving every later tag one behind the broker's (issue
+    #1683).
+    """
+
+    def test(self):
+        conn = self._connect()
+        ch = conn.channel()
+        queue = self._unique_queue()
+        ch.queue_declare(queue=queue, durable=False, exclusive=True)
+
+        acked = []
+        reported = []
+        select_sent = threading.Event()
+
+        raw_confirm_delivery = ch._channel.confirm_delivery
+
+        def _hooked(*args, **kwargs):
+            result = raw_confirm_delivery(*args, **kwargs)
+            # Confirm.Select is written and Confirm.SelectOk is still in
+            # flight.  The hook only makes the timing deterministic; any thread
+            # publishing while another is inside confirm_delivery lands in the
+            # same window.
+            select_sent.set()
+            return result
+
+        ch._channel.confirm_delivery = _hooked
+
+        def _publish(body):
+            ch.basic_publish(
+                exchange='',
+                routing_key=queue,
+                body=body,
+                on_publish=lambda tag, b=body: reported.append(
+                    (b.decode(), tag)),
+            )
+
+        def _on_confirm(method_frame):
+            acked.append(method_frame.method.delivery_tag)
+
+        enabler = threading.Thread(target=ch.confirm_delivery,
+                                   args=(_on_confirm,))
+        enabler.start()
+        try:
+            self.assertTrue(select_sent.wait(BLOCKING_CALL_TIMEOUT),
+                            'Confirm.Select was never written')
+            _publish(b'A')
+        finally:
+            enabler.join(timeout=BLOCKING_CALL_TIMEOUT)
+        self.assertFalse(enabler.is_alive(), 'confirm_delivery did not return')
+
+        _publish(b'B')
+        _publish(b'C')
+
+        # The broker may ack with multiple=True, so assert how far the
+        # confirmations reached rather than counting individual tags.
+        @retry_assertion(timeout_sec=BLOCKING_CALL_TIMEOUT)
+        def assert_all_confirmed():
+            assert acked, 'no publisher confirm arrived'
+            self.assertEqual(max(acked), 3)
+
+        assert_all_confirmed()
+
+        self.assertEqual(reported, [('A', 1), ('B', 2), ('C', 3)])
+        self.assertEqual(ch.next_publish_seq_no, 4)

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -610,3 +610,67 @@ class TestPublishDuringConfirmSelectRoundTrip(ThreadSafeTestCaseBase):
 
         self.assertEqual(reported, [('A', 1), ('B', 2), ('C', 3)])
         self.assertEqual(ch.next_publish_seq_no, 4)
+
+
+class TestConfirmDeliveryRetryAgainstRealChannel(ThreadSafeTestCaseBase):
+    """
+    A retried confirm_delivery must not raise or reset the counter on a real broker.
+
+    A confirm_delivery that timed out may still have reached the broker, so the retry sends a second
+    Confirm.Select to an already-confirming channel.  The wrapper's own retry unit test uses a mock
+    raw channel, so this exercises the real pika Channel accepting that second Confirm.Select and
+    the counter surviving it (issue #1683).
+    """
+
+    def test(self):
+        conn = self._connect()
+        ch = conn.channel()
+        queue = self._unique_queue()
+        ch.queue_declare(queue=queue, durable=False, exclusive=True)
+
+        acked = []
+
+        def _on_confirm(method_frame):
+            acked.append(method_frame.method.delivery_tag)
+
+        ch.confirm_delivery(_on_confirm)
+
+        reported = []
+
+        def _publish(body):
+            ch.basic_publish(
+                exchange='',
+                routing_key=queue,
+                body=body,
+                on_publish=lambda tag, b=body: reported.append(
+                    (b.decode(), tag)),
+            )
+
+        _publish(b'A')
+
+        # Simulate the state left by a confirm_delivery that timed out after
+        # the broker already enabled confirms: the wrapper never cached the
+        # Confirm.SelectOk, so the retry is let through the guard.
+        ch._confirm_select_ok = None
+
+        # confirm_delivery blocks on the round trip, so by the time it returns
+        # the IOLoop has already run publish A, which was scheduled ahead of
+        # it; the counter is therefore a deterministic 1 (property 2).  The real
+        # channel must accept this second Confirm.Select without raising, and
+        # the retry must not reset the counter the broker never reset.
+        ch.confirm_delivery(_on_confirm)
+        self.assertEqual(ch.next_publish_seq_no, 2)
+
+        # If the retry had reset the counter, B would be tag 1; tag 2 proves it
+        # was preserved across the second Confirm.Select.
+        _publish(b'B')
+
+        @retry_assertion(timeout_sec=BLOCKING_CALL_TIMEOUT)
+        def assert_all_confirmed():
+            assert acked, 'no publisher confirm arrived'
+            self.assertEqual(max(acked), 2)
+
+        assert_all_confirmed()
+
+        self.assertEqual(reported, [('A', 1), ('B', 2)])
+        self.assertEqual(ch.next_publish_seq_no, 3)

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -1606,6 +1606,77 @@ class ConsumerWorkPoolTests(unittest.TestCase):
         # single RPC also schedules its own callback cleanup.
         self.assertEqual(raw_ch.confirm_delivery.call_count, 1)
 
+    def test_confirm_delivery_arms_the_counter_before_the_response(self):
+        """
+        The counter must be armed when Confirm.Select is written, not when Confirm.SelectOk comes
+        back.
+
+        The broker numbers from the first publish it processes after Confirm.Select, so a publish
+        issued during the round trip is numbered by the broker.  Arming on the calling thread once
+        the RPC returned left every one of those uncounted and the tags permanently behind.
+        """
+        ch, raw_ch, wrapper = self._make_channel()
+        pending_select_ok = []
+        armed_during_round_trip = []
+
+        def fake_confirm(ack_nack_callback, callback):
+            # Confirm.Select is on the wire; SelectOk is still in flight.
+            pending_select_ok.append(callback)
+
+        raw_ch.confirm_delivery.side_effect = fake_confirm
+
+        def execute(cb):
+            cb()
+            if pending_select_ok:
+                # Still mid round trip: a publish running now gets tag 1.
+                armed_during_round_trip.append(ch._next_publish_seq_no)
+                pending_select_ok.pop()('Confirm.SelectOk')
+
+        wrapper._schedule_unchecked.side_effect = execute
+
+        ch.confirm_delivery(MagicMock())
+        self.assertEqual(armed_during_round_trip, [0])
+
+    def test_confirm_delivery_holds_its_lock_across_the_rpc(self):
+        """
+        The guard is only meaningful if a second caller cannot pass it mid round trip.
+
+        Checked from inside the raw call, which runs while the lock is held, rather than by racing
+        two threads and hoping to catch the window.
+        """
+        ch, raw_ch, wrapper = self._make_channel()
+        locked_during_rpc = []
+
+        def fake_confirm(ack_nack_callback, callback):
+            locked_during_rpc.append(ch._confirm_lock.locked())
+            callback('Confirm.SelectOk')
+
+        raw_ch.confirm_delivery.side_effect = fake_confirm
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        ch.confirm_delivery(MagicMock())
+        self.assertEqual(locked_during_rpc, [True])
+
+    def test_confirm_delivery_retry_does_not_rearm_the_counter(self):
+        """A retry after a timeout must not reset a counter the broker never reset."""
+        ch, raw_ch, wrapper = self._make_channel()
+
+        def fake_confirm(ack_nack_callback, callback):
+            callback('Confirm.SelectOk')
+
+        raw_ch.confirm_delivery.side_effect = fake_confirm
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        ch.confirm_delivery(MagicMock())
+        # Publishes have advanced the counter since confirms were enabled.
+        ch._next_publish_seq_no = 7
+        # Simulate the first attempt having failed, so the cached frame is gone
+        # and the guard lets a second Confirm.Select through.
+        ch._confirm_select_ok = None
+
+        ch.confirm_delivery(MagicMock())
+        self.assertEqual(ch._next_publish_seq_no, 7)
+
     def test_next_publish_seq_no_property_none_before_confirms(self):
         """next_publish_seq_no returns None when confirms are not enabled."""
         ch, _raw_ch, _wrapper = self._make_channel()

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -2027,6 +2027,54 @@ class BlockingRPCErrorPathTests(unittest.TestCase):
             ch.queue_declare(queue='q', timeout=0.5)
         self.assertIs(ctx.exception, reason)
 
+    def test_on_sent_error_does_not_mask_delivered_response(self):
+        """An on_sent hook raising after channel_method already delivered its response must not turn
+        a successful RPC into a raised error.
+        """
+        ch, raw_ch, wrapper = self._make_channel()
+        ok = object()
+
+        def deliver(*_args, callback, **_kwargs):
+            callback(ok)  # broker response delivered synchronously
+
+        raw_ch.queue_declare.side_effect = deliver
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        def boom():
+            raise RuntimeError('hook failed after send')
+
+        result = ch._blocking_rpc('queue_declare',
+                                  raw_ch.queue_declare,
+                                  0.5,
+                                  on_sent=boom,
+                                  queue='q')
+        self.assertIs(result, ok)
+
+    def test_on_sent_error_surfaces_when_response_outstanding(self):
+        """If on_sent raises before the response arrives, the error surfaces: the post-send state
+        the caller needed was not established.
+        """
+        ch, raw_ch, wrapper = self._make_channel()
+
+        def no_response(*_args, callback, **_kwargs):
+            pass  # broker has not responded yet
+
+        raw_ch.queue_declare.side_effect = no_response
+        wrapper._schedule_unchecked.side_effect = lambda cb: cb()
+
+        boom = RuntimeError('hook failed before response')
+
+        def raise_boom():
+            raise boom
+
+        with self.assertRaises(RuntimeError) as ctx:
+            ch._blocking_rpc('queue_declare',
+                             raw_ch.queue_declare,
+                             0.5,
+                             on_sent=raise_boom,
+                             queue='q')
+        self.assertIs(ctx.exception, boom)
+
 
 class BasicGetTests(unittest.TestCase):
     """Cover Channel.basic_get success, empty, error and channel-close paths."""


### PR DESCRIPTION
## Proposed Changes

`ThreadSafeChannel.confirm_delivery()` armed the delivery-tag counter on the **calling** thread, after the RPC returned. But `Confirm.Select` is written on the IOLoop thread, and `basic_publish`'s `_publish` closure increments that same counter on the IOLoop thread too. The broker starts numbering at the first publish it processes after `Confirm.Select`; the wrapper started counting a full network round trip later.

Every publish issued in that window was numbered by the broker and skipped by the wrapper, so **every tag reported afterwards was permanently behind the broker's**, and the message published during the round trip got no `on_publish` callback at all. An application correlating confirms by that tag acks the wrong message. This is not a narrow race: the window is the whole `Confirm.Select` -> `Confirm.SelectOk` round trip, and it is hit by exactly the pattern this class exists for, one thread enabling confirms while another publishes.

The idempotency guard at the top of the method was also unlocked, so two threads could both find `_confirm_select_ok` unset, both send `Confirm.Select`, and both arm the counter. The second arming reset a counter that was already numbering live publishes, handing the same tags out twice. The docstring promises idempotency, on a class whose whole purpose is thread safety.

### The fix

**Arm the counter on the IOLoop thread.** `_blocking_rpc` gains an `on_sent` hook that runs on the IOLoop thread the moment `channel_method` writes its frame, inside the same callback and therefore ahead of every publish the IOLoop has queued behind it. `confirm_delivery` arms `_next_publish_seq_no` from there. Every write to the counter is now on the IOLoop thread and the calling thread only reads it, the same invariant #1679 established for the close path.

Arming happens only once. A `confirm_delivery` that timed out may still have reached the broker, and the retry's second `Confirm.Select` does not reset the broker's counter, so neither may the wrapper's.

**Serialize `confirm_delivery` on a per-channel lock** held across the guard and the RPC, so the second caller waits and is then handed the cached `Confirm.SelectOk`. A per-channel lock rather than the connection-wide `_channel_waiters_lock`, because the call blocks for a broker round trip and must not stall operations on other channels.

### Before and after

Publishing `A` during the round trip, then `B` and `C`, against a broker that numbered all three 1 to 3:

|        | `on_publish` tags                | `next_publish_seq_no` |
| ------ | -------------------------------- | --------------------- |
| before | `[('B', 1), ('C', 2)]`           | 3                     |
| after  | `[('A', 1), ('B', 2), ('C', 3)]` | 4                     |

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

### What was tested

Full suite against a local RabbitMQ: 1512 passed, 61 skipped. `hatch run fmt-check`, `lint-check`, `docfmt-check` and `typecheck` are all clean.

Four new tests, each confirmed failing against unfixed `main` and passing with the fix:

- `test_confirm_delivery_arms_the_counter_before_the_response` pins that the counter is armed while `Confirm.SelectOk` is still in flight.
- `test_confirm_delivery_holds_its_lock_across_the_rpc` pins that a second caller cannot pass the guard mid round trip. Checked from inside the raw call, which runs while the lock is held, rather than by racing two threads and hoping to catch the window.
- `test_confirm_delivery_retry_does_not_rearm_the_counter` pins that a retry after a timeout does not reset a counter the broker never reset.
- `TestPublishDuringConfirmSelectRoundTrip` publishes through a real `Confirm.Select` round trip and compares the tags handed to `on_publish` against the tags the broker confirms. Against unfixed `main` it reproduces the table above exactly. The broker may coalesce confirms with `multiple=True`, so it asserts how far the confirmations reached rather than counting individual tags.

## Fixes

- Fixes #1683