### PR TITLE
Fix `Connection.close()` self-deadlock from a consumer callback

### DIFF
--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -1683,6 +1683,29 @@ class Connection:
         for ch in channels:
             ch._shutdown_pool(timeout=max(0.0, deadline - time.monotonic()))
 
+    def _is_pool_worker_thread(self) -> bool:
+        """
+        True if the calling thread is one of this connection's pool worker threads.
+
+        Covers every channel's consumer worker plus the connection's own event-callback worker
+        (:attr:`_connection_work_pool`).  :meth:`close` uses this to detect that it is running from
+        inside a delivery/event callback so it can avoid joining :attr:`_ioloop_thread`: that thread's
+        post-``ioloop.start()`` cleanup tail (:meth:`_shutdown_all_consumer_pools`,
+        :meth:`_shutdown_connection_pool`) joins every pool worker in turn, including this one, so
+        joining it here would deadlock each thread waiting on the other (issue #1686).
+
+        Reading each pool's ``_thread`` without its lock is safe here: a worker only executes this
+        check from within its own run loop, by which point ``_thread`` was already assigned (under
+        the pool's lock, before ``start()``) by the thread that created it - that assignment
+        happens-before anything the worker itself observes.
+        """
+        current = threading.current_thread()
+        if current is self._connection_work_pool._thread:
+            return True
+        with self._channel_waiters_lock:
+            channels = list(self._channels)
+        return any(current is ch._consumer_work_pool._thread for ch in channels)
+
     def _shutdown_connection_pool(self, timeout: float | None = None) -> None:
         """
         Shut down the connection-level event-callback pool.
@@ -1796,6 +1819,14 @@ class Connection:
         callback).  When called from the IOLoop thread the close is initiated synchronously and the
         method returns immediately without joining.
 
+        Also safe to call from a delivery or connection-event callback running on one of this
+        connection's pool worker threads (e.g. a consumer's ``on_message_callback``).  The IOLoop
+        thread's own post-close cleanup joins every pool worker, including whichever one is running
+        the callback that called ``close()``, so joining :attr:`_ioloop_thread` from there would
+        deadlock the two threads against each other. In that case the close is scheduled and this
+        method returns immediately without joining; the worker exits normally once the callback
+        returns.
+
         Calling ``close()`` on an already-closed connection is a no-op.
 
         :param timeout: Seconds to wait for a clean close before force-stopping the IOLoop. Defaults
@@ -1824,6 +1855,18 @@ class Connection:
                     exc_info=True)
 
         self._connection.ioloop.add_callback_threadsafe(_safe_close)
+
+        if self._is_pool_worker_thread():
+            # Called from within a delivery or connection-event callback running on one of this
+            # connection's pool worker threads. The IOLoop thread's post-close cleanup tail
+            # (_shutdown_all_consumer_pools / _shutdown_connection_pool) joins every pool worker,
+            # including this one, once ioloop.start() returns - so joining self._ioloop_thread here
+            # would deadlock: this thread waiting on the IOLoop thread, which is waiting on this
+            # thread to return from the very callback that called close(). The close is already
+            # scheduled above; leave the pool's own self-join guard
+            # (_BoundedWorkPool.shutdown) to let this worker exit normally once the callback returns.
+            return
+
         self._ioloop_thread.join(timeout=timeout)
         if self._ioloop_thread.is_alive():
             self._connection.ioloop.add_callback_threadsafe(

--- a/pika/adapters/thread_safe_connection.py
+++ b/pika/adapters/thread_safe_connection.py
@@ -1825,14 +1825,17 @@ class Connection:
         the callback that called ``close()``, so joining :attr:`_ioloop_thread` from there would
         deadlock the two threads against each other. In that case the close is scheduled and this
         method returns immediately without joining; the worker exits normally once the callback
-        returns.
+        returns.  Because this path does not join the IOLoop thread, *timeout* is not applied on it:
+        the close is best-effort and an unresponsive broker is not force-stopped from here, so a
+        healthy handshake is assumed (see #1706).
 
         Calling ``close()`` on an already-closed connection is a no-op.
 
         :param timeout: Seconds to wait for a clean close before force-stopping the IOLoop. Defaults
             to 10 seconds, which is sufficient for a healthy broker on any reasonable network. The
             pathological force path may wait up to twice this (once for the clean join, once for the
-            forced join). Pass ``None`` to wait indefinitely.
+            forced join). Pass ``None`` to wait indefinitely. Ignored when ``close()`` is called
+            from one of this connection's pool worker threads (see above).
         """
         if threading.current_thread() is self._ioloop_thread:
             try:
@@ -1863,8 +1866,11 @@ class Connection:
             # including this one, once ioloop.start() returns - so joining self._ioloop_thread here
             # would deadlock: this thread waiting on the IOLoop thread, which is waiting on this
             # thread to return from the very callback that called close(). The close is already
-            # scheduled above; leave the pool's own self-join guard
-            # (_BoundedWorkPool.shutdown) to let this worker exit normally once the callback returns.
+            # scheduled above, so return without joining. This worker then returns from the
+            # callback and, when the cleanup tail calls shutdown() on its pool and joins it, exits
+            # via the drained-and-shutdown check at the top of _run_worker. (The shutdown() self-
+            # join guard is not what saves us here: that fires only when a worker shuts down its own
+            # pool, whereas here the IOLoop thread, not this worker, calls shutdown().)
             return
 
         self._ioloop_thread.join(timeout=timeout)

--- a/tests/acceptance/thread_safe_connection_test.py
+++ b/tests/acceptance/thread_safe_connection_test.py
@@ -10,6 +10,7 @@ real AMQP frame exchange, and real concurrent threads.
 """
 
 import threading
+import time
 import unittest
 import uuid
 
@@ -356,6 +357,75 @@ class TestConcurrentClose(ThreadSafeTestCaseBase):
 
         self.assertEqual([], errors)
         self.assertTrue(conn.is_closed)
+
+
+class TestCloseFromConsumerCallback(ThreadSafeTestCaseBase):
+    """
+    Connection.close() called from a consumer's on_message_callback must return promptly.
+
+    Regression test for issue #1686. close() used to join the IOLoop thread unconditionally, but the
+    IOLoop thread's own post-close cleanup tail (_shutdown_all_consumer_pools) joins every channel's
+    consumer worker - including the very worker running this callback - before it can exit. Joining
+    from inside the callback therefore self-deadlocked: this thread waiting on the IOLoop thread,
+    which was waiting on this thread to return from the callback that called close(). With the fix,
+    close() detects it is running on a pool worker thread and returns immediately after scheduling the
+    close, letting the worker (and then the IOLoop thread) exit normally once the callback returns.
+    """
+
+    def test_bounded_timeout_returns_promptly(self):
+        conn = self._connect()
+        ch = conn.channel()
+        queue = self._unique_queue()
+        ch.queue_declare(queue=queue, durable=False, exclusive=True)
+        ch.basic_publish(exchange='', routing_key=queue, body=b'stop')
+
+        done = threading.Event()
+        elapsed = [None]
+
+        def on_message(channel, method, _properties, _body):
+            channel.basic_ack(method.delivery_tag)
+            started = time.monotonic()
+            conn.close(timeout=BLOCKING_CALL_TIMEOUT)
+            elapsed[0] = time.monotonic() - started
+            done.set()
+
+        ch.basic_consume(queue=queue, on_message_callback=on_message)
+
+        self.assertTrue(
+            done.wait(timeout=BLOCKING_CALL_TIMEOUT),
+            'conn.close() called from the consumer callback did not return '
+            f'within {BLOCKING_CALL_TIMEOUT}s')
+        self.assertLess(
+            elapsed[0], 2,
+            'conn.close() blocked instead of returning immediately when '
+            'called from the consumer callback')
+
+        retry_assertion(BLOCKING_CALL_TIMEOUT)(
+            lambda: self.assertTrue(conn.is_closed))()
+
+    def test_unbounded_timeout_does_not_deadlock(self):
+        conn = self._connect()
+        ch = conn.channel()
+        queue = self._unique_queue()
+        ch.queue_declare(queue=queue, durable=False, exclusive=True)
+        ch.basic_publish(exchange='', routing_key=queue, body=b'stop')
+
+        done = threading.Event()
+
+        def on_message(channel, method, _properties, _body):
+            channel.basic_ack(method.delivery_tag)
+            conn.close(timeout=None)
+            done.set()
+
+        ch.basic_consume(queue=queue, on_message_callback=on_message)
+
+        self.assertTrue(
+            done.wait(timeout=BLOCKING_CALL_TIMEOUT),
+            'conn.close(timeout=None) called from the consumer callback '
+            'deadlocked')
+
+        retry_assertion(BLOCKING_CALL_TIMEOUT)(
+            lambda: self.assertTrue(conn.is_closed))()
 
 
 class TestAddCallbackThreadsafeAfterClose(ThreadSafeTestCaseBase):

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -3291,11 +3291,21 @@ class ConnectionTests(unittest.TestCase):
         conn._ioloop_thread.join.assert_not_called()
 
     def test_is_pool_worker_thread_false_for_unrelated_thread(self):
-        """A thread that owns none of this connection's pools must not be misidentified."""
+        """
+        A thread that owns none of this connection's pools must not be misidentified.
+
+        The pools point at real but distinct worker threads (not ``None``), so this exercises a
+        genuine thread-identity mismatch rather than the current thread being compared against an
+        unset ``_thread``.
+        """
         conn, _mock_conn, _mock_ioloop = self._make_connection()
         ch = Channel(MagicMock(), conn)
         with conn._channel_waiters_lock:
             conn._channels.append(ch)
+        # Distinct thread objects that are never this thread; the check must
+        # compare identities and return False, not match on a shared default.
+        conn._connection_work_pool._thread = threading.Thread()
+        ch._consumer_work_pool._thread = threading.Thread()
 
         self.assertFalse(conn._is_pool_worker_thread())
 

--- a/tests/unit/thread_safe_connection_tests.py
+++ b/tests/unit/thread_safe_connection_tests.py
@@ -3239,6 +3239,66 @@ class ConnectionTests(unittest.TestCase):
         conn.close()
         mock_conn.close.assert_called_once()
 
+    def test_close_from_connection_pool_worker_schedules_but_does_not_join(
+            self):
+        """
+        Close() called from the connection's own event-callback worker must not join the IOLoop
+        thread.
+
+        Regression test for issue #1686. The IOLoop thread's post-close cleanup tail joins this
+        worker as part of _shutdown_connection_pool, so a join here would deadlock the two threads
+        against each other.
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+        conn._ioloop_thread = MagicMock()
+        # Simulate close() running on the connection's event-callback worker.
+        conn._connection_work_pool._thread = threading.current_thread()
+
+        conn.close()
+
+        mock_ioloop.add_callback_threadsafe.assert_called_once()
+        # The close must still be scheduled onto the IOLoop...
+        mock_ioloop.add_callback_threadsafe.call_args[0][0]()
+        mock_conn.close.assert_called_once()
+        # ...but this thread must not have joined the IOLoop thread.
+        conn._ioloop_thread.join.assert_not_called()
+
+    def test_close_from_channel_consumer_worker_schedules_but_does_not_join(
+            self):
+        """
+        Close() called from a channel's consumer worker (e.g. inside on_message_callback) must not
+        join the IOLoop thread.
+
+        Regression test for issue #1686: `Connection.close()` deadlocks against its own IOLoop
+        cleanup tail when called from a consumer callback. The IOLoop thread's post-close cleanup
+        tail joins every tracked channel's consumer worker, including this one, so joining the
+        IOLoop thread from here would deadlock: this thread waiting on the IOLoop thread, which is
+        waiting on this thread to return from the callback that called close().
+        """
+        conn, mock_conn, mock_ioloop = self._make_connection()
+        conn._ioloop_thread = MagicMock()
+        ch = Channel(MagicMock(), conn)
+        # Simulate close() running on this channel's consumer worker thread.
+        ch._consumer_work_pool._thread = threading.current_thread()
+        with conn._channel_waiters_lock:
+            conn._channels.append(ch)
+
+        conn.close()
+
+        mock_ioloop.add_callback_threadsafe.assert_called_once()
+        mock_ioloop.add_callback_threadsafe.call_args[0][0]()
+        mock_conn.close.assert_called_once()
+        conn._ioloop_thread.join.assert_not_called()
+
+    def test_is_pool_worker_thread_false_for_unrelated_thread(self):
+        """A thread that owns none of this connection's pools must not be misidentified."""
+        conn, _mock_conn, _mock_ioloop = self._make_connection()
+        ch = Channel(MagicMock(), conn)
+        with conn._channel_waiters_lock:
+            conn._channels.append(ch)
+
+        self.assertFalse(conn._is_pool_worker_thread())
+
     def test_abort_swallows_close_errors(self):
         conn, _mock_conn, _ = self._make_connection()
         # Force conn.close() to raise


### PR DESCRIPTION
## Proposed Changes

`Connection.close()` (the `ThreadSafeConnection` wrapper) deadlocked when called from inside a consumer's `on_message_callback` or from the connection's own event-callback worker, exactly as described in #1686.

Root cause: `close()` joined `_ioloop_thread` from any calling thread other than the IOLoop thread itself. But the IOLoop thread's own post-`ioloop.start()` cleanup tail joins every pool worker before it exits - including the very worker currently running the callback that called `close()`. That worker was joining the IOLoop thread while the IOLoop thread was joining it back: a hard self-deadlock. With the default `timeout=10` this burned the close budget twice (20s) before giving up and logging a warning that named the wrong thread; with `timeout=None` it never returned at all.

Fix: `close()` now detects when it is running on one of the connection's own pool worker threads (a channel's consumer worker, or the connection's event-callback worker) and, in that case, schedules the close and returns immediately without joining - the same shortcut it already takes when called from the IOLoop thread itself. The worker's own pool already has a self-join guard for this shape (`_BoundedWorkPool.shutdown`), so it exits normally once the callback returns, and the IOLoop thread's join on it then completes on its own.

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1686

## Further Comments

Verified against a real broker, not just mocks: reverting only the production fix (keeping the new tests) reproduces the issue's exact reported symptom, including the false "IOLoop thread did not exit within the close timeout" warning, for both the bounded-timeout and `timeout=None` cases. Restoring the fix, both pass and the full existing acceptance and unit suites for this file stay green.
