### PR TITLE
Stop an out-of-range `timestamp` header from closing the connection

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -264,10 +264,14 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
         seconds = _PACK_UNSIGNED_LONG_LONG.unpack_from(encoded, offset)[0]
         try:
             value = _EPOCH + timedelta(seconds=seconds)
-        except (OverflowError, ValueError):
-            # Raising would escape the frame decoder, where the transport
-            # reports anything unexpected as a lost stream and drops the
-            # connection.
+        except OverflowError:
+            # A u64 past what `datetime` can hold overflows the `timedelta` or
+            # its addition to the epoch; both raise `OverflowError` (never
+            # `ValueError`, unlike `datetime.fromtimestamp`). Raising would
+            # escape the frame decoder, where the transport reports anything
+            # unexpected as a lost stream and drops the connection, so fall
+            # back to the raw seconds. This loses the `timestamp` type: re-
+            # encoding the int yields a long-long ('l'), not a 'T'.
             value = seconds
         offset += 8
 

--- a/pika/data.py
+++ b/pika/data.py
@@ -216,6 +216,8 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     :param encoded: The binary encoded data to decode
     :param offset: The starting byte offset
+    :returns: tuple of (decoded value, new offset). A `timestamp` is a u64, so one outside the range
+        `datetime` can hold decodes to its raw integer seconds.
     :raises: pika.exceptions.InvalidFieldTypeException
     """
     # Dispatch on the raw type-tag byte (avoids a bytes allocation per field);
@@ -253,9 +255,14 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
 
     # Timestamp
     elif kind == _FIELD_TIMESTAMP:
-        value = datetime.fromtimestamp(
-            _PACK_UNSIGNED_LONG_LONG.unpack_from(encoded, offset)[0],
-            timezone.utc)
+        seconds = _PACK_UNSIGNED_LONG_LONG.unpack_from(encoded, offset)[0]
+        try:
+            value = datetime.fromtimestamp(seconds, timezone.utc)
+        except (OSError, OverflowError, ValueError):
+            # Raising would escape the frame decoder, where the transport
+            # reports anything unexpected as a lost stream and drops the
+            # connection.
+            value = seconds
         offset += 8
 
     # Field Table

--- a/pika/data.py
+++ b/pika/data.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import calendar
 import decimal
 import struct
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from pika import exceptions
@@ -51,6 +51,12 @@ _PACK_TAG_INT = struct.Struct('>ci')
 _PACK_TAG_LONG_LONG = struct.Struct('>cq')
 _PACK_TAG_UNSIGNED_LONG_LONG = struct.Struct('>cQ')
 _PACK_TAG_BYTE_INT = struct.Struct('>cBi')
+
+# Reference point for decoding the `timestamp` field type. Adding a
+# `timedelta` is a little slower than `datetime.fromtimestamp` but stays in
+# Python, so the range that decodes does not vary by platform: on Windows
+# `fromtimestamp` goes through a `time_t` that stops at year 3000.
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
 
 # Single-byte `bytes` objects indexed by value. Shared with `pika.spec`,
 # which imports this table for its bit-field buffers.
@@ -257,8 +263,8 @@ def decode_value(encoded: bytes, offset: int) -> tuple[Any, int]:
     elif kind == _FIELD_TIMESTAMP:
         seconds = _PACK_UNSIGNED_LONG_LONG.unpack_from(encoded, offset)[0]
         try:
-            value = datetime.fromtimestamp(seconds, timezone.utc)
-        except (OSError, OverflowError, ValueError):
+            value = _EPOCH + timedelta(seconds=seconds)
+        except (OverflowError, ValueError):
             # Raising would escape the frame decoder, where the transport
             # reports anything unexpected as a lost stream and drops the
             # connection.

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -206,9 +206,7 @@ class DataTests(unittest.TestCase):
 
     def test_decode_value_timestamp_out_of_datetime_range(self):
         # `timestamp` is a u64 (AMQP 0-9-1 errata), so the wire carries values
-        # `datetime` cannot hold; they must not raise out of the decoder. These
-        # cover each exception `datetime.fromtimestamp` raises across that
-        # range: ValueError, OSError and OverflowError.
+        # `datetime` cannot hold; they must not raise out of the decoder.
         values = (253402300800, 1772000000000, 2**63 - 1, 2**64 - 1)
         decoded = {}
         for seconds in values:

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -190,3 +190,30 @@ class DataTests(unittest.TestCase):
         result, _ = data.decode_table(encoded, 0)
         self.assertIsInstance(result['k'], bytes)
         self.assertEqual(result['k'], raw)
+
+    def test_decode_value_timestamp_max_representable(self):
+        encoded = b'\x00\x00\x00\x0b\x01kT' + struct.pack('>Q', 253402300799)
+        result, _ = data.decode_table(encoded, 0)
+        self.assertEqual(
+            result['k'],
+            datetime.datetime(9999,
+                              12,
+                              31,
+                              23,
+                              59,
+                              59,
+                              tzinfo=datetime.timezone.utc))
+
+    def test_decode_value_timestamp_out_of_datetime_range(self):
+        # `timestamp` is a u64 (AMQP 0-9-1 errata), so the wire carries values
+        # `datetime` cannot hold; they must not raise out of the decoder. These
+        # cover each exception `datetime.fromtimestamp` raises across that
+        # range: ValueError, OSError and OverflowError.
+        values = (253402300800, 1772000000000, 2**63 - 1, 2**64 - 1)
+        decoded = {}
+        for seconds in values:
+            encoded = (b'\x00\x00\x00\x0b\x01kT' + struct.pack('>Q', seconds))
+            result, offset = data.decode_table(encoded, 0)
+            self.assertEqual(offset, 15)
+            decoded[seconds] = result['k']
+        self.assertEqual(decoded, {seconds: seconds for seconds in values})

--- a/tests/unit/frame_tests.py
+++ b/tests/unit/frame_tests.py
@@ -1,5 +1,6 @@
 """Tests for pika.frame."""
 
+import struct
 import unittest
 
 from pika import DeliveryMode, exceptions, frame, spec
@@ -105,6 +106,22 @@ class FrameTests(unittest.TestCase):
 
     def test_decode_heartbeat_frame_bytes_consumed(self):
         self.assertEqual(frame.decode_frame(self.HEARTBEAT)[0], 8)
+
+    def test_decode_header_frame_timestamp_out_of_datetime_range(self):
+        # `timestamp` is a u64, so a header can carry a value `datetime` cannot
+        # hold. Decoding must not raise: an exception escaping here reaches the
+        # connection's read path, which reports it as a lost stream and drops
+        # the connection.
+        table = b'\x02ts' + b'T' + struct.pack('>Q', 1772000000000)
+        payload = (struct.pack('>HHQ', spec.BasicProperties.INDEX, 0, 0) +
+                   struct.pack('>H', spec.BasicProperties.FLAG_HEADERS) +
+                   struct.pack('>I', len(table)) + table)
+        encoded = (struct.pack('>BHI', spec.FRAME_HEADER, 1, len(payload)) +
+                   payload + bytes((spec.FRAME_END,)))
+        consumed, frame_value = frame.decode_frame(encoded)
+        self.assertEqual(consumed, len(encoded))
+        assert isinstance(frame_value, frame.Header)
+        self.assertEqual(frame_value.properties.headers, {'ts': 1772000000000})
 
     def test_decode_frame_invalid_frame_type(self):
         self.assertRaises(exceptions.InvalidFrameError, frame.decode_frame,


### PR DESCRIPTION
## Proposed Changes

A field-table `timestamp` that falls outside the range `datetime` can represent takes down the whole connection instead of being decoded.

`'T'` is a 64-bit unsigned integer per the AMQP 0-9-1 errata, and RabbitMQ neither range-checks nor rejects it (`rabbit_binary_parser` reads `Value:64/unsigned`, `rabbit_binary_generator` writes it back as `<<V:64>>`). `pika.data.decode_value` passed the raw value to `datetime.fromtimestamp()` unguarded, so anything past year 9999 raised from inside the frame decoder. Nothing on that path expects a stdlib exception, so the transport's generic read-error handler relabelled it as `StreamLostError` and dropped the connection. On a consumer the message was never acked, so it came back on reconnect and the client died again: one header became an unbreakable crash loop, reported as a network fault rather than a decode fault.

The trigger is not exotic. A millisecond epoch does it, and so does any pre-1970 time written by the RabbitMQ Java client, which encodes `'T'` as a signed long (`ValueWriter.writeTimestamp` and `ValueReader.readTimestamp` go through `DataInputStream.readLong`) and therefore puts a large u64 on the wire.

This guards the conversion in `decode_value` and falls back to the raw seconds:

```python
elif kind == _FIELD_TIMESTAMP:
    seconds = _PACK_UNSIGNED_LONG_LONG.unpack_from(encoded, offset)[0]
    try:
        value = _EPOCH + timedelta(seconds=seconds)
    except OverflowError:
        value = seconds
    offset += 8
```

The conversion adds a `timedelta` to a fixed UTC epoch instead of calling `datetime.fromtimestamp`. `fromtimestamp` goes through the platform `time_t`, so the range that decodes varies by OS (on Windows it stops near year 3000) and it raises a mix of `OSError`, `ValueError`, and `OverflowError` depending on the value and platform, as the unguarded code on `main` did:

| u64 on the wire | `datetime.fromtimestamp` on `main` (Linux) |
| --- | --- |
| `253402300799` | `datetime(9999, 12, 31, 23, 59, 59)`, the last value that works |
| `253402300800` | `ValueError: year must be in 1..9999, not 10000` |
| `1772000000000` | `ValueError: year must be in 1..9999, not 58122` |
| `9223372036854775807` | `OSError: [Errno 75] Value too large for defined data type` |
| `18446744073709551615` | `OverflowError: timestamp out of range for platform time_t` |

Adding a `timedelta` is platform-independent: every value past what `datetime` can hold raises `OverflowError`, from either the `timedelta` construction or the addition to the epoch, so that single type is caught and the raw seconds returned. Yielding the raw `int` rather than raising follows what the module already does with a long string that is not valid UTF-8: it decodes to `bytes` instead of failing the frame.

`decode_value`'s docstring gains a `:returns:` line recording the fallback, since that is the user-visible contract.

This does not change how pika interprets the field. pika reads `'T'` as unsigned, which agrees with the broker and the errata, and that is left alone.

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1698

## Further Comments

### Compatibility

Every value that decoded to a `datetime` before decodes to the same `datetime` now. Only values that previously killed the connection behave differently. Confirmed by decoding 50k random u64 values (none raise) and 20k random in-range values (all identical to the previous expression).

Callers reading a timestamp out of `properties.headers` can now see an `int` where they saw a `datetime`. Nothing that previously worked stops working, since those cases previously lost the connection, so I have not marked this a breaking change. If you would rather treat the widened return type as one, say so and I will relabel it and add a release note.

### Tests

Two regression tests in `tests/unit/data_tests.py` and one in `tests/unit/frame_tests.py`. The frame-level one matters most: the failure boundary is an exception escaping `frame.decode_frame`, which is what reached the connection's read path.

Before the fix, on `main` (unguarded `datetime.fromtimestamp`):

```
tests/unit/data_tests.py::DataTests::test_decode_value_timestamp_max_representable PASSED
tests/unit/data_tests.py::DataTests::test_decode_value_timestamp_out_of_datetime_range FAILED
tests/unit/frame_tests.py::FrameTests::test_decode_header_frame_timestamp_out_of_datetime_range FAILED

FAILED tests/unit/data_tests.py::DataTests::test_decode_value_timestamp_out_of_datetime_range - ValueError: year must be in 1..9999, not 10000
FAILED tests/unit/frame_tests.py::FrameTests::test_decode_header_frame_timestamp_out_of_datetime_range - ValueError: year must be in 1..9999, not 58122
2 failed, 1 passed, 969 deselected
```

After the fix, all three pass.
