### PR TITLE
Resolve "Drop the versionless License :: classifier now that license is a valid SPDX expression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ description = "Pika Python AMQP Client Library"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: BSD License",
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## Proposed Changes

This PR drops the deprecated classifier from the metadata as outlined in the
issue.

Testing done after applying the change:

```bash
❯ uv build .
❯ unzip dist/pika-1.4.0-py3-none-any.whl
❯ cat pika-1.4.0.dist-info/METADATA | grep License
License: BSD-3-Clause
License-File: LICENSE
  <a href='https://github.com/pika/pika/blob/main/LICENSE'><img src='https://img.shields.io/pypi/l/pika.svg?' alt='License'></a>
```
... the classifier is now gone and the metadata looks sane.

> Without the change, the metadata contains the deprecated classifier:
> 
> ```bash
> ❯ cat pika-1.4.0.dist-info/METADATA|grep License
> License: BSD-3-Clause
> Classifier: License :: OSI Approved :: BSD License
> License-File: LICENSE
>   <a href='https://github.com/pika/pika/blob/main/LICENSE'><img src='https://img.shields.io/pypi/l/pika.svg?' alt='License'></a>
> ```
> ... which is also shown in the output when building:
>
>        ********************************************************************************
>        Please consider removing the following classifiers in favor of a SPDX license expression:
>
>        License :: OSI Approved :: BSD License
>
>        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
>        ********************************************************************************

## Types of Changes

- [x] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document

Closes https://github.com/pika/pika/issues/1700