### PR TITLE
Stop `StreamLostError` from hiding the original traceback

### DIFF
--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -445,21 +445,24 @@ class BaseConnection(connection.Connection):
 
         if error is None:
             # Either result of `eof_received()` or abort
+            reason = None
             if self._got_eof:
-                error = pika.exceptions.StreamLostError(
+                reason = pika.exceptions.StreamLostError(
                     'Transport indicated EOF',
                     host=self.params.host,
                     port=self.params.port)
         else:
-            error = pika.exceptions.StreamLostError(
+            reason = pika.exceptions.StreamLostError(
                 f'Stream connection lost: {error!r}',
                 host=self.params.host,
                 port=self.params.port)
+            # pika/pika#1390: keep the original traceback reachable
+            reason.__cause__ = error
 
-        LOGGER.log(logging.DEBUG if error is None else logging.ERROR,
-                   'connection_lost: %r', error)
+        LOGGER.log(logging.DEBUG if reason is None else logging.ERROR,
+                   'connection_lost: %r', reason)
 
-        self._on_stream_terminated(error)
+        self._on_stream_terminated(reason)
 
     def _proto_eof_received(self) -> bool:
         """

--- a/pika/adapters/base_connection.py
+++ b/pika/adapters/base_connection.py
@@ -456,7 +456,10 @@ class BaseConnection(connection.Connection):
                 f'Stream connection lost: {error!r}',
                 host=self.params.host,
                 port=self.params.port)
-            # pika/pika#1390: keep the original traceback reachable
+            # pika/pika#1390: keep the original traceback reachable. This pins
+            # the error's traceback (and the frame locals it captured) for as
+            # long as this reason is held as self._error, an accepted cost for
+            # diagnosability.
             reason.__cause__ = error
 
         LOGGER.log(logging.DEBUG if reason is None else logging.ERROR,

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1170,7 +1170,9 @@ class Connection(abc.ABC):
         The callback will be passed the connection and an exception instance. The exception will
         either be an instance of `exceptions.ConnectionClosed` if a fully-open connection was closed
         by user or broker or exception of another type that describes the cause of connection
-        closure/failure.
+        closure/failure. If the stream died because some other exception was raised - for example
+        from one of your own callbacks - that exception is available as the reason's `__cause__`,
+        so `traceback.print_exception(reason)` shows where it came from.
 
         :param callback: Callback to call on close, having the signature:
             callback(pika.connection.Connection, exception)

--- a/pika/connection.py
+++ b/pika/connection.py
@@ -1171,8 +1171,8 @@ class Connection(abc.ABC):
         either be an instance of `exceptions.ConnectionClosed` if a fully-open connection was closed
         by user or broker or exception of another type that describes the cause of connection
         closure/failure. If the stream died because some other exception was raised - for example
-        from one of your own callbacks - that exception is available as the reason's `__cause__`,
-        so `traceback.print_exception(reason)` shows where it came from.
+        from one of your own callbacks - most adapters chain that exception onto the reason as its
+        `__cause__`, so inspecting `reason.__cause__` reveals where it came from.
 
         :param callback: Callback to call on close, having the signature:
             callback(pika.connection.Connection, exception)
@@ -2169,9 +2169,11 @@ class Connection(abc.ABC):
                 self._error,
             (exceptions.StreamLostError, exceptions.ConnectionClosedByBroker)):
             # Heuristically deduce error based on connection state
+            original_error = self._error
+            deduced_error: Exception | None = None
             if self.connection_state == self.CONNECTION_PROTOCOL:
                 LOGGER.error('Probably incompatible Protocol Versions')
-                self._error = exceptions.IncompatibleProtocolError(
+                deduced_error = exceptions.IncompatibleProtocolError(
                     repr(self._error),
                     host=self.params.host,
                     port=self.params.port)
@@ -2179,7 +2181,7 @@ class Connection(abc.ABC):
                 LOGGER.error(
                     'Connection closed while authenticating indicating a '
                     'probable authentication error')
-                self._error = exceptions.ProbableAuthenticationError(
+                deduced_error = exceptions.ProbableAuthenticationError(
                     repr(self._error),
                     host=self.params.host,
                     port=self.params.port)
@@ -2187,7 +2189,7 @@ class Connection(abc.ABC):
                 LOGGER.error('Connection closed while tuning the connection '
                              'indicating a probable permission error when '
                              'accessing a virtual host')
-                self._error = exceptions.ProbableAccessDeniedError(
+                deduced_error = exceptions.ProbableAccessDeniedError(
                     repr(self._error),
                     host=self.params.host,
                     port=self.params.port)
@@ -2197,6 +2199,11 @@ class Connection(abc.ABC):
             ]:
                 LOGGER.warning('Unexpected connection state on disconnect: %i',
                                self.connection_state)
+            if deduced_error is not None:
+                # pika/pika#1390: keep the original error (and the __cause__
+                # traceback it carries) reachable behind the heuristic one.
+                deduced_error.__cause__ = original_error
+                self._error = deduced_error
 
         # Transition to closed state
         self._set_connection_state(self.CONNECTION_CLOSED)

--- a/tests/unit/base_connection_tests.py
+++ b/tests/unit/base_connection_tests.py
@@ -49,6 +49,32 @@ class BaseConnectionTests(unittest.TestCase):
                           None,
                           internal_connection_workflow=True)
 
+    def test_proto_connection_lost_chains_original_error(self):
+        try:
+            raise ZeroDivisionError('division by zero')
+        except ZeroDivisionError as exc:
+            original = exc
+
+        with mock.patch.object(self.connection,
+                               '_on_stream_terminated') as term_mock:
+            self.connection._proto_connection_lost(original)
+
+        reason = term_mock.call_args[0][0]
+        self.assertIsInstance(reason, pika.exceptions.StreamLostError)
+        self.assertIs(reason.__cause__, original)
+        self.assertIsNotNone(reason.__cause__.__traceback__)
+
+    def test_proto_connection_lost_eof_has_no_cause(self):
+        self.connection._got_eof = True
+
+        with mock.patch.object(self.connection,
+                               '_on_stream_terminated') as term_mock:
+            self.connection._proto_connection_lost(None)
+
+        reason = term_mock.call_args[0][0]
+        self.assertIsInstance(reason, pika.exceptions.StreamLostError)
+        self.assertIsNone(reason.__cause__)
+
     def test_tcp_options_with_dict_tcp_options(self):
 
         tcp_options = {'TCP_KEEPIDLE': 60}

--- a/tests/unit/connection_tests.py
+++ b/tests/unit/connection_tests.py
@@ -369,6 +369,26 @@ class ConnectionTests(unittest.TestCase):
             self.assertIs(type(conn_exc), exceptions.ProbableAccessDeniedError)
             self.assertSequenceEqual(conn_exc.args, [repr(original_exc)])
 
+    def test_on_stream_terminated_pre_open_error_chains_original(self):
+        """A pre-open heuristic error keeps the original error as its `__cause__` (pika/pika#1390),
+        so the chained traceback is not lost when `StreamLostError` is replaced.
+        """
+        with mock.patch.object(self.connection.callbacks,
+                               'process') as process_mock:
+            self.connection._adapter_disconnect_stream = mock.Mock()
+
+            self.connection._set_connection_state(
+                self.connection.CONNECTION_START)
+            self.connection._opened = False
+
+            original_exc = exceptions.StreamLostError(1, 'error text')
+            self.connection._on_stream_terminated(original_exc)
+
+            conn_exc = process_mock.call_args_list[0][0][4]
+            self.assertIs(type(conn_exc),
+                          exceptions.ProbableAuthenticationError)
+            self.assertIs(conn_exc.__cause__, original_exc)
+
     @mock.patch('pika.connection.Connection._adapter_connect_stream')
     def test_new_conn_should_use_first_channel(self, connect):
         """_next_channel_number in new conn should always be 1."""


### PR DESCRIPTION
## Proposed Changes

An exception raised from user code (an `on_open_callback`, for example) tears down the stream and reaches close callbacks as a `StreamLostError` carrying only the `repr` of the original exception. The traceback showing where it happened is lost.

Set `__cause__` on the wrapping `StreamLostError` instead, so `traceback.print_exception(reason)` prints the full chain, and `BlockingConnection` does so automatically since it re-raises the reason. The `add_on_close_callback` docstring mentions this. The error message is unchanged.

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Fixes

- Fixes #1390

## Further Comments

The issue's preferred fix, propagating the exception out of `ioloop.start()`, would change the error-delivery contract of every async adapter, so this does the smaller thing and just preserves the traceback. The `error`/`reason` split in `_proto_connection_lost` is cosmetic - no behavior change.
