### PR TITLE
Reject decimal.Decimal values with no AMQP wire representation

### DIFF
--- a/pika/data.py
+++ b/pika/data.py
@@ -167,16 +167,24 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
     elif isinstance(value, decimal.Decimal):
         if not value.is_finite():
             raise exceptions.UnencodableDecimalError(value)
-        value = value.normalize()
-        exponent = value.as_tuple().exponent
+        # Derive the mantissa and scale from as_tuple() using integer
+        # arithmetic. normalize() and Decimal multiplication both apply the
+        # thread-local context precision (28 digits by default), which would
+        # silently round a high-precision value down to a small mantissa that
+        # passes the range check below and encodes as a different number.
+        sign, digits, exponent = value.as_tuple()
         assert isinstance(exponent, int)  # guaranteed by is_finite() above
+        raw = 0
+        for digit in digits:
+            raw = raw * 10 + digit
+        if sign:
+            raw = -raw
         if exponent < 0:
             decimals = -exponent
-            raw = int(value * (decimal.Decimal(10)**decimals))
         else:
             # per spec, the "decimals" octet is unsigned (!)
             decimals = 0
-            raw = int(value)
+            raw *= 10**exponent
         # 4.2.5.3: the scale is an unsigned octet and the value a signed long;
         # a Decimal whose scale or mantissa doesn't fit those bounds has no
         # AMQP decimal representation.

--- a/pika/data.py
+++ b/pika/data.py
@@ -165,14 +165,24 @@ def encode_value(pieces: list[bytes], value: Any) -> int:
         pieces.append(_PACK_TAG_DOUBLE.pack(b'd', value))
         return 9
     elif isinstance(value, decimal.Decimal):
+        if not value.is_finite():
+            raise exceptions.UnencodableDecimalError(value)
         value = value.normalize()
-        if value.as_tuple().exponent < 0:
-            decimals = -value.as_tuple().exponent
+        exponent = value.as_tuple().exponent
+        assert isinstance(exponent, int)  # guaranteed by is_finite() above
+        if exponent < 0:
+            decimals = -exponent
             raw = int(value * (decimal.Decimal(10)**decimals))
-            pieces.append(_PACK_TAG_BYTE_INT.pack(b'D', decimals, raw))
         else:
             # per spec, the "decimals" octet is unsigned (!)
-            pieces.append(_PACK_TAG_BYTE_INT.pack(b'D', 0, int(value)))
+            decimals = 0
+            raw = int(value)
+        # 4.2.5.3: the scale is an unsigned octet and the value a signed long;
+        # a Decimal whose scale or mantissa doesn't fit those bounds has no
+        # AMQP decimal representation.
+        if decimals > 255 or not -2**31 <= raw < 2**31:
+            raise exceptions.UnencodableDecimalError(value)
+        pieces.append(_PACK_TAG_BYTE_INT.pack(b'D', decimals, raw))
         return 6
     elif isinstance(value, datetime):
         pieces.append(

--- a/pika/exceptions.py
+++ b/pika/exceptions.py
@@ -422,6 +422,15 @@ class ShortStringTooLong(AMQPError):
             f'{self.args[0]!s:.300}')
 
 
+class UnencodableDecimalError(AMQPError):
+
+    @override
+    def __repr__(self) -> str:
+        return (
+            f'{self.__class__.__name__}: decimal.Decimal value has no AMQP decimal '
+            f'representation: {self.args[0]!s:.300}')
+
+
 class DuplicateGetOkCallback(ChannelError):
 
     @override

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -156,6 +156,35 @@ class DataTests(unittest.TestCase):
         self.assertRaises(exceptions.UnencodableDecimalError, data.encode_value,
                           [], decimal.Decimal('Infinity'))
 
+    def test_encode_decimal_excess_precision_is_not_silently_rounded(self):
+        # A finite value with more significant digits than the thread-local
+        # decimal context precision (28 by default) must be rejected, not
+        # silently rounded down to a small mantissa and encoded as a different
+        # number. as_tuple() keeps every digit regardless of context.
+        value = decimal.Decimal('1.0000000000000000000000000000005')
+        self.assertRaises(exceptions.UnencodableDecimalError, data.encode_value,
+                          [], value)
+
+    def test_encode_decimal_context_precision_does_not_affect_result(self):
+        # Encoding must not depend on the ambient decimal context, so a low
+        # context precision cannot round an in-range value before it is packed.
+        value = decimal.Decimal('12345.6789')
+        with decimal.localcontext() as ctx:
+            ctx.prec = 3
+            pieces = []
+            data.encode_table(pieces, {'k': value})
+        decoded, _ = data.decode_table(b''.join(pieces), 0)
+        self.assertEqual(decoded, {'k': value})
+
+    def test_encode_decimal_preserves_trailing_zeros(self):
+        # Dropping normalize() keeps the scale exactly as given, so a value
+        # with trailing fractional zeros round-trips to that same scale.
+        value = decimal.Decimal('1.10')
+        pieces = []
+        data.encode_table(pieces, {'k': value})
+        decoded, _ = data.decode_table(b''.join(pieces), 0)
+        self.assertEqual(decoded, {'k': value})
+
     def test_decode_value_short_short_int(self):
         # b'b' = signed byte
         encoded = b'\x00\x00\x00\x04\x01kb\xff'

--- a/tests/unit/data_tests.py
+++ b/tests/unit/data_tests.py
@@ -138,6 +138,24 @@ class DataTests(unittest.TestCase):
         self.assertEqual(value, b'\xff\xfe')
         self.assertEqual(offset, 3)
 
+    def test_encode_decimal_scale_too_large(self):
+        value = decimal.Decimal('0.' + '0' * 300 + '1')
+        self.assertRaises(exceptions.UnencodableDecimalError, data.encode_value,
+                          [], value)
+
+    def test_encode_decimal_mantissa_out_of_range(self):
+        value = decimal.Decimal('99999999999999999999.99')
+        self.assertRaises(exceptions.UnencodableDecimalError, data.encode_value,
+                          [], value)
+
+    def test_encode_decimal_nan(self):
+        self.assertRaises(exceptions.UnencodableDecimalError, data.encode_value,
+                          [], decimal.Decimal('NaN'))
+
+    def test_encode_decimal_infinity(self):
+        self.assertRaises(exceptions.UnencodableDecimalError, data.encode_value,
+                          [], decimal.Decimal('Infinity'))
+
     def test_decode_value_short_short_int(self):
         # b'b' = signed byte
         encoded = b'\x00\x00\x00\x04\x01kb\xff'

--- a/tests/unit/exceptions_test.py
+++ b/tests/unit/exceptions_test.py
@@ -1,5 +1,6 @@
 """Tests for pika.exceptions."""
 
+import decimal
 import unittest
 from unittest.mock import MagicMock
 
@@ -359,6 +360,12 @@ class ExceptionTests(unittest.TestCase):
             repr(exceptions.ShortStringTooLong('toolong')),
             'ShortStringTooLong: AMQP Short String can contain up to 255 bytes: toolong'
         )
+
+    def test_unencodable_decimal_error_repr(self):
+        self.assertEqual(
+            repr(exceptions.UnencodableDecimalError(decimal.Decimal('NaN'))),
+            'UnencodableDecimalError: decimal.Decimal value has no AMQP decimal '
+            'representation: NaN')
 
     def test_duplicate_get_ok_callback_repr(self):
         self.assertEqual(


### PR DESCRIPTION
## Proposed Changes

`encode_value()` computes a scale and mantissa for any `decimal.Decimal` passed as an AMQP table value, but never checks that either one actually fits the wire format before packing it. The AMQP decimal type stores the scale as an unsigned octet and the value as a signed 32-bit integer (section 4.2.5.3 of the 0-9-1 spec).

Three ways to hit this while reading through `data.py`:

- A `Decimal` with more than 255 digits after the decimal point (e.g. `Decimal('0.' + '0' * 300 + '1')`) produces a scale that doesn't fit in a byte.
- A `Decimal` whose scaled mantissa is too large for a signed 32-bit int (e.g. `Decimal('99999999999999999999.99')`) overflows the other half of the format.
- `Decimal('NaN')` or `Decimal('Infinity')` have a string exponent (`'n'`/`'N'`/`'F'`) instead of an int, so the existing `exponent < 0` comparison raises `TypeError` rather than doing anything sensible.

All three currently propagate a low-level exception (`struct.error` or `TypeError`) straight out of `encode_value()`, rather than a `pika` exception an application can catch and handle. `encode_short_string()` already guards its own 255-byte limit and raises `ShortStringTooLong`; this does the equivalent for decimals, checking `Decimal.is_finite()` and the scale/mantissa bounds up front and raising a new `UnencodableDecimalError` instead.

## Types of Changes

- [x] Bugfix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Cosmetics

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

No issue was filed for this; I ran into it while reading `data.py` and confirmed all three crashes with a small reproduction script before writing the fix.

## Further Comments

Ran the full unit suite (`pytest tests/unit`, excluding the tornado/asyncio adapter tests that need optional extras not installed locally) plus `ruff check`, `yapf --diff --style google`, and `mypy` on the touched files; all clean. The existing `test_encode_table` case (which round-trips a plain `Decimal('3.14')`) still passes, so the common case is unaffected.
