### PR TITLE
CI: Test against pre-release Python 3.15 in a non-blocking leg

### DIFF
--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: boolean
         default: false
+      allow-prereleases:
+        description: 'Let setup-python resolve pre-release Python builds (alpha, beta, rc)'
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-windows:
@@ -36,6 +41,7 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ inputs.allow-prereleases }}
       - name: Resolve RabbitMQ and Erlang versions
         id: versions
         shell: pwsh
@@ -92,6 +98,7 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ inputs.allow-prereleases }}
       - name: Install and start RabbitMQ
         run: ./.ci/linux/gha-setup.sh
       - name: Install dependencies
@@ -122,6 +129,7 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
+          allow-prereleases: ${{ inputs.allow-prereleases }}
       - name: Install and start RabbitMQ
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -12,9 +12,10 @@ on:
         required: true
         type: string
       macos-runner:
-        description: 'macOS runner image, e.g. macos-latest or macos-15-intel'
-        required: true
+        description: 'macOS runner image, e.g. macos-latest or macos-15-intel. Unused when linux-only is true'
+        required: false
         type: string
+        default: macos-latest
       legacy:
         description: 'Apply legacy-Python tweaks (virtualenv pin)'
         required: false
@@ -25,10 +26,21 @@ on:
         required: false
         type: boolean
         default: false
+      linux-only:
+        description: 'Run only the Linux jobs, skipping the windows and macos legs'
+        required: false
+        type: boolean
+        default: false
+      upload-coverage:
+        description: 'Upload a coverage artifact for the coverage job to collect'
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build-windows:
     name: build/test on windows-latest py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
+    if: ${{ !inputs.linux-only }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -77,6 +89,7 @@ jobs:
       - name: Test with pytest
         run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage artifact
+        if: ${{ inputs.upload-coverage }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-windows-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
@@ -108,6 +121,7 @@ jobs:
       - name: Test with pytest
         run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage artifact
+        if: ${{ inputs.upload-coverage }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-linux-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
@@ -117,6 +131,7 @@ jobs:
 
   build-macos:
     name: build/test on ${{ inputs.macos-runner }} py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
+    if: ${{ !inputs.linux-only }}
     runs-on: ${{ inputs.macos-runner }}
     strategy:
       fail-fast: false
@@ -141,6 +156,7 @@ jobs:
       - name: Test with pytest
         run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
       - name: Upload coverage artifact
+        if: ${{ inputs.upload-coverage }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-macos-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -32,6 +32,18 @@ jobs:
       macos-runner: macos-15-intel
       legacy: true
 
+  # Pre-release Python. Deliberately absent from the `tests-passed` needs list:
+  # this leg reports breakage early without letting an unreleased interpreter
+  # block a merge. Promote it into `test-modern` once 3.15 ships a final
+  # release, and add the trove classifier at the same time.
+  test-preview:
+    uses: ./.github/workflows/_test.yaml
+    with:
+      python-versions: '["3.15"]'
+      ubuntu-runner: ubuntu-latest
+      macos-runner: macos-latest
+      allow-prereleases: true
+
   coverage:
     name: upload coverage to Codecov
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -34,15 +34,22 @@ jobs:
 
   # Pre-release Python. Deliberately absent from the `tests-passed` needs list:
   # this leg reports breakage early without letting an unreleased interpreter
-  # block a merge. Promote it into `test-modern` once 3.15 ships a final
-  # release, and add the trove classifier at the same time.
+  # block a merge. That non-blocking property depends on branch protection
+  # requiring only the `tests-passed` check, not every individual job; keep it
+  # that way. Promote it into `test-modern` once 3.15 ships a final release,
+  # and add the trove classifier at the same time.
+  #
+  # Linux-only and no coverage upload: this is an early-warning smoke test, so
+  # it skips the slow, expensive macOS and Windows legs and keeps pre-release
+  # coverage out of the Codecov report.
   test-preview:
     uses: ./.github/workflows/_test.yaml
     with:
       python-versions: '["3.15"]'
       ubuntu-runner: ubuntu-latest
-      macos-runner: macos-latest
       allow-prereleases: true
+      linux-only: true
+      upload-coverage: false
 
   coverage:
     name: upload coverage to Codecov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,9 +109,11 @@ the `codegen` workflow enforces on every pull request.
   path-filtered job never reports to a required status check, and running
   unconditionally also catches a hand-edited `spec.py`.
 - **Tests** (`.github/workflows/main.yaml`): the entry point on every push
-  and pull request. Calls the reusable test workflow twice, once for Python
-  3.10-3.14 and once for 3.7-3.9, builds the docs, and gates all of it
-  behind a `tests-passed` job. Acceptance tests require a RabbitMQ server
+  and pull request. Calls the reusable test workflow three times: once for
+  Python 3.10-3.14, once for 3.7-3.9, and once for pre-release 3.15 in a
+  non-blocking, Linux-only `test-preview` leg (absent from the `tests-passed`
+  needs list). It also builds the docs and gates the blocking legs behind a
+  `tests-passed` job. Acceptance tests require a RabbitMQ server
   (started via Docker in CI). Coverage is uploaded to Codecov.
 - **Reusable tests** (`.github/workflows/_test.yaml`): the matrix itself,
   Linux, macOS, and Windows crossed with each Python version and with TLS


### PR DESCRIPTION
## Proposed Changes

Python 3.15 ships in under a month. Good time to start surfacing friction against it now, without declaring official support and without blocking CI on failures.

https://peps.python.org/pep-0790/#release-schedule

## Types of Changes

<!-- What types of changes does your code introduce to this project?
Put an `x` in the boxes that apply -->

- [ ] Bugfix <!-- non-breaking change which fixes issue -->
- [ ] New feature <!-- non-breaking change which adds functionality -->
- [ ] Breaking change <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] Documentation <!-- correction or otherwise -->
- [ ] Cosmetics <!-- whitespace, appearance -->

## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to
ask on the [`pika-python`](https://groups.google.com/forum/#!forum/pika-python)
mailing list. We're here to help! This is simply a reminder of what we
are going to look for before merging your code. -->

- [x] I have read the `CONTRIBUTING.md` document
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Fixes

<!-- Link related issues using GitHub keywords:
- Fixes #123
- Closes #456
- Resolves owner/repo#789
-->

- Fixes #

## Further Comments

Checked again local CPython 3.15.0rc2 (uv-managed), Ubuntu 26.04
Status: 1539 passed, 61 skipped, 0 failed