### PR TITLE
CI: run macOS on one Python version in a minimal non-blocking leg

### DIFF
--- a/.ci/README.md
+++ b/.ci/README.md
@@ -6,13 +6,22 @@ pika's acceptance tests on GitHub Actions.
 ## How the test matrix works
 
 `.github/workflows/main.yaml` triggers on push and PR. It calls the reusable
-workflow `.github/workflows/_test.yaml` twice:
+workflow `.github/workflows/_test.yaml` three times. Each call matrices over
+`python-version` and `test-tls: [true, false]`; `test-modern` and
+`test-legacy` run on both the Linux and Windows runners, while `test-preview`
+is Linux-only:
 
-- `test-modern` - Python 3.10-3.14, ubuntu-latest, macos-latest
-- `test-legacy` - Python 3.7-3.9, ubuntu-22.04, macos-15-intel
+- `test-modern` - Python 3.10-3.14, ubuntu-latest + windows-latest
+- `test-legacy` - Python 3.7-3.9, ubuntu-22.04 + windows-latest
+- `test-preview` - pre-release Python 3.15, ubuntu-latest; non-blocking
 
-Each invocation matrices over `python-version` and `test-tls: [true, false]`,
-producing job names like `build/test on ubuntu-latest py3.12 tls=true`.
+macOS runs separately as the standalone `test-macos` job in `main.yaml` (not
+through the reusable workflow): only the latest supported CPython on
+macos-latest, both TLS modes. It is slow and occasionally flaky, so it is kept
+minimal and non-blocking, but still exercises the BSD-only KQueuePoller path
+and feeds its coverage to Codecov.
+
+Job names look like `build/test on ubuntu-latest py3.12 tls=true`.
 
 The `--use-tls` pytest flag is passed when `test-tls` is true, directing tests
 to connect on port 5671 instead of 5672.

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -11,11 +11,6 @@ on:
         description: 'Ubuntu runner image, e.g. ubuntu-latest or ubuntu-22.04'
         required: true
         type: string
-      macos-runner:
-        description: 'macOS runner image, e.g. macos-latest or macos-15-intel. Unused when linux-only is true'
-        required: false
-        type: string
-        default: macos-latest
       legacy:
         description: 'Apply legacy-Python tweaks (virtualenv pin)'
         required: false
@@ -27,7 +22,7 @@ on:
         type: boolean
         default: false
       linux-only:
-        description: 'Run only the Linux jobs, skipping the windows and macos legs'
+        description: 'Run only the Linux jobs, skipping the windows leg'
         required: false
         type: boolean
         default: false
@@ -125,41 +120,6 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-linux-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
-          path: coverage.xml
-          retention-days: 7
-          if-no-files-found: error
-
-  build-macos:
-    name: build/test on ${{ inputs.macos-runner }} py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
-    if: ${{ !inputs.linux-only }}
-    runs-on: ${{ inputs.macos-runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ${{ fromJSON(inputs.python-versions) }}
-        test-tls: [true, false]
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ matrix.python-version }}
-          allow-prereleases: ${{ inputs.allow-prereleases }}
-      - name: Install and start RabbitMQ
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: ./.ci/macos/gha-setup.sh
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip wheel
-          python -m pip install hatch ${{ inputs.legacy && '"virtualenv<21.0.0"' || '' }}
-      - name: Test with pytest
-        run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
-      - name: Upload coverage artifact
-        if: ${{ inputs.upload-coverage }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-macos-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
           path: coverage.xml
           retention-days: 7
           if-no-files-found: error

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,6 @@ jobs:
     with:
       python-versions: '["3.10","3.11","3.12","3.13","3.14"]'
       ubuntu-runner: ubuntu-latest
-      macos-runner: macos-latest
       legacy: false
 
   test-legacy:
@@ -29,7 +28,6 @@ jobs:
     with:
       python-versions: '["3.7","3.8","3.9"]'
       ubuntu-runner: ubuntu-22.04
-      macos-runner: macos-15-intel
       legacy: true
 
   # Pre-release Python. Deliberately absent from the `tests-passed` needs list:
@@ -51,10 +49,53 @@ jobs:
       linux-only: true
       upload-coverage: false
 
+  # macOS is slow and occasionally flaky, so it is not run across the full
+  # matrix like Linux and Windows. This single leg exercises only the latest
+  # supported CPython on macos-latest (both TLS modes), enough to keep the
+  # BSD-only KQueuePoller path covered by real runs. Deliberately absent from
+  # the `tests-passed` needs list so a macOS flake does not block a merge; its
+  # coverage still feeds Codecov (see the `coverage` job). Bump the Python
+  # version here when a newer stable release joins `test-modern`.
+  test-macos:
+    name: build/test on macos-latest py${{ matrix.python-version }} tls=${{ matrix.test-tls }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.14']
+        test-tls: [true, false]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install and start RabbitMQ
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: ./.ci/macos/gha-setup.sh
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install hatch
+      - name: Test with pytest
+        run: hatch run test -v --cov=pika --cov-report=xml:coverage.xml ${{ matrix.test-tls && '--use-tls' || '' }}
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-macos-py${{ matrix.python-version }}-tls-${{ matrix.test-tls }}
+          path: coverage.xml
+          retention-days: 7
+          if-no-files-found: error
+
   coverage:
     name: upload coverage to Codecov
     runs-on: ubuntu-latest
-    needs: [test-modern, test-legacy]
+    # Wait for the macOS leg too so its coverage (the only source for the
+    # BSD-only KQueuePoller lines) is merged, but tolerate a macOS flake: run
+    # as long as the blocking legs passed.
+    needs: [test-modern, test-legacy, test-macos]
+    if: ${{ !cancelled() && needs.test-modern.result == 'success' && needs.test-legacy.result == 'success' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download coverage artifacts

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
   # and add the trove classifier at the same time.
   #
   # Linux-only and no coverage upload: this is an early-warning smoke test, so
-  # it skips the slow, expensive macOS and Windows legs and keeps pre-release
+  # it skips the slow, expensive Windows legs and keeps pre-release
   # coverage out of the Codecov report.
   test-preview:
     uses: ./.github/workflows/_test.yaml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,13 +111,16 @@ the `codegen` workflow enforces on every pull request.
 - **Tests** (`.github/workflows/main.yaml`): the entry point on every push
   and pull request. Calls the reusable test workflow three times: once for
   Python 3.10-3.14, once for 3.7-3.9, and once for pre-release 3.15 in a
-  non-blocking, Linux-only `test-preview` leg (absent from the `tests-passed`
-  needs list). It also builds the docs and gates the blocking legs behind a
-  `tests-passed` job. Acceptance tests require a RabbitMQ server
-  (started via Docker in CI). Coverage is uploaded to Codecov.
+  non-blocking, Linux-only `test-preview` leg. macOS runs as a separate,
+  non-blocking `test-macos` job (latest supported Python on macos-latest
+  only), kept minimal because macOS is slow and flaky. Both non-blocking legs
+  are absent from the `tests-passed` needs list. It also builds the docs and
+  gates the blocking legs behind `tests-passed`. Acceptance tests require a
+  RabbitMQ server (started via Docker in CI). Coverage is uploaded to Codecov.
 - **Reusable tests** (`.github/workflows/_test.yaml`): the matrix itself,
-  Linux, macOS, and Windows crossed with each Python version and with TLS
-  on and off. Invoked via `workflow_call`; never triggered directly.
+  Linux and Windows crossed with each Python version and with TLS on and off
+  (macOS runs separately; see the `test-macos` job in `main.yaml`). Invoked
+  via `workflow_call`; never triggered directly.
 - **Docs** (`.github/workflows/docs.yaml`): runs `hatch run docs:build`.
   Invoked via `workflow_call` from the test workflow.
 - **CodeQL** (`.github/workflows/codeql-analysis.yml`): security analysis on


### PR DESCRIPTION
## Summary

macOS runners are slow and occasionally flaky, so testing every supported Python version there is not worth the cost. This restructures CI to test only the latest supported CPython on macOS, in a minimal non-blocking leg, while keeping the platform covered where it matters.

- Removed macOS from the reusable `_test.yaml`, which now covers Linux and Windows. Dropped the `macos-runner` input and its use in `test-modern` and `test-legacy`.
- Added a standalone `test-macos` job to `main.yaml` running the latest supported CPython (3.14) on `macos-latest` across both TLS modes. It is absent from the `tests-passed` needs list, so a macOS flake does not block a merge, but it still exercises the BSD-only `KQueuePoller` path.
- The `coverage` job now waits for `test-macos` so the macOS coverage of `KQueuePoller` is merged into the Codecov report, while tolerating a macOS flake so a failure there does not drop the whole upload.
- Kept `macos-latest` in the mypy matrix so `KQueuePoller`'s kqueue code stays type-checked (mypy narrows the platform for the type checker, so only a darwin run reaches that code).
- Updated `.ci/README.md` and `AGENTS.md` to describe the split.

## Context

This came out of a review of the change. A prior draft removed macOS entirely, which surfaced that macOS was the only environment exercising `KQueuePoller` both at runtime (its tests are `skipIf(not hasattr(select, 'kqueue'))`) and for type checking, and that dropping its coverage risked the Codecov project status. Keeping a single latest-Python macOS leg preserves all of that at a fraction of the runtime cost.

## What was tested

- All three workflows parse; `_test.yaml` runs Linux and Windows only; `test-macos` runs `macos-latest` with `python-version: ['3.14']` and `test-tls: [true, false]`; `test-macos` is excluded from `tests-passed`; `mypy` still includes `macos-latest`.
- CI on this PR.

## Note

If branch protection lists required checks by name, the old per-Python `build/test on macos-*` entries no longer report and may need pruning from repo settings.
